### PR TITLE
Expose DustLocalState::sync_time

### DIFF
--- a/ledger-wasm/ledger-v6.template.d.ts
+++ b/ledger-wasm/ledger-v6.template.d.ts
@@ -354,6 +354,7 @@ export class DustLocalState {
   toString(compact?: boolean): string;
   readonly utxos: QualifiedDustOutput[];
   readonly params: DustParameters;
+  readonly syncTime: Date;
 }
 
 /**

--- a/ledger-wasm/src/dust.rs
+++ b/ledger-wasm/src/dust.rs
@@ -1351,6 +1351,11 @@ impl DustLocalState {
     pub fn params(&self) -> Result<DustParameters, JsError> {
         Ok(DustParameters(self.0.params))
     }
+
+    #[wasm_bindgen(getter, js_name = "syncTime")]
+    pub fn sync_time(&self) -> Date {
+        seconds_to_js_date(self.0.sync_time.to_secs())
+    }
 }
 
 #[wasm_bindgen]

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -1300,7 +1300,7 @@ pub struct DustLocalState<D: DB> {
     commitment_tree_first_free: u64,
     night_indices: HashMap<InitialNonce, u64, D>,
     dust_utxos: HashMap<DustNullifier, DustWalletUtxoState, D>,
-    sync_time: Timestamp,
+    pub sync_time: Timestamp,
     pub params: DustParameters,
 }
 tag_enforcement_test!(DustLocalState<InMemoryDB>);


### PR DESCRIPTION
This will allow to read the latest sync_time and use it in the processTtls() method 