### PR TITLE
Adjust ESK serialization to make the default untagged and tagged as a…

### DIFF
--- a/ledger-wasm/ledger-v6.template.d.ts
+++ b/ledger-wasm/ledger-v6.template.d.ts
@@ -1328,8 +1328,10 @@ export class EncryptionSecretKey {
   test<P extends Proofish>(offer: ZswapOffer<P>): boolean;
 
   yesIKnowTheSecurityImplicationsOfThis_serialize(): Uint8Array;
+  yesIKnowTheSecurityImplicationsOfThis_taggedSerialize(): Uint8Array;
 
   static deserialize(raw: Uint8Array): EncryptionSecretKey
+  static taggedDeserialize(raw: Uint8Array): EncryptionSecretKey
 }
 
 export class ZswapSecretKeys {

--- a/ledger-wasm/src/zswap_keys.rs
+++ b/ledger-wasm/src/zswap_keys.rs
@@ -369,7 +369,6 @@ impl EncryptionSecretKey {
         )?))
     }
 
-    #[wasm_bindgen(js_name = "deserialize")]
     pub fn deserialize(raw: Uint8Array) -> Result<EncryptionSecretKey, JsError> {
         use std::io::{Error, ErrorKind};
         let deserialized: transient_crypto::encryption::SecretKey =

--- a/ledger-wasm/src/zswap_keys.rs
+++ b/ledger-wasm/src/zswap_keys.rs
@@ -18,6 +18,8 @@ use js_sys::Uint8Array;
 use onchain_runtime_wasm::from_value_ser;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
+use serialize::Deserializable;
+use serialize::Serializable;
 use serialize::tagged_serialize;
 use std::cell::RefCell;
 use std::ops::Deref;
@@ -333,8 +335,8 @@ impl EncryptionSecretKey {
         })
     }
 
-    #[wasm_bindgen(js_name = "yesIKnowTheSecurityImplicationsOfThis_serialize")]
-    pub fn serialize(&self) -> Result<Uint8Array, JsError> {
+    #[wasm_bindgen(js_name = "yesIKnowTheSecurityImplicationsOfThis_taggedSerialize")]
+    pub fn tagged_serialize(&self) -> Result<Uint8Array, JsError> {
         let mut res = Vec::new();
         tagged_serialize(
             self.0
@@ -346,10 +348,41 @@ impl EncryptionSecretKey {
         Ok(Uint8Array::from(&res[..]))
     }
 
-    pub fn deserialize(raw: Uint8Array) -> Result<EncryptionSecretKey, JsError> {
+    #[wasm_bindgen(js_name = "yesIKnowTheSecurityImplicationsOfThis_serialize")]
+    pub fn serialize(&self) -> Result<Uint8Array, JsError> {
+        let mut res = Vec::new();
+        Serializable::serialize(
+            self.0
+                .borrow()
+                .as_ref()
+                .ok_or(JsError::new(ESK_CLEAR_MSG))?,
+            &mut res,
+        )?;
+        Ok(Uint8Array::from(&res[..]))
+    }
+
+    #[wasm_bindgen(js_name = "taggedDeserialize")]
+    pub fn tagged_deserialize(raw: Uint8Array) -> Result<EncryptionSecretKey, JsError> {
         Ok(EncryptionSecretKey::wrap(from_value_ser(
             raw,
             "EncryptionSecretKey",
         )?))
+    }
+
+    #[wasm_bindgen(js_name = "deserialize")]
+    pub fn deserialize(raw: Uint8Array) -> Result<EncryptionSecretKey, JsError> {
+        use std::io::{Error, ErrorKind};
+        let deserialized: transient_crypto::encryption::SecretKey =
+            Deserializable::deserialize(&mut raw.to_vec().as_slice(), 0).map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "Unable to deserialize {}. Error: {}",
+                        "EncryptionSecretKey",
+                        e.to_string()
+                    ),
+                )
+            })?;
+        Ok(EncryptionSecretKey::wrap(deserialized))
     }
 }


### PR DESCRIPTION
…n alternative

This change is needed to enable wallet to use untagged serialization when needed.