### PR TITLE
test: regression tests for tryApply crash on collapsed Merkle tree

### DIFF
--- a/zswap/tests/state.rs
+++ b/zswap/tests/state.rs
@@ -22,6 +22,7 @@ use midnight_zswap::{Offer, Output as ZswapOutput};
 use rand::rngs::{OsRng, StdRng};
 use rand::{Rng, SeedableRng};
 use storage::db::{DB, InMemoryDB};
+use storage::storage::Map;
 use transient_crypto::proofs::ProofPreimage;
 
 #[test]
@@ -108,5 +109,252 @@ fn state_filtering() {
     assert_eq!(
         state.filter(&[*(output.contract_address.clone()).unwrap().deref()]),
         reference_tree
+    );
+}
+
+/// Verifies that `try_apply` with new outputs succeeds on a state whose
+/// Merkle tree has been filtered (collapsed) — as the indexer would provide
+/// for per-contract tracking — when `whitelist` is `None`.
+///
+/// This test documents expected behavior: `first_free` always points beyond
+/// the collapsed region, so `update_hash(first_free, ...)` reaches a Stub.
+#[test]
+fn try_apply_output_on_filtered_state_no_whitelist() {
+    let mut rng = StdRng::seed_from_u64(0x42);
+    let addr_a = ContractAddress(OsRng.r#gen());
+    let addr_b = ContractAddress(OsRng.r#gen());
+    let mut state: State<InMemoryDB> = State::new();
+
+    // Insert outputs for two different contracts
+    for (i, addr) in [(0, addr_a), (1, addr_b), (2, addr_a), (3, addr_b), (4, addr_a)] {
+        let coin = CoinInfo {
+            nonce: OsRng.r#gen(),
+            type_: ShieldedTokenType(OsRng.r#gen()),
+            value: (i + 1) as u128 * 100,
+        };
+        let output = ZswapOutput::new_contract_owned(&mut rng, &coin, None, addr).unwrap();
+        let offer = Offer {
+            inputs: vec![].into(),
+            outputs: vec![output].into(),
+            transient: vec![].into(),
+            deltas: vec![].into(),
+        };
+        state = state.try_apply(&offer, None).unwrap().0;
+    }
+    state = state.post_block_update(Default::default());
+
+    // Filter for contract A only (positions 0, 2, 4 retained; 1, 3 collapsed)
+    let filtered_tree = state.filter(&[addr_a]);
+    let filtered_state = State {
+        coin_coms: filtered_tree,
+        coin_coms_set: state.coin_coms_set.clone(),
+        first_free: state.first_free,
+        nullifiers: state.nullifiers.clone(),
+        past_roots: state.past_roots.clone(),
+    };
+
+    // Apply a new output to the filtered state with whitelist=None
+    let new_coin = CoinInfo {
+        nonce: OsRng.r#gen(),
+        type_: ShieldedTokenType(OsRng.r#gen()),
+        value: 999,
+    };
+    let new_output = ZswapOutput::new_contract_owned(&mut rng, &new_coin, None, addr_a).unwrap();
+    let new_offer = Offer {
+        inputs: vec![].into(),
+        outputs: vec![new_output].into(),
+        transient: vec![].into(),
+        deltas: vec![].into(),
+    };
+
+    // With whitelist=None, on_whitelist always returns true, so collapse is NOT
+    // called in apply_output. update_hash(first_free, ...) should succeed.
+    let result = filtered_state.try_apply(&new_offer, None);
+    assert!(result.is_ok(), "try_apply on filtered state with whitelist=None should succeed");
+}
+
+/// Verifies that `try_apply` with new outputs succeeds on a filtered state
+/// when a whitelist is provided containing the contract address.
+///
+/// When the whitelist contains the output's contract address, `on_whitelist`
+/// returns true and collapse is NOT called — the output is retained in the
+/// per-contract tree.
+#[test]
+fn try_apply_output_on_filtered_state_with_matching_whitelist() {
+    let mut rng = StdRng::seed_from_u64(0x42);
+    let addr_a = ContractAddress(OsRng.r#gen());
+    let addr_b = ContractAddress(OsRng.r#gen());
+    let mut state: State<InMemoryDB> = State::new();
+
+    // Build up state with interleaved contract outputs
+    for addr in [addr_a, addr_b, addr_a, addr_b] {
+        let coin = CoinInfo {
+            nonce: OsRng.r#gen(),
+            type_: ShieldedTokenType(OsRng.r#gen()),
+            value: OsRng.r#gen(),
+        };
+        let output = ZswapOutput::new_contract_owned(&mut rng, &coin, None, addr).unwrap();
+        let offer = Offer {
+            inputs: vec![].into(),
+            outputs: vec![output].into(),
+            transient: vec![].into(),
+            deltas: vec![].into(),
+        };
+        state = state.try_apply(&offer, None).unwrap().0;
+    }
+    state = state.post_block_update(Default::default());
+
+    // Filter for contract A
+    let filtered_tree = state.filter(&[addr_a]);
+    let filtered_state = State {
+        coin_coms: filtered_tree,
+        coin_coms_set: state.coin_coms_set.clone(),
+        first_free: state.first_free,
+        nullifiers: state.nullifiers.clone(),
+        past_roots: state.past_roots.clone(),
+    };
+
+    // Create whitelist containing contract A
+    let whitelist: Map<ContractAddress, ()> = Map::new().insert(addr_a, ());
+
+    // Apply new contract-A output with matching whitelist
+    let new_coin = CoinInfo {
+        nonce: OsRng.r#gen(),
+        type_: ShieldedTokenType(OsRng.r#gen()),
+        value: 500,
+    };
+    let new_output = ZswapOutput::new_contract_owned(&mut rng, &new_coin, None, addr_a).unwrap();
+    let new_offer = Offer {
+        inputs: vec![].into(),
+        outputs: vec![new_output].into(),
+        transient: vec![].into(),
+        deltas: vec![].into(),
+    };
+
+    let result = filtered_state.try_apply(&new_offer, Some(whitelist));
+    assert!(
+        result.is_ok(),
+        "try_apply on filtered state with matching whitelist should succeed"
+    );
+}
+
+/// Demonstrates that `try_apply` panics when `first_free` incorrectly points
+/// into a collapsed region of the Merkle tree. This reproduces the crash
+/// mechanism observed in the WASM `ZswapChainState.tryApply()` bug — where
+/// the client-side state has a collapsed tree that includes position
+/// `first_free`, causing `update_hash` to panic with
+/// "Attempted to insert into collapsed portion of Merkle tree!"
+///
+/// In production, this can happen when the deserialized state from the indexer
+/// has the Merkle tree collapsed more aggressively than `filter()` would do
+/// (e.g., the entire tree is collapsed including the `first_free` position).
+///
+/// Related: https://github.com/midnightntwrk/midnight-ledger/issues/179
+#[test]
+#[should_panic = "Attempted to insert into collapsed portion of Merkle tree!"]
+fn try_apply_panics_when_first_free_in_collapsed_tree() {
+    let mut rng = StdRng::seed_from_u64(0x42);
+    let addr = ContractAddress(OsRng.r#gen());
+    let mut state: State<InMemoryDB> = State::new();
+
+    // Insert several outputs
+    for _ in 0..5 {
+        let coin = CoinInfo {
+            nonce: OsRng.r#gen(),
+            type_: ShieldedTokenType(OsRng.r#gen()),
+            value: OsRng.r#gen(),
+        };
+        let output = ZswapOutput::new_contract_owned(&mut rng, &coin, None, addr).unwrap();
+        let offer = Offer {
+            inputs: vec![].into(),
+            outputs: vec![output].into(),
+            transient: vec![].into(),
+            deltas: vec![].into(),
+        };
+        state = state.try_apply(&offer, None).unwrap().0;
+    }
+    state = state.post_block_update(Default::default());
+
+    // Simulate a broken deserialized state: collapse the ENTIRE used range
+    // INCLUDING first_free's position by collapsing 0..first_free (one past
+    // what filter() would do).
+    let bad_tree = state.coin_coms.collapse(0, state.first_free);
+    let bad_state = State {
+        coin_coms: bad_tree,
+        coin_coms_set: state.coin_coms_set.clone(),
+        first_free: state.first_free,
+        nullifiers: state.nullifiers.clone(),
+        past_roots: state.past_roots.clone(),
+    };
+
+    // Attempt to apply a new output — this crashes because update_hash
+    // tries to insert at first_free, which is now in a collapsed region.
+    let new_coin = CoinInfo {
+        nonce: OsRng.r#gen(),
+        type_: ShieldedTokenType(OsRng.r#gen()),
+        value: 100,
+    };
+    let new_output = ZswapOutput::new_contract_owned(&mut rng, &new_coin, None, addr).unwrap();
+    let new_offer = Offer {
+        inputs: vec![].into(),
+        outputs: vec![new_output].into(),
+        transient: vec![].into(),
+        deltas: vec![].into(),
+    };
+
+    // This should panic with "Attempted to insert into collapsed portion of Merkle tree!"
+    let _ = bad_state.try_apply(&new_offer, None);
+}
+
+/// Verifies that `try_apply` with a whitelist works correctly when an output
+/// is NOT on the whitelist. The output gets inserted then immediately collapsed,
+/// and a subsequent insert at the next position succeeds.
+///
+/// This tests the insert-then-collapse pattern in `apply_output` when
+/// `!on_whitelist(...)` is true, which is the normal code path for per-contract
+/// state tracking.
+#[test]
+fn try_apply_with_non_matching_whitelist_collapses_outputs() {
+    let mut rng = StdRng::seed_from_u64(0x42);
+    let addr_a = ContractAddress(OsRng.r#gen());
+    let addr_b = ContractAddress(OsRng.r#gen());
+    let mut state: State<InMemoryDB> = State::new();
+    state = state.post_block_update(Default::default());
+
+    // Create whitelist for contract A
+    let whitelist: Map<ContractAddress, ()> = Map::new().insert(addr_a, ());
+
+    // Apply an output for contract B (not on whitelist) — should be collapsed
+    let coin_b = CoinInfo {
+        nonce: OsRng.r#gen(),
+        type_: ShieldedTokenType(OsRng.r#gen()),
+        value: 200,
+    };
+    let output_b = ZswapOutput::new_contract_owned(&mut rng, &coin_b, None, addr_b).unwrap();
+    let offer_b = Offer {
+        inputs: vec![].into(),
+        outputs: vec![output_b].into(),
+        transient: vec![].into(),
+        deltas: vec![].into(),
+    };
+    let (state2, _) = state.try_apply(&offer_b, Some(whitelist.clone())).unwrap();
+
+    // Now apply an output for contract A (on whitelist) — should succeed
+    let coin_a = CoinInfo {
+        nonce: OsRng.r#gen(),
+        type_: ShieldedTokenType(OsRng.r#gen()),
+        value: 300,
+    };
+    let output_a = ZswapOutput::new_contract_owned(&mut rng, &coin_a, None, addr_a).unwrap();
+    let offer_a = Offer {
+        inputs: vec![].into(),
+        outputs: vec![output_a].into(),
+        transient: vec![].into(),
+        deltas: vec![].into(),
+    };
+    let result = state2.try_apply(&offer_a, Some(whitelist));
+    assert!(
+        result.is_ok(),
+        "try_apply should succeed even after prior outputs were collapsed by whitelist filtering"
     );
 }


### PR DESCRIPTION
## Summary

- Adds unit tests in `transient-crypto/src/merkle_tree.rs` and integration tests in `zswap/tests/state.rs` that document and reproduce the crash mechanism behind the WASM `RuntimeError: unreachable` observed in `ZswapChainState.tryApply()` when applied to states with collapsed Merkle trees
- The crash occurs when `update_hash` is called at a position within a collapsed subtree, triggering the panic at `merkle_tree.rs:853` ("Attempted to insert into collapsed portion of Merkle tree!")
- Tests cover: insert after full collapse, power-of-two boundaries, incremental insert-collapse pattern, filtered state with/without whitelist, and the specific failure case where `first_free` points into a collapsed region

## Test plan

- [x] All new unit tests pass: `cargo test -p midnight-transient-crypto`
- [x] All new integration tests pass: `cargo test -p midnight-zswap --test state`
- [x] Existing tests unaffected (pre-existing `test_proof_sizes` failure is unrelated — missing prover key file)

Related: midnightntwrk/midnight-js#535

🤖 Generated with [Claude Code](https://claude.com/claude-code)