### PR TITLE
Chore: enabling clippy rule uninit_assumed_init in CI cmd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,8 @@ jobs:
       # We still permit certain Clippy rules with `-A` args. since they will be
       # addressed in upcoming PRs and changes that are currently in progress. This
       # allows us to start running these checks even before they are fully implemented.
-      - name: Cargo clippy (--all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes -Aclippy::uninit_assumed_init)
-        run: MIDNIGHT_LEDGER_EXPERIMENTAL=1 MIDNIGHT_PP='' cargo clippy --all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes -Aclippy::uninit_assumed_init
+      - name: Cargo clippy (--all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes)
+        run: MIDNIGHT_LEDGER_EXPERIMENTAL=1 MIDNIGHT_PP='' cargo clippy --all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes
 
       - name: Build and Test (default features)
         run: |


### PR DESCRIPTION
This is just to allow clippy cmd in CI to check for [uninit_assumed_init](https://rust-lang.github.io/rust-clippy/master/index.html#uninit_assumed_init) rule. I was trying to fix an issue reported about this rule but it was already fixed by PR #99 .

This is just a tiny PR but I think it's good that as many rules as possible to be checked by clippy at CI run.