### PR TITLE
More flexible `findPathForLeaf`

### DIFF
--- a/CHANGELOG_onchain-runtime.md
+++ b/CHANGELOG_onchain-runtime.md
@@ -1,5 +1,10 @@
 # `midnight-onchain-runtime` Changelog
 
+## Unreleased
+
+- feat: add more flexibility to `findPathForLeaf`, allowing it to scan index
+  ranges, and find elements by hash instead of by value.
+
 ## Version `2.0.0`
 
 - breaking: pull in breaking transient-crypto changes

--- a/integration-tests/src/test/no-proving/StateBoundedMerkleTree.test.ts
+++ b/integration-tests/src/test/no-proving/StateBoundedMerkleTree.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { StateBoundedMerkleTree, valueToBigInt } from '@midnight-ntwrk/ledger';
+import { StateBoundedMerkleTree, leafHash, valueToBigInt } from '@midnight-ntwrk/ledger';
 import { Static } from '@/test-objects';
 
 describe('Ledger API - StateBoundedMerkleTree', () => {
@@ -173,5 +173,88 @@ describe('Ledger API - StateBoundedMerkleTree', () => {
     expect(Array.isArray(root!.value)).toBe(true);
     expect(root!.value.length).toBeGreaterThan(0);
     expect(root!.value[0]).toBeInstanceOf(Uint8Array);
+  });
+
+  /**
+   * Test findPathForLeaf with index range parameters.
+   *
+   * @given A StateBoundedMerkleTree with a leaf at index 0
+   * @when Searching with range that includes/excludes the leaf
+   * @then Should find the leaf only when the range covers its index
+   */
+  test("'findPathForLeaf' should respect index range parameters", () => {
+    let tree = new StateBoundedMerkleTree(3);
+    tree = tree.update(0n, Static.alignedValue);
+
+    // Without range, finds the leaf (same as existing test)
+    expect(tree.findPathForLeaf(Static.alignedValue)).toBeDefined();
+
+    // Unbounded range also finds the leaf
+    expect(tree.findPathForLeaf(Static.alignedValue, undefined, undefined)).toBeDefined();
+
+    // Range covering the leaf finds it
+    const pathInRange = tree.findPathForLeaf(Static.alignedValue, 0n, 3n);
+    expect(pathInRange).toBeDefined();
+    expect(Array.isArray(pathInRange!.value)).toBe(true);
+
+    // Range excluding the leaf does not find it
+    expect(tree.findPathForLeaf(Static.alignedValue, 1n, 3n)).toBeUndefined();
+  });
+
+  /**
+   * Test findPathForLeaf with alreadyHashed=false.
+   *
+   * @given A StateBoundedMerkleTree with a leaf at index 0
+   * @when Searching with alreadyHashed=false (default behaviour)
+   * @then Should find the leaf normally
+   */
+  test("'findPathForLeaf' with alreadyHashed=false behaves like default", () => {
+    let tree = new StateBoundedMerkleTree(3);
+    tree = tree.update(0n, Static.alignedValue);
+
+    const pathDefault = tree.findPathForLeaf(Static.alignedValue);
+    const pathExplicit = tree.findPathForLeaf(Static.alignedValue, undefined, undefined, false);
+
+    expect(pathDefault).toBeDefined();
+    expect(pathExplicit).toBeDefined();
+  });
+
+  /**
+   * Test findPathForLeaf with alreadyHashed=true.
+   *
+   * @given A StateBoundedMerkleTree with a leaf at index 0
+   * @when Searching with the leaf's hash and alreadyHashed=true
+   * @then Should find the leaf and return a valid path
+   */
+  test("'findPathForLeaf' with alreadyHashed=true finds leaf by hash", () => {
+    let tree = new StateBoundedMerkleTree(3);
+    tree = tree.update(0n, Static.alignedValue);
+
+    const hash = leafHash(Static.alignedValue);
+    const path = tree.findPathForLeaf(hash, undefined, undefined, true);
+
+    expect(path).toBeDefined();
+    expect(Array.isArray(path!.value)).toBe(true);
+    expect(Array.isArray(path!.alignment)).toBe(true);
+  });
+
+  /**
+   * Test findPathForLeaf with alreadyHashed=true and index range.
+   *
+   * @given A StateBoundedMerkleTree with a leaf at index 0
+   * @when Searching with hash, alreadyHashed=true, and a restrictive range
+   * @then Should only find the leaf when the range covers its index
+   */
+  test("'findPathForLeaf' with alreadyHashed=true respects range", () => {
+    let tree = new StateBoundedMerkleTree(3);
+    tree = tree.update(0n, Static.alignedValue);
+
+    const hash = leafHash(Static.alignedValue);
+
+    const found = tree.findPathForLeaf(hash, 0n, 3n, true);
+    expect(found).toBeDefined();
+
+    const notFound = tree.findPathForLeaf(hash, 1n, 3n, true);
+    expect(notFound).toBeUndefined();
   });
 });

--- a/onchain-runtime-wasm/onchain-runtime-v3.d.ts
+++ b/onchain-runtime-wasm/onchain-runtime-v3.d.ts
@@ -939,7 +939,12 @@ export class StateBoundedMerkleTree {
    * Returns undefined if the leaf is not in the tree.
    * @internal
    */
-  findPathForLeaf(leaf: AlignedValue): AlignedValue | undefined;
+  findPathForLeaf(
+    leaf: AlignedValue,
+    indexStart?: bigint,
+    indexEnd?: bigint,
+    alreadyHashed?: bool,
+  ): AlignedValue | undefined;
 
   /**
    * Internal implementation of the path construction primitive

--- a/onchain-runtime-wasm/src/state.rs
+++ b/onchain-runtime-wasm/src/state.rs
@@ -106,14 +106,32 @@ impl StateBoundedMerkleTree {
 
     // path_for_leaf(leaf: AlignedValue): AlignedValue
     #[wasm_bindgen(js_name = "findPathForLeaf")]
-    pub fn find_path_for_leaf(&self, leaf: JsValue) -> Result<JsValue, JsError> {
+    pub fn find_path_for_leaf(
+        &self,
+        leaf: JsValue,
+        index_start: Option<u64>,
+        index_end: Option<u64>,
+        already_hashed: Option<bool>,
+    ) -> Result<JsValue, JsError> {
         let leaf: AlignedValue = from_value(leaf)?;
-        Ok(self
-            .0
-            .find_path_for_leaf(ValueReprAlignedValue(leaf))
-            .map(|v| to_value(&AlignedValue::from(v)))
-            .transpose()?
-            .unwrap_or(JsValue::UNDEFINED))
+        let bound = |idx| match idx {
+            Some(idx) => std::ops::Bound::Included(idx),
+            None => std::ops::Bound::Unbounded,
+        };
+        let range = (bound(index_start), bound(index_end));
+        let already_hashed = already_hashed.unwrap_or(false);
+        let res = if already_hashed {
+            let leaf_hash = base_crypto::hash::HashOutput::try_from(&*leaf.value)
+                .map_err(|_| JsError::new("failed to decode declared hash as 32-byte hash"))?;
+            self.0
+                .find_path_for_hashed_leaf_within_range(leaf_hash, range)
+                .map(|v| to_value(&AlignedValue::from(v)))
+        } else {
+            self.0
+                .find_path_for_leaf_within_range(ValueReprAlignedValue(leaf), range)
+                .map(|v| to_value(&AlignedValue::from(v)))
+        };
+        Ok(res.transpose()?.unwrap_or(JsValue::UNDEFINED))
     }
 
     // path_for_leaf(index: number, leaf: AlignedValue): AlignedValue

--- a/transient-crypto/src/merkle_tree.rs
+++ b/transient-crypto/src/merkle_tree.rs
@@ -35,7 +35,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::Hash;
 #[cfg(feature = "proptest")]
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{Bound, Deref, RangeBounds, RangeInclusive};
 use storage_core as storage;
 use storage_core::DefaultDB;
 use storage_core::Storable;
@@ -60,6 +60,71 @@ pub struct MerklePath<T> {
 
 /// The domain separator used in leaf commitments.
 pub const LEAF_HASH_DOMAIN_SEP: &[u8] = b"mdn:lh";
+
+fn range_sub(range: (Bound<u64>, Bound<u64>), sub: u64) -> Option<(Bound<u64>, Bound<u64>)> {
+    // For the start, if subtraction were to overflow, the start becomes unbounded
+    let start = match range.0 {
+        Bound::Unbounded => Bound::Unbounded,
+        Bound::Included(n) => match n.checked_sub(sub) {
+            Some(m) => Bound::Included(m),
+            None => Bound::Unbounded,
+        },
+        Bound::Excluded(n) => match n.checked_sub(sub) {
+            Some(m) => Bound::Excluded(m),
+            None => Bound::Unbounded,
+        },
+    };
+    // For the end, if subtraction were to overflow, the range is empty
+    // Note that Included/Excluded can be handled the same, it just allows a corner-case where we
+    // return an empty range of Some(..=0) instead of None
+    let end = match range.1 {
+        Bound::Unbounded => Bound::Unbounded,
+        Bound::Included(n) => Bound::Included(n.checked_sub(sub)?),
+        Bound::Excluded(n) => Bound::Excluded(n.checked_sub(sub)?),
+    };
+    if range_empty((start, end)) {
+        None
+    } else {
+        Some((start, end))
+    }
+}
+
+fn range_empty(range: (Bound<u64>, Bound<u64>)) -> bool {
+    if let Some((start, end)) = range_force_inclusive(range) {
+        start > end
+    } else {
+        true
+    }
+}
+
+fn range_force_inclusive(range: (Bound<u64>, Bound<u64>)) -> Option<(u64, u64)> {
+    let inclusive_start = match range.0 {
+        Bound::Unbounded => 0,
+        Bound::Included(n) => n,
+        Bound::Excluded(u64::MAX) => return None,
+        Bound::Excluded(n) => n + 1,
+    };
+    let inclusive_end = match range.1 {
+        Bound::Unbounded => u64::MAX,
+        Bound::Included(n) => n,
+        Bound::Excluded(0) => return None,
+        Bound::Excluded(n) => n - 1,
+    };
+    Some((inclusive_start, inclusive_end))
+}
+
+fn overlap(a: (Bound<u64>, Bound<u64>), b: impl RangeBounds<u64>) -> Option<RangeInclusive<u64>> {
+    let b = (b.start_bound().cloned(), b.end_bound().cloned());
+    let a_inclusive = range_force_inclusive(a)?;
+    let b_inclusive = range_force_inclusive(b)?;
+    let start = u64::max(a_inclusive.0, b_inclusive.0);
+    let end = u64::min(a_inclusive.1, b_inclusive.1);
+    if start <= end {
+        Some(start..=end)
+    } else {
+        None
+    }
+}
 
 /// An index into a Merkle tree which could not be resolved, as there is no item
 /// there, or the path was deliberately collapsed.
@@ -582,29 +647,39 @@ impl<A: Storable<D>, D: DB> MerkleTreeNode<A, D> {
         Ok(())
     }
 
-    fn leaves(&self) -> Vec<LeafOrCollapsed<'_, A>> {
+    fn leaves_in_range(&self, range: (Bound<u64>, Bound<u64>)) -> Vec<LeafOrCollapsed<'_, A>> {
         match self {
-            Leaf { hash, aux } => vec![LeafOrCollapsed::Leaf {
+            Leaf { hash, aux } if range.contains(&0) => vec![LeafOrCollapsed::Leaf {
                 index: 0,
                 hash: *hash,
                 aux,
             }],
-            Stub { .. } => Vec::new(),
-            Collapsed { .. } => vec![LeafOrCollapsed::Collapsed {
-                start: 0,
-                end: (1u64 << self.height()) - 1,
-            }],
+            Stub { .. } | Leaf { .. } => Vec::new(),
+            Collapsed { .. } => {
+                if let Some(range) = overlap(range, 0..(1 << self.height())) {
+                    vec![LeafOrCollapsed::Collapsed {
+                        start: *range.start(),
+                        end: *range.end(),
+                    }]
+                } else {
+                    Vec::new()
+                }
+            }
             Node { left, right, .. } => left
-                .leaves()
+                .leaves_in_range(range)
                 .into_iter()
                 .chain(
-                    right
-                        .leaves()
+                    range_sub(range, 1 << left.height())
                         .into_iter()
+                        .flat_map(|sub_range| right.leaves_in_range(sub_range).into_iter())
                         .map(|leaf| leaf.upgrade(1 << left.height())),
                 )
                 .collect(),
         }
+    }
+
+    fn leaves(&self) -> Vec<LeafOrCollapsed<'_, A>> {
+        self.leaves_in_range((Bound::Unbounded, Bound::Unbounded))
     }
 
     fn new(height: u8) -> Self {
@@ -1072,12 +1147,43 @@ impl<A: Storable<D>, D: DB> MerkleTree<A, D> {
     ///
     /// May panic if the Merkle tree has not been rehashed.
     pub fn find_path_for_leaf<T: BinaryHashRepr>(&self, leaf: T) -> Option<MerklePath<T>> {
-        let hash = leaf_hash(&leaf);
-        for (index, hash2) in self.0.leaves().into_iter().filter_map(|leaf| match leaf {
-            LeafOrCollapsed::Leaf { index, hash, .. } => Some((index, hash)),
-            _ => None,
-        }) {
-            if hash == hash2 {
+        self.find_path_for_leaf_inner(leaf_hash(&leaf), leaf, ..)
+    }
+
+    /// Acts as [`find_path_for_leaf`], but limits search to a specified range.
+    pub fn find_path_for_leaf_within_range<T: BinaryHashRepr>(
+        &self,
+        leaf: T,
+        range: impl RangeBounds<u64>,
+    ) -> Option<MerklePath<T>> {
+        self.find_path_for_leaf_inner(leaf_hash(&leaf), leaf, range)
+    }
+
+    /// Acts as [`find_path_for_leaf_within_range`], but takes the leaf to be pre-hashed.
+    pub fn find_path_for_hashed_leaf_within_range(
+        &self,
+        leaf_hash: HashOutput,
+        range: impl RangeBounds<u64>,
+    ) -> Option<MerklePath<HashOutput>> {
+        self.find_path_for_leaf_inner(leaf_hash, leaf_hash, range)
+    }
+
+    fn find_path_for_leaf_inner<T>(
+        &self,
+        leaf_hash: HashOutput,
+        leaf: T,
+        range: impl RangeBounds<u64>,
+    ) -> Option<MerklePath<T>> {
+        for (index, hash) in self
+            .0
+            .leaves_in_range((range.start_bound().cloned(), range.end_bound().cloned()))
+            .into_iter()
+            .filter_map(|leaf| match leaf {
+                LeafOrCollapsed::Leaf { index, hash, .. } => Some((index, hash)),
+                _ => None,
+            })
+        {
+            if leaf_hash == hash {
                 return self.path_for_leaf(index, leaf).ok();
             }
         }
@@ -1130,11 +1236,7 @@ impl<A: Storable<D>, D: DB> MerkleTree<A, D> {
     /// Given a leaf at a specific index, produces a [`MerklePath`] for it.
     ///
     /// May panic if the Merkle tree has not been rehashed.
-    pub fn path_for_leaf<T: BinaryHashRepr>(
-        &self,
-        index: u64,
-        leaf: T,
-    ) -> Result<MerklePath<T>, InvalidIndex> {
+    pub fn path_for_leaf<T>(&self, index: u64, leaf: T) -> Result<MerklePath<T>, InvalidIndex> {
         if self.height() == 0 {
             return if index == 0 {
                 Ok(MerklePath {

--- a/transient-crypto/src/merkle_tree.rs
+++ b/transient-crypto/src/merkle_tree.rs
@@ -1542,4 +1542,123 @@ mod tests {
             assert_eq!(aux, 10);
         }
     }
+
+    #[test]
+    fn test_find_path_for_leaf_within_range() {
+        let tree = new_mt::<()>(32)
+            .update(0, &Fr::from(10u64), ())
+            .and_then(|mt| mt.update(5, &Fr::from(20u64), ()))
+            .and_then(|mt| mt.update(10, &Fr::from(30u64), ()))
+            .unwrap()
+            .rehash();
+
+        // Full range finds the leaf
+        assert!(
+            tree.find_path_for_leaf_within_range(Fr::from(20u64), ..)
+                .is_some()
+        );
+
+        // Range containing the leaf finds it
+        assert!(
+            tree.find_path_for_leaf_within_range(Fr::from(20u64), 3..=7)
+                .is_some()
+        );
+
+        // Range excluding the leaf does not find it
+        assert!(
+            tree.find_path_for_leaf_within_range(Fr::from(20u64), 0..=4)
+                .is_none()
+        );
+        assert!(
+            tree.find_path_for_leaf_within_range(Fr::from(20u64), 6..=100)
+                .is_none()
+        );
+
+        // Path produced is valid
+        let path = tree
+            .find_path_for_leaf_within_range(Fr::from(30u64), 8..=12)
+            .expect("leaf at index 10 should be in range 8..=12");
+        assert_eq!(path.root(), tree.root().unwrap());
+    }
+
+    #[test]
+    fn test_find_path_for_hashed_leaf_within_range() {
+        let tree = new_mt::<()>(32)
+            .update(0, &Fr::from(10u64), ())
+            .and_then(|mt| mt.update(5, &Fr::from(20u64), ()))
+            .unwrap()
+            .rehash();
+
+        let hash = leaf_hash(&Fr::from(20u64));
+
+        // Finds by hash
+        assert!(
+            tree.find_path_for_hashed_leaf_within_range(hash, ..)
+                .is_some()
+        );
+
+        // Range restriction works
+        assert!(
+            tree.find_path_for_hashed_leaf_within_range(hash, 5..=5)
+                .is_some()
+        );
+        assert!(
+            tree.find_path_for_hashed_leaf_within_range(hash, 0..=4)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_find_within_range_with_collapsed() {
+        let tree = new_mt::<()>(6)
+            .update(0, &Fr::from(10u64), ())
+            .and_then(|mt| mt.update(5, &Fr::from(20u64), ()))
+            .and_then(|mt| mt.update(10, &Fr::from(30u64), ()))
+            .unwrap()
+            .collapse(0, 4)
+            .rehash();
+
+        // Leaf in collapsed region is not found
+        assert!(
+            tree.find_path_for_leaf_within_range(Fr::from(10u64), ..)
+                .is_none()
+        );
+
+        // Leaf outside collapsed region is found
+        assert!(
+            tree.find_path_for_leaf_within_range(Fr::from(20u64), ..)
+                .is_some()
+        );
+
+        // Range restricted to collapsed region returns nothing
+        assert!(
+            tree.find_path_for_leaf_within_range(Fr::from(20u64), 0..=4)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_find_within_range_duplicate_leaves() {
+        let val = Fr::from(42u64);
+        let tree = new_mt::<()>(6)
+            .update(2, &val, ())
+            .and_then(|mt| mt.update(5, &val, ()))
+            .and_then(|mt| mt.update(8, &val, ()))
+            .unwrap()
+            .rehash();
+
+        // Restricting range picks the correct duplicate
+        let path = tree
+            .find_path_for_leaf_within_range(val, 4..=6)
+            .expect("should find leaf at index 5");
+        assert_eq!(path.root(), tree.root().unwrap());
+
+        let path = tree
+            .find_path_for_leaf_within_range(val, 7..=10)
+            .expect("should find leaf at index 8");
+        assert_eq!(path.root(), tree.root().unwrap());
+
+        // Empty range finds nothing
+        assert!(tree.find_path_for_leaf_within_range(val, 3..=4).is_none());
+    }
 }


### PR DESCRIPTION
## Description

<!-- describe what this PR does, and why it is needed -->
`findPathForLeaf` only worked on values inserted into Merkle trees with `insert`, and not `insertHash`. While we relied on `pathForLeaf` to be used for other Merkle trees, and to be generally preferable due to it not performing an O(n) scan of the tree, we didn't provide good mechanisms for contracts to determine which index elements actually ended up with.

The solution is to make `findPathForLeaf` more expressive. This PR allows it to scan ranges in the tree, and to search for hashes rather than elements.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.
