### PR TITLE
DEBUG: Add debug SSH session to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -356,3 +356,4 @@ jobs:
         with:
           name: 'proof-server-test-results-${{ matrix.runner }}'
           path: target/test-*
+


### PR DESCRIPTION
For some reason, attic will not authenticate to the server:

 > ✍️ Configuring server "default"
 > Error: Unauthorized: Unauthorized.

So I'm adding a tmate SSH session to the workflow to debug it
