### PR TITLE
Fix: solve reported clippy issue for rule large-enum-variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,8 @@ jobs:
       # We still permit certain Clippy rules with `-A` args. since they will be
       # addressed in upcoming PRs and changes that are currently in progress. This
       # allows us to start running these checks even before they are fully implemented.
-      - name: Cargo clippy (--all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::large_enum_variant -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes -Aclippy::uninit_assumed_init)
-        run: MIDNIGHT_LEDGER_EXPERIMENTAL=1 MIDNIGHT_PP='' cargo clippy --all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::large_enum_variant -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes -Aclippy::uninit_assumed_init
+      - name: Cargo clippy (--all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes -Aclippy::uninit_assumed_init)
+        run: MIDNIGHT_LEDGER_EXPERIMENTAL=1 MIDNIGHT_PP='' cargo clippy --all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes -Aclippy::uninit_assumed_init
 
       - name: Build and Test (default features)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 - Remove special-casing of validation behaviour depending on the
   `test-utilities` feature being present.
-- Change ledger `DustSpendError::BackingNightNotFound` enum variant to now hold its data value on the heap (to reduce Enum size), i.e. this variant is now defined as: `BackingNightNotFound(Box<QualifiedDustOutput>)`.
+- Change ledger `DustSpendError::BackingNightNotFound`, `ZswapPreimageEvidence::Ciphertext`, `EventDetails::ParamChange`, and `ContractAction::Deploy` enum variants to now hold their data values on the heap (to reduce Enum sizes), i.e. these variants are now defined as `BackingNightNotFound(Box<QualifiedDustOutput>)`, `Ciphertext(Box<CoinCiphertext>)`, `ParamChange(Sp<LedgerParameters, D>)` and `Deploy(Sp<ContractDeploy<D>, D>)` respectively.
+- Change ledger-wasm `ZswapTransientTypes::UnprovenTransient` enum variant to now hold its data value on the heap (to reduce Enum size), i.e. this variant is now defined as: `UnprovenTransient(Box<zswap::Transient<ProofPreimage, InMemoryDB>>)`.
 
 ## 6.1.0
 

--- a/ledger-wasm/src/conversions.rs
+++ b/ledger-wasm/src/conversions.rs
@@ -524,7 +524,7 @@ where
 {
     match action {
         ContractAction::Call(call) => JsValue::from(ContractCall::from((**call).clone())),
-        ContractAction::Deploy(deploy) => JsValue::from(ContractDeploy(deploy.clone())),
+        ContractAction::Deploy(deploy) => JsValue::from(ContractDeploy((**deploy).clone())),
         ContractAction::Maintain(upd) => JsValue::from(MaintenanceUpdate(upd.clone())),
     }
 }

--- a/ledger/src/events.rs
+++ b/ledger/src/events.rs
@@ -57,7 +57,7 @@ tag_enforcement_test!(EventSource);
 #[storable(base)]
 #[tag = "zswap-preimage-evidence[v1]"]
 pub enum ZswapPreimageEvidence {
-    Ciphertext(CoinCiphertext),
+    Ciphertext(Box<CoinCiphertext>),
     PublicPreimage {
         coin: CoinInfo,
         recipient: Recipient,
@@ -104,7 +104,7 @@ pub enum EventDetails<D: DB> {
         entry_point: EntryPointBuf,
         logged_item: StateValue<D>,
     },
-    ParamChange(LedgerParameters),
+    ParamChange(Sp<LedgerParameters, D>),
     DustInitialUtxo {
         output: QualifiedDustOutput,
         generation: DustGenerationInfo,

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -327,7 +327,7 @@ impl<D: DB> LedgerState<D> {
                 content: EventDetails::ZswapOutput {
                     commitment: output.coin_com,
                     preimage_evidence: match &output.ciphertext {
-                        Some(ciph) => ZswapPreimageEvidence::Ciphertext((**ciph).clone()),
+                        Some(ciph) => ZswapPreimageEvidence::Ciphertext(Box::new((**ciph).clone())),
                         None => ZswapPreimageEvidence::None,
                     },
                     contract: output.contract_address.clone(),
@@ -438,7 +438,7 @@ impl<D: DB> LedgerState<D> {
                     state,
                     vec![Event {
                         source: tx.event_source(),
-                        content: EventDetails::ParamChange(new_params.clone()).clone(),
+                        content: EventDetails::ParamChange(Sp::new(new_params.clone())),
                     }],
                 );
                 Ok(res)

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -1476,7 +1476,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: St
                     .map(move |act| (segment_id, act))
             })
             .filter_map(|(segment_id, action)| match action {
-                ContractAction::Deploy(d) => Some((segment_id, d)),
+                ContractAction::Deploy(d) => Some((segment_id, (*d).clone())),
                 _ => None,
             })
     }
@@ -2613,7 +2613,7 @@ impl<D: DB> MaintenanceUpdate<D> {
 #[derive_where(Clone, PartialEq, Eq; P)]
 pub enum ContractAction<P: ProofKind<D>, D: DB> {
     Call(#[storable(child)] Sp<ContractCall<P, D>, D>),
-    Deploy(ContractDeploy<D>),
+    Deploy(Sp<ContractDeploy<D>, D>),
     Maintain(MaintenanceUpdate<D>),
 }
 tag_enforcement_test!(ContractAction<(), InMemoryDB>);
@@ -2626,7 +2626,7 @@ impl<P: ProofKind<D>, D: DB> From<ContractCall<P, D>> for ContractAction<P, D> {
 
 impl<P: ProofKind<D>, D: DB> From<ContractDeploy<D>> for ContractAction<P, D> {
     fn from(deploy: ContractDeploy<D>) -> Self {
-        ContractAction::Deploy(deploy)
+        ContractAction::Deploy(Sp::new(deploy))
     }
 }
 


### PR DESCRIPTION
This solves a few issues reported by clippy with regards to [large-enum-variant](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant) rule.