### PR TITLE
Fix: solve reported clippy issue for rule too_many_arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,8 @@ jobs:
       # We still permit certain Clippy rules with `-A` args. since they will be
       # addressed in upcoming PRs and changes that are currently in progress. This
       # allows us to start running these checks even before they are fully implemented.
-      - name: Cargo clippy (--all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes)
-        run: MIDNIGHT_LEDGER_EXPERIMENTAL=1 MIDNIGHT_PP='' cargo clippy --all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::too_many_arguments -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes
+      - name: Cargo clippy (--all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes)
+        run: MIDNIGHT_LEDGER_EXPERIMENTAL=1 MIDNIGHT_PP='' cargo clippy --all-targets --workspace --all-features --all -- -Dwarnings -Aclippy::type_complexity -Aclippy::mutable_key_type -Aclippy::derived_hash_with_manual_eq -Aclippy::unbuffered_bytes
 
       - name: Cargo audit
         run: MIDNIGHT_LEDGER_EXPERIMENTAL=1 nix develop .#ci -c cargo audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 - Change ledger `DustSpendError::BackingNightNotFound`, `ZswapPreimageEvidence::Ciphertext`, `EventDetails::ParamChange`, and `ContractAction::Deploy` enum variants to now hold their data values on the heap (to reduce Enum sizes), i.e. these variants are now defined as `BackingNightNotFound(Box<QualifiedDustOutput>)`, `Ciphertext(Box<CoinCiphertext>)`, `ParamChange(Sp<LedgerParameters, D>)` and `Deploy(Sp<ContractDeploy<D>, D>)` respectively.
 - Change ledger-wasm `ZswapTransientTypes::UnprovenTransient` enum variant to now hold its data value on the heap (to reduce Enum size), i.e. this variant is now defined as: `UnprovenTransient(Box<zswap::Transient<ProofPreimage, InMemoryDB>>)`.
 - fix: correctly rehash generation Merkle tree on cNgD processing.
+- Change in `Intent::new` method/API of the `construct` module to now receive an argument (defined as type `IntentParams<S, D>`) which contains all attributes to be used for creating the `Intent`, instead of expecting all those attributes as separate function arguments.
 
 ## 6.1.0
 

--- a/ledger-wasm/src/intent.rs
+++ b/ledger-wasm/src/intent.rs
@@ -18,7 +18,10 @@ use crate::unshielded::UnshieldedOffer;
 use base_crypto::signatures::Signature;
 use base_crypto::time::Timestamp;
 use js_sys::{Date, Uint8Array};
-use ledger::structure::{ErasedIntent, Intent as LedgerIntent, ProofMarker, ProofPreimageMarker};
+use ledger::{
+    construct::IntentParams,
+    structure::{ErasedIntent, Intent as LedgerIntent, ProofMarker, ProofPreimageMarker},
+};
 use onchain_runtime_wasm::from_value_ser;
 use serialize::tagged_serialize;
 use std::ops::Deref;
@@ -238,7 +241,18 @@ impl Intent {
     pub fn new(ttl: &Date) -> Result<Intent, JsError> {
         let ttl = Timestamp::from_secs(js_date_to_seconds(ttl));
         Ok(Intent(IntentTypes::UnprovenWithSignaturePreBinding(
-            LedgerIntent::new(&mut OsRng, None, None, vec![], vec![], vec![], None, ttl),
+            LedgerIntent::new(
+                &mut OsRng,
+                IntentParams {
+                    guaranteed_unshielded_offer: None,
+                    fallible_unshielded_offer: None,
+                    calls: vec![],
+                    updates: vec![],
+                    deploys: vec![],
+                    dust_actions: None,
+                    ttl,
+                },
+            ),
         )))
     }
 

--- a/ledger/src/test_utilities.rs
+++ b/ledger/src/test_utilities.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::construct::ContractCallPrototype;
+use crate::construct::{ContractCallPrototype, IntentParams};
 use crate::dust::DustResolver;
 use crate::dust::{
     DustActions, DustLocalState, DustOutput, DustPublicKey, DustRegistration, DustSecretKey,
@@ -983,13 +983,15 @@ pub fn test_intents<D: DB, R: Rng + CryptoRng + ?Sized>(
         1,
         Intent::new(
             rng,
-            None,
-            None,
-            calls,
-            updates,
-            deploys,
-            None,
-            tblock + Duration::from_secs(3600),
+            IntentParams {
+                guaranteed_unshielded_offer: None,
+                fallible_unshielded_offer: None,
+                calls,
+                updates,
+                deploys,
+                dust_actions: None,
+                ttl: tblock + Duration::from_secs(3600),
+            },
         ),
     )
 }
@@ -1012,13 +1014,15 @@ pub fn test_intents_adv<S: SignatureKind<D>, D: DB, R: Rng + CryptoRng + ?Sized>
         segment,
         Intent::new(
             rng,
-            None,
-            None,
-            calls,
-            updates,
-            deploys,
-            None,
-            tblock + Duration::from_secs(3600),
+            IntentParams {
+                guaranteed_unshielded_offer: None,
+                fallible_unshielded_offer: None,
+                calls,
+                updates,
+                deploys,
+                dust_actions: None,
+                ttl: tblock + Duration::from_secs(3600),
+            },
         ),
     );
 

--- a/ledger/tests/intent.rs
+++ b/ledger/tests/intent.rs
@@ -31,7 +31,7 @@ use midnight_ledger::structure::{
     UtxoOutput, UtxoSpend,
 };
 use midnight_ledger::test_utilities::{test_intents, test_resolver, tx_prove, verifier_key};
-use midnight_ledger::verify::WellFormedStrictness;
+use midnight_ledger::{construct::IntentParams, verify::WellFormedStrictness};
 use midnight_ledger::{structure::StandardTransaction, test_utilities::TestState};
 use onchain_runtime::cost_model::INITIAL_COST_MODEL;
 use onchain_runtime::ops::Key;
@@ -94,13 +94,15 @@ async fn well_formed() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent
@@ -150,13 +152,15 @@ async fn well_formed_sign_wrong_key() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent
@@ -212,13 +216,15 @@ async fn well_formed_signature_verification_failure_all() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent
@@ -320,13 +326,15 @@ async fn unsealed_no_signature_check() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent
@@ -416,13 +424,15 @@ async fn well_formed_failure_segment_guaranteed() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent
@@ -480,13 +490,15 @@ async fn merge_failure_segment_clash() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let tx = Transaction::new(
@@ -667,13 +679,15 @@ async fn balanced_utxos_1_intent() {
         1,
         Intent::new(
             &mut rng,
-            guaranteed_unshielded_offer,
-            fallible_unshielded_offer,
-            vec![call],
-            Vec::new(),
-            Vec::new(),
-            None,
-            state.time,
+            IntentParams {
+                guaranteed_unshielded_offer,
+                fallible_unshielded_offer,
+                calls: vec![call],
+                updates: vec![],
+                deploys: vec![],
+                dust_actions: None,
+                ttl: state.time,
+            },
         ),
     );
 
@@ -945,13 +959,15 @@ async fn intents_cannot_balance_across_segments() {
         1,
         Intent::new(
             &mut rng,
-            guaranteed_unshielded_offer_1,
-            fallible_unshielded_offer_1,
-            vec![call_1],
-            Vec::new(),
-            Vec::new(),
-            None,
-            ttl,
+            IntentParams {
+                guaranteed_unshielded_offer: guaranteed_unshielded_offer_1,
+                fallible_unshielded_offer: fallible_unshielded_offer_1,
+                calls: vec![call_1],
+                updates: vec![],
+                deploys: vec![],
+                dust_actions: None,
+                ttl,
+            },
         ),
     );
 
@@ -959,13 +975,15 @@ async fn intents_cannot_balance_across_segments() {
         2,
         Intent::new(
             &mut rng,
-            None,
-            fallible_unshielded_offer_2,
-            vec![call_2],
-            Vec::new(),
-            Vec::new(),
-            None,
-            ttl,
+            IntentParams {
+                guaranteed_unshielded_offer: None,
+                fallible_unshielded_offer: fallible_unshielded_offer_2,
+                calls: vec![call_2],
+                updates: vec![],
+                deploys: vec![],
+                dust_actions: None,
+                ttl,
+            },
         ),
     );
 
@@ -1251,13 +1269,15 @@ async fn causality_check_sanity_check() {
         1,
         Intent::new(
             &mut rng,
-            guaranteed_unshielded_offer_1,
-            fallible_unshielded_offer_1,
-            vec![call_1],
-            Vec::new(),
-            Vec::new(),
-            None,
-            ttl,
+            IntentParams {
+                guaranteed_unshielded_offer: guaranteed_unshielded_offer_1,
+                fallible_unshielded_offer: fallible_unshielded_offer_1,
+                calls: vec![call_1],
+                updates: vec![],
+                deploys: vec![],
+                dust_actions: None,
+                ttl,
+            },
         ),
     );
 
@@ -1265,13 +1285,15 @@ async fn causality_check_sanity_check() {
         2,
         Intent::new(
             &mut rng,
-            None,
-            fallible_unshielded_offer_2,
-            vec![call_2],
-            Vec::new(),
-            Vec::new(),
-            None,
-            ttl,
+            IntentParams {
+                guaranteed_unshielded_offer: None,
+                fallible_unshielded_offer: fallible_unshielded_offer_2,
+                calls: vec![call_2],
+                updates: vec![],
+                deploys: vec![],
+                dust_actions: None,
+                ttl,
+            },
         ),
     );
 
@@ -1448,13 +1470,15 @@ async fn imbalanced_utxos_1_intent() {
         1,
         Intent::new(
             &mut rng,
-            guaranteed_unshielded_offer,
-            None,
-            vec![call],
-            Vec::new(),
-            vec![],
-            None,
-            ttl,
+            IntentParams {
+                guaranteed_unshielded_offer,
+                fallible_unshielded_offer: None,
+                calls: vec![call],
+                updates: vec![],
+                deploys: vec![],
+                dust_actions: None,
+                ttl,
+            },
         ),
     );
 
@@ -1632,13 +1656,15 @@ async fn imbalanced_utxos_1_intent_fallible() {
         1,
         Intent::new(
             &mut rng,
-            None,
-            fallible_unshielded_offer,
-            vec![call],
-            Vec::new(),
-            vec![],
-            None,
-            ttl,
+            IntentParams {
+                guaranteed_unshielded_offer: None,
+                fallible_unshielded_offer,
+                calls: vec![call],
+                updates: vec![],
+                deploys: vec![],
+                dust_actions: None,
+                ttl,
+            },
         ),
     );
 
@@ -1701,13 +1727,15 @@ async fn apply() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent
@@ -1767,13 +1795,15 @@ async fn apply_duplicate_failure() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent
@@ -1850,13 +1880,15 @@ async fn apply_expired_ttl_failure() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent
@@ -1923,13 +1955,15 @@ async fn apply_ttl_in_future_failure() {
 
     let intent = Intent::new(
         &mut rng,
-        guaranteed_unshielded_offer,
-        fallible_unshielded_offer,
-        vec![call],
-        Vec::new(),
-        Vec::new(),
-        None,
-        ttl,
+        IntentParams {
+            guaranteed_unshielded_offer,
+            fallible_unshielded_offer,
+            calls: vec![call],
+            updates: vec![],
+            deploys: vec![],
+            dust_actions: None,
+            ttl,
+        },
     );
 
     let (_, intent_proven) = intent.prove(0, prover, &INITIAL_COST_MODEL).await.unwrap();


### PR DESCRIPTION
This solves a few issues reported by clippy with regards to [too_many_arguments](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments) rule.

BREAKING CHANGE:
Change in `Intent::new` method/API of the `construct` module to now receive an argument (defined as type `IntentParams<S, D>`) which contains all attributes to be used for creating the `Intent`, instead of expecting all those attributes as separate function arguments.