### PR TITLE
Reinstate Crates.io changes for v7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,6 +2802,7 @@ dependencies = [
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto",
+ "midnight-zkir",
  "midnight-zswap",
  "pastey",
  "proptest",
@@ -2816,7 +2817,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zeroize",
- "zkir",
 ]
 
 [[package]]
@@ -2974,6 +2974,7 @@ dependencies = [
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto",
+ "midnight-zkir",
  "midnight-zswap",
  "rand 0.8.5",
  "regex",
@@ -2987,7 +2988,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "zkir",
  "zkir-v3",
 ]
 
@@ -3184,6 +3184,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "midnight-zkir"
+version = "2.1.0"
+dependencies = [
+ "actix-rt",
+ "anyhow",
+ "clap",
+ "console",
+ "const-hex",
+ "env_logger",
+ "futures-executor",
+ "group",
+ "hex",
+ "indicatif",
+ "log",
+ "midnight-base-crypto",
+ "midnight-circuits",
+ "midnight-proofs",
+ "midnight-serialize",
+ "midnight-transient-crypto",
+ "midnight-zk-stdlib",
+ "midnight-zkir",
+ "pastey",
+ "proptest",
+ "proptest-derive",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "midnight-zkir-v3-wasm"
 version = "3.0.0-rc.1"
 dependencies = [
@@ -3208,10 +3243,10 @@ dependencies = [
  "js-sys",
  "midnight-serialize",
  "midnight-transient-crypto",
+ "midnight-zkir",
  "rand 0.8.5",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "zkir",
 ]
 
 [[package]]
@@ -3242,6 +3277,7 @@ dependencies = [
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto",
+ "midnight-zkir",
  "pastey",
  "rand 0.8.5",
  "rayon",
@@ -3251,7 +3287,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zeroize",
- "zkir",
 ]
 
 [[package]]
@@ -6042,41 +6077,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.44",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "zkir"
-version = "2.1.0"
-dependencies = [
- "actix-rt",
- "anyhow",
- "clap",
- "console",
- "const-hex",
- "env_logger",
- "futures-executor",
- "group",
- "hex",
- "indicatif",
- "log",
- "midnight-base-crypto",
- "midnight-circuits",
- "midnight-proofs",
- "midnight-serialize",
- "midnight-transient-crypto",
- "midnight-zk-stdlib",
- "pastey",
- "proptest",
- "proptest-derive",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "serde",
- "serde_bytes",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "zkir",
 ]
 
 [[package]]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -28,7 +28,7 @@ storage = { version = "1.0.0", path = "../storage", package = "midnight-storage"
 serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
 midnight-ledger-static = { version = "9.0.0", path = "../static", package = "midnight-ledger-static" }
 
-zkir_v2 = { version = "2.1.0", path = "../zkir", package = "zkir", optional = true }
+zkir_v2 = { version = "2.1.0", path = "../zkir", package = "midnight-zkir", optional = true }
 
 tokio = { version = "^1.46.1", features = ["rt", "macros"] }
 lazy_static = "^1.5.0"

--- a/proof-server/Cargo.toml
+++ b/proof-server/Cargo.toml
@@ -16,7 +16,7 @@ transient-crypto = { path = "../transient-crypto", package = "midnight-transient
 storage = { path = "../storage", package = "midnight-storage" }
 serialize = { path = "../serialize", package = "midnight-serialize" }
 
-zkir = { path = "../zkir", package = "zkir" }
+zkir = { path = "../zkir", package = "midnight-zkir" }
 zkir-v3 = { path = "../zkir-v3", optional = true }
 
 introspection = "0.1.0"

--- a/zkir-wasm/Cargo.toml
+++ b/zkir-wasm/Cargo.toml
@@ -12,7 +12,7 @@ proptest = []
 
 [dependencies]
 transient-crypto = { path = "../transient-crypto", package = "midnight-transient-crypto" }
-zkir = { path = "../zkir" }
+zkir = { path = "../zkir", package = "midnight-zkir" }
 serialize = { path = "../serialize", package = "midnight-serialize" }
 
 rand = { version = "^0.8.4", features = ["getrandom"] }

--- a/zkir/Cargo.toml
+++ b/zkir/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "zkir"
+name = "midnight-zkir"
 version = "2.1.0"
 edition = "2024"
 license.workspace = true
@@ -56,5 +56,5 @@ proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.5", optional = true }
 
 [dev-dependencies]
-zkir = { path = ".", features = ["proptest"] }
+zkir = { path = ".", features = ["proptest"], package = "midnight-zkir" }
 actix-rt = "^2.9.0"

--- a/zswap/Cargo.toml
+++ b/zswap/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "^1.0.219", features = ["derive"] }
 derive-where = "^1.5.0"
 
 [dev-dependencies]
-zkir_v2 = { path = "../zkir", package = "zkir" }
+zkir_v2 = { path = "../zkir", package = "midnight-zkir" }
 fake = { version = "^2.10.0", features = ["derive"] }
 rand = { version = "^0.8.4", features = ["getrandom"] }
 futures = "^0.3.31"

--- a/zswap/Cargo.toml
+++ b/zswap/Cargo.toml
@@ -11,13 +11,13 @@ default = ["proof-verifying"]
 proof-verifying = []
 
 [dependencies]
-base-crypto = { path = "../base-crypto", package = "midnight-base-crypto" }
-transient-crypto = { path = "../transient-crypto", package = "midnight-transient-crypto" }
-coin-structure = { path = "../coin-structure", package = "midnight-coin-structure" }
-storage = { path = "../storage", package = "midnight-storage" }
-serialize = { path = "../serialize", package = "midnight-serialize" }
-midnight-onchain-runtime = { path = "../onchain-runtime", package = "midnight-onchain-runtime", features = [ "vendored" ] }
-midnight-ledger-static = { path = "../static", package = "midnight-ledger-static" }
+base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
+transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto" }
+coin-structure = { version = "2.0.0", path = "../coin-structure", package = "midnight-coin-structure" }
+storage = { version = "1.0.0", path = "../storage", package = "midnight-storage" }
+serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
+midnight-onchain-runtime = { version = "2.0.0", path = "../onchain-runtime", package = "midnight-onchain-runtime", features = [ "vendored" ] }
+midnight-ledger-static = { version = "9.0.0", path = "../static", package = "midnight-ledger-static" }
 
 # rand 0.9.0 is not yet supported by some of our dependencies, we will
 # stick with 0.8.0 for now.


### PR DESCRIPTION
## Summary
- Rename the `zkir` crate from `zkir` to `midnight-zkir` for crates.io publishing
- Update all workspace references (`ledger`, `proof-server`, `zkir-wasm`, `zswap`) to use the new `midnight-zkir` package name
- Regenerate `Cargo.lock` to reflect the rename