### PR TITLE
Change segment's range in Transaction::from_parts_randomized()

### DIFF
--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -248,7 +248,7 @@ impl Transaction {
             return Err(JsError::new("Intent offer must be unproven."));
         }
 
-        let segment_id = OsRng.gen_range(1..u16::MAX);
+        let segment_id = OsRng.gen_range(2..u16::MAX);
         let mut intents = vec![];
         if intent.is_some() {
             intents.push((segment_id, intent.unwrap().clone().try_into()?));


### PR DESCRIPTION
In a common use-case, where a wallet receives some tx and adds a dust payment by merging it with a new tx created via from_parts_randomized(), it's possible to get a segments conflict:
1) Transaction::fromParts() always sets the segment_id = 1
2) Transaction::fromPartsRandomized() generates random segment in the range of `1..u16::MAX`, which could lead to the merge conflict when both tx segments will be equal to 1. This issue already happened once on CI.

This PR changes the possible random segment range to `2..u16::MAX` to solve that issue.