### PR TITLE
Add 'lastBlockTime' to 'CallContext' in WASM API

### DIFF
--- a/onchain-runtime-wasm/onchain-runtime-v3.d.ts
+++ b/onchain-runtime-wasm/onchain-runtime-v3.d.ts
@@ -302,6 +302,10 @@ export type CallContext = {
    * A public address identifying an entity.
    */
   caller?: PublicAddress,
+  /**
+   * The {@link secondsSinceEpoch} of the previous block
+   */
+  lastBlockTime: bigint,
 };
 /**
  * Context information about the block forwarded to {@link CallContext}.

--- a/storage/src/stress_test.rs
+++ b/storage/src/stress_test.rs
@@ -120,7 +120,7 @@ pub(crate) mod runner {
         ///   test fails. Note that this preserves the relative ordering /
         ///   interleaving of stdout and stderr.
         pub(crate) fn run_with_args(&self, test_name: &str, args: &[&str]) {
-            let pkg_name = env!("CARGO_PKG_NAME");
+            let pkg_name = "midnight-storage";
             let bin_name = "stress";
 
             println!("{test_name}: building stress-test runner ...");


### PR DESCRIPTION
The current `onchain-runtime-wasm` package exports a type declaration for `QueryContext`:

```
export class QueryContext {
   ...
  block: CallContext;
   ...
}
```

where `CallContext` is defined:

```
export type CallContext = {
  ownAddress: ContractAddress,
  /**
   * The commitment indices map accessible to the contract.
   */
  comIndices: Map<CoinCommitment, number>
  /**
   * The seconds since the UNIX epoch that have elapsed
   */
  secondsSinceEpoch: bigint,
  /**
   * The maximum error on {@link secondsSinceEpoch} that should occur, as a
   * positive seconds value
   */
  secondsSinceEpochErr: number,
  /**
   * The hash of the block prior to this transaction, as a hex-encoded string
   */
  parentBlockHash: string,
  /**
   * The balances held by the called contract at the time it was called.
   */
  balance: Map<TokenType, bigint>,
  /**
   * A public address identifying an entity.
   */
  caller?: PublicAddress,
};
```

Notice, there's no `lastBlockTime` field in `CallContext`.

We have a test in the Compact repository that executes an expression:

```
  context.currentQueryContext.block = {
    ownAddress: context.currentQueryContext.address,
    secondsSinceEpoch: 0n,
    secondsSinceEpochErr: 0,
    parentBlockHash: '0'.repeat(64),
    balance: new Map([[tokenType, initialBalance]]),
    comIndices: new Map(),
  };
```

The above expression throws:

```
Error: Error: missing field `lastBlockTime`
 ❯ __wbg_Error_e17e777aac105295 ../../../../../nix/store/h3334rdymn36g1f08nd8zyhij5a3a8ms--midnight-ntwrk-compact-runtime_0.14.102_node_modules/node_modules/@midnight-ntwrk/onchain-runtime-v3/midnight_onchain_runtime_wasm_bg.js:2502:17
 ❯ null.<anonymous> wasm:/wasm/00562b36:1:1253844
 ❯ null.<anonymous> wasm:/wasm/00562b36:1:783358
 ❯ null.<anonymous> wasm:/wasm/00562b36:1:1213422
 ❯ QueryContext.set block [as block] ../../../../../nix/store/h3334rdymn36g1f08nd8zyhij5a3a8ms--midnight-ntwrk-compact-runtime_0.14.102_node_modules/node_modules/@midnight-ntwrk/onchain-runtime-v3/midnight_onchain_runtime_wasm_bg.js:1811:26
 ❯ test.ts:1820:35
    1818|       } as const;
    1819|     
    1820|       context.currentQueryContext.block = {
       |                                   ^
    1821|         ownAddress: context.currentQueryContext.address,
    1822|         secondsSinceEpoch: 0n,

```

This means that WASM is expecting a `lastBlockTime` even though there's no `lastBlockTime` in the type definition of `CallContext`. This PR just adds the missing member declaration.