### PR TITLE
Update CI to use fixed attic action to allow non-trusted code.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             accept-flake-config = true
 
       - name: Cache Nix
-        uses: input-output-hk/actions/attic@e0990284d4e88052ddc376519731419354851a42
+        uses: input-output-hk/actions/attic@6d5d62ad59441a3c869a0e8abee4e1bf8b440c2f
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           endpoint: https://attic.ci.iog.io
@@ -184,7 +184,7 @@ jobs:
             accept-flake-config = true
 
       - name: Cache Nix
-        uses: input-output-hk/actions/attic@e0990284d4e88052ddc376519731419354851a42
+        uses: input-output-hk/actions/attic@6d5d62ad59441a3c869a0e8abee4e1bf8b440c2f
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           endpoint: https://attic.ci.iog.io


### PR DESCRIPTION
This hopefully unblocks some of the external contributors PRs once merged.

The nix cache workflow is *meant* to not attempt to write to cache on external PRs, but still did so on an oversight, this pulls in the fix for it.