### PR TITLE
Fix token type computation for contract-minted tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 - fix: proof server now correctly fetches Dust keys on startup
 - fix: proof server no longer crashes if trying to fetch keys from within a worker thread
+- fix: correct token type computation in contract mints
 - feat: proof server now fetches missing artifacts on demand
 - feat: add endpoints for estimating fees with a margin depending on allowed
   block adjustment

--- a/ledger/src/verify.rs
+++ b/ledger/src/verify.rs
@@ -27,15 +27,11 @@ use crate::structure::{
 use crate::structure::{SignatureKind, VerifiedTransaction};
 use crate::utils::SortedIter;
 use crate::verify::MalformedTransaction::IntentSignatureVerificationFailure;
-use base_crypto::BinaryHashRepr;
 use base_crypto::hash::HashOutput;
-use base_crypto::hash::persistent_hash;
 use base_crypto::signatures::VerifyingKey;
 use base_crypto::time::{Duration, Timestamp};
 use coin_structure::coin::PublicAddress;
-use coin_structure::coin::{
-    Commitment, Nullifier, ShieldedTokenType, TokenType, UnshieldedTokenType,
-};
+use coin_structure::coin::{Commitment, Nullifier, TokenType};
 use coin_structure::contract::ContractAddress;
 use onchain_runtime::ops::Op;
 use onchain_runtime::state::{
@@ -794,9 +790,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> StandardTransa
 
                 for (segment, transcript) in transcripts {
                     for (pre_token, val) in transcript.effects.shielded_mints.clone() {
-                        let tt = ShieldedTokenType(persistent_hash(
-                            (call.address, pre_token).binary_vec().as_slice(),
-                        ));
+                        let tt = call.address.custom_shielded_token_type(pre_token);
                         update_balance(
                             &mut res,
                             TokenType::Shielded(tt),
@@ -807,9 +801,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> StandardTransa
                     }
 
                     for (pre_token, val) in transcript.effects.unshielded_mints.clone() {
-                        let tt = UnshieldedTokenType(persistent_hash(
-                            (call.address, pre_token).binary_vec().as_slice(),
-                        ));
+                        let tt = call.address.custom_unshielded_token_type(pre_token);
                         update_balance(
                             &mut res,
                             TokenType::Unshielded(tt),


### PR DESCRIPTION
The balance calculation was incorrectly rolling its own computation of token types for contract mints, instead of using the established `ContractAddress::custom_token_type` method. This lead to downstream errors when trying to use the minted tokens.