### PR TITLE
fix: innately sorted

### DIFF
--- a/ledger/src/utils.rs
+++ b/ledger/src/utils.rs
@@ -41,12 +41,6 @@ impl<R: Read> CapturingReader<R> {
     }
 }
 
-pub(crate) fn sorted<T: Ord>(iter: impl Iterator<Item = T>) -> Vec<T> {
-    let mut res: Vec<T> = iter.collect();
-    res.sort();
-    res
-}
-
 pub(crate) trait SortedIter {
     type Item<'a>
     where


### PR DESCRIPTION
Usages of this collection were having to sort, so we may as well store in a sorted manner to prevent non-determinism from creeping in.