### PR TITLE
[WASM] Standartize toString() usage in Wasm

### DIFF
--- a/integration-tests/src/test/no-proving/DustGenerationState.test.ts
+++ b/integration-tests/src/test/no-proving/DustGenerationState.test.ts
@@ -26,16 +26,14 @@ describe('Ledger API - DustGenerationState', () => {
   test('should print out information as string', () => {
     const dustGenerationState = new DustGenerationState();
 
-    const expected = `DustGenerationState(
-    DustGenerationState {
-        address_delegation: {},
-        generating_tree: MerkleTree(root = Some(-)) {},
-        generating_tree_first_free: 0,
-        generating_set: {},
-        night_indices: {},
-        root_history: {},
-    },
-)`;
+    const expected = `DustGenerationState {
+    address_delegation: {},
+    generating_tree: MerkleTree(root = Some(-)) {},
+    generating_tree_first_free: 0,
+    generating_set: {},
+    night_indices: {},
+    root_history: {},
+}`;
 
     expect(dustGenerationState.toString()).toEqual(expected);
   });

--- a/integration-tests/src/test/no-proving/DustLocalState.test.ts
+++ b/integration-tests/src/test/no-proving/DustLocalState.test.ts
@@ -59,26 +59,24 @@ describe('Ledger API - DustLocalState', () => {
    */
   test('should print out information as string', () => {
     const localState = new DustLocalState(initialParameters);
-    const expected = `DustLocalState(
-    DustLocalState {
-        generating_tree: MerkleTree(root = Some(-)) {},
-        generating_tree_first_free: 0,
-        commitment_tree: MerkleTree(root = Some(-)) {},
-        commitment_tree_first_free: 0,
-        night_indices: {},
-        dust_utxos: {},
-        sync_time: Timestamp(
-            0,
+    const expected = `DustLocalState {
+    generating_tree: MerkleTree(root = Some(-)) {},
+    generating_tree_first_free: 0,
+    commitment_tree: MerkleTree(root = Some(-)) {},
+    commitment_tree_first_free: 0,
+    night_indices: {},
+    dust_utxos: {},
+    sync_time: Timestamp(
+        0,
+    ),
+    params: DustParameters {
+        night_dust_ratio: ${NIGHT_DUST_RATIO},
+        generation_decay_rate: ${GENERATION_DECAY_RATE},
+        dust_grace_period: Duration(
+            ${DUST_GRACE_PERIOD_IN_SECONDS},
         ),
-        params: DustParameters {
-            night_dust_ratio: ${NIGHT_DUST_RATIO},
-            generation_decay_rate: ${GENERATION_DECAY_RATE},
-            dust_grace_period: Duration(
-                ${DUST_GRACE_PERIOD_IN_SECONDS},
-            ),
-        },
     },
-)`;
+}`;
 
     expect(localState.toString()).toEqual(expected);
   });

--- a/integration-tests/src/test/no-proving/DustParameters.test.ts
+++ b/integration-tests/src/test/no-proving/DustParameters.test.ts
@@ -29,15 +29,13 @@ describe('Ledger API - DustParameters', () => {
    * @then Should return formatted string with default values
    */
   test('should print out information as string', () => {
-    const expected = `DustParameters(
-    DustParameters {
-        night_dust_ratio: ${NIGHT_DUST_RATIO},
-        generation_decay_rate: ${GENERATION_DECAY_RATE},
-        dust_grace_period: Duration(
-            ${DUST_GRACE_PERIOD_IN_SECONDS},
-        ),
-    },
-)`;
+    const expected = `DustParameters {
+    night_dust_ratio: ${NIGHT_DUST_RATIO},
+    generation_decay_rate: ${GENERATION_DECAY_RATE},
+    dust_grace_period: Duration(
+        ${DUST_GRACE_PERIOD_IN_SECONDS},
+    ),
+}`;
 
     expect(initialParameters.toString()).toEqual(expected);
   });

--- a/integration-tests/src/test/no-proving/DustState.test.ts
+++ b/integration-tests/src/test/no-proving/DustState.test.ts
@@ -26,24 +26,22 @@ describe('Ledger API - DustState', () => {
   test('should print out information as string', () => {
     const dustState = new DustState();
 
-    const expected = `DustState(
-    DustState {
-        utxo: DustUtxoState {
-            commitments: MerkleTree(root = Some(-)) {},
-            commitments_first_free: 0,
-            nullifiers: {},
-            root_history: {},
-        },
-        generation: DustGenerationState {
-            address_delegation: {},
-            generating_tree: MerkleTree(root = Some(-)) {},
-            generating_tree_first_free: 0,
-            generating_set: {},
-            night_indices: {},
-            root_history: {},
-        },
+    const expected = `DustState {
+    utxo: DustUtxoState {
+        commitments: MerkleTree(root = Some(-)) {},
+        commitments_first_free: 0,
+        nullifiers: {},
+        root_history: {},
     },
-)`;
+    generation: DustGenerationState {
+        address_delegation: {},
+        generating_tree: MerkleTree(root = Some(-)) {},
+        generating_tree_first_free: 0,
+        generating_set: {},
+        night_indices: {},
+        root_history: {},
+    },
+}`;
 
     expect(dustState.toString()).toEqual(expected);
   });

--- a/integration-tests/src/test/no-proving/DustUtxoState.test.ts
+++ b/integration-tests/src/test/no-proving/DustUtxoState.test.ts
@@ -26,14 +26,12 @@ describe('Ledger API - DustUtxoState', () => {
   test('should print out information as string', () => {
     const dustUtxoState = new DustUtxoState();
 
-    const expected = `DustUtxoState(
-    DustUtxoState {
-        commitments: MerkleTree(root = Some(-)) {},
-        commitments_first_free: 0,
-        nullifiers: {},
-        root_history: {},
-    },
-)`;
+    const expected = `DustUtxoState {
+    commitments: MerkleTree(root = Some(-)) {},
+    commitments_first_free: 0,
+    nullifiers: {},
+    root_history: {},
+}`;
 
     expect(dustUtxoState.toString()).toEqual(expected);
   });

--- a/ledger-wasm/src/dust.rs
+++ b/ledger-wasm/src/dust.rs
@@ -69,9 +69,9 @@ impl Event {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self)
+            format!("{:?}", &self.0)
         } else {
-            format!("{:#?}", &self)
+            format!("{:#?}", &self.0)
         }
     }
 }
@@ -1032,9 +1032,9 @@ impl DustParameters {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self)
+            format!("{:?}", &self.0)
         } else {
-            format!("{:#?}", &self)
+            format!("{:#?}", &self.0)
         }
     }
 
@@ -1112,9 +1112,9 @@ impl DustUtxoState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self)
+            format!("{:?}", &self.0)
         } else {
-            format!("{:#?}", &self)
+            format!("{:#?}", &self.0)
         }
     }
 }
@@ -1146,9 +1146,9 @@ impl DustGenerationState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self)
+            format!("{:?}", &self.0)
         } else {
-            format!("{:#?}", &self)
+            format!("{:#?}", &self.0)
         }
     }
 }
@@ -1177,16 +1177,18 @@ impl DustState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self)
+            format!("{:?}", &self.0)
         } else {
-            format!("{:#?}", &self)
+            format!("{:#?}", &self.0)
         }
     }
 
+    #[wasm_bindgen(getter)]
     pub fn utxo(&self) -> Result<DustUtxoState, JsError> {
         Ok(DustUtxoState(self.0.utxo.clone()))
     }
 
+    #[wasm_bindgen(getter)]
     pub fn generation(&self) -> Result<DustGenerationState, JsError> {
         Ok(DustGenerationState(self.0.generation.clone()))
     }
@@ -1330,9 +1332,9 @@ impl DustLocalState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self)
+            format!("{:?}", &self.0)
         } else {
-            format!("{:#?}", &self)
+            format!("{:#?}", &self.0)
         }
     }
 


### PR DESCRIPTION
In toString() methods we should print the internal object without a wrapper:
```
 - format!("{:?}", &self)
 + format!("{:?}", &self.0)
```
Additionally, adds missing getter tags in DustState