### PR TITLE
feat: parity-db log pipeline processing trigger

### DIFF
--- a/storage-core/Cargo.toml
+++ b/storage-core/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 
 proptest = ["dep:proptest", "dep:proptest-derive", "base-crypto/proptest"]
 sqlite = ["dep:rusqlite", "dep:r2d2_sqlite", "dep:r2d2", "dep:fs2"]
-parity-db = ["dep:parity-db"]
+parity-db = ["dep:parity-db", "parity-db/instrumentation"]
 bench = ["dep:criterion", "dep:pprof"]
 public-internal-structure = []
 state-translation = ["public-internal-structure", "dep:hashbrown"]

--- a/storage-core/src/backend.rs
+++ b/storage-core/src/backend.rs
@@ -915,6 +915,11 @@ impl<D: DB> StorageBackend<D> {
         culled.len()
     }
 
+    /// Drive the underlying DB log-processing pipeline, if supported.
+    pub fn run_log_pipeline(&self) {
+        self.database.run_log_pipeline();
+    }
+
     /// Remove all unreachable nodes from memory and the DB.
     ///
     /// Here "unreachable" nodes are nodes with `ref_count == 0` and `root_count

--- a/storage-core/src/backend.rs
+++ b/storage-core/src/backend.rs
@@ -915,9 +915,9 @@ impl<D: DB> StorageBackend<D> {
         culled.len()
     }
 
-    /// Drive the underlying DB log-processing pipeline, if supported.
-    pub fn run_log_pipeline(&self) {
-        self.database.run_log_pipeline();
+    /// Flush the underlying DB log-processing pipeline, if supported.
+    pub fn flush_log_pipeline(&self) {
+        self.database.flush_log_pipeline();
     }
 
     /// Remove all unreachable nodes from memory and the DB.

--- a/storage-core/src/db.rs
+++ b/storage-core/src/db.rs
@@ -148,10 +148,10 @@ pub trait DB: Default + Sync + Send + Debug + DummyArbitrary + 'static {
     where
         I: Iterator<Item = (ArenaHash<Self::Hasher>, Update<Self::Hasher>)>;
 
-    /// Run the DB's internal log processing pipeline, if any.
+    /// Flush the DB's internal log processing pipeline, if any.
     ///
     /// Backends without a background log pipeline can keep this default no-op.
-    fn run_log_pipeline(&self) {}
+    fn flush_log_pipeline(&self) {}
 
     /// Batch get nodes.
     ///

--- a/storage-core/src/db.rs
+++ b/storage-core/src/db.rs
@@ -148,6 +148,11 @@ pub trait DB: Default + Sync + Send + Debug + DummyArbitrary + 'static {
     where
         I: Iterator<Item = (ArenaHash<Self::Hasher>, Update<Self::Hasher>)>;
 
+    /// Run the DB's internal log processing pipeline, if any.
+    ///
+    /// Backends without a background log pipeline can keep this default no-op.
+    fn run_log_pipeline(&self) {}
+
     /// Batch get nodes.
     ///
     /// For `DB`s that use expensive transactions, implementors should combine

--- a/storage-core/src/db/paritydb.rs
+++ b/storage-core/src/db/paritydb.rs
@@ -248,6 +248,16 @@ impl<H: WellBehavedHasher> DB for ParityDb<H> {
         self.db.commit_changes(ops).expect("Failed to commit to db");
     }
 
+    fn run_log_pipeline(&self) {
+        self.db
+            .process_commits()
+            .expect("Failed to process ParityDB commit queue");
+        self.db.flush_logs().expect("Failed to flush ParityDB logs");
+        self.db
+            .enact_logs()
+            .expect("Failed to enact ParityDB logs");
+    }
+
     fn batch_get_nodes<I>(
         &self,
         keys: I,

--- a/storage-core/src/db/paritydb.rs
+++ b/storage-core/src/db/paritydb.rs
@@ -248,7 +248,7 @@ impl<H: WellBehavedHasher> DB for ParityDb<H> {
         self.db.commit_changes(ops).expect("Failed to commit to db");
     }
 
-    fn run_log_pipeline(&self) {
+    fn flush_log_pipeline(&self) {
         self.db
             .process_commits()
             .expect("Failed to process ParityDB commit queue");

--- a/storage-core/src/storage.rs
+++ b/storage-core/src/storage.rs
@@ -311,8 +311,8 @@ impl<D: DB, T: Sync + Send + 'static> DB for WrappedDB<D, T> {
         self.db.batch_update(iter)
     }
 
-    fn run_log_pipeline(&self) {
-        self.db.run_log_pipeline()
+    fn flush_log_pipeline(&self) {
+        self.db.flush_log_pipeline()
     }
 
     fn batch_get_nodes<I>(

--- a/storage-core/src/storage.rs
+++ b/storage-core/src/storage.rs
@@ -311,6 +311,10 @@ impl<D: DB, T: Sync + Send + 'static> DB for WrappedDB<D, T> {
         self.db.batch_update(iter)
     }
 
+    fn run_log_pipeline(&self) {
+        self.db.run_log_pipeline()
+    }
+
     fn batch_get_nodes<I>(
         &self,
         keys: I,


### PR DESCRIPTION
## Summary
- Add `run_log_pipeline()` method to the `DB` trait and `StorageBackend` to drive ParityDB's internal log processing pipeline on demand
- Implement `run_log_pipeline()` for the ParityDB backend, calling `process_commits()`, `flush_logs()`, and `enact_logs()` in sequence
- Enable the `parity-db/instrumentation` feature flag for the parity-db feature
- Thread `run_log_pipeline()` through `WrappedDB` delegation