### PR TITLE
[PM-20790] Fix rehashing in cNgD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
   `test-utilities` feature being present.
 - Change ledger `DustSpendError::BackingNightNotFound`, `ZswapPreimageEvidence::Ciphertext`, `EventDetails::ParamChange`, and `ContractAction::Deploy` enum variants to now hold their data values on the heap (to reduce Enum sizes), i.e. these variants are now defined as `BackingNightNotFound(Box<QualifiedDustOutput>)`, `Ciphertext(Box<CoinCiphertext>)`, `ParamChange(Sp<LedgerParameters, D>)` and `Deploy(Sp<ContractDeploy<D>, D>)` respectively.
 - Change ledger-wasm `ZswapTransientTypes::UnprovenTransient` enum variant to now hold its data value on the heap (to reduce Enum size), i.e. this variant is now defined as: `UnprovenTransient(Box<zswap::Transient<ProofPreimage, InMemoryDB>>)`.
+- fix: correctly rehash generation Merkle tree on cNgD processing.
 
 ## 6.1.0
 

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -1176,7 +1176,7 @@ impl<D: DB> DustState<D> {
                     .generation
                     .generating_tree
                     .insertion_evidence(*idx)
-                    .expect("must be able to produce evidence for udpated path"),
+                    .expect("must be able to produce evidence for updated path"),
                 block_time: context.block_context.tblock,
             });
         }
@@ -1665,6 +1665,7 @@ impl<D: DB> DustLocalState<D> {
                     Ok((state, gen_collapses))
                 }
                 EventDetails::DustGenerationDtimeUpdate { update, block_time } => {
+                    debug_assert!(update.path.iter().all(|entry| entry.hash.is_some()));
                     state.generating_tree =
                         state.generating_tree.update_from_evidence(update.clone())?;
                     if *block_time < state.sync_time {

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -786,13 +786,14 @@ impl<D: DB> LedgerState<D> {
                             dust_state.generation.generating_tree = dust_state
                                 .generation
                                 .generating_tree
-                                .update_hash(*idx, gen_info.merkle_hash(), gen_info);
+                                .update_hash(*idx, gen_info.merkle_hash(), gen_info)
+                                .rehash();
                             event_push(EventDetails::DustGenerationDtimeUpdate {
                                 update: dust_state
                                     .generation
                                     .generating_tree
                                     .insertion_evidence(*idx)
-                                    .expect("must be able to produce evidence for udpated path"),
+                                    .expect("must be able to produce evidence for updated path"),
                                 block_time: tblock,
                             });
                         }


### PR DESCRIPTION
Fixes a stall in syncing due to not providing enough Merkle tree evidence to catch up.