### PR TITLE
chore: update Cargo.lock for rc.5 versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-ledger"
-version = "8.0.0-rc.4"
+version = "8.0.0-rc.5"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-ledger-wasm"
-version = "8.0.0-rc.4"
+version = "8.0.0-rc.5"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-proof-server"
-version = "8.0.0-rc.4"
+version = "8.0.0-rc.5"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-zswap"
-version = "8.0.0-rc.4"
+version = "8.0.0-rc.5"
 dependencies = [
  "criterion",
  "derive-where",


### PR DESCRIPTION
## Summary

Auto-generated lockfile update reflecting the rc.4 → rc.5 version bump for midnight-ledger, midnight-ledger-wasm, and midnight-proof-server.

## Changes

- `Cargo.lock`: version bumps from rc.4 to rc.5 for:
  - `midnight-ledger`
  - `midnight-ledger-wasm`
  - `midnight-proof-server`