### PR TITLE
ZKIR optimizations for `ConstrainBits`, `CondSelect`, `ReconstituteField`

### DIFF
--- a/.tag-decompositions/ir-source[v2-generic]
+++ b/.tag-decompositions/ir-source[v2-generic]
@@ -1,0 +1,1 @@
+((ir-minor-version[v2],u32,bool,vec(ir-instruction[v2])))

--- a/.tag-decompositions/ir-source[v3-generic]
+++ b/.tag-decompositions/ir-source[v3-generic]
@@ -1,0 +1,1 @@
+((ir-minor-version[v3],vec(zkir-typed-identifier[v1]),bool,vec(ir-instruction[v3])))

--- a/.tag-decompositions/prover-key[v7](ir-source[v2-generic])
+++ b/.tag-decompositions/prover-key[v7](ir-source[v2-generic])
@@ -1,0 +1,1 @@
+prover-key[v7](ir-source[v2-generic])

--- a/.tag-decompositions/prover-key[v7](ir-source[v3-generic])
+++ b/.tag-decompositions/prover-key[v7](ir-source[v3-generic])
@@ -1,0 +1,1 @@
+prover-key[v7](ir-source[v3-generic])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 ## Unreleased
 
 - feat: add `apply_guaranteed_only` and `GuaranteedApplyResult` for split-phase transaction execution with deferred event generation.
+- feat: proof-server support for ZKIR 2.1
 - fix: fix potential panic in MPT path removal, unlikely to be currently triggerable.
 - fix: fix potential panic in bridge fee processing
 - fix: address non-associativity of Dust event processing.

--- a/CHANGELOG_serialize.md
+++ b/CHANGELOG_serialize.md
@@ -1,5 +1,9 @@
 # `serialize` Changelog
 
+## Unreleased
+
+- feat: add `peek_tag` to identify a tag before deserialization
+
 ## Version `1.1.0`
 
 - feat: add `tagged_deserialize_sequence`, which deserializes a sequence of tagged values

--- a/CHANGELOG_zkir.md
+++ b/CHANGELOG_zkir.md
@@ -1,5 +1,9 @@
 # `zkir` Changelog
 
+## Unreleased
+
+- feat: IR version 2.1, functionally identical to 2.0, but with additional optimizations
+
 ## Version `2.1.0`
 
 - breaking: pull in breaking proof system changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -44,7 +44,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -387,7 +387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
 dependencies = [
  "nix 0.30.1",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -398,9 +398,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -508,7 +508,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -545,9 +545,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -581,7 +581,7 @@ dependencies = [
  "midnight-curves",
  "midnight-proofs",
  "num-bigint",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
 ]
@@ -745,7 +745,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -848,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1641,7 +1641,7 @@ checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
 dependencies = [
  "deunicode",
  "dummy",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1923,7 +1923,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1947,7 +1947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_xorshift",
  "subtle",
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "gzip-header"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
+checksum = "86848f4fd157d91041a62c78046fb7b248bcc2dce78376d436a1756e9a038577"
 dependencies = [
  "crc32fast",
 ]
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper",
@@ -2729,9 +2729,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2809,7 +2809,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "reqwest",
  "serde",
@@ -2847,7 +2847,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hash",
  "sha2",
  "sha3-circuit",
@@ -2868,7 +2868,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "zeroize",
 ]
@@ -2931,7 +2931,7 @@ dependencies = [
  "pprof",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "reqwest",
  "serde",
@@ -2971,7 +2971,7 @@ dependencies = [
  "midnight-transient-crypto",
  "midnight-zswap",
  "pastey",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
  "serde-wasm-bindgen",
@@ -3005,7 +3005,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3026,7 +3026,7 @@ dependencies = [
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
@@ -3049,7 +3049,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_bytes",
 ]
@@ -3072,7 +3072,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rpds",
  "serde",
  "serde_bytes",
@@ -3104,7 +3104,7 @@ dependencies = [
  "midnight-zkir",
  "midnight-zkir-v3",
  "midnight-zswap",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "reqwest",
  "rustls",
@@ -3150,7 +3150,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_bytes",
 ]
@@ -3182,7 +3182,7 @@ dependencies = [
  "pprof",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "serde_json",
@@ -3218,7 +3218,7 @@ dependencies = [
  "proptest-derive",
  "r2d2",
  "r2d2_sqlite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "rusqlite",
  "serde",
@@ -3240,7 +3240,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "quote 1.0.45",
- "rand 0.8.5",
+ "rand 0.8.6",
  "syn 2.0.117",
 ]
 
@@ -3274,7 +3274,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
@@ -3304,7 +3304,7 @@ dependencies = [
  "midnight-proofs",
  "num-bigint",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2",
  "sha3-circuit",
 ]
@@ -3334,7 +3334,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
  "serde_bytes",
@@ -3371,7 +3371,7 @@ dependencies = [
  "pastey",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
  "serde_bytes",
@@ -3391,7 +3391,7 @@ dependencies = [
  "midnight-serialize",
  "midnight-transient-crypto",
  "midnight-zkir-v3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3408,7 +3408,7 @@ dependencies = [
  "midnight-serialize",
  "midnight-transient-crypto",
  "midnight-zkir",
- "rand 0.8.5",
+ "rand 0.8.6",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -3443,7 +3443,7 @@ dependencies = [
  "midnight-transient-crypto",
  "midnight-zkir",
  "pastey",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "serde_json",
@@ -3519,7 +3519,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3561,7 +3561,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3649,7 +3649,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3725,7 +3725,7 @@ dependencies = [
  "lz4",
  "memmap2",
  "parking_lot",
- "rand 0.9.3",
+ "rand 0.9.4",
  "siphasher",
  "snap",
  "winapi",
@@ -3899,9 +3899,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -4003,10 +4003,10 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
@@ -4071,7 +4071,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4154,9 +4154,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4165,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4181,7 +4181,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4224,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -4245,9 +4245,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4271,7 +4271,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4427,7 +4427,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -4463,7 +4463,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4476,7 +4476,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4670,7 +4670,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4856,7 +4856,7 @@ dependencies = [
  "midnight-curves",
  "midnight-proofs",
  "num-bigint",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5065,9 +5065,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.17.4"
+version = "12.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d14d7cb9c6fa5b95a6f3de8af95b356a528d391998fa45a07d320a5573e51"
+checksum = "6aba7211a1803a826f108af9f4d86d25abe880712f2a6449479279e861b293f8"
 dependencies = [
  "debugid",
  "memmap2",
@@ -5077,9 +5077,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.17.4"
+version = "12.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39505731ae891b2dde47b0e4ae2ec40a7ced3476ab1129f1bf829e3fba62bb83"
+checksum = "595bddd9d363c2ef6fc9fb33b98416ff209c5aae8bdca89a7dbbf2ef5e0ecc45"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -5326,9 +5326,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -5396,7 +5396,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -5498,9 +5498,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typewit"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc19094686c694eb41b3b99dcc2f2975d4b078512fa22ae6c63f7ca318bdcff7"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "ucd-trie"
@@ -5595,9 +5595,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5612,7 +5612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33995a1fee055ff743281cde33a41f0d618ee0bdbe8bdf6859e11864499c2595"
 dependencies = [
  "bindgen",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fslock",
  "gzip-header",
  "home",
@@ -5849,7 +5849,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -5877,9 +5877,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6344,7 +6344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,6 +3331,7 @@ dependencies = [
  "midnight-transient-crypto",
  "midnight-zk-stdlib",
  "midnight-zkir",
+ "num-bigint",
  "pastey",
  "proptest",
  "proptest-derive",
@@ -3339,6 +3340,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_repr",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3376,6 +3378,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_repr",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4765,6 +4768,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/proof-server/src/versioned_ir.rs
+++ b/proof-server/src/versioned_ir.rs
@@ -15,7 +15,9 @@ use std::sync::Arc;
 
 use ledger::prove::Resolver;
 use rand::rngs::OsRng;
+#[allow(unused_imports)]
 use serialize::tagged_deserialize;
+use std::io::Cursor;
 use transient_crypto::proofs::{Proof, ProofPreimage, Zkir};
 use zkir as zkir_v2;
 
@@ -23,7 +25,7 @@ use crate::endpoints::PUBLIC_PARAMS;
 
 #[cfg(feature = "experimental")]
 pub(crate) fn k(request: &[u8]) -> Result<u8, &'static str> {
-    if let Ok(ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(request) {
+    if let Ok(ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(request)) {
         Ok(ir_v2.k())
     } else if let Ok(ir_v3) = tagged_deserialize::<zkir_v3::IrSource>(request) {
         Ok(ir_v3.k())
@@ -34,7 +36,7 @@ pub(crate) fn k(request: &[u8]) -> Result<u8, &'static str> {
 
 #[cfg(not(feature = "experimental"))]
 pub(crate) fn k(request: &[u8]) -> Result<u8, &'static str> {
-    if let Ok(ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(request) {
+    if let Ok(ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(request)) {
         Ok(ir_v2.k())
     } else {
         Err("Unsupported ZKIR version")
@@ -43,7 +45,7 @@ pub(crate) fn k(request: &[u8]) -> Result<u8, &'static str> {
 
 #[cfg(feature = "experimental")]
 pub(crate) fn check(ppi: Arc<ProofPreimage>, ir: &[u8]) -> Result<Vec<Option<usize>>, String> {
-    if let Ok(ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(ir) {
+    if let Ok(ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(ir)) {
         ppi.check(&ir_v2).map_err(|e| e.to_string())
     } else if let Ok(ir_v3) = tagged_deserialize::<zkir_v3::IrSource>(ir) {
         ppi.check(&ir_v3).map_err(|e| e.to_string())
@@ -54,7 +56,7 @@ pub(crate) fn check(ppi: Arc<ProofPreimage>, ir: &[u8]) -> Result<Vec<Option<usi
 
 #[cfg(not(feature = "experimental"))]
 pub(crate) fn check(ppi: Arc<ProofPreimage>, ir: &[u8]) -> Result<Vec<Option<usize>>, String> {
-    if let Ok(ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(ir) {
+    if let Ok(ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(ir)) {
         ppi.check(&ir_v2).map_err(|e| e.to_string())
     } else {
         Err("Unsupported ZKIR version".to_string())
@@ -67,7 +69,7 @@ pub(crate) async fn prove(
     ir_source: &[u8],
     resolver: &Resolver,
 ) -> Result<(Proof, Vec<Option<usize>>), String> {
-    if let Ok(_ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(ir_source) {
+    if let Ok(_ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(ir_source)) {
         ppi.prove::<zkir_v2::IrSource>(OsRng, &*PUBLIC_PARAMS, resolver)
             .await
             .map_err(|e| e.to_string())
@@ -86,7 +88,7 @@ pub(crate) async fn prove(
     ir_source: &[u8],
     resolver: &Resolver,
 ) -> Result<(Proof, Vec<Option<usize>>), String> {
-    if let Ok(_ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(ir_source) {
+    if let Ok(_ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(ir_source)) {
         ppi.prove::<zkir_v2::IrSource>(OsRng, &*PUBLIC_PARAMS, resolver)
             .await
             .map_err(|e| e.to_string())

--- a/proof-server/tests/integration_tests.rs
+++ b/proof-server/tests/integration_tests.rs
@@ -627,6 +627,7 @@ mod k_endpoint {
 
     fn create_minimal_ir_source() -> zkir_v2::IrSource {
         zkir_v2::IrSource {
+            version: Default::default(),
             num_inputs: 1,
             do_communications_commitment: false,
             instructions: std::sync::Arc::new(vec![]),

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -69,11 +69,7 @@ pub fn peek_tag(reader: &mut (impl Read + Seek)) -> std::io::Result<String> {
         .enumerate()
         .filter(|(_, b)| **b == b':')
         .nth(1)
-        .ok_or_else(|| {
-            err(format!(
-                "tagged data does not begin with a colon-separated tag"
-            ))
-        })?
+        .ok_or_else(|| err("tagged data does not begin with a colon-separated tag".to_string()))?
         .0;
     let raw_tag = &buf[GLOBAL_TAG.len()..second_colon];
     String::from_utf8(raw_tag.to_owned())

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -15,7 +15,7 @@ use crate::VecExt;
 use crate::serializable::GLOBAL_TAG;
 use crate::tagged::Tagged;
 use std::borrow::Cow;
-use std::io::{BufRead, Read};
+use std::io::{self, BufRead, Read, Seek};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{collections::HashMap, collections::HashSet, hash::Hash};
@@ -38,6 +38,52 @@ pub fn tagged_deserialize_sequence<T: Deserializable + Tagged>(
         res.push(tagged_deserialize_inner(&mut reader, false)?);
     }
     Ok(res)
+}
+
+/// Attempts to identify the tag a stream starts with without consuming it, allowing determining a
+/// stream's type *before* deserializing it.
+pub fn peek_tag(reader: &mut (impl Read + Seek)) -> std::io::Result<String> {
+    let position = reader.stream_position()?;
+    // Note that colons are special-cased -- we should expect two, one for `GLOBAL_TAG`, and one
+    // for the end of the read tag. We read up to a limit of 512 bytes, and then take up to the
+    // second b':', converting to string, returning an error if not possible.
+    const READ_LIMIT: usize = 512;
+    let mut buf = [0u8; READ_LIMIT];
+    let mut offset = 0;
+    while offset < READ_LIMIT {
+        let read = reader.read(&mut buf[offset..])?;
+        if read == 0 {
+            break;
+        }
+        offset += read;
+    }
+    reader.seek(std::io::SeekFrom::Start(position))?;
+    let err = |msg| io::Error::new(io::ErrorKind::InvalidData, msg);
+    if !buf.starts_with(GLOBAL_TAG.as_bytes()) {
+        return Err(err(format!(
+            "tagged data does not begin with '{GLOBAL_TAG}'"
+        )));
+    }
+    let second_colon = buf
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| **b == b':')
+        .nth(1)
+        .ok_or_else(|| {
+            err(format!(
+                "tagged data does not begin with a colon-separated tag"
+            ))
+        })?
+        .0;
+    let raw_tag = &buf[GLOBAL_TAG.len()..second_colon];
+    String::from_utf8(raw_tag.to_owned())
+        .map_err(|e| err(format!("tag not utf-8: {e}")))
+        .map(|s| {
+            s.replace(
+                |c: char| -> bool { !c.is_ascii_alphanumeric() && !":_-()[],".contains(c) },
+                "�",
+            )
+        })
 }
 
 fn tagged_deserialize_inner<T: Deserializable + Tagged>(

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -22,7 +22,7 @@ mod tagged;
 mod util;
 
 pub use crate::deserializable::{
-    Deserializable, RECURSION_LIMIT, tagged_deserialize, tagged_deserialize_sequence,
+    Deserializable, RECURSION_LIMIT, peek_tag, tagged_deserialize, tagged_deserialize_sequence,
 };
 pub use crate::serializable::{GLOBAL_TAG, Serializable, tagged_serialize, tagged_serialized_size};
 pub use crate::tagged::Tagged;

--- a/storage-core/src/db/sql.rs
+++ b/storage-core/src/db/sql.rs
@@ -674,9 +674,7 @@ impl<H: WellBehavedHasher> DB for SqlDB<H> {
         self.with_tx(Deferred, |tx| {
             let sql = "SELECT COUNT(*) FROM node";
             let mut stmt = tx.prepare(sql).unwrap();
-            let result = stmt
-                .query_row([], |row| row.get::<_, i64>(0))
-                .unwrap() as usize;
+            let result = stmt.query_row([], |row| row.get::<_, i64>(0)).unwrap() as usize;
             stmt.finalize().unwrap();
             result
         })

--- a/transient-crypto/benches/benchmarking.rs
+++ b/transient-crypto/benches/benchmarking.rs
@@ -23,7 +23,7 @@ use midnight_zk_stdlib::Relation;
 use rand::RngCore;
 use rand::{Rng, rngs::OsRng};
 use serde_json::json;
-use serialize::tagged_serialize;
+use serialize::{tagged_deserialize, tagged_serialize};
 
 /// Helper function to run benchmarks with multiple data points for zero-parameter operations.
 fn with_json_iter<F>(group_name: &str, c: &mut Criterion, mut benchmark_fn: F)
@@ -152,6 +152,16 @@ pub fn proof_verification(c: &mut Criterion) {
                 preimage.public_transcript_inputs.clone(),
                 vec![],
             ))
+        }
+        fn load_ir_from_tagged(
+            reader: impl std::io::Read + std::io::Seek,
+        ) -> std::io::Result<Self> {
+            tagged_deserialize(reader)
+        }
+        fn load_prover_key_from_tagged(
+            reader: impl std::io::Read + std::io::Seek,
+        ) -> std::io::Result<midnight_transient_crypto::proofs::ProverKey<Self>> {
+            tagged_deserialize(reader)
         }
     }
 

--- a/transient-crypto/src/mock_verify.rs
+++ b/transient-crypto/src/mock_verify.rs
@@ -35,7 +35,7 @@ use midnight_zk_stdlib::Relation;
 use rand::Rng;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use serialize::{Deserializable, Serializable, Tagged, tagged_serialize};
+use serialize::{Deserializable, Serializable, Tagged, tagged_deserialize, tagged_serialize};
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use std::fs;
@@ -376,6 +376,14 @@ impl Zkir for TestIr {
             preimage.public_transcript_inputs.clone(),
             vec![],
         ))
+    }
+    fn load_ir_from_tagged(reader: impl std::io::Read + std::io::Seek) -> std::io::Result<Self> {
+        tagged_deserialize(reader)
+    }
+    fn load_prover_key_from_tagged(
+        reader: impl std::io::Read + std::io::Seek,
+    ) -> std::io::Result<ProverKey<Self>> {
+        tagged_deserialize(reader)
     }
 }
 

--- a/transient-crypto/src/proofs.rs
+++ b/transient-crypto/src/proofs.rs
@@ -37,7 +37,6 @@ use serialize::{
 };
 #[cfg(feature = "proptest")]
 use serialize::{NoStrategy, simple_arbitrary};
-use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::io::{self, Read};
@@ -46,6 +45,7 @@ use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 use std::{any::Any, cmp::Ordering};
 use std::{borrow::Cow, num::NonZeroUsize};
+use std::{fmt::Debug, io::Seek};
 use storage_core::Storable;
 use storage_core::arena::ArenaKey;
 use storage_core::db::DB;
@@ -149,7 +149,7 @@ impl<T: Zkir> From<MidnightPK<T>> for ProverKey<T> {
 
 /// An intermediate representation for Midnight's circuits.
 #[allow(async_fn_in_trait)]
-pub trait Zkir: Relation + Tagged + Deserializable + Any + Send + Sync + Debug {
+pub trait Zkir: Relation + Any + Send + Sync + Debug {
     /// Check that a proof preimage satisfies the circuit
     ///
     /// Returns which outputs were skipped in the proof preimage, and how many
@@ -206,6 +206,14 @@ pub trait Zkir: Relation + Tagged + Deserializable + Any + Send + Sync + Debug {
 
         Ok((ProverKey::from(pk), VerifierKey::from(vk)))
     }
+
+    /// Loads IR from a tagged serialization. Separated from `Deserializable` to allow for
+    /// backwards-compatible deserialization of old variants.
+    fn load_ir_from_tagged(reader: impl Read + Seek) -> io::Result<Self>;
+
+    /// Loads a prover key from a tagged serialization. Separated from `Deserializable` to allow
+    /// for backwards-compatible deserialization of old variants.
+    fn load_prover_key_from_tagged(reader: impl Read + Seek) -> io::Result<ProverKey<Self>>;
 }
 
 impl<T: Zkir> PartialEq for ProverKey<T> {
@@ -237,7 +245,7 @@ pub(crate) enum InnerProverKey<T: Zkir> {
     Initialized(Arc<MidnightPK<T>>),
 }
 
-impl<T: Zkir> Tagged for ProverKey<T> {
+impl<T: Zkir + Tagged> Tagged for ProverKey<T> {
     fn tag() -> Cow<'static, str> {
         Cow::Owned(format!("prover-key[v7]({})", T::tag()))
     }
@@ -744,9 +752,10 @@ impl ProofPreimage {
                 "failed to find proving key for '{}'",
                 &self.key_location.0
             )))?;
-        let ir = tagged_deserialize::<Z>(&mut &proof_data.ir_source[..])?;
+        let ir = Z::load_ir_from_tagged(io::Cursor::new(&proof_data.ir_source[..]))?;
         let verifier_key = tagged_deserialize::<VerifierKey>(&mut &proof_data.verifier_key[..])?;
-        let prover_key = tagged_deserialize::<ProverKey<Z>>(&mut &proof_data.prover_key[..])?;
+        let prover_key =
+            Z::load_prover_key_from_tagged(io::Cursor::new(&proof_data.prover_key[..]))?;
         let (proof, pis, pi_skips) = ir.prove(rng, params, prover_key, self).await?;
         debug!("proof created; verifying to make sure");
         let k = verifier_key.force_init()?.k();

--- a/zkir-v3/Cargo.toml
+++ b/zkir-v3/Cargo.toml
@@ -37,6 +37,7 @@ const-hex = "^1.14.0"
 serde = { version = "^1.0.0", features = ["derive", "rc"] }
 serde_bytes = { version = "^0.11.0" }
 serde_json = { version = "^1.0.0" }
+serde_repr = "^0.1.0"
 anyhow = "^1.0.102"
 hex = "^0.4.3"
 # rand 0.9.0 is not yet supported by some of our dependencies, we will

--- a/zkir-v3/src/ir.rs
+++ b/zkir-v3/src/ir.rs
@@ -33,7 +33,7 @@ use crate::ir_types::IrType;
 /// A low-level IR allowing the prover to populate circuit witnesses.
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize, Serializable)]
-#[tag = "ir-source[v3]"]
+#[tag = "ir-source[v3-generic]"]
 pub struct IrSource {
     /// The minor version of this IR.
     pub version: IrMinorVersion,
@@ -49,12 +49,19 @@ tag_enforcement_test!(ProverKey<IrSource>);
 
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(
-    Clone, Debug, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, Serializable,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    Serializable,
 )]
 #[tag = "ir-minor-version[v3]"]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IrMinorVersion {
+    #[default]
     V0,
 }
 
@@ -614,8 +621,8 @@ impl IrSource {
     /// Attempts to parse an arbitrary input as IR.
     pub fn load<R: Read>(reader: R) -> io::Result<Self> {
         let value: serde_json::Value = serde_json::from_reader(reader)?;
-        match &value {
-            serde_json::Value::Object(obj) => {
+        match value {
+            serde_json::Value::Object(mut obj) => {
                 let ver = serde_json::from_value(
                     obj.get("version")
                         .ok_or(io::Error::new(
@@ -625,7 +632,16 @@ impl IrSource {
                         .clone(),
                 )?;
                 match ver {
-                    SerdeVersion { major: 3, minor: 0 } => Ok(serde_json::from_value(value)?),
+                    SerdeVersion {
+                        major: 3,
+                        minor: 0..=0,
+                    } => {
+                        obj.insert(
+                            "version".into(),
+                            serde_json::Value::Number(ver.minor.into()),
+                        );
+                        Ok(serde_json::from_value(serde_json::Value::Object(obj))?)
+                    }
                     SerdeVersion { major, minor } => Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("Unhandled version: {major}.{minor}"),

--- a/zkir-v3/src/ir.rs
+++ b/zkir-v3/src/ir.rs
@@ -20,7 +20,7 @@ use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "proptest")]
 use serialize::randomised_serialization_test;
-use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
+use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test, tagged_deserialize};
 use std::io::{self, Read};
 use std::sync::Arc;
 use transient_crypto::curve::Fr;
@@ -35,6 +35,8 @@ use crate::ir_types::IrType;
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize, Serializable)]
 #[tag = "ir-source[v3]"]
 pub struct IrSource {
+    /// The minor version of this IR.
+    pub version: IrMinorVersion,
     /// The list of input identifiers for this circuit
     pub inputs: Vec<TypedIdentifier>,
     /// Whether this IR should compile a communications commitment
@@ -44,6 +46,17 @@ pub struct IrSource {
 }
 tag_enforcement_test!(IrSource);
 tag_enforcement_test!(ProverKey<IrSource>);
+
+#[cfg_attr(feature = "proptest", derive(Arbitrary))]
+#[derive(
+    Clone, Debug, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, Serializable,
+)]
+#[tag = "ir-minor-version[v3]"]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum IrMinorVersion {
+    V0,
+}
 
 impl Zkir for IrSource {
     fn check(
@@ -74,6 +87,14 @@ impl Zkir for IrSource {
         let proof = prove::<_, TranscriptHash>(params_k.as_ref(), &pk, self, &pis, preproc, rng)?;
 
         Ok((Proof(proof), pis.into_iter().map(Fr).collect(), pi_skips))
+    }
+
+    fn load_ir_from_tagged(reader: impl Read + io::Seek) -> io::Result<Self> {
+        tagged_deserialize(reader)
+    }
+
+    fn load_prover_key_from_tagged(reader: impl Read + io::Seek) -> io::Result<ProverKey<Self>> {
+        tagged_deserialize(reader)
     }
 }
 

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -23,7 +23,6 @@ use base_crypto::fab::{Alignment, AlignmentAtom, AlignmentSegment};
 use base_crypto::hash::persistent_hash;
 use base_crypto::repr::BinaryHashRepr;
 use group::Group;
-use midnight_circuits::instructions::RangeCheckInstructions;
 use midnight_circuits::instructions::{
     ArithInstructions, AssertionInstructions, AssignmentInstructions, BinaryInstructions,
     ControlFlowInstructions, ConversionInstructions, DecompositionInstructions, EccInstructions,

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -27,7 +27,7 @@ use midnight_circuits::instructions::RangeCheckInstructions;
 use midnight_circuits::instructions::{
     ArithInstructions, AssertionInstructions, AssignmentInstructions, BinaryInstructions,
     ControlFlowInstructions, ConversionInstructions, DecompositionInstructions, EccInstructions,
-    EqualityInstructions, PublicInputInstructions, ZeroInstructions,
+    EqualityInstructions, PublicInputInstructions, RangeCheckInstructions, ZeroInstructions,
 };
 use midnight_circuits::types::{
     AssignedBit, AssignedByte, AssignedNative, AssignedNativePoint, InnerValue,
@@ -1097,7 +1097,7 @@ impl Relation for IrSource {
             keccak_256: false,
             sha3_256: false,
             blake2b: false,
-            nr_pow2range_cols: 1,
+            nr_pow2range_cols: 4,
             secp256k1: false,
             bls12_381: false,
             base64: false,

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -38,7 +38,7 @@ use midnight_proofs::{
 };
 use midnight_zk_stdlib::{Relation, ZkStdLib, ZkStdLibArch};
 use num_bigint::BigUint;
-use serialize::{Deserializable, Serializable, VecExt};
+use serialize::{Deserializable, Serializable, VecExt, tagged_deserialize, tagged_serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use transient_crypto::curve::outer;
@@ -1105,10 +1105,13 @@ impl Relation for IrSource {
     }
 
     fn write_relation<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        Serializable::serialize(&self, writer)
+        let mut raw = Vec::new();
+        tagged_serialize(&self, &mut raw)?;
+        raw.serialize(writer)
     }
 
     fn read_relation<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        Deserializable::deserialize(reader, 0)
+        let raw: Vec<u8> = Deserializable::deserialize(reader, 0)?;
+        tagged_deserialize(&mut &raw[..])
     }
 }

--- a/zkir-wasm/src/lib.rs
+++ b/zkir-wasm/src/lib.rs
@@ -167,7 +167,7 @@ pub async fn check(ser_preimage: Uint8Array, provider: JsValue) -> Result<Vec<Js
             &preimage.key_location.0
         )));
     };
-    let ir: IrSource = tagged_deserialize(&mut &data.ir_source[..])?;
+    let ir = IrSource::load_from_tagged(std::io::Cursor::new(&data.ir_source[..]))?;
     let res = preimage
         .check(&ir)
         .map_err(|e| JsError::new(&e.to_string()))?;
@@ -244,7 +244,7 @@ impl Zkir {
 
     #[wasm_bindgen]
     pub fn deserialize(bytes: Uint8Array) -> Result<Self, JsError> {
-        let ir: IrSource = tagged_deserialize(&mut &bytes.to_vec()[..])?;
+        let ir = IrSource::load_from_tagged(std::io::Cursor::new(&bytes.to_vec()[..]))?;
         Ok(Self(ir))
     }
 

--- a/zkir-wasm/src/lib.rs
+++ b/zkir-wasm/src/lib.rs
@@ -250,7 +250,7 @@ impl Zkir {
 
     pub fn serialize(&self) -> Result<Uint8Array, JsError> {
         let mut buf = Vec::new();
-        tagged_serialize(&self.0, &mut buf)?;
+        self.0.serialize_to_tagged(&mut buf)?;
         Ok(buf[..].into())
     }
 }

--- a/zkir/Cargo.toml
+++ b/zkir/Cargo.toml
@@ -36,6 +36,7 @@ const-hex = "^1.14.0"
 serde = { version = "^1.0.0", features = ["derive", "rc"] }
 serde_bytes = { version = "^0.11.0" }
 serde_json = { version = "^1.0.0" }
+serde_repr = "^0.1.20"
 anyhow = "^1.0.102"
 hex = "^0.4.3"
 # rand 0.9.0 is not yet supported by some of our dependencies, we will
@@ -43,6 +44,7 @@ hex = "^0.4.3"
 rand = "^0.8.0"
 rand_chacha = "^0.3.1"
 tracing = { version = "^0.1.41" }
+num-bigint = { version = "0.4" }
 
 log = { version = "^0.4.28", optional = true }
 tracing-subscriber = { version = "^0.3.19", optional = true }

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "proptest")]
 use serialize::randomised_serialization_test;
 use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
-use std::io::{self, Read};
+use std::io::{self, Read, Seek};
 use std::sync::Arc;
 use transient_crypto::curve::Fr;
 use transient_crypto::proofs::{
@@ -33,8 +33,10 @@ use transient_crypto::proofs::{
 /// A low-level IR allowing the prover to populate circuit witnesses.
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize, Serializable)]
-#[tag = "ir-source[v2]"]
+#[tag = "ir-source[v2-generic]"]
 pub struct IrSource {
+    /// The minor version of this IR.
+    pub version: IrMinorVersion,
     /// The number of inputs, the initial elements in the memory
     pub num_inputs: u32,
     /// Whether or not this IR should compile a communications commitment
@@ -44,6 +46,53 @@ pub struct IrSource {
 }
 tag_enforcement_test!(IrSource);
 tag_enforcement_test!(ProverKey<IrSource>);
+
+#[derive(Serializable, Clone)]
+#[tag = "ir-source[v2]"]
+pub(crate) struct OldIrSource {
+    pub(crate) num_inputs: u32,
+    pub(crate) do_communications_commitment: bool,
+    pub(crate) instructions: Arc<Vec<Instruction>>,
+}
+
+impl From<OldIrSource> for IrSource {
+    fn from(value: OldIrSource) -> Self {
+        IrSource {
+            version: IrMinorVersion::V0,
+            num_inputs: value.num_inputs,
+            do_communications_commitment: value.do_communications_commitment,
+            instructions: value.instructions,
+        }
+    }
+}
+
+impl From<IrSource> for OldIrSource {
+    fn from(value: IrSource) -> Self {
+        OldIrSource {
+            num_inputs: value.num_inputs,
+            do_communications_commitment: value.do_communications_commitment,
+            instructions: value.instructions,
+        }
+    }
+}
+
+#[cfg_attr(feature = "proptest", derive(Arbitrary))]
+#[derive(
+    Clone, Debug, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, Serializable,
+)]
+#[tag = "ir-minor-version[v2]"]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum IrMinorVersion {
+    V0,
+    V1,
+}
+
+impl Default for IrMinorVersion {
+    fn default() -> Self {
+        IrMinorVersion::V1
+    }
+}
 
 impl Zkir for IrSource {
     fn check(
@@ -74,6 +123,32 @@ impl Zkir for IrSource {
         let proof = prove::<_, TranscriptHash>(params_k.as_ref(), &pk, self, &pis, preproc, rng)?;
 
         Ok((Proof(proof), pis.into_iter().map(Fr).collect(), pi_skips))
+    }
+
+    fn load_ir_from_tagged(reader: impl Read + Seek) -> io::Result<Self> {
+        Self::load_from_tagged(reader)
+    }
+
+    fn load_prover_key_from_tagged(mut reader: impl Read + Seek) -> io::Result<ProverKey<Self>> {
+        let pos = reader.stream_position()?;
+        // We try to first deserialize as the generic version. If this with an 'expected
+        // header tag' error, we rewind, and try again with the old tag.
+        match serialize::tagged_deserialize::<ProverKey<IrSource>>(&mut reader) {
+            Ok(v) => return Ok(v),
+            Err(e) if !e.to_string().contains("expected header tag") => return Err(e),
+            _ => {}
+        }
+        reader.seek(io::SeekFrom::Start(pos))?;
+        #[derive(Serializable)]
+        #[tag = "prover-key[v7](ir-source[v2])"]
+        struct FakeProverKey(Vec<u8>);
+        let FakeProverKey(data) = serialize::tagged_deserialize::<FakeProverKey>(reader)?;
+        let mut header = Vec::new();
+        Serializable::serialize(&(data.len() as u32), &mut header)?;
+        let mut header_cursor = &header[..];
+        let mut data_cursor = &data[..];
+        let mut reader = Read::chain(&mut header_cursor, &mut data_cursor);
+        Deserializable::deserialize(&mut reader, 0)
     }
 }
 
@@ -386,11 +461,28 @@ impl IrSource {
         }
     }
 
+    /// Attempts to load from a tagged source, which may be *either* of
+    /// - `ir-source[v2-generic]`
+    /// - `ir-source[v2]`
+    /// This is due to a need for a backwards-compatible format change.
+    pub fn load_from_tagged<R: Read + Seek>(mut reader: R) -> io::Result<Self> {
+        let pos = reader.stream_position()?;
+        // We try to first deserialize as the generic version. If this with an 'expected
+        // header tag' error, we rewind, and try again with the old tag.
+        match serialize::tagged_deserialize::<IrSource>(&mut reader) {
+            Ok(v) => return Ok(v),
+            Err(e) if !e.to_string().contains("expected header tag") => return Err(e),
+            _ => {}
+        }
+        reader.seek(io::SeekFrom::Start(pos))?;
+        serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
+    }
+
     /// Attempts to parse an arbitrary input as IR.
     pub fn load<R: Read>(reader: R) -> io::Result<Self> {
         let value: serde_json::Value = serde_json::from_reader(reader)?;
-        match &value {
-            serde_json::Value::Object(obj) => {
+        match value {
+            serde_json::Value::Object(mut obj) => {
                 let ver = serde_json::from_value(
                     obj.get("version")
                         .ok_or(io::Error::new(
@@ -400,7 +492,16 @@ impl IrSource {
                         .clone(),
                 )?;
                 match ver {
-                    SerdeVersion { major: 2, minor: 0 } => Ok(serde_json::from_value(value)?),
+                    SerdeVersion {
+                        major: 2,
+                        minor: 0..=1,
+                    } => {
+                        obj.insert(
+                            "version".into(),
+                            serde_json::Value::Number(ver.minor.into()),
+                        );
+                        Ok(serde_json::from_value(serde_json::Value::Object(obj))?)
+                    }
                     SerdeVersion { major, minor } => Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("Unhandled version: {major}.{minor}"),

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "proptest")]
 use serialize::randomised_serialization_test;
 use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
-use std::io::{self, Read, Seek};
+use std::io::{self, Read, Seek, Write};
 use std::sync::Arc;
 use transient_crypto::curve::Fr;
 use transient_crypto::proofs::{
@@ -78,20 +78,22 @@ impl From<IrSource> for OldIrSource {
 
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(
-    Clone, Debug, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, Serializable,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    Serializable,
 )]
 #[tag = "ir-minor-version[v2]"]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IrMinorVersion {
     V0,
+    #[default]
     V1,
-}
-
-impl Default for IrMinorVersion {
-    fn default() -> Self {
-        IrMinorVersion::V1
-    }
 }
 
 impl Zkir for IrSource {
@@ -141,8 +143,8 @@ impl Zkir for IrSource {
         reader.seek(io::SeekFrom::Start(pos))?;
         #[derive(Serializable)]
         #[tag = "prover-key[v7](ir-source[v2])"]
-        struct FakeProverKey(Vec<u8>);
-        let FakeProverKey(data) = serialize::tagged_deserialize::<FakeProverKey>(reader)?;
+        struct FacadeProverKey(Vec<u8>);
+        let FacadeProverKey(data) = serialize::tagged_deserialize::<FacadeProverKey>(reader)?;
         let mut header = Vec::new();
         Serializable::serialize(&(data.len() as u32), &mut header)?;
         let mut header_cursor = &header[..];
@@ -464,6 +466,7 @@ impl IrSource {
     /// Attempts to load from a tagged source, which may be *either* of
     /// - `ir-source[v2-generic]`
     /// - `ir-source[v2]`
+    ///
     /// This is due to a need for a backwards-compatible format change.
     pub fn load_from_tagged<R: Read + Seek>(mut reader: R) -> io::Result<Self> {
         let pos = reader.stream_position()?;
@@ -476,6 +479,15 @@ impl IrSource {
         }
         reader.seek(io::SeekFrom::Start(pos))?;
         serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
+    }
+
+    /// Writes out with tag, preserving v0's old tag structure.
+    pub fn serialize_to_tagged<W: Write>(&self, writer: W) -> io::Result<()> {
+        if self.version == IrMinorVersion::V0 {
+            serialize::tagged_serialize(&OldIrSource::from(self.clone()), writer)
+        } else {
+            serialize::tagged_serialize(self, writer)
+        }
     }
 
     /// Attempts to parse an arbitrary input as IR.

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -146,9 +146,9 @@ impl Zkir for IrSource {
         let tag = peek_tag(&mut reader)?;
         let expected_tag_new = <ProverKey<IrSource>>::tag();
         let expected_tag_old = FacadeProverKey::tag();
-        if &tag == &expected_tag_new {
+        if tag == expected_tag_new {
             serialize::tagged_deserialize(&mut reader)
-        } else if &tag == &expected_tag_old {
+        } else if tag == expected_tag_old {
             let FacadeProverKey(data) = serialize::tagged_deserialize::<FacadeProverKey>(reader)?;
             let mut header = Vec::new();
             Serializable::serialize(&(data.len() as u32), &mut header)?;
@@ -485,9 +485,9 @@ impl IrSource {
         let tag = peek_tag(&mut reader)?;
         let expected_tag_new = IrSource::tag();
         let expected_tag_old = OldIrSource::tag();
-        if &tag == &expected_tag_new {
+        if tag == expected_tag_new {
             serialize::tagged_deserialize(&mut reader)
-        } else if &tag == &expected_tag_old {
+        } else if tag == expected_tag_old {
             serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
         } else {
             Err(io::Error::new(

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -22,7 +22,9 @@ use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "proptest")]
 use serialize::randomised_serialization_test;
-use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
+use serialize::{
+    Deserializable, Serializable, Tagged, peek_tag, tag_enforcement_test, tagged_serialize,
+};
 use std::io::{self, Read, Seek, Write};
 use std::sync::Arc;
 use transient_crypto::curve::Fr;
@@ -66,12 +68,17 @@ impl From<OldIrSource> for IrSource {
     }
 }
 
-impl From<IrSource> for OldIrSource {
-    fn from(value: IrSource) -> Self {
-        OldIrSource {
-            num_inputs: value.num_inputs,
-            do_communications_commitment: value.do_communications_commitment,
-            instructions: value.instructions,
+impl TryFrom<&IrSource> for OldIrSource {
+    type Error = ();
+    fn try_from(value: &IrSource) -> Result<Self, ()> {
+        if value.version == IrMinorVersion::V0 {
+            Ok(OldIrSource {
+                num_inputs: value.num_inputs,
+                do_communications_commitment: value.do_communications_commitment,
+                instructions: value.instructions.clone(),
+            })
+        } else {
+            Err(())
         }
     }
 }
@@ -95,6 +102,10 @@ pub enum IrMinorVersion {
     #[default]
     V1,
 }
+
+#[derive(Serializable)]
+#[tag = "prover-key[v7](ir-source[v2])"]
+struct FacadeProverKey(Vec<u8>);
 
 impl Zkir for IrSource {
     fn check(
@@ -132,25 +143,27 @@ impl Zkir for IrSource {
     }
 
     fn load_prover_key_from_tagged(mut reader: impl Read + Seek) -> io::Result<ProverKey<Self>> {
-        let pos = reader.stream_position()?;
-        // We try to first deserialize as the generic version. If this with an 'expected
-        // header tag' error, we rewind, and try again with the old tag.
-        match serialize::tagged_deserialize::<ProverKey<IrSource>>(&mut reader) {
-            Ok(v) => return Ok(v),
-            Err(e) if !e.to_string().contains("expected header tag") => return Err(e),
-            _ => {}
+        let tag = peek_tag(&mut reader)?;
+        let expected_tag_new = <ProverKey<IrSource>>::tag();
+        let expected_tag_old = FacadeProverKey::tag();
+        if &tag == &expected_tag_new {
+            serialize::tagged_deserialize(&mut reader)
+        } else if &tag == &expected_tag_old {
+            let FacadeProverKey(data) = serialize::tagged_deserialize::<FacadeProverKey>(reader)?;
+            let mut header = Vec::new();
+            Serializable::serialize(&(data.len() as u32), &mut header)?;
+            let mut header_cursor = &header[..];
+            let mut data_cursor = &data[..];
+            let mut reader = Read::chain(&mut header_cursor, &mut data_cursor);
+            Deserializable::deserialize(&mut reader, 0)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "expected one of '{expected_tag_new}' or '{expected_tag_old}', got '{tag}'."
+                ),
+            ))
         }
-        reader.seek(io::SeekFrom::Start(pos))?;
-        #[derive(Serializable)]
-        #[tag = "prover-key[v7](ir-source[v2])"]
-        struct FacadeProverKey(Vec<u8>);
-        let FacadeProverKey(data) = serialize::tagged_deserialize::<FacadeProverKey>(reader)?;
-        let mut header = Vec::new();
-        Serializable::serialize(&(data.len() as u32), &mut header)?;
-        let mut header_cursor = &header[..];
-        let mut data_cursor = &data[..];
-        let mut reader = Read::chain(&mut header_cursor, &mut data_cursor);
-        Deserializable::deserialize(&mut reader, 0)
     }
 }
 
@@ -469,24 +482,47 @@ impl IrSource {
     ///
     /// This is due to a need for a backwards-compatible format change.
     pub fn load_from_tagged<R: Read + Seek>(mut reader: R) -> io::Result<Self> {
-        let pos = reader.stream_position()?;
-        // We try to first deserialize as the generic version. If this with an 'expected
-        // header tag' error, we rewind, and try again with the old tag.
-        match serialize::tagged_deserialize::<IrSource>(&mut reader) {
-            Ok(v) => return Ok(v),
-            Err(e) if !e.to_string().contains("expected header tag") => return Err(e),
-            _ => {}
+        let tag = peek_tag(&mut reader)?;
+        let expected_tag_new = IrSource::tag();
+        let expected_tag_old = OldIrSource::tag();
+        if &tag == &expected_tag_new {
+            serialize::tagged_deserialize(&mut reader)
+        } else if &tag == &expected_tag_old {
+            serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "expected one of '{expected_tag_new}' or '{expected_tag_old}', got '{tag}'."
+                ),
+            ))
         }
-        reader.seek(io::SeekFrom::Start(pos))?;
-        serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
     }
 
     /// Writes out with tag, preserving v0's old tag structure.
     pub fn serialize_to_tagged<W: Write>(&self, writer: W) -> io::Result<()> {
-        if self.version == IrMinorVersion::V0 {
-            serialize::tagged_serialize(&OldIrSource::from(self.clone()), writer)
+        if let Ok(old_ir) = OldIrSource::try_from(self) {
+            serialize::tagged_serialize(&old_ir, writer)
         } else {
             serialize::tagged_serialize(self, writer)
+        }
+    }
+
+    /// Writes out a prover key with tag, preserving v0's old tag structure.
+    pub fn serialize_prover_key_to_tagged<W: Write>(
+        version: IrMinorVersion,
+        pk: &ProverKey<Self>,
+        writer: W,
+    ) -> io::Result<()> {
+        match version {
+            IrMinorVersion::V0 => {
+                let mut raw = Vec::new();
+                Serializable::serialize(pk, &mut raw)?;
+                let container = <Vec<u8> as Deserializable>::deserialize(&mut &raw[..], 0)?;
+                let facade = FacadeProverKey(container);
+                tagged_serialize(&facade, writer)
+            }
+            IrMinorVersion::V1 => tagged_serialize(pk, writer),
         }
     }
 

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ir::{IrMinorVersion, OldIrSource};
+
 use super::ir::{Instruction as I, IrSource};
 use anyhow::{anyhow, bail};
 use base_crypto::fab::{Alignment, AlignmentAtom, AlignmentSegment};
@@ -31,8 +33,9 @@ use midnight_proofs::{
 };
 use midnight_zk_stdlib::{Relation, ZkStdLib, ZkStdLibArch};
 use num_bigint::BigUint;
-use serialize::{Deserializable, Serializable, VecExt};
+use serialize::{Deserializable, Serializable, VecExt, tagged_deserialize, tagged_serialize};
 use std::cmp::Ordering;
+use std::io::Read;
 use transient_crypto::curve::EmbeddedGroupAffine;
 use transient_crypto::curve::{FR_BITS, FR_BYTES_STORED, Fr};
 use transient_crypto::curve::{embedded, outer};
@@ -601,11 +604,28 @@ impl Relation for IrSource {
         for ins in self.instructions.iter() {
             match ins {
                 I::Assert { cond } => std.assert_non_zero(layouter, idx(&memory, *cond)?)?,
+                I::CondSelect { bit, a, b } if self.version == IrMinorVersion::V0 => {
+                    let bit = std.is_zero(layouter, idx(&memory, *bit)?)?;
+                    // Note that b comes first here, because the is_zero negates the bit.
+                    // The negation is to ensure the bit bound. This may be
+                    // excessive, but user input could violate it otherwise.
+                    let result =
+                        std.select(layouter, &bit, idx(&memory, *b)?, idx(&memory, *a)?)?;
+                    mem_push(result, &mut memory)?;
+                }
                 I::CondSelect { bit, a, b } => {
                     let bit: AssignedBit<_> = std.convert(layouter, idx(&memory, *bit)?)?;
                     let result =
                         std.select(layouter, &bit, idx(&memory, *a)?, idx(&memory, *b)?)?;
                     mem_push(result, &mut memory)?;
+                }
+                I::ConstrainBits { var, bits } if self.version == IrMinorVersion::V0 => {
+                    drop(std.assigned_to_le_bits(
+                        layouter,
+                        idx(&memory, *var)?,
+                        Some(*bits as usize),
+                        *bits as usize >= FR_BITS,
+                    )?)
                 }
                 I::ConstrainBits { var, bits } => {
                     if *bits < FR_BITS as u32 {
@@ -704,6 +724,27 @@ impl Relation for IrSource {
 
                     mem_push(divisor, &mut memory)?;
                     mem_push(modulus, &mut memory)?;
+                }
+                I::ReconstituteField {
+                    divisor,
+                    modulus,
+                    bits,
+                } if self.version == IrMinorVersion::V0 => {
+                    let divisor_bits = std.assigned_to_le_bits(
+                        layouter,
+                        idx(&memory, *divisor)?,
+                        Some(FR_BITS - *bits as usize),
+                        true,
+                    )?;
+                    let modulus_bits = std.assigned_to_le_bits(
+                        layouter,
+                        idx(&memory, *modulus)?,
+                        Some(*bits as usize),
+                        true,
+                    )?;
+                    let reconstituted = std
+                        .assigned_from_le_bits(layouter, &[modulus_bits, divisor_bits].concat())?;
+                    mem_push(reconstituted, &mut memory)?;
                 }
                 I::ReconstituteField {
                     divisor,
@@ -819,6 +860,10 @@ impl Relation for IrSource {
             .instructions
             .iter()
             .any(|op| matches!(op, I::PersistentHash { .. }));
+        let nr_pow2range_cols = match self.version {
+            IrMinorVersion::V0 => 1,
+            IrMinorVersion::V1 => 4,
+        };
         ZkStdLibArch {
             jubjub: jubjub || hash_to_curve,
             poseidon: poseidon || hash_to_curve,
@@ -827,7 +872,7 @@ impl Relation for IrSource {
             sha3_256: false,
             keccak_256: false,
             blake2b: false,
-            nr_pow2range_cols: 4,
+            nr_pow2range_cols,
             secp256k1: false,
             bls12_381: false,
             base64: false,
@@ -836,10 +881,28 @@ impl Relation for IrSource {
     }
 
     fn write_relation<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        Serializable::serialize(&self, writer)
+        if self.version == IrMinorVersion::V0 {
+            Serializable::serialize(&OldIrSource::from(self.clone()), writer)
+        } else {
+            // 0xff is a magic byte indicating non-v0 versions. These are tagged, and in a vec
+            // container. This byte is *not* representable in v0, as it is illegal for a SCALE
+            // encoded u32.
+            writer.write_all(&[0xff])?;
+            let mut raw = Vec::new();
+            tagged_serialize(&self, &mut raw)?;
+            raw.serialize(writer)
+        }
     }
 
     fn read_relation<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        Deserializable::deserialize(reader, 0)
+        let first_byte: u8 = Deserializable::deserialize(reader, 0)?;
+        if first_byte != 0xff {
+            let mut cursor = &[first_byte][..];
+            let mut reader = Read::chain(&mut cursor, reader);
+            OldIrSource::deserialize(&mut reader, 0).map(Into::into)
+        } else {
+            let raw: Vec<u8> = Deserializable::deserialize(reader, 0)?;
+            tagged_deserialize(&mut &raw[..])
+        }
     }
 }

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -610,7 +610,7 @@ impl Relation for IrSource {
                     // The negation is to ensure the bit bound. This may be
                     // excessive, but user input could violate it otherwise.
                     let result =
-                        std.select(layouter, &bit, idx(&memory, *a)?, idx(&memory, *b)?)?;
+                        std.select(layouter, &bit, idx(&memory, *b)?, idx(&memory, *a)?)?;
                     mem_push(result, &mut memory)?;
                 }
                 I::CondSelect { bit, a, b } => {

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -886,8 +886,8 @@ impl Relation for IrSource {
     }
 
     fn write_relation<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        if self.version == IrMinorVersion::V0 {
-            Serializable::serialize(&OldIrSource::from(self.clone()), writer)
+        if let Ok(old_ir) = OldIrSource::try_from(self) {
+            Serializable::serialize(&old_ir, writer)
         } else {
             // 0xff is a magic byte indicating non-v0 versions. These are tagged, and in a vec
             // container. This byte is *not* representable in v0, as it is illegal for a SCALE

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -732,23 +732,19 @@ impl Relation for IrSource {
                 } if self.version == IrMinorVersion::V0 => {
                     let divisor_bits = std.assigned_to_le_bits(
                         layouter,
-                        &divisor,
-                        &(BigUint::from(1u32) << (FR_BITS as u32 - *bits)),
+                        idx(&memory, *divisor)?,
+                        Some(FR_BITS - *bits as usize),
+                        *bits as usize >= FR_BITS,
                     )?;
-                    std.assert_lower_than_fixed(
+                    let modulus_bits = std.assigned_to_le_bits(
                         layouter,
-                        &modulus,
-                        &(BigUint::from(1u32) << *bits),
+                        idx(&memory, *modulus)?,
+                        Some(*bits as usize),
+                        true,
                     )?;
 
-                    let reconstituted = std.linear_combination(
-                        layouter,
-                        &[
-                            (outer::Scalar::from(1), modulus),
-                            (outer::Scalar::from(2).pow([*bits as u64]), divisor),
-                        ],
-                        outer::Scalar::from(0),
-                    )?;
+                    let reconstituted = std
+                        .assigned_from_le_bits(layouter, &[modulus_bits, divisor_bits].concat())?;
                     mem_push(reconstituted, &mut memory)?;
                 }
                 I::ReconstituteField {

--- a/zkir/src/lib.rs
+++ b/zkir/src/lib.rs
@@ -24,7 +24,7 @@ use transient_crypto::proofs::{
 mod ir;
 mod ir_vm;
 
-pub use ir::{Instruction, IrSource};
+pub use ir::{Instruction, IrMinorVersion, IrSource};
 pub use ir_vm::Preprocessed;
 
 /// Implements `ProvingProvider` locally

--- a/zkir/src/lib.rs
+++ b/zkir/src/lib.rs
@@ -16,7 +16,6 @@ extern crate tracing;
 
 use base_crypto::rng::SplittableRng;
 use rand::{CryptoRng, Rng};
-use serialize::tagged_deserialize;
 use transient_crypto::curve::Fr;
 use transient_crypto::proofs::{
     ParamsProverProvider, Proof, ProofPreimage, ProvingProvider, Resolver,
@@ -57,7 +56,7 @@ impl<'a, R: Rng + CryptoRng + SplittableRng, S: Resolver, P: ParamsProverProvide
                     preimage.key_location.0
                 )
             })?;
-        let ir: IrSource = tagged_deserialize(&mut &proving_data.ir_source[..])?;
+        let ir = IrSource::load_from_tagged(std::io::Cursor::new(&proving_data.ir_source[..]))?;
         preimage.check(&ir)
     }
     async fn prove(

--- a/zkir/src/main.rs
+++ b/zkir/src/main.rs
@@ -17,11 +17,12 @@
 use base_crypto::data_provider::{self, MidnightDataProvider};
 use clap::{Parser, Subcommand};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use midnight_zkir::IrSource;
-use serialize::{tagged_deserialize, tagged_serialize};
+use midnight_zkir::{IrMinorVersion, IrSource};
+use serialize::tagged_serialize;
+use serialize::{Deserializable, Serializable, Tagged};
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Write};
+use std::io::{self, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing::info;
@@ -29,7 +30,7 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::Registry;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::prelude::*;
-use transient_crypto::proofs::Zkir;
+use transient_crypto::proofs::{ProverKey, Zkir};
 
 #[derive(Parser)]
 #[clap(version, about, long_about = None)]
@@ -85,10 +86,12 @@ fn maybe_bzkir(path: impl AsRef<Path>) -> anyhow::Result<IrSource> {
         Some(Some("zkir")) => {
             let ir = IrSource::load(BufReader::new(File::open(&path)?))?;
             let mut bzkir = BufWriter::new(File::create(path.as_ref().with_extension("bzkir"))?);
-            tagged_serialize(&ir, &mut bzkir)?;
+            ir.serialize_to_tagged(&mut bzkir)?;
             Ok(ir)
         }
-        _ => Ok(tagged_deserialize(&mut BufReader::new(File::open(path)?))?),
+        _ => Ok(IrSource::load_from_tagged(&mut BufReader::new(
+            File::open(path)?,
+        ))?),
     }
 }
 
@@ -122,6 +125,27 @@ fn extract_files_from_dir(dir: impl AsRef<Path>) -> anyhow::Result<Vec<OsString>
     files.sort();
     files.dedup();
     Ok(files)
+}
+
+fn pk_serialize(
+    version: IrMinorVersion,
+    pk: &ProverKey<IrSource>,
+    writer: impl Write,
+) -> io::Result<()> {
+    match version {
+        IrMinorVersion::V0 => {
+            #[derive(Serializable)]
+            #[tag = "prover-key[v7](ir-source[v2])"]
+            struct FacadeProverKey(Vec<u8>);
+            let mut raw = Vec::new();
+            Serializable::serialize(pk, &mut raw)?;
+            let container = <Vec<u8>>::deserialize(&mut &raw[..], 0)?;
+            let facade = FacadeProverKey(container);
+            tagged_serialize(&facade, writer)
+        }
+        IrMinorVersion::V1 => tagged_serialize(pk, writer),
+        _ => unreachable!(),
+    }
 }
 
 #[tokio::main]
@@ -221,7 +245,7 @@ async fn main() -> anyhow::Result<()> {
                     BufWriter::new(File::create(key_dir.join(file).with_extension("verifier"))?);
                 pb.enable_steady_tick(Duration::from_millis(100));
                 let (pk, vk) = ir.keygen(&pp).await?;
-                tagged_serialize(&pk, &mut pk_file)?;
+                pk_serialize(ir.version, &pk, &mut pk_file)?;
                 tagged_serialize(&vk, &mut vk_file)?;
                 pb.finish();
                 overall.set_message(format!("{n}/{}", data.len()));
@@ -262,7 +286,7 @@ async fn main() -> anyhow::Result<()> {
             pb.set_message(format!("Compiling circuit {ir_file:?} (k={k})"));
             pb.enable_steady_tick(Duration::from_millis(100));
             let (pk, vk) = ir.keygen(&pp).await?;
-            tagged_serialize(&pk, &mut pk_file)?;
+            pk_serialize(ir.version, &pk, &mut pk_file)?;
             tagged_serialize(&vk, &mut vk_file)?;
             pb.finish();
         }

--- a/zkir/src/main.rs
+++ b/zkir/src/main.rs
@@ -17,12 +17,11 @@
 use base_crypto::data_provider::{self, MidnightDataProvider};
 use clap::{Parser, Subcommand};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use midnight_zkir::{IrMinorVersion, IrSource};
+use midnight_zkir::IrSource;
 use serialize::tagged_serialize;
-use serialize::{Deserializable, Serializable, Tagged};
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter, Write};
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing::info;
@@ -30,7 +29,7 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::Registry;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::prelude::*;
-use transient_crypto::proofs::{ProverKey, Zkir};
+use transient_crypto::proofs::Zkir;
 
 #[derive(Parser)]
 #[clap(version, about, long_about = None)]

--- a/zkir/src/main.rs
+++ b/zkir/src/main.rs
@@ -127,27 +127,6 @@ fn extract_files_from_dir(dir: impl AsRef<Path>) -> anyhow::Result<Vec<OsString>
     Ok(files)
 }
 
-fn pk_serialize(
-    version: IrMinorVersion,
-    pk: &ProverKey<IrSource>,
-    writer: impl Write,
-) -> io::Result<()> {
-    match version {
-        IrMinorVersion::V0 => {
-            #[derive(Serializable)]
-            #[tag = "prover-key[v7](ir-source[v2])"]
-            struct FacadeProverKey(Vec<u8>);
-            let mut raw = Vec::new();
-            Serializable::serialize(pk, &mut raw)?;
-            let container = <Vec<u8>>::deserialize(&mut &raw[..], 0)?;
-            let facade = FacadeProverKey(container);
-            tagged_serialize(&facade, writer)
-        }
-        IrMinorVersion::V1 => tagged_serialize(pk, writer),
-        _ => unreachable!(),
-    }
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
@@ -245,7 +224,7 @@ async fn main() -> anyhow::Result<()> {
                     BufWriter::new(File::create(key_dir.join(file).with_extension("verifier"))?);
                 pb.enable_steady_tick(Duration::from_millis(100));
                 let (pk, vk) = ir.keygen(&pp).await?;
-                pk_serialize(ir.version, &pk, &mut pk_file)?;
+                IrSource::serialize_prover_key_to_tagged(ir.version, &pk, &mut pk_file)?;
                 tagged_serialize(&vk, &mut vk_file)?;
                 pb.finish();
                 overall.set_message(format!("{n}/{}", data.len()));
@@ -286,7 +265,7 @@ async fn main() -> anyhow::Result<()> {
             pb.set_message(format!("Compiling circuit {ir_file:?} (k={k})"));
             pb.enable_steady_tick(Duration::from_millis(100));
             let (pk, vk) = ir.keygen(&pp).await?;
-            pk_serialize(ir.version, &pk, &mut pk_file)?;
+            IrSource::serialize_prover_key_to_tagged(ir.version, &pk, &mut pk_file)?;
             tagged_serialize(&vk, &mut vk_file)?;
             pb.finish();
         }

--- a/zkir/tests/proofs.rs
+++ b/zkir/tests/proofs.rs
@@ -422,6 +422,7 @@ mod proof_tests {
            ]
         }"#;
         let ir = IrSource::load(ir_raw.as_bytes()).unwrap();
+        dbg!(&ir);
 
         let (pk, vk) = ir.keygen(&TestParams).await.unwrap();
         let mut pk_data = Vec::new();

--- a/zkir/tests/proofs.rs
+++ b/zkir/tests/proofs.rs
@@ -422,7 +422,6 @@ mod proof_tests {
            ]
         }"#;
         let ir = IrSource::load(ir_raw.as_bytes()).unwrap();
-        dbg!(&ir);
 
         let (pk, vk) = ir.keygen(&TestParams).await.unwrap();
         let mut pk_data = Vec::new();

--- a/zswap/src/prove.rs
+++ b/zswap/src/prove.rs
@@ -196,7 +196,7 @@ mod tests {
             use std::fs::File;
             use std::path::PathBuf;
             let file = PathBuf::from("./static").join(ir).with_extension("bzkir");
-            let ir = tagged_deserialize::<IrSource>(&mut File::open(file).unwrap()).unwrap();
+            let ir = IrSource::load_from_tagged(&mut File::open(file).unwrap()).unwrap();
             ir.instructions
                 .iter()
                 .filter_map(|ins| match ins {


### PR DESCRIPTION
## Summary
- Optimize `ConstrainBits` to use `assert_lower_than_fixed` range check instead of bit decomposition, skipping the constraint entirely when bits >= field size
- Optimize `CondSelect` to use direct bit conversion + select instead of `is_zero` negation trick
- Optimize `ReconstituteField` to use `linear_combination` instead of bit decomposition and reconstitution
- Add `num-bigint` dependency to both `zkir` and `zkir-v3` crates
- Increase `nr_pow2range_cols` from 1 to 4 for the new range check approach