### PR TITLE
CI updates moving towards making external contributions doable

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           endpoint: https://attic.ci.iog.io
-          cache: midnight
+          cache: midnight-public
           access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Configure cargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Run integration tests
         run: |
           export MN_AXIOS=true
+          set -o pipefail
           cd integration-tests
           yarn
           yarn lint
@@ -226,13 +227,6 @@ jobs:
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh
-
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
-        with:
-          toolchain: stable # Or 'nightly', 'beta', or a specific version like '1.70.0'
-          override: true
-          profile: minimal # Installs rustc, cargo, and rust-std. Use 'default' for rustfmt, clippy, etc.
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,20 +40,6 @@ jobs:
           echo "Workspace cleaning attempted."
         shell: bash
 
-      - name: Setup api.github.com credentials
-        uses: extractions/netrc@f6f1722d05ce2890aa86fd9654565b1214ac53a4
-        with:
-          machine: api.github.com
-          username: ${{ secrets.GH_USERNAME }}
-          password: ${{ secrets.GH_PASSWORD }}
-
-      - name: Setup github.com credentials
-        uses: extractions/netrc@f6f1722d05ce2890aa86fd9654565b1214ac53a4
-        with:
-          machine: github.com
-          username: ${{ secrets.GH_USERNAME }}
-          password: ${{ secrets.GH_PASSWORD }}
-
       - name: Configure git rewrite
         run: |
           mkdir -p $HOME/.config/git
@@ -70,8 +56,6 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            netrc-file = ~/.netrc
-            access-tokens = github.com=${{ secrets.GH_PASSWORD }} api.github.com=${{ secrets.GH_PASSWORD }}
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
             accept-flake-config = true
@@ -112,12 +96,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-         always-auth: true
-         registry-url: https://npm.pkg.github.com/
-         scope: '@midnight-ntwrk'
          node-version: 22
-        env:
-         NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTBOT_PACKAGES_WRITE }}
 
       - name: Run integration tests
         run: |
@@ -218,20 +197,6 @@ jobs:
           echo "Workspace cleaning attempted."
         shell: bash
 
-      - name: Setup api.github.com credentials
-        uses: extractions/netrc@f6f1722d05ce2890aa86fd9654565b1214ac53a4
-        with:
-          machine: api.github.com
-          username: ${{ secrets.GH_USERNAME }}
-          password: ${{ secrets.GH_PASSWORD }}
-
-      - name: Setup github.com credentials
-        uses: extractions/netrc@f6f1722d05ce2890aa86fd9654565b1214ac53a4
-        with:
-          machine: github.com
-          username: ${{ secrets.GH_USERNAME }}
-          password: ${{ secrets.GH_PASSWORD }}
-
       - name: Configure git rewrite
         run: |
           mkdir -p $HOME/.config/git
@@ -248,8 +213,6 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable #trya
           extra_nix_config: |
-            netrc-file = ~/.netrc
-            access-tokens = github.com=${{ secrets.GH_PASSWORD }} api.github.com=${{ secrets.GH_PASSWORD }}
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
             accept-flake-config = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
             accept-flake-config = true
 
-      - name: Cache Nix
-        uses: input-output-hk/actions/attic@latest
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          endpoint: https://attic.ci.iog.io
-          cache: midnight
-          access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      #- name: Cache Nix
+      #  uses: input-output-hk/actions/attic@latest
+      #  with:
+      #    nix_path: nixpkgs=channel:nixos-unstable
+      #    endpoint: https://attic.ci.iog.io
+      #    cache: midnight
+      #    access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Fix Nix permissions (needed on macos self hosted runner)
         run: |
@@ -217,13 +217,13 @@ jobs:
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
             accept-flake-config = true
 
-      - name: Cache Nix
-        uses: input-output-hk/actions/attic@latest
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          endpoint: https://attic.ci.iog.io
-          cache: midnight
-          access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      #- name: Cache Nix
+      #  uses: input-output-hk/actions/attic@latest
+      #  with:
+      #    nix_path: nixpkgs=channel:nixos-unstable
+      #    endpoint: https://attic.ci.iog.io
+      #    cache: midnight
+      #    access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh
@@ -283,28 +283,28 @@ jobs:
         run: |
           nix develop .#ci -c cargo spellcheck -j1
 
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1
-        if: success() || failure()
-        with:
-          check_name: 'Proof Server - JUnit Test Results - ${{ matrix.runner }}'
-          report_paths: '**/target/test-*.xml'
+      #- name: Publish Test Report
+      #  uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1
+      #  if: success() || failure()
+      #  with:
+      #    check_name: 'Proof Server - JUnit Test Results - ${{ matrix.runner }}'
+      #    report_paths: '**/target/test-*.xml'
 
-      - name: Publish Test Summary
-        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b
-        if: always() && matrix.runner != 'self-hosted'
-        with:
-          check_name: 'Proof Server - Test Results - ${{ matrix.runner }}'
-          files: |
-            **/target/test-*.xml
+      #- name: Publish Test Summary
+      #  uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b
+      #  if: always() && matrix.runner != 'self-hosted'
+      #  with:
+      #    check_name: 'Proof Server - Test Results - ${{ matrix.runner }}'
+      #    files: |
+      #      **/target/test-*.xml
 
-      - name: Publish Test Summary
-        uses: EnricoMi/publish-unit-test-result-action/macos@170bf24d20d201b842d7a52403b73ed297e6645b
-        if: always() && matrix.runner == 'self-hosted'
-        with:
-          check_name: 'Proof Server - Test Results - ${{ matrix.runner }}'
-          files: |
-            **/target/test-*.xml
+      #- name: Publish Test Summary
+      #  uses: EnricoMi/publish-unit-test-result-action/macos@170bf24d20d201b842d7a52403b73ed297e6645b
+      #  if: always() && matrix.runner == 'self-hosted'
+      #  with:
+      #    check_name: 'Proof Server - Test Results - ${{ matrix.runner }}'
+      #    files: |
+      #      **/target/test-*.xml
 
       - name: Upload Artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
             accept-flake-config = true
 
-      #- name: Cache Nix
-      #  uses: input-output-hk/actions/attic@latest
-      #  with:
-      #    nix_path: nixpkgs=channel:nixos-unstable
-      #    endpoint: https://attic.ci.iog.io
-      #    cache: midnight
-      #    access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      - name: Cache Nix
+        uses: input-output-hk/actions/attic@latest
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          endpoint: https://attic.ci.iog.io
+          cache: midnight-public
+          access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Fix Nix permissions (needed on macos self hosted runner)
         run: |
@@ -216,13 +216,13 @@ jobs:
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
             accept-flake-config = true
 
-      #- name: Cache Nix
-      #  uses: input-output-hk/actions/attic@latest
-      #  with:
-      #    nix_path: nixpkgs=channel:nixos-unstable
-      #    endpoint: https://attic.ci.iog.io
-      #    cache: midnight
-      #    access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      - name: Cache Nix
+        uses: input-output-hk/actions/attic@latest
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          endpoint: https://attic.ci.iog.io
+          cache: midnight-public
+          access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
 
       - name: Build and Test
         run: |
-          nix develop .#ci -c cargo config -Z unstable-options get net.git-fetch-with-cli
           nix build -L --max-jobs 1
 
       - name: Add Homebrew and git bin to PATH for Yarn, verify git is installed
@@ -114,50 +113,50 @@ jobs:
          name: logs-${{ matrix.runner }}
          path: integration-tests/logs/
 
-      - name: Publish IT Test Report
-        uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1
-        if: success() || failure()
-        with:
-          check_name: 'IT Test Report - ${{ matrix.runner }}'
-          report_paths: '**/reports/test-*.xml'
+      #- name: Publish IT Test Report
+      #  uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1
+      #  if: success() || failure()
+      #  with:
+      #    check_name: 'IT Test Report - ${{ matrix.runner }}'
+      #    report_paths: '**/reports/test-*.xml'
 
-      - name: Publish Test Coverage
-        uses: MishaKav/jest-coverage-comment@d74238813c33e6ea20530ff91b5ea37953d11c91
-        with:
-          title: 'Integration tests summary - ${{ matrix.runner }}'
-          unique-id-for-comment: ${{ matrix.runner }}
-          coverage-summary-path: ./integration-tests/coverage/coverage-summary.json
-          junitxml-path: ./integration-tests/reports/test-report.xml
-          coverage-path: ./integration-tests/coverage.txt
+      #- name: Publish Test Coverage
+      #  uses: MishaKav/jest-coverage-comment@d74238813c33e6ea20530ff91b5ea37953d11c91
+      #  with:
+      #    title: 'Integration tests summary - ${{ matrix.runner }}'
+      #    unique-id-for-comment: ${{ matrix.runner }}
+      #    coverage-summary-path: ./integration-tests/coverage/coverage-summary.json
+      #    junitxml-path: ./integration-tests/reports/test-report.xml
+      #    coverage-path: ./integration-tests/coverage.txt
 
-      - name: Publish ITest Summary
-        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b
-        if: always() && matrix.runner != 'self-hosted'
-        with:
-         check_name: 'Test Results - ${{ matrix.runner }}'
-         files: |
-           **/reports/test-*.xml
+      #- name: Publish ITest Summary
+      #  uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b
+      #  if: always() && matrix.runner != 'self-hosted'
+      #  with:
+      #   check_name: 'Test Results - ${{ matrix.runner }}'
+      #   files: |
+      #     **/reports/test-*.xml
 
-      - name: Publish ITest Summary
-        uses: EnricoMi/publish-unit-test-result-action/macos@170bf24d20d201b842d7a52403b73ed297e6645b
-        if: always() && matrix.runner == 'self-hosted'
-        with:
-         check_name: 'Test Results - ${{ matrix.runner }}'
-         files: |
-           **/reports/test-*.xml
+      #- name: Publish ITest Summary
+      #  uses: EnricoMi/publish-unit-test-result-action/macos@170bf24d20d201b842d7a52403b73ed297e6645b
+      #  if: always() && matrix.runner == 'self-hosted'
+      #  with:
+      #   check_name: 'Test Results - ${{ matrix.runner }}'
+      #   files: |
+      #     **/reports/test-*.xml
 
-      - name: Publish Test Report CTRF
-        uses: ctrf-io/github-test-reporter@646f98cfc16c6f7a0e1f6100cabe2deb95dd2eef # v1.0.22
-        if: always()
-        with:
-          title: Ledger WASM - Integration test results - ${{ matrix.runner }}
-          report-path: './integration-tests/reports/ctrf-report.json'
-          pull-request-report: true
-          overwrite-comment: true
-          status-check: true
-          comment-tag: '${{ github.workflow }}-${{ github.job }}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #- name: Publish Test Report CTRF
+      #  uses: ctrf-io/github-test-reporter@646f98cfc16c6f7a0e1f6100cabe2deb95dd2eef # v1.0.22
+      #  if: always()
+      #  with:
+      #    title: Ledger WASM - Integration test results - ${{ matrix.runner }}
+      #    report-path: './integration-tests/reports/ctrf-report.json'
+      #    pull-request-report: true
+      #    overwrite-comment: true
+      #    status-check: true
+      #    comment-tag: '${{ github.workflow }}-${{ github.job }}'
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Test Results
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
@@ -263,7 +262,6 @@ jobs:
       - name: Build and Test (default features)
         run: |
           cargo install cargo2junit
-          nix develop .#ci -c cargo config -Z unstable-options get net.git-fetch-with-cli
           nix develop .#ci -c cargo test --release -- -Z unstable-options --format json --report-time --nocapture --test-threads=1 | tee test-results.json
           cat test-results.json | cargo2junit > ./target/test-results.xml
           cp test-results.json ./target/

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           endpoint: https://attic.ci.iog.io
-          cache: midnight
+          cache: midnight-public
           access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Create proof-server images

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           endpoint: https://attic.ci.iog.io
-          cache: midnight
+          cache: midnight-public
           access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Configure cargo

--- a/.github/workflows/prepare-cost-model-docker.yml
+++ b/.github/workflows/prepare-cost-model-docker.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           endpoint: https://attic.ci.iog.io
-          cache: midnight
+          cache: midnight-public
           access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Configure cargo

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           endpoint: https://attic.ci.iog.io
-          cache: midnight
+          cache: midnight-public
           access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Get project versions

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           endpoint: https://attic.ci.iog.io
-          cache: midnight
+          cache: midnight-public
           access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Cache dependencies


### PR DESCRIPTION
Removes secrets from CI workflow and temporarily fully disables the test reporting (which still failing on failing tests). Test reporting should be re-added later with a `on: workflow_run` trigger instead.