### PR TITLE
Switch to standard GitHub runners, expand test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,29 +19,9 @@ jobs:
   nix-build:
     strategy:
       matrix:
-        os: [ubuntu-latest-8-core-x64, macOSTestRunner, macos-latest]
-        include:
-          - os: ubuntu-latest-8-core-x64
-            runner: ubuntu-latest-8-core-x64
-          - os: macOSTestRunner
-            runner: self-hosted
-          - os: macos-latest
-            runner: macos-latest
-    runs-on: ${{ matrix.runner }}
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Force clean workspace before checkout (Self-hosted macOS only)
-        if: runner.os == 'macOS' # Or matrix.os == 'macOSTestRunner'
-        run: |
-          WORKSPACE_PATH="${{ github.workspace }}"
-          echo "Attempting to forcefully clean workspace: $WORKSPACE_PATH"
-          # Ensure current user owns the directory
-          sudo chown -R $(whoami):$(id -gn) "$WORKSPACE_PATH" || true
-          sudo chown -R $(whoami) /nix/var/log/ || true
-          # Remove all contents, including hidden files
-          sudo rm -rf "$WORKSPACE_PATH"/* "$WORKSPACE_PATH"/.[!.]* || true
-          echo "Workspace cleaning attempted."
-        shell: bash
-
       - name: Configure git rewrite
         run: |
           mkdir -p $HOME/.config/git
@@ -62,14 +42,13 @@ jobs:
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
             accept-flake-config = true
 
-      # FIXME: temp disable to torture-test the macos-latest runner.
-      #- name: Cache Nix
-      #  uses: input-output-hk/actions/attic@latest
-      #  with:
-      #    nix_path: nixpkgs=channel:nixos-unstable
-      #    endpoint: https://attic.ci.iog.io
-      #    cache: midnight-public
-      #    access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      - name: Cache Nix
+        uses: input-output-hk/actions/attic@latest
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          endpoint: https://attic.ci.iog.io
+          cache: midnight-public
+          access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Fix Nix permissions (needed on macos self hosted runner)
         run: |
@@ -178,28 +157,9 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest-8-core-x64, macOSTestRunner]
-        include:
-          # Configuration for the GitHub-hosted Linux runner
-          - os: ubuntu-latest-8-core-x64
-            runner: ubuntu-latest-8-core-x64
-          # Configuration for your self-hosted macOS runner
-          - os: macOSTestRunner
-            runner: self-hosted
-    runs-on: ${{ matrix.runner }}
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Force clean workspace before checkout (Self-hosted macOS only)
-        if: runner.os == 'macOS' # Or matrix.os == 'macOSTestRunner'
-        run: |
-          WORKSPACE_PATH="${{ github.workspace }}"
-          echo "Attempting to forcefully clean workspace: $WORKSPACE_PATH"
-          # Ensure current user owns the directory
-          sudo chown -R $(whoami):$(id -gn) "$WORKSPACE_PATH" || true
-          # Remove all contents, including hidden files
-          sudo rm -rf "$WORKSPACE_PATH"/* "$WORKSPACE_PATH"/.[!.]* || true
-          echo "Workspace cleaning attempted."
-        shell: bash
-
       - name: Configure git rewrite
         run: |
           mkdir -p $HOME/.config/git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   nix-build:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git rewrite
@@ -49,12 +49,6 @@ jobs:
           endpoint: https://attic.ci.iog.io
           cache: midnight-public
           access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
-
-      - name: Fix Nix permissions (needed on macos self hosted runner)
-        run: |
-          sudo mkdir -m 0755 -p /nix/var/nix/{profiles,gcroots}/per-user/$USER
-          sudo chown -R $USER:nixbld /nix/var/nix/{profiles,gcroots}/per-user/$USER
-        shell: bash # Ensure bash is used for these commands
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh
@@ -157,7 +151,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git rewrite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,14 @@ jobs:
   nix-build:
     strategy:
       matrix:
-        os: [ubuntu-latest-8-core-x64, macOSTestRunner]
+        os: [ubuntu-latest-8-core-x64, macOSTestRunner, macos-latest]
         include:
           - os: ubuntu-latest-8-core-x64
             runner: ubuntu-latest-8-core-x64
           - os: macOSTestRunner
             runner: self-hosted
+          - os: macos-latest
+            runner: macos-latest
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Force clean workspace before checkout (Self-hosted macOS only)
@@ -60,13 +62,14 @@ jobs:
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
             accept-flake-config = true
 
-      - name: Cache Nix
-        uses: input-output-hk/actions/attic@latest
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          endpoint: https://attic.ci.iog.io
-          cache: midnight-public
-          access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      # FIXME: temp disable to torture-test the macos-latest runner.
+      #- name: Cache Nix
+      #  uses: input-output-hk/actions/attic@latest
+      #  with:
+      #    nix_path: nixpkgs=channel:nixos-unstable
+      #    endpoint: https://attic.ci.iog.io
+      #    cache: midnight-public
+      #    access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Fix Nix permissions (needed on macos self hosted runner)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,38 +93,38 @@ jobs:
       - name: Upload Logs
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
-         name: logs-${{ matrix.runner }}
+         name: logs-${{ matrix.os }}
          path: integration-tests/logs/
 
       #- name: Publish IT Test Report
       #  uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1
       #  if: success() || failure()
       #  with:
-      #    check_name: 'IT Test Report - ${{ matrix.runner }}'
+      #    check_name: 'IT Test Report - ${{ matrix.os }}'
       #    report_paths: '**/reports/test-*.xml'
 
       #- name: Publish Test Coverage
       #  uses: MishaKav/jest-coverage-comment@d74238813c33e6ea20530ff91b5ea37953d11c91
       #  with:
-      #    title: 'Integration tests summary - ${{ matrix.runner }}'
-      #    unique-id-for-comment: ${{ matrix.runner }}
+      #    title: 'Integration tests summary - ${{ matrix.os }}'
+      #    unique-id-for-comment: ${{ matrix.os }}
       #    coverage-summary-path: ./integration-tests/coverage/coverage-summary.json
       #    junitxml-path: ./integration-tests/reports/test-report.xml
       #    coverage-path: ./integration-tests/coverage.txt
 
       #- name: Publish ITest Summary
       #  uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b
-      #  if: always() && matrix.runner != 'self-hosted'
+      #  if: always() && matrix.os != 'self-hosted'
       #  with:
-      #   check_name: 'Test Results - ${{ matrix.runner }}'
+      #   check_name: 'Test Results - ${{ matrix.os }}'
       #   files: |
       #     **/reports/test-*.xml
 
       #- name: Publish ITest Summary
       #  uses: EnricoMi/publish-unit-test-result-action/macos@170bf24d20d201b842d7a52403b73ed297e6645b
-      #  if: always() && matrix.runner == 'self-hosted'
+      #  if: always() && matrix.os == 'self-hosted'
       #  with:
-      #   check_name: 'Test Results - ${{ matrix.runner }}'
+      #   check_name: 'Test Results - ${{ matrix.os }}'
       #   files: |
       #     **/reports/test-*.xml
 
@@ -132,7 +132,7 @@ jobs:
       #  uses: ctrf-io/github-test-reporter@646f98cfc16c6f7a0e1f6100cabe2deb95dd2eef # v1.0.22
       #  if: always()
       #  with:
-      #    title: Ledger WASM - Integration test results - ${{ matrix.runner }}
+      #    title: Ledger WASM - Integration test results - ${{ matrix.os }}
       #    report-path: './integration-tests/reports/ctrf-report.json'
       #    pull-request-report: true
       #    overwrite-comment: true
@@ -145,13 +145,13 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
         if: always()
         with:
-          name: 'ledger-wasm-test-results-ctrf-${{ matrix.runner }}'
+          name: 'ledger-wasm-test-results-ctrf-${{ matrix.os }}'
           path: './integration-tests/reports/ctrf-report.json'
 
       - name: Upload Artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
-          name: 'ledger-wasm-test-results-junit-${{ matrix.runner }}'
+          name: 'ledger-wasm-test-results-junit-${{ matrix.os }}'
           path: ./integration-tests/reports/test-report.xml
 
   build:
@@ -242,27 +242,27 @@ jobs:
       #  uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1
       #  if: success() || failure()
       #  with:
-      #    check_name: 'Proof Server - JUnit Test Results - ${{ matrix.runner }}'
+      #    check_name: 'Proof Server - JUnit Test Results - ${{ matrix.os }}'
       #    report_paths: '**/target/test-*.xml'
 
       #- name: Publish Test Summary
       #  uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b
-      #  if: always() && matrix.runner != 'self-hosted'
+      #  if: always() && matrix.os != 'self-hosted'
       #  with:
-      #    check_name: 'Proof Server - Test Results - ${{ matrix.runner }}'
+      #    check_name: 'Proof Server - Test Results - ${{ matrix.os }}'
       #    files: |
       #      **/target/test-*.xml
 
       #- name: Publish Test Summary
       #  uses: EnricoMi/publish-unit-test-result-action/macos@170bf24d20d201b842d7a52403b73ed297e6645b
-      #  if: always() && matrix.runner == 'self-hosted'
+      #  if: always() && matrix.os == 'self-hosted'
       #  with:
-      #    check_name: 'Proof Server - Test Results - ${{ matrix.runner }}'
+      #    check_name: 'Proof Server - Test Results - ${{ matrix.os }}'
       #    files: |
       #      **/target/test-*.xml
 
       - name: Upload Artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
-          name: 'proof-server-test-results-${{ matrix.runner }}'
+          name: 'proof-server-test-results-${{ matrix.os }}'
           path: target/test-*

--- a/base-crypto/src/fab/encoding.rs
+++ b/base-crypto/src/fab/encoding.rs
@@ -456,12 +456,15 @@ struct AlignedValueUnchecked {
 }
 
 impl TryFrom<AlignedValueUnchecked> for AlignedValue {
-    type Error = &'static str;
+    type Error = String;
     fn try_from(unchecked: AlignedValueUnchecked) -> Result<AlignedValue, Self::Error> {
         if !unchecked.alignment.fits(&unchecked.value) {
-            Err("value deserialized as aligned failed alignment check")
+            Err(format!(
+                "value deserialized as aligned failed alignment check (value: {:?}; alignment: {:?})",
+                &unchecked.value, &unchecked.alignment
+            ))
         } else if !unchecked.value.0.iter().all(ValueAtom::is_in_normal_form) {
-            Err("aligned value is not in normal form (has trailing zero bytes)")
+            Err("aligned value is not in normal form (has trailing zero bytes)".into())
         } else {
             Ok(AlignedValue {
                 value: unchecked.value,

--- a/integration-tests/src/test/no-proving/functions.test.ts
+++ b/integration-tests/src/test/no-proving/functions.test.ts
@@ -741,7 +741,11 @@ describe('Ledger API - functions', () => {
     const isUserAddress = true;
 
     const recipient: AlignedValue = {
-      value: [RuntimeCoinCommitmentUtils.getArrayForIsLeft(isUserAddress), encodedUserAddress, new Uint8Array([])],
+      value: [
+        RuntimeCoinCommitmentUtils.getArrayForIsLeft(isUserAddress),
+        Static.trimTrailingZeros(encodedUserAddress),
+        new Uint8Array([])
+      ],
       alignment: [
         { tag: 'atom', value: { tag: 'bytes', length: BOOLEAN_HASH_BYTES } },
         { tag: 'atom', value: { tag: 'bytes', length: PERSISTENT_HASH_BYTES } },
@@ -770,7 +774,7 @@ describe('Ledger API - functions', () => {
       value: [
         RuntimeCoinCommitmentUtils.getArrayForIsLeft(isUserAddress),
         new Uint8Array(PERSISTENT_HASH_BYTES),
-        encodedContractAddress
+        Static.trimTrailingZeros(encodedContractAddress)
       ],
       alignment: [
         { tag: 'atom', value: { tag: 'bytes', length: BOOLEAN_HASH_BYTES } },
@@ -802,7 +806,7 @@ describe('Ledger API - functions', () => {
       value: [
         RuntimeCoinCommitmentUtils.getArrayForIsLeft(invalidIsUserAddress),
         new Uint8Array(),
-        encodedContractAddress
+        Static.trimTrailingZeros(encodedContractAddress)
       ],
       alignment: [
         { tag: 'atom', value: { tag: 'bytes', length: BOOLEAN_HASH_BYTES } },
@@ -832,7 +836,11 @@ describe('Ledger API - functions', () => {
     const isUserAddress = false;
 
     const recipient: AlignedValue = {
-      value: [RuntimeCoinCommitmentUtils.getArrayForIsLeft(isUserAddress), new Uint8Array(), encodedContractAddress],
+      value: [
+        RuntimeCoinCommitmentUtils.getArrayForIsLeft(isUserAddress),
+        new Uint8Array(),
+        Static.trimTrailingZeros(encodedContractAddress)
+      ],
       alignment: [
         { tag: 'atom', value: { tag: 'bytes', length: BOOLEAN_HASH_BYTES } },
         { tag: 'atom', value: { tag: 'bytes', length: PERSISTENT_HASH_BYTES } },

--- a/integration-tests/src/test/proving/TransactionBig.test.ts
+++ b/integration-tests/src/test/proving/TransactionBig.test.ts
@@ -119,6 +119,6 @@ describe.concurrent('Ledger API - TransactionBig [@slow][@proving]', () => {
 
       assertSerializationSuccess(transaction, SignatureMarker.signature, ProofMarker.proof, BindingMarker.preBinding);
     },
-    5 * 60000
+    15 * 60000
   );
 });

--- a/integration-tests/src/test/utils/RuntimeCoinCommitmentUtils.ts
+++ b/integration-tests/src/test/utils/RuntimeCoinCommitmentUtils.ts
@@ -28,7 +28,7 @@ export class RuntimeCoinCommitmentUtils {
     const encoded = encodeShieldedCoinInfo(coinInfo);
     const value = bigIntToValue(encoded.value);
     return {
-      value: [encoded.nonce, Static.trimTrailingZeros(encoded.color), value[0]],
+      value: [Static.trimTrailingZeros(encoded.nonce), Static.trimTrailingZeros(encoded.color), value[0]],
       alignment: [
         { tag: 'atom', value: { tag: 'bytes', length: PERSISTENT_HASH_BYTES } },
         { tag: 'atom', value: { tag: 'bytes', length: PERSISTENT_HASH_BYTES } },
@@ -43,7 +43,11 @@ export class RuntimeCoinCommitmentUtils {
     const isUserAddress = false;
 
     return {
-      value: [RuntimeCoinCommitmentUtils.getArrayForIsLeft(isUserAddress), new Uint8Array([]), encodedContractAddress],
+      value: [
+        RuntimeCoinCommitmentUtils.getArrayForIsLeft(isUserAddress),
+        new Uint8Array([]),
+        Static.trimTrailingZeros(encodedContractAddress)
+      ],
       alignment: [
         { tag: 'atom', value: { tag: 'bytes', length: BOOLEAN_HASH_BYTES } },
         { tag: 'atom', value: { tag: 'bytes', length: PERSISTENT_HASH_BYTES } },
@@ -65,13 +69,14 @@ export class RuntimeCoinCommitmentUtils {
   }
 
   static assertOutcomes(coin: AlignedValue, recipient: AlignedValue) {
+    console.log(JSON.stringify(coin, null, 4), JSON.stringify(recipient, null, 4));
     const commitment = runtimeCoinCommitment(coin, recipient);
 
     expect(commitment).toBeDefined();
     expect(commitment.value).toBeInstanceOf(Array);
     expect(commitment.value.length).toEqual(1);
     expect(commitment.value[0]).toBeInstanceOf(Uint8Array);
-    expect(commitment.value[0].length).toEqual(PERSISTENT_HASH_BYTES);
+    expect(commitment.value[0].length).toBeLessThanOrEqual(PERSISTENT_HASH_BYTES);
 
     expect(commitment.alignment).toBeInstanceOf(Array);
     expect(commitment.alignment.length).toEqual(1);

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
     dir: './src/test',
     include: ['**/*.test.ts'],
     setupFiles: ['src/vitest.setup.ts'],
-    testTimeout: 5 * 60_000,
-    hookTimeout: 5 * 60_000,
+    testTimeout: 15 * 60_000,
+    hookTimeout: 15 * 60_000,
     reporters: [
       'default',
       ['junit', { outputFile: './reports/test-report.xml' }],


### PR DESCRIPTION
Includes #37, as this causes spurious CI failures.
Moves from custom runners to GitHub standard ones, and enables aarch64 linux CI.