### PR TITLE
Fix zkir builds.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -394,7 +394,7 @@
               buildInputs = [
                 packages.public-params
               ];
-              cargoBuildFlags = "--package zkir --features binary";
+              cargoBuildFlags = "--package midnight-zkir --features binary";
               nativeBuildInputs = [
                 packages.rust-build-toolchain
               ];
@@ -420,7 +420,7 @@
               buildInputs = [
                 packages.public-params
               ];
-              cargoBuildFlags = "--package zkir-v3 --features binary";
+              cargoBuildFlags = "--package midnight-zkir-v3 --features binary";
               nativeBuildInputs = [
                 packages.rust-build-toolchain
               ];


### PR DESCRIPTION
The flake.nix packages broke due to changing the package names on publication to crates.io.