### PR TITLE
Generalize `ecMul` in transient-crypto to support scalars over the Jubjub order

### DIFF
--- a/CHANGELOG_transient-crypto.md
+++ b/CHANGELOG_transient-crypto.md
@@ -1,5 +1,9 @@
 # `transient-crypto` Changelog
 
+## Version `2.0.1`
+
+- bug fix: generalize ecMul to support scalars over the Jubjub order
+
 ## Version `2.0.0`
 
 - breaking: pull in breaking midnight-zk changes

--- a/transient-crypto/src/fab.rs
+++ b/transient-crypto/src/fab.rs
@@ -18,7 +18,7 @@
 
 use std::iter::once;
 
-use crate::curve::{EmbeddedFr, EmbeddedGroupAffine};
+use crate::curve::{EmbeddedFr, EmbeddedGroupAffine, embedded};
 use crate::curve::{FR_BYTES, FR_BYTES_STORED, Fr};
 use crate::hash::transient_commit;
 use crate::merkle_tree::{MerklePath, MerkleTreeDigest};
@@ -169,7 +169,9 @@ impl TryFrom<&ValueAtom> for EmbeddedFr {
 
     fn try_from(value: &ValueAtom) -> Result<EmbeddedFr, InvalidBuiltinDecode> {
         if value.0.len() <= FR_BYTES {
-            EmbeddedFr::from_le_bytes(&value.0).ok_or(InvalidBuiltinDecode("EmbeddedFr"))
+            let mut bytes = [0u8; 64];
+            bytes[..32].copy_from_slice(&value.0);
+            Ok(EmbeddedFr(embedded::Scalar::from_bytes_wide(&bytes)))
         } else {
             Err(InvalidBuiltinDecode("EmbeddedFr"))
         }


### PR DESCRIPTION
Fixes https://github.com/midnightntwrk/midnight-security/issues/64

ZKIRv2 does not have types and thus the signature of function `ecMul` expects a "native" scalar (from BLS12-381) instead of a Jubjub scalar.

The internal functions for parsing native scalars as Jubjub scalars failed (before this PR) if the input was bigger than the Jubjub order. Some important use cases (such as verifying Schnorr signatures over Jubjub) require this cast to not fail.

This is not a breaking change for the ledger.