### PR TITLE
Add new Wasm API methods to set a guaranteed and fallible offers

### DIFF
--- a/integration-tests/src/test/no-proving/Intent.test.ts
+++ b/integration-tests/src/test/no-proving/Intent.test.ts
@@ -719,6 +719,11 @@ describe('Ledger API - Intent', () => {
     const deployIntent = intent.addDeploy(contractDeploy);
     expect(() => tx.addIntent(segment, deployIntent)).toThrowError();
 
+    const intentWithOffer = Intent.new(TTL);
+    const fallibleOffer = getNewUnshieldedOffer();
+    intentWithOffer.fallibleUnshieldedOffer = fallibleOffer;
+    expect(() => tx.addIntent(segment, intentWithOffer)).toThrowError();
+
     expect(tx.intents).toBeDefined();
     expect(tx.intents!.size).toBe(1);
     const key = [...tx.intents!.keys()][0];

--- a/integration-tests/src/test/no-proving/Intent.test.ts
+++ b/integration-tests/src/test/no-proving/Intent.test.ts
@@ -717,7 +717,7 @@ describe('Ledger API - Intent', () => {
     expect(tx.intents).toBeDefined();
     expect(tx.intents!.size).toBe(1);
     expect(tx.intents!.has(0)).toBe(true);
-    expect(tx.intents!.get(0)).toEqual(intent);
+    expect(tx.intents!.get(0)!.toString()).toEqual(intent.toString());
   });
 
   /**
@@ -737,7 +737,7 @@ describe('Ledger API - Intent', () => {
     expect(tx.intents).toBeDefined();
     expect(tx.intents!.size).toBe(1);
     expect(tx.intents!.has(1)).toBe(true);
-    expect(tx.intents!.get(1)).toEqual(intent);
+    expect(tx.intents!.get(1)!.toString()).toEqual(intent.toString());
   });
 
   /**
@@ -757,7 +757,7 @@ describe('Ledger API - Intent', () => {
     expect(tx.intents).toBeDefined();
     expect(tx.intents!.size).toBe(1);
     expect(tx.intents!.has(5)).toBe(true);
-    expect(tx.intents!.get(5)).toEqual(intent);
+    expect(tx.intents!.get(5)!.toString()).toEqual(intent.toString());
   });
 
   /**

--- a/integration-tests/src/test/no-proving/Intent.test.ts
+++ b/integration-tests/src/test/no-proving/Intent.test.ts
@@ -800,8 +800,7 @@ describe('Ledger API - Intent', () => {
     expect(tx.intents!.has(1)).toBe(true);
 
     tx = tx.addIntent(segment, undefined);
-    expect(tx.intents).toBeDefined();
-    expect(tx.intents!.has(1)).toBe(false);
+    expect(tx.intents).toBeUndefined();
   });
 
   /**

--- a/integration-tests/src/test/no-proving/Intent.test.ts
+++ b/integration-tests/src/test/no-proving/Intent.test.ts
@@ -714,6 +714,11 @@ describe('Ledger API - Intent', () => {
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
     tx = tx.addIntent(segment, intent);
 
+    // verify we can't add intent with fallible transcripts, fallible offers, or contract deployments present
+    const contractDeploy = new ContractDeploy(new ContractState());
+    const deployIntent = intent.addDeploy(contractDeploy);
+    expect(() => tx.addIntent(segment, deployIntent)).toThrowError();
+
     expect(tx.intents).toBeDefined();
     expect(tx.intents!.size).toBe(1);
     const key = [...tx.intents!.keys()][0];

--- a/integration-tests/src/test/no-proving/Intent.test.ts
+++ b/integration-tests/src/test/no-proving/Intent.test.ts
@@ -706,7 +706,7 @@ describe('Ledger API - Intent', () => {
    *
    * @given A transaction and an intent
    * @when Adding intent to segment using GuaranteedOnly specifier
-   * @then Should add intent to segment 0 (guaranteed segment)
+   * @then Should add intent to segment > 1
    */
   test('should add intent to transaction using addIntent with GuaranteedOnly', () => {
     const intent = Intent.new(TTL);
@@ -716,8 +716,8 @@ describe('Ledger API - Intent', () => {
 
     expect(tx.intents).toBeDefined();
     expect(tx.intents!.size).toBe(1);
-    expect(tx.intents!.has(0)).toBe(true);
-    expect(tx.intents!.get(0)!.toString()).toEqual(intent.toString());
+    const key = [...tx.intents!.keys()][0];
+    expect(tx.intents!.get(key)!.toString()).toEqual(intent.toString());
   });
 
   /**
@@ -744,14 +744,17 @@ describe('Ledger API - Intent', () => {
    * Test adding intent to transaction using Specific segment specifier.
    *
    * @given A transaction and an intent
-   * @when Adding intent to segment using Specific specifier with value 5
-   * @then Should add intent to segment 5
+   * @when Adding intent to segment using Specific specifier with value > 0
+   * @then Should add intent to a specified segment
    */
   test('should add intent to transaction using addIntent with Specific segment', () => {
     const intent = Intent.new(TTL);
+    const zeroSegment: SegmentSpecifier = { tag: 'specific', value: 0 };
     const segment: SegmentSpecifier = { tag: 'specific', value: 5 };
 
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    expect(() => tx.addIntent(zeroSegment, intent)).toThrowError();
+
     tx = tx.addIntent(segment, intent);
 
     expect(tx.intents).toBeDefined();
@@ -764,22 +767,19 @@ describe('Ledger API - Intent', () => {
    * Test adding multiple intents to different segments.
    *
    * @given A transaction and multiple intents
-   * @when Adding intents to segments 0, 1, and 3
+   * @when Adding intents to segments 1, and 3
    * @then Should have intents in all specified segments
    */
   test('should add multiple intents to different segments', () => {
     const intent1 = Intent.new(TTL);
     const intent2 = Intent.new(TTL);
-    const intent3 = Intent.new(TTL);
 
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    tx = tx.addIntent({ tag: 'guaranteedOnly' }, intent1);
-    tx = tx.addIntent({ tag: 'first' }, intent2);
-    tx = tx.addIntent({ tag: 'specific', value: 3 }, intent3);
+    tx = tx.addIntent({ tag: 'first' }, intent1);
+    tx = tx.addIntent({ tag: 'specific', value: 3 }, intent2);
 
     expect(tx.intents).toBeDefined();
-    expect(tx.intents!.size).toBe(3);
-    expect(tx.intents!.has(0)).toBe(true);
+    expect(tx.intents!.size).toBe(2);
     expect(tx.intents!.has(1)).toBe(true);
     expect(tx.intents!.has(3)).toBe(true);
   });

--- a/integration-tests/src/test/no-proving/Intent.test.ts
+++ b/integration-tests/src/test/no-proving/Intent.test.ts
@@ -23,10 +23,12 @@ import {
   type PreBinding,
   sampleIntentHash,
   sampleUserAddress,
+  Transaction,
   UnshieldedOffer,
-  VerifierKeyRemove
+  VerifierKeyRemove,
+  type SegmentSpecifier
 } from '@midnight-ntwrk/ledger';
-import { getNewUnshieldedOffer, Random, Static } from '@/test-objects';
+import { getNewUnshieldedOffer, LOCAL_TEST_NETWORK_ID, Random, Static } from '@/test-objects';
 
 describe('Ledger API - Intent', () => {
   const TTL = new Date();
@@ -697,6 +699,132 @@ describe('Ledger API - Intent', () => {
     expect(deserialized.guaranteedUnshieldedOffer?.outputs.length).toEqual(2);
     expect(deserialized.fallibleUnshieldedOffer?.inputs.length).toEqual(2);
     expect(deserialized.fallibleUnshieldedOffer?.outputs.length).toEqual(2);
+  });
+
+  /**
+   * Test adding intent to transaction using addIntent method.
+   *
+   * @given A transaction and an intent
+   * @when Adding intent to segment using GuaranteedOnly specifier
+   * @then Should add intent to segment 0 (guaranteed segment)
+   */
+  test('should add intent to transaction using addIntent with GuaranteedOnly', () => {
+    const intent = Intent.new(TTL);
+    const segment: SegmentSpecifier = { tag: 'guaranteedOnly' };
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addIntent(segment, intent);
+
+    expect(tx.intents).toBeDefined();
+    expect(tx.intents!.size).toBe(1);
+    expect(tx.intents!.has(0)).toBe(true);
+    expect(tx.intents!.get(0)).toEqual(intent);
+  });
+
+  /**
+   * Test adding intent to transaction using First segment specifier.
+   *
+   * @given A transaction and an intent
+   * @when Adding intent to segment using First specifier
+   * @then Should add intent to segment 1
+   */
+  test('should add intent to transaction using addIntent with First', () => {
+    const intent = Intent.new(TTL);
+    const segment: SegmentSpecifier = { tag: 'first' };
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addIntent(segment, intent);
+
+    expect(tx.intents).toBeDefined();
+    expect(tx.intents!.size).toBe(1);
+    expect(tx.intents!.has(1)).toBe(true);
+    expect(tx.intents!.get(1)).toEqual(intent);
+  });
+
+  /**
+   * Test adding intent to transaction using Specific segment specifier.
+   *
+   * @given A transaction and an intent
+   * @when Adding intent to segment using Specific specifier with value 5
+   * @then Should add intent to segment 5
+   */
+  test('should add intent to transaction using addIntent with Specific segment', () => {
+    const intent = Intent.new(TTL);
+    const segment: SegmentSpecifier = { tag: 'specific', value: 5 };
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addIntent(segment, intent);
+
+    expect(tx.intents).toBeDefined();
+    expect(tx.intents!.size).toBe(1);
+    expect(tx.intents!.has(5)).toBe(true);
+    expect(tx.intents!.get(5)).toEqual(intent);
+  });
+
+  /**
+   * Test adding multiple intents to different segments.
+   *
+   * @given A transaction and multiple intents
+   * @when Adding intents to segments 0, 1, and 3
+   * @then Should have intents in all specified segments
+   */
+  test('should add multiple intents to different segments', () => {
+    const intent1 = Intent.new(TTL);
+    const intent2 = Intent.new(TTL);
+    const intent3 = Intent.new(TTL);
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addIntent({ tag: 'guaranteedOnly' }, intent1);
+    tx = tx.addIntent({ tag: 'first' }, intent2);
+    tx = tx.addIntent({ tag: 'specific', value: 3 }, intent3);
+
+    expect(tx.intents).toBeDefined();
+    expect(tx.intents!.size).toBe(3);
+    expect(tx.intents!.has(0)).toBe(true);
+    expect(tx.intents!.has(1)).toBe(true);
+    expect(tx.intents!.has(3)).toBe(true);
+  });
+
+  /**
+   * Test removing intent from a transaction by passing undefined.
+   *
+   * @given A transaction with intent in segment 1
+   * @when Adding undefined intent to the same segment
+   * @then Should remove the intent from that segment
+   */
+  test('should remove intent from transaction when passing undefined', () => {
+    const intent = Intent.new(TTL);
+    const segment: SegmentSpecifier = { tag: 'first' };
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addIntent(segment, intent);
+    expect(tx.intents!.has(1)).toBe(true);
+
+    tx = tx.addIntent(segment, undefined);
+    expect(tx.intents).toBeDefined();
+    expect(tx.intents!.has(1)).toBe(false);
+  });
+
+  /**
+   * Test adding intent using Random segment specifier.
+   *
+   * @given A transaction and an intent
+   * @when Adding intent using Random specifier
+   * @then Should add intent to a random segment between 2 and 65535
+   */
+  test('should add intent to random segment using addIntent with Random', () => {
+    const intent = Intent.new(TTL);
+    const segment: SegmentSpecifier = { tag: 'random' };
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addIntent(segment, intent);
+
+    expect(tx.intents).toBeDefined();
+    expect(tx.intents!.size).toBe(1);
+
+    // Check that the segment is in valid range [2, 65535)
+    const segments = Array.from(tx.intents!.keys());
+    expect(segments[0]).toBeGreaterThanOrEqual(2);
+    expect(segments[0]).toBeLessThan(65535);
   });
 
   /**

--- a/integration-tests/src/test/no-proving/Transaction.test.ts
+++ b/integration-tests/src/test/no-proving/Transaction.test.ts
@@ -1247,21 +1247,6 @@ describe('Ledger API - Transaction', () => {
   });
 
   /**
-   * Test error when trying to add offer with segment 0 using Specific specifier.
-   *
-   * @given A transaction and an offer
-   * @when Attempting to add offer with Specific segment value 0
-   * @then Should throw error about illegal specification of segment 0
-   */
-  test('should throw error when adding offer with Specific segment 0', () => {
-    const offer = Static.unprovenOfferFromOutput(0);
-    const segment: SegmentSpecifier = { tag: 'specific', value: 0 };
-
-    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    expect(() => tx.addZswapOffer(segment, offer)).toThrow('illegal manual specification of segment 0');
-  });
-
-  /**
    * Test adding offer using Random segment specifier.
    *
    * @given A transaction and an offer

--- a/integration-tests/src/test/no-proving/Transaction.test.ts
+++ b/integration-tests/src/test/no-proving/Transaction.test.ts
@@ -1257,7 +1257,7 @@ describe('Ledger API - Transaction', () => {
     const offer = Static.unprovenOfferFromOutput(0);
     const segment: SegmentSpecifier = { tag: 'specific', value: 0 };
 
-    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
     expect(() => tx.addOffer(segment, offer)).toThrow('illegal manual specification of segment 0');
   });
 

--- a/integration-tests/src/test/no-proving/Transaction.test.ts
+++ b/integration-tests/src/test/no-proving/Transaction.test.ts
@@ -1243,8 +1243,7 @@ describe('Ledger API - Transaction', () => {
     expect(tx.fallibleOffer!.has(1)).toBe(true);
 
     tx = tx.addOffer(segment, undefined);
-    expect(tx.fallibleOffer).toBeDefined();
-    expect(tx.fallibleOffer!.has(1)).toBe(false);
+    expect(tx.fallibleOffer).toBeUndefined();
   });
 
   /**

--- a/integration-tests/src/test/no-proving/Transaction.test.ts
+++ b/integration-tests/src/test/no-proving/Transaction.test.ts
@@ -1151,17 +1151,17 @@ describe('Ledger API - Transaction', () => {
   });
 
   /**
-   * Test adding offer to transaction using addOffer with GuaranteedOnly.
+   * Test adding offer to transaction using addZswapOffer with GuaranteedOnly.
    *
    * @given A transaction and an unshielded offer
    * @when Adding offer using GuaranteedOnly specifier
    * @then Should set the guaranteed offer on the transaction
    */
-  test('should add offer to transaction using addOffer with GuaranteedOnly', () => {
+  test('should add offer to transaction using addZswapOffer with GuaranteedOnly', () => {
     const offer = Static.unprovenOfferFromOutput(0);
 
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    tx = tx.addOffer(GUARANTEED_ONLY_SPECIFIER, offer);
+    tx = tx.addZswapOffer(GUARANTEED_ONLY_SPECIFIER, offer);
 
     expect(tx.guaranteedOffer).toBeDefined();
     expect(tx.guaranteedOffer?.toString()).toEqual(offer.toString());
@@ -1174,11 +1174,11 @@ describe('Ledger API - Transaction', () => {
    * @when Adding offer using First specifier
    * @then Should add offer to fallible segment 1
    */
-  test('should add offer to transaction using addOffer with First', () => {
+  test('should add offer to transaction using addZswapOffer with First', () => {
     const offer = Static.unprovenOfferFromOutput(1);
 
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    tx = tx.addOffer(FIRST_SEGMENT_SPECIFIER, offer);
+    tx = tx.addZswapOffer(FIRST_SEGMENT_SPECIFIER, offer);
 
     expect(tx.fallibleOffer).toBeDefined();
     expect(tx.fallibleOffer!.size).toBe(1);
@@ -1192,11 +1192,11 @@ describe('Ledger API - Transaction', () => {
    * @when Adding offer using Specific specifier with value 2
    * @then Should add offer to fallible segment 2
    */
-  test('should add offer to transaction using addOffer with Specific segment', () => {
+  test('should add offer to transaction using addZswapOffer with Specific segment', () => {
     const offer = Static.unprovenOfferFromOutput(2);
 
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    tx = tx.addOffer(SPECIFIC_VALUE_SPECIFIER, offer);
+    tx = tx.addZswapOffer(SPECIFIC_VALUE_SPECIFIER, offer);
 
     expect(tx.fallibleOffer).toBeDefined();
     expect(tx.fallibleOffer!.size).toBe(1);
@@ -1216,9 +1216,9 @@ describe('Ledger API - Transaction', () => {
     const offer3 = Static.unprovenOfferFromOutput(10);
 
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    tx = tx.addOffer({ tag: 'guaranteedOnly' }, offer1);
-    tx = tx.addOffer({ tag: 'first' }, offer2);
-    tx = tx.addOffer({ tag: 'specific', value: 10 }, offer3);
+    tx = tx.addZswapOffer({ tag: 'guaranteedOnly' }, offer1);
+    tx = tx.addZswapOffer({ tag: 'first' }, offer2);
+    tx = tx.addZswapOffer({ tag: 'specific', value: 10 }, offer3);
 
     expect(tx.guaranteedOffer).toBeDefined();
     expect(tx.fallibleOffer).toBeDefined();
@@ -1239,10 +1239,10 @@ describe('Ledger API - Transaction', () => {
     const segment: SegmentSpecifier = { tag: 'first' };
 
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    tx = tx.addOffer(segment, offer);
+    tx = tx.addZswapOffer(segment, offer);
     expect(tx.fallibleOffer!.has(1)).toBe(true);
 
-    tx = tx.addOffer(segment, undefined);
+    tx = tx.addZswapOffer(segment, undefined);
     expect(tx.fallibleOffer).toBeUndefined();
   });
 
@@ -1258,7 +1258,7 @@ describe('Ledger API - Transaction', () => {
     const segment: SegmentSpecifier = { tag: 'specific', value: 0 };
 
     const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    expect(() => tx.addOffer(segment, offer)).toThrow('illegal manual specification of segment 0');
+    expect(() => tx.addZswapOffer(segment, offer)).toThrow('illegal manual specification of segment 0');
   });
 
   /**
@@ -1268,12 +1268,12 @@ describe('Ledger API - Transaction', () => {
    * @when Adding offer using Random specifier
    * @then Should add offer to a random fallible segment between 2 and 65535
    */
-  test('should add offer to random segment using addOffer with Random', () => {
+  test('should add offer to random segment using addZswapOffer with Random', () => {
     const offer = Static.unprovenOfferFromOutput(10);
     const segment: SegmentSpecifier = { tag: 'random' };
 
     let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
-    tx = tx.addOffer(segment, offer);
+    tx = tx.addZswapOffer(segment, offer);
 
     expect(tx.fallibleOffer).toBeDefined();
     expect(tx.fallibleOffer!.size).toBe(1);

--- a/integration-tests/src/test/no-proving/Transaction.test.ts
+++ b/integration-tests/src/test/no-proving/Transaction.test.ts
@@ -1150,6 +1150,141 @@ describe('Ledger API - Transaction', () => {
     expect(tx2.fallibleOffer!.size).toBe(1);
   });
 
+  /**
+   * Test adding offer to transaction using addOffer with GuaranteedOnly.
+   *
+   * @given A transaction and an unshielded offer
+   * @when Adding offer using GuaranteedOnly specifier
+   * @then Should set the guaranteed offer on the transaction
+   */
+  test('should add offer to transaction using addOffer with GuaranteedOnly', () => {
+    const offer = Static.unprovenOfferFromOutput(0);
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addOffer(GUARANTEED_ONLY_SPECIFIER, offer);
+
+    expect(tx.guaranteedOffer).toBeDefined();
+    expect(tx.guaranteedOffer?.toString()).toEqual(offer.toString());
+  });
+
+  /**
+   * Test adding offer to a fallible segment using First specifier.
+   *
+   * @given A transaction and an unshielded offer
+   * @when Adding offer using First specifier
+   * @then Should add offer to fallible segment 1
+   */
+  test('should add offer to transaction using addOffer with First', () => {
+    const offer = Static.unprovenOfferFromOutput(1);
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addOffer(FIRST_SEGMENT_SPECIFIER, offer);
+
+    expect(tx.fallibleOffer).toBeDefined();
+    expect(tx.fallibleOffer!.size).toBe(1);
+    expect(tx.fallibleOffer!.has(1)).toBe(true);
+  });
+
+  /**
+   * Test adding offer to a specific fallible segment.
+   *
+   * @given A transaction and an unshielded offer
+   * @when Adding offer using Specific specifier with value 2
+   * @then Should add offer to fallible segment 2
+   */
+  test('should add offer to transaction using addOffer with Specific segment', () => {
+    const offer = Static.unprovenOfferFromOutput(2);
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addOffer(SPECIFIC_VALUE_SPECIFIER, offer);
+
+    expect(tx.fallibleOffer).toBeDefined();
+    expect(tx.fallibleOffer!.size).toBe(1);
+    expect(tx.fallibleOffer!.has(2)).toBe(true);
+  });
+
+  /**
+   * Test adding multiple offers to different segments.
+   *
+   * @given A transaction and multiple offers
+   * @when Adding offers to guaranteed and multiple fallible segments
+   * @then Should have offers in all specified segments
+   */
+  test('should add multiple offers to different segments', () => {
+    const offer1 = Static.unprovenOfferFromOutput(0);
+    const offer2 = Static.unprovenOfferFromOutput(1);
+    const offer3 = Static.unprovenOfferFromOutput(10);
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addOffer({ tag: 'guaranteedOnly' }, offer1);
+    tx = tx.addOffer({ tag: 'first' }, offer2);
+    tx = tx.addOffer({ tag: 'specific', value: 10 }, offer3);
+
+    expect(tx.guaranteedOffer).toBeDefined();
+    expect(tx.fallibleOffer).toBeDefined();
+    expect(tx.fallibleOffer!.size).toBe(2);
+    expect(tx.fallibleOffer!.has(1)).toBe(true);
+    expect(tx.fallibleOffer!.has(10)).toBe(true);
+  });
+
+  /**
+   * Test removing offer from fallible segment by passing undefined.
+   *
+   * @given A transaction with an offer in fallible segment 1
+   * @when Adding undefined offer to the same segment
+   * @then Should remove the offer from that segment
+   */
+  test('should remove offer from fallible segment when passing undefined', () => {
+    const offer = Static.unprovenOfferFromOutput(1);
+    const segment: SegmentSpecifier = { tag: 'first' };
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addOffer(segment, offer);
+    expect(tx.fallibleOffer!.has(1)).toBe(true);
+
+    tx = tx.addOffer(segment, undefined);
+    expect(tx.fallibleOffer).toBeDefined();
+    expect(tx.fallibleOffer!.has(1)).toBe(false);
+  });
+
+  /**
+   * Test error when trying to add offer with segment 0 using Specific specifier.
+   *
+   * @given A transaction and an offer
+   * @when Attempting to add offer with Specific segment value 0
+   * @then Should throw error about illegal specification of segment 0
+   */
+  test('should throw error when adding offer with Specific segment 0', () => {
+    const offer = Static.unprovenOfferFromOutput(0);
+    const segment: SegmentSpecifier = { tag: 'specific', value: 0 };
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    expect(() => tx.addOffer(segment, offer)).toThrow('illegal manual specification of segment 0');
+  });
+
+  /**
+   * Test adding offer using Random segment specifier.
+   *
+   * @given A transaction and an offer
+   * @when Adding offer using Random specifier
+   * @then Should add offer to a random fallible segment between 2 and 65535
+   */
+  test('should add offer to random segment using addOffer with Random', () => {
+    const offer = Static.unprovenOfferFromOutput(10);
+    const segment: SegmentSpecifier = { tag: 'random' };
+
+    let tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID);
+    tx = tx.addOffer(segment, offer);
+
+    expect(tx.fallibleOffer).toBeDefined();
+    expect(tx.fallibleOffer!.size).toBe(1);
+
+    // Check that the segment is in valid range [2, 65535)
+    const segments = Array.from(tx.fallibleOffer!.keys());
+    expect(segments[0]).toBeGreaterThanOrEqual(2);
+    expect(segments[0]).toBeLessThan(65535);
+  });
+
   function testSpecificSegment(segment: SegmentSpecifier, expectedSegment?: number) {
     const { state, addr, encodedAddr, op, token, unbalancedStrictness, balancedStrictness } = setup();
 

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -1253,7 +1253,7 @@ export class Transaction<S extends Signaturish, P extends Proofish, B extends Bi
    *
    * @throws If called on bound transactions.
    */
-  addOffer(
+  addZswapOffer(
     segment: SegmentSpecifier,
     offer: UnprovenOffer | undefined,
   ): Transaction<S, P, B>;

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -1171,7 +1171,7 @@ export class Transaction<S extends Signaturish, P extends Proofish, B extends Bi
   ): Transaction<S, P, B>;
 
   /**
-   * Adds a provided offer to the segment specified.
+   * Adds Zswap offer to the segment specified.
    *
    * @throws If called on bound transactions.
    */

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -1145,21 +1145,12 @@ export class Transaction<S extends Signaturish, P extends Proofish, B extends Bi
   ): Transaction<S, P, B>;
 
   /**
-   * Sets a provided guaranteed offer.
+   * Adds a provided offer to the segment specified.
    *
    * @throws If called on bound, proven, or proof-erased transactions.
    */
-  setGuaranteedOffer(
-    offer: UnprovenOffer | undefined,
-  ): Transaction<S, P, B>;
-
-  /**
-   * Sets a provided fallible offer to the segment specified.
-   *
-   * @throws If called on bound, proven, or proof-erased transactions.
-   */
-  setFallibleOffer(
-    segment: number,
+  addOffer(
+    segment: SegmentSpecifier,
     offer: UnprovenOffer | undefined,
   ): Transaction<S, P, B>;
 

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -1145,6 +1145,25 @@ export class Transaction<S extends Signaturish, P extends Proofish, B extends Bi
   ): Transaction<S, P, B>;
 
   /**
+   * Sets a provided guaranteed offer.
+   *
+   * @throws If called on bound, proven, or proof-erased transactions.
+   */
+  setGuaranteedOffer(
+    offer: UnprovenOffer | undefined,
+  ): Transaction<S, P, B>;
+
+  /**
+   * Sets a provided fallible offer to the segment specified.
+   *
+   * @throws If called on bound, proven, or proof-erased transactions.
+   */
+  setFallibleOffer(
+    segment: number,
+    offer: UnprovenOffer | undefined,
+  ): Transaction<S, P, B>;
+
+  /**
    * Erases the proofs contained in this transaction
    */
   eraseProofs(): Transaction<S, NoProof, NoBinding>;

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -1147,11 +1147,21 @@ export class Transaction<S extends Signaturish, P extends Proofish, B extends Bi
   /**
    * Adds a provided offer to the segment specified.
    *
-   * @throws If called on bound, proven, or proof-erased transactions.
+   * @throws If called on bound transactions.
    */
   addOffer(
     segment: SegmentSpecifier,
     offer: UnprovenOffer | undefined,
+  ): Transaction<S, P, B>;
+
+  /**
+   * Adds provided intent to the segment specified.
+   *
+   * @throws If called on bound transactions.
+   */
+  addIntent(
+    segment: SegmentSpecifier,
+    intent: Intent<S, P, B> | undefined,
   ): Transaction<S, P, B>;
 
   /**

--- a/ledger-wasm/src/intent.rs
+++ b/ledger-wasm/src/intent.rs
@@ -18,7 +18,9 @@ use crate::unshielded::UnshieldedOffer;
 use base_crypto::signatures::Signature;
 use base_crypto::time::Timestamp;
 use js_sys::{Date, Uint8Array};
-use ledger::structure::{ErasedIntent, Intent as LedgerIntent, ProofMarker, ProofPreimageMarker};
+use ledger::structure::{
+    ContractAction, ErasedIntent, Intent as LedgerIntent, ProofMarker, ProofPreimageMarker,
+};
 use onchain_runtime_wasm::from_value_ser;
 use serialize::tagged_serialize;
 use std::ops::Deref;
@@ -1180,5 +1182,24 @@ impl Intent {
                 JsValue::from(NoBinding(val.binding_commitment))
             }
         })
+    }
+
+    pub fn has_contract_deployments(&self) -> bool {
+        self.0
+            .as_erased()
+            .actions
+            .iter()
+            .any(|action| matches!(*action, ContractAction::Deploy(_)))
+    }
+
+    pub fn has_fallible_transcripts(&self) -> bool {
+        self.0.as_erased()
+            .actions
+            .iter()
+            .any(|action| matches!(&*action, ContractAction::Call(call) if call.fallible_transcript.is_some()))
+    }
+
+    pub fn has_fallible_offers(&self) -> bool {
+        self.0.as_erased().fallible_unshielded_offer.is_some()
     }
 }

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -841,7 +841,7 @@ impl Transaction {
         Ok(())
     }
 
-    #[wasm_bindgen(setter, js_name = "addOffer")]
+    #[wasm_bindgen(js_name = "addOffer")]
     pub fn add_offer(
         &mut self,
         segment: JsValue,
@@ -1038,7 +1038,7 @@ impl Transaction {
         }
     }
 
-    #[wasm_bindgen(setter, js_name = "addIntent")]
+    #[wasm_bindgen(js_name = "addIntent")]
     pub fn add_intent(
         &mut self,
         segment: JsValue,

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -841,8 +841,8 @@ impl Transaction {
         Ok(())
     }
 
-    #[wasm_bindgen(js_name = "addOffer")]
-    pub fn add_offer(
+    #[wasm_bindgen(js_name = "addZswapOffer")]
+    pub fn add_zswap_offer(
         &mut self,
         segment: JsValue,
         raw_offer: JsValue,

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -29,8 +29,8 @@ use hex::ToHex;
 use js_sys::{Array, BigInt, Date, Function, JsString, Map, Promise, Uint8Array};
 use ledger::construct::SegmentSpecifier;
 use ledger::structure::{
-    BindingKind, ContractAction, PedersenDowngradeable, ProofKind, ProofMarker,
-    ProofPreimageMarker, ProofVersioned, SignatureKind,
+    BindingKind, PedersenDowngradeable, ProofKind, ProofMarker, ProofPreimageMarker,
+    ProofVersioned, SignatureKind,
 };
 use onchain_runtime::state::EntryPointBuf;
 use onchain_runtime_wasm::context::CostModel;
@@ -1062,14 +1062,16 @@ impl Transaction {
             SegmentSpecifier::Random => OsRng.gen_range(2..u16::MAX),
             SegmentSpecifier::GuaranteedOnly => {
                 // verify there are no fallible transcripts, fallible offers, or contract deployments present
-                let tx = get_dyn_transaction(self.0.clone());
-                if tx.has_fallible_transcripts()
-                    || tx.has_fallible_offers()
-                    || tx.has_contract_deployments()
-                {
-                    return Err(JsError::new(
-                        "cannot use guaranteed segment with fallible transactions, offers, or contract deployments",
-                    ));
+                if intent.is_some() {
+                    let intent = intent.as_ref().unwrap();
+                    if intent.has_contract_deployments()
+                        || intent.has_fallible_transcripts()
+                        || intent.has_fallible_offers()
+                    {
+                        return Err(JsError::new(
+                            "cannot use guaranteed segment with fallible transactions, offers, or contract deployments",
+                        ));
+                    }
                 }
                 OsRng.gen_range(2..u16::MAX)
             }
@@ -1212,9 +1214,6 @@ pub(crate) trait Transactionable {
         tblock: &Date,
     ) -> Result<VerifiedTransaction, JsError>;
     fn as_erased(&self) -> ledger::structure::Transaction<(), (), NoBinding, InMemoryDB>;
-    fn has_fallible_transcripts(&self) -> bool;
-    fn has_fallible_offers(&self) -> bool;
-    fn has_contract_deployments(&self) -> bool;
 }
 
 impl<
@@ -1374,40 +1373,6 @@ where
     }
     fn as_erased(&self) -> ledger::structure::Transaction<(), (), NoBinding, InMemoryDB> {
         self.erase_proofs().erase_signatures()
-    }
-
-    fn has_fallible_transcripts(&self) -> bool {
-        match &self {
-            ledger::structure::Transaction::Standard(stx) => stx.intents.values().any(|intent| {
-                intent
-                    .actions
-                    .iter()
-                    .any(|action| matches!(&*action, ContractAction::Call(call) if call.fallible_transcript.is_some()))
-            }),
-            ledger::structure::Transaction::ClaimRewards(_) => false,
-        }
-    }
-
-    fn has_fallible_offers(&self) -> bool {
-        match &self {
-            ledger::structure::Transaction::Standard(stx) => stx
-                .intents
-                .values()
-                .any(|intent| intent.fallible_unshielded_offer.is_some()),
-            ledger::structure::Transaction::ClaimRewards(_) => false,
-        }
-    }
-
-    fn has_contract_deployments(&self) -> bool {
-        match &self {
-            ledger::structure::Transaction::Standard(stx) => stx.intents.values().any(|intent| {
-                intent
-                    .actions
-                    .iter()
-                    .any(|action| matches!(*action, ContractAction::Deploy(_)))
-            }),
-            ledger::structure::Transaction::ClaimRewards(_) => false,
-        }
     }
 }
 

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -758,13 +758,6 @@ impl Transaction {
         get_dyn_transaction(self.0.clone()).binding_randomness()
     }
 
-    #[wasm_bindgen(setter, js_name = "setGuaranteedOffer")]
-    pub fn set_guaranteed_offer_alias(&mut self, offer: JsValue) -> Result<Transaction, JsError> {
-        let mut tx = self.clone();
-        tx.set_guaranteed_offer(offer)?;
-        Ok(tx)
-    }
-
     #[wasm_bindgen(getter, js_name = "guaranteedOffer")]
     pub fn guaranteed_offer(&self) -> Option<ZswapOffer> {
         get_dyn_transaction(self.0.clone()).guaranteed_offer()
@@ -848,24 +841,33 @@ impl Transaction {
         Ok(())
     }
 
-    #[wasm_bindgen(setter, js_name = "setFallibleOffer")]
-    pub fn set_fallible_offer(
-        &mut self,
-        segment: u16,
-        offer: JsValue,
-    ) -> Result<Transaction, JsError> {
+    #[wasm_bindgen(setter, js_name = "addOffer")]
+    pub fn add_offer(&mut self, segment: JsValue, offer: JsValue) -> Result<Transaction, JsError> {
         let mut tx = self.clone();
+        let segment: SegmentSpecifier = from_value(segment)?;
         let zswap_offer = if offer.is_null() || offer.is_undefined() {
             None
         } else {
             ZswapOffer::try_ref(&offer)?
         };
 
-        let current_fallible_offers = get_dyn_transaction(self.0.clone()).fallible_offer();
+        if matches!(segment, SegmentSpecifier::GuaranteedOnly) {
+            tx.set_guaranteed_offer(offer)?;
+            return Ok(tx);
+        }
 
+        let current_fallible_offers = get_dyn_transaction(self.0.clone()).fallible_offer();
         if current_fallible_offers.is_none() && zswap_offer.is_none() {
             return Ok(tx);
         }
+        let segment = match segment {
+            SegmentSpecifier::First => 1,
+            SegmentSpecifier::Random => OsRng.gen_range(2..u16::MAX),
+            SegmentSpecifier::GuaranteedOnly | SegmentSpecifier::Specific(0) => {
+                return Err(JsError::new("illegal manual specification of segment 0"));
+            }
+            SegmentSpecifier::Specific(seg) => seg,
+        };
 
         let offers = current_fallible_offers.unwrap_or(Map::new());
 
@@ -875,17 +877,17 @@ impl Transaction {
             offers.delete(&JsValue::from(segment));
         }
 
-        tx.set_fallible_offer_map(Some(offers))?;
+        tx.set_fallible_offer(Some(offers))?;
         Ok(tx)
     }
 
     #[wasm_bindgen(getter, js_name = "fallibleOffer")]
-    pub fn fallible_offer_map(&self) -> Option<Map> {
+    pub fn fallible_offer(&self) -> Option<Map> {
         get_dyn_transaction(self.0.clone()).fallible_offer()
     }
 
     #[wasm_bindgen(setter, js_name = "fallibleOffer")]
-    pub fn set_fallible_offer_map(&mut self, offers_map: Option<Map>) -> Result<(), JsError> {
+    pub fn set_fallible_offer(&mut self, offers_map: Option<Map>) -> Result<(), JsError> {
         use TransactionTypes::*;
         use ledger::structure::Transaction::Standard;
 

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -183,11 +183,8 @@ impl Transaction {
         } else {
             ZswapOffer::try_ref(&guaranteed)?
         };
-        if guaranteed.is_some()
-            && !matches!(
-                guaranteed.as_ref().unwrap().0,
-                ZswapOfferTypes::UnprovenOffer(_)
-            )
+        if let Some(ref guaranteed) = guaranteed
+            && !matches!(guaranteed.0, ZswapOfferTypes::UnprovenOffer(_))
         {
             return Err(JsError::new("Guaranteed offer must be unproven."));
         }
@@ -197,11 +194,8 @@ impl Transaction {
         } else {
             ZswapOffer::try_ref(&fallible)?
         };
-        if fallible.is_some()
-            && !matches!(
-                fallible.as_ref().unwrap().0,
-                ZswapOfferTypes::UnprovenOffer(_)
-            )
+        if let Some(ref fallible) = fallible
+            && !matches!(fallible.0, ZswapOfferTypes::UnprovenOffer(_))
         {
             return Err(JsError::new("Fallible offer must be unproven."));
         }
@@ -211,9 +205,9 @@ impl Transaction {
         } else {
             Intent::try_ref(&intent)?
         };
-        if intent.is_some()
+        if let Some(ref intent) = intent
             && !matches!(
-                intent.as_ref().unwrap().0,
+                intent.0,
                 IntentTypes::UnprovenWithSignaturePreBinding(_)
                     | IntentTypes::UnprovenWithSignatureErasedPreBinding(_)
             )
@@ -255,11 +249,8 @@ impl Transaction {
         } else {
             ZswapOffer::try_ref(&guaranteed)?
         };
-        if guaranteed.is_some()
-            && !matches!(
-                guaranteed.as_ref().unwrap().0,
-                ZswapOfferTypes::UnprovenOffer(_)
-            )
+        if let Some(ref guaranteed) = guaranteed
+            && !matches!(guaranteed.0, ZswapOfferTypes::UnprovenOffer(_))
         {
             return Err(JsError::new("Guaranteed offer must be unproven."));
         }
@@ -269,11 +260,8 @@ impl Transaction {
         } else {
             ZswapOffer::try_ref(&fallible)?
         };
-        if fallible.is_some()
-            && !matches!(
-                fallible.as_ref().unwrap().0,
-                ZswapOfferTypes::UnprovenOffer(_)
-            )
+        if let Some(ref fallible) = fallible
+            && !matches!(fallible.0, ZswapOfferTypes::UnprovenOffer(_))
         {
             return Err(JsError::new("Fallible offer must be unproven."));
         }
@@ -283,9 +271,9 @@ impl Transaction {
         } else {
             Intent::try_ref(&intent)?
         };
-        if intent.is_some()
+        if let Some(ref intent) = intent
             && !matches!(
-                intent.as_ref().unwrap().0,
+                intent.0,
                 IntentTypes::UnprovenWithSignaturePreBinding(_)
                     | IntentTypes::UnprovenWithSignatureErasedPreBinding(_)
             )
@@ -1062,16 +1050,14 @@ impl Transaction {
             SegmentSpecifier::Random => OsRng.gen_range(2..u16::MAX),
             SegmentSpecifier::GuaranteedOnly => {
                 // verify there are no fallible transcripts, fallible offers, or contract deployments present
-                if intent.is_some() {
-                    let intent = intent.as_ref().unwrap();
-                    if intent.has_contract_deployments()
+                if let Some(ref intent) = intent
+                    && (intent.has_contract_deployments()
                         || intent.has_fallible_transcripts()
-                        || intent.has_fallible_offers()
-                    {
-                        return Err(JsError::new(
-                            "cannot use guaranteed segment with fallible transactions, offers, or contract deployments",
-                        ));
-                    }
+                        || intent.has_fallible_offers())
+                {
+                    return Err(JsError::new(
+                        "cannot use guaranteed segment with fallible transactions, offers, or contract deployments",
+                    ));
                 }
                 OsRng.gen_range(2..u16::MAX)
             }

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -873,7 +873,7 @@ impl Transaction {
             SegmentSpecifier::Specific(seg) => seg,
         };
 
-        let offers = current_fallible_offers.unwrap_or(Map::new());
+        let offers = current_fallible_offers.unwrap_or_default();
 
         if zswap_offer.is_some() {
             offers.set(&JsValue::from(segment), &raw_offer);
@@ -1063,7 +1063,7 @@ impl Transaction {
             SegmentSpecifier::Specific(seg) => seg,
         };
 
-        let intents = current_intents.unwrap_or(Map::new());
+        let intents = current_intents.unwrap_or_default();
 
         if intent.is_some() {
             intents.set(&JsValue::from(segment), &raw_intent);

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -29,8 +29,8 @@ use hex::ToHex;
 use js_sys::{Array, BigInt, Date, Function, JsString, Map, Promise, Uint8Array};
 use ledger::construct::SegmentSpecifier;
 use ledger::structure::{
-    BindingKind, PedersenDowngradeable, ProofKind, ProofMarker, ProofPreimageMarker,
-    ProofVersioned, SignatureKind,
+    BindingKind, ContractAction, PedersenDowngradeable, ProofKind, ProofMarker,
+    ProofPreimageMarker, ProofVersioned, SignatureKind,
 };
 use onchain_runtime::state::EntryPointBuf;
 use onchain_runtime_wasm::context::CostModel;
@@ -855,7 +855,10 @@ impl Transaction {
             ZswapOffer::try_ref(&raw_offer)?
         };
 
-        if matches!(segment, SegmentSpecifier::GuaranteedOnly) {
+        if matches!(
+            segment,
+            SegmentSpecifier::GuaranteedOnly | SegmentSpecifier::Specific(0)
+        ) {
             tx.set_guaranteed_offer(raw_offer)?;
             return Ok(tx);
         }
@@ -867,9 +870,7 @@ impl Transaction {
         let segment = match segment {
             SegmentSpecifier::First => 1,
             SegmentSpecifier::Random => OsRng.gen_range(2..u16::MAX),
-            SegmentSpecifier::GuaranteedOnly | SegmentSpecifier::Specific(0) => {
-                return Err(JsError::new("illegal manual specification of segment 0"));
-            }
+            SegmentSpecifier::GuaranteedOnly | SegmentSpecifier::Specific(0) => unreachable!(),
             SegmentSpecifier::Specific(seg) => seg,
         };
 
@@ -1059,7 +1060,22 @@ impl Transaction {
         let segment = match segment {
             SegmentSpecifier::First => 1,
             SegmentSpecifier::Random => OsRng.gen_range(2..u16::MAX),
-            SegmentSpecifier::GuaranteedOnly | SegmentSpecifier::Specific(0) => 0,
+            SegmentSpecifier::GuaranteedOnly => {
+                // verify there are no fallible transcripts, fallible offers, or contract deployments present
+                let tx = get_dyn_transaction(self.0.clone());
+                if tx.has_fallible_transcripts()
+                    || tx.has_fallible_offers()
+                    || tx.has_contract_deployments()
+                {
+                    return Err(JsError::new(
+                        "cannot use guaranteed segment with fallible transactions, offers, or contract deployments",
+                    ));
+                }
+                OsRng.gen_range(2..u16::MAX)
+            }
+            SegmentSpecifier::Specific(0) => {
+                return Err(JsError::new("illegal manual specification of segment 0"));
+            }
             SegmentSpecifier::Specific(seg) => seg,
         };
 
@@ -1196,6 +1212,9 @@ pub(crate) trait Transactionable {
         tblock: &Date,
     ) -> Result<VerifiedTransaction, JsError>;
     fn as_erased(&self) -> ledger::structure::Transaction<(), (), NoBinding, InMemoryDB>;
+    fn has_fallible_transcripts(&self) -> bool;
+    fn has_fallible_offers(&self) -> bool;
+    fn has_contract_deployments(&self) -> bool;
 }
 
 impl<
@@ -1355,6 +1374,40 @@ where
     }
     fn as_erased(&self) -> ledger::structure::Transaction<(), (), NoBinding, InMemoryDB> {
         self.erase_proofs().erase_signatures()
+    }
+
+    fn has_fallible_transcripts(&self) -> bool {
+        match &self {
+            ledger::structure::Transaction::Standard(stx) => stx.intents.values().any(|intent| {
+                intent
+                    .actions
+                    .iter()
+                    .any(|action| matches!(&*action, ContractAction::Call(call) if call.fallible_transcript.is_some()))
+            }),
+            ledger::structure::Transaction::ClaimRewards(_) => false,
+        }
+    }
+
+    fn has_fallible_offers(&self) -> bool {
+        match &self {
+            ledger::structure::Transaction::Standard(stx) => stx
+                .intents
+                .values()
+                .any(|intent| intent.fallible_unshielded_offer.is_some()),
+            ledger::structure::Transaction::ClaimRewards(_) => false,
+        }
+    }
+
+    fn has_contract_deployments(&self) -> bool {
+        match &self {
+            ledger::structure::Transaction::Standard(stx) => stx.intents.values().any(|intent| {
+                intent
+                    .actions
+                    .iter()
+                    .any(|action| matches!(*action, ContractAction::Deploy(_)))
+            }),
+            ledger::structure::Transaction::ClaimRewards(_) => false,
+        }
     }
 }
 

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -842,17 +842,21 @@ impl Transaction {
     }
 
     #[wasm_bindgen(setter, js_name = "addOffer")]
-    pub fn add_offer(&mut self, segment: JsValue, offer: JsValue) -> Result<Transaction, JsError> {
+    pub fn add_offer(
+        &mut self,
+        segment: JsValue,
+        raw_offer: JsValue,
+    ) -> Result<Transaction, JsError> {
         let mut tx = self.clone();
         let segment: SegmentSpecifier = from_value(segment)?;
-        let zswap_offer = if offer.is_null() || offer.is_undefined() {
+        let zswap_offer = if raw_offer.is_null() || raw_offer.is_undefined() {
             None
         } else {
-            ZswapOffer::try_ref(&offer)?
+            ZswapOffer::try_ref(&raw_offer)?
         };
 
         if matches!(segment, SegmentSpecifier::GuaranteedOnly) {
-            tx.set_guaranteed_offer(offer)?;
+            tx.set_guaranteed_offer(raw_offer)?;
             return Ok(tx);
         }
 
@@ -872,7 +876,7 @@ impl Transaction {
         let offers = current_fallible_offers.unwrap_or(Map::new());
 
         if zswap_offer.is_some() {
-            offers.set(&JsValue::from(segment), &offer);
+            offers.set(&JsValue::from(segment), &raw_offer);
         } else if offers.has(&JsValue::from(segment)) {
             offers.delete(&JsValue::from(segment));
         }
@@ -1032,6 +1036,43 @@ impl Transaction {
             }
             _ => Err(JsError::new("Not a standard transaction."))?,
         }
+    }
+
+    #[wasm_bindgen(setter, js_name = "addIntent")]
+    pub fn add_intent(
+        &mut self,
+        segment: JsValue,
+        raw_intent: JsValue,
+    ) -> Result<Transaction, JsError> {
+        let mut tx = self.clone();
+        let segment: SegmentSpecifier = from_value(segment)?;
+        let intent = if raw_intent.is_null() || raw_intent.is_undefined() {
+            None
+        } else {
+            Intent::try_ref(&raw_intent)?
+        };
+
+        let current_intents = get_dyn_transaction(self.0.clone()).intents();
+        if current_intents.is_none() && intent.is_none() {
+            return Ok(tx);
+        }
+        let segment = match segment {
+            SegmentSpecifier::First => 1,
+            SegmentSpecifier::Random => OsRng.gen_range(2..u16::MAX),
+            SegmentSpecifier::GuaranteedOnly | SegmentSpecifier::Specific(0) => 0,
+            SegmentSpecifier::Specific(seg) => seg,
+        };
+
+        let intents = current_intents.unwrap_or(Map::new());
+
+        if intent.is_some() {
+            intents.set(&JsValue::from(segment), &raw_intent);
+        } else if intents.has(&JsValue::from(segment)) {
+            intents.delete(&JsValue::from(segment));
+        }
+
+        tx.set_intents(Some(intents))?;
+        Ok(tx)
     }
 
     #[wasm_bindgen(getter, js_name = "intents")]

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -758,6 +758,13 @@ impl Transaction {
         get_dyn_transaction(self.0.clone()).binding_randomness()
     }
 
+    #[wasm_bindgen(setter, js_name = "setGuaranteedOffer")]
+    pub fn set_guaranteed_offer_alias(&mut self, offer: JsValue) -> Result<Transaction, JsError> {
+        let mut tx = self.clone();
+        tx.set_guaranteed_offer(offer)?;
+        Ok(tx)
+    }
+
     #[wasm_bindgen(getter, js_name = "guaranteedOffer")]
     pub fn guaranteed_offer(&self) -> Option<ZswapOffer> {
         get_dyn_transaction(self.0.clone()).guaranteed_offer()
@@ -841,13 +848,44 @@ impl Transaction {
         Ok(())
     }
 
+    #[wasm_bindgen(setter, js_name = "setFallibleOffer")]
+    pub fn set_fallible_offer(
+        &mut self,
+        segment: u16,
+        offer: JsValue,
+    ) -> Result<Transaction, JsError> {
+        let mut tx = self.clone();
+        let zswap_offer = if offer.is_null() || offer.is_undefined() {
+            None
+        } else {
+            ZswapOffer::try_ref(&offer)?
+        };
+
+        let current_fallible_offers = get_dyn_transaction(self.0.clone()).fallible_offer();
+
+        if current_fallible_offers.is_none() && zswap_offer.is_none() {
+            return Ok(tx);
+        }
+
+        let offers = current_fallible_offers.unwrap_or(Map::new());
+
+        if zswap_offer.is_some() {
+            offers.set(&JsValue::from(segment), &offer);
+        } else if offers.has(&JsValue::from(segment)) {
+            offers.delete(&JsValue::from(segment));
+        }
+
+        tx.set_fallible_offer_map(Some(offers))?;
+        Ok(tx)
+    }
+
     #[wasm_bindgen(getter, js_name = "fallibleOffer")]
-    pub fn fallible_offer(&self) -> Option<Map> {
+    pub fn fallible_offer_map(&self) -> Option<Map> {
         get_dyn_transaction(self.0.clone()).fallible_offer()
     }
 
     #[wasm_bindgen(setter, js_name = "fallibleOffer")]
-    pub fn set_fallible_offer(&mut self, offers_map: Option<Map>) -> Result<(), JsError> {
+    pub fn set_fallible_offer_map(&mut self, offers_map: Option<Map>) -> Result<(), JsError> {
         use TransactionTypes::*;
         use ledger::structure::Transaction::Standard;
 

--- a/ledger/src/construct.rs
+++ b/ledger/src/construct.rs
@@ -92,6 +92,7 @@ impl<S: SignatureKind<D>, D: DB>
         res
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_calls<P>(
         &self,
         rng: &mut (impl Rng + CryptoRng),


### PR DESCRIPTION
Adds new WASM API methods `addZswapOffer(segment, offer)` and `addIntent(segment, intent)`.

Closes https://shielded.atlassian.net/browse/PM-22402