### PR TITLE
Extend wallet-level control and visibility into events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 ## Unreleased
 
 - feat: expose finer-grained control for the wallet in wasm bindings.
+- feat: expose event contents to the extent that they are useful to the wallet in wasm bindings.
 
 ## 8.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 # Change Log
 
+## Unreleased
+
+- feat: expose finer-grained control for the wallet in wasm bindings.
+
 ## 8.0.3
 
 - fix: various fixed to transcript partioning:

--- a/CHANGELOG_serialize.md
+++ b/CHANGELOG_serialize.md
@@ -1,5 +1,9 @@
 # `serialize` Changelog
 
+## Version `1.1.0`
+
+- feat: add `tagged_deserialize_sequence`, which deserializes a sequence of tagged values
+
 ## Version `1.0.0`
 
 - version bump in preparation for full stablisation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-serialize"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "crypto",
  "konst",

--- a/integration-tests/src/test/no-proving/WalletControl.test.ts
+++ b/integration-tests/src/test/no-proving/WalletControl.test.ts
@@ -30,7 +30,38 @@ import { TestState } from '@/test/utils/TestState';
 import { LOCAL_TEST_NETWORK_ID, type ShieldedTokenType, Static } from '@/test-objects';
 import { assertSerializationSuccess } from '@/test-utils';
 
-describe('Confirmed bugs', () => {
+describe('Wallet Control - Finer ZswapLocalState control', () => {
+  function setupWithCoin(value: bigint = 10n) {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    let ledgerState = new LedgerState(LOCAL_TEST_NETWORK_ID, new ZswapChainState());
+    const coinInfo = Static.shieldedCoinInfo(value);
+    const offer = ZswapOffer.fromOutput(
+      ZswapOutput.new(coinInfo, 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey),
+      coinInfo.type,
+      coinInfo.value
+    );
+    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, offer);
+    const strictness = new WellFormedStrictness();
+    strictness.enforceBalancing = false;
+    const ctx = new TransactionContext(ledgerState, Static.blockContext(new Date(0)));
+    const vtx = tx.wellFormed(ledgerState, strictness, new Date(0));
+    const [newLedger, result] = ledgerState.apply(vtx, ctx);
+    ledgerState = newLedger.postBlockUpdate(new Date(0));
+    return { secretKeys, ledgerState, coinInfo, events: result.events };
+  }
+
+  function serializeEvents(events: Event[]): Uint8Array {
+    const parts = events.map((e) => e.serialize());
+    const totalLength = parts.reduce((acc, p) => acc + p.length, 0);
+    const result = new Uint8Array(totalLength);
+    let currentOffset = 0;
+    parts.forEach((part) => {
+      result.set(part, currentOffset);
+      currentOffset += part.length;
+    });
+    return result;
+  }
+
   test('replayRawEvents drops every event after the first when given concatenated bytes', () => {
     const sk = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
     const ledger = new LedgerState(LOCAL_TEST_NETWORK_ID, new ZswapChainState());
@@ -72,39 +103,6 @@ describe('Confirmed bugs', () => {
     expect(raw.state.coins.size).toEqual(2);
     expect(raw.state.firstFree).toEqual(2n);
   });
-});
-
-describe('Wallet Control - Finer ZswapLocalState control', () => {
-  function setupWithCoin(value: bigint = 10n) {
-    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
-    let ledgerState = new LedgerState(LOCAL_TEST_NETWORK_ID, new ZswapChainState());
-    const coinInfo = Static.shieldedCoinInfo(value);
-    const offer = ZswapOffer.fromOutput(
-      ZswapOutput.new(coinInfo, 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey),
-      coinInfo.type,
-      coinInfo.value
-    );
-    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, offer);
-    const strictness = new WellFormedStrictness();
-    strictness.enforceBalancing = false;
-    const ctx = new TransactionContext(ledgerState, Static.blockContext(new Date(0)));
-    const vtx = tx.wellFormed(ledgerState, strictness, new Date(0));
-    const [newLedger, result] = ledgerState.apply(vtx, ctx);
-    ledgerState = newLedger.postBlockUpdate(new Date(0));
-    return { secretKeys, ledgerState, coinInfo, events: result.events };
-  }
-
-  function serializeEvents(events: Event[]): Uint8Array {
-    const parts = events.map((e) => e.serialize());
-    const totalLength = parts.reduce((acc, p) => acc + p.length, 0);
-    const result = new Uint8Array(totalLength);
-    let currentOffset = 0;
-    parts.forEach((part) => {
-      result.set(part, currentOffset);
-      currentOffset += part.length;
-    });
-    return result;
-  }
 
   test('merkleTreeRoot - blank tree has a defined bigint root', () => {
     const localState = new ZswapLocalState();

--- a/integration-tests/src/test/no-proving/WalletControl.test.ts
+++ b/integration-tests/src/test/no-proving/WalletControl.test.ts
@@ -1,0 +1,566 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  coinNullifier,
+  createShieldedCoinInfo,
+  type Event,
+  LedgerState,
+  MerkleTreeCollapsedUpdate,
+  Transaction,
+  TransactionContext,
+  WellFormedStrictness,
+  ZswapChainState,
+  ZswapLocalState,
+  ZswapOffer,
+  ZswapOutput,
+  ZswapSecretKeys
+} from '@midnight-ntwrk/ledger';
+import { TestState } from '@/test/utils/TestState';
+import { LOCAL_TEST_NETWORK_ID, type ShieldedTokenType, Static } from '@/test-objects';
+import { assertSerializationSuccess } from '@/test-utils';
+
+describe('Confirmed bugs', () => {
+  test('replayRawEvents drops every event after the first when given concatenated bytes', () => {
+    const sk = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    const ledger = new LedgerState(LOCAL_TEST_NETWORK_ID, new ZswapChainState());
+    const strictness = new WellFormedStrictness();
+    strictness.enforceBalancing = false;
+
+    const coin1 = createShieldedCoinInfo(Static.defaultShieldedTokenType().raw, 10n);
+    const coin2 = createShieldedCoinInfo(Static.defaultShieldedTokenType().raw, 20n);
+    const offer = ZswapOffer.fromOutput(
+      ZswapOutput.new(coin1, 0, sk.coinPublicKey, sk.encryptionPublicKey),
+      coin1.type,
+      coin1.value
+    ).merge(
+      ZswapOffer.fromOutput(
+        ZswapOutput.new(coin2, 0, sk.coinPublicKey, sk.encryptionPublicKey),
+        coin2.type,
+        coin2.value
+      )
+    );
+
+    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, offer);
+    const ctx = new TransactionContext(ledger, Static.blockContext(new Date(0)));
+    const vtx = tx.wellFormed(ledger, strictness, new Date(0));
+    const [, result] = ledger.apply(vtx, ctx);
+
+    expect(result.events.length).toEqual(2);
+
+    const parts = result.events.map((e: Event) => e.serialize());
+    const totalLength = parts.reduce((acc: number, p: Uint8Array) => acc + p.length, 0);
+    const rawBytes = new Uint8Array(totalLength);
+    let offset = 0;
+    parts.forEach((part: Uint8Array) => {
+      rawBytes.set(part, offset);
+      offset += part.length;
+    });
+
+    const raw = new ZswapLocalState().replayRawEvents(sk, rawBytes);
+
+    expect(raw.state.coins.size).toEqual(2);
+    expect(raw.state.firstFree).toEqual(2n);
+  });
+});
+
+describe('Wallet Control - Finer ZswapLocalState control', () => {
+  function setupWithCoin(value: bigint = 10n) {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    let ledgerState = new LedgerState(LOCAL_TEST_NETWORK_ID, new ZswapChainState());
+    const coinInfo = Static.shieldedCoinInfo(value);
+    const offer = ZswapOffer.fromOutput(
+      ZswapOutput.new(coinInfo, 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey),
+      coinInfo.type,
+      coinInfo.value
+    );
+    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, offer);
+    const strictness = new WellFormedStrictness();
+    strictness.enforceBalancing = false;
+    const ctx = new TransactionContext(ledgerState, Static.blockContext(new Date(0)));
+    const vtx = tx.wellFormed(ledgerState, strictness, new Date(0));
+    const [newLedger, result] = ledgerState.apply(vtx, ctx);
+    ledgerState = newLedger.postBlockUpdate(new Date(0));
+    return { secretKeys, ledgerState, coinInfo, events: result.events };
+  }
+
+  function serializeEvents(events: Event[]): Uint8Array {
+    const parts = events.map((e) => e.serialize());
+    const totalLength = parts.reduce((acc, p) => acc + p.length, 0);
+    const result = new Uint8Array(totalLength);
+    let currentOffset = 0;
+    parts.forEach((part) => {
+      result.set(part, currentOffset);
+      currentOffset += part.length;
+    });
+    return result;
+  }
+
+  test('merkleTreeRoot - blank tree has a defined bigint root', () => {
+    const localState = new ZswapLocalState();
+    expect(localState.merkleTreeRoot).toBeDefined();
+    expect(typeof localState.merkleTreeRoot).toBe('bigint');
+  });
+
+  test('merkleTreeRoot - changes after each new coin', () => {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    let ledgerState = new LedgerState(LOCAL_TEST_NETWORK_ID, new ZswapChainState());
+    const strictness = new WellFormedStrictness();
+    strictness.enforceBalancing = false;
+    let localState = new ZswapLocalState();
+
+    const coin1 = Static.shieldedCoinInfo(100n);
+    const offer1 = ZswapOffer.fromOutput(
+      ZswapOutput.new(coin1, 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey),
+      coin1.type,
+      coin1.value
+    );
+    const tx1 = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, offer1);
+    const ctx1 = new TransactionContext(ledgerState, Static.blockContext(new Date(0)));
+    const vtx1 = tx1.wellFormed(ledgerState, strictness, new Date(0));
+    const [ledger2, result1] = ledgerState.apply(vtx1, ctx1);
+    localState = localState.replayEvents(secretKeys, result1.events);
+    const root1 = localState.merkleTreeRoot;
+
+    ledgerState = ledger2.postBlockUpdate(new Date(0));
+    const coin2 = Static.shieldedCoinInfo(200n);
+    const offer2 = ZswapOffer.fromOutput(
+      ZswapOutput.new(coin2, 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey),
+      coin2.type,
+      coin2.value
+    );
+    const tx2 = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, offer2);
+    const ctx2 = new TransactionContext(ledgerState, Static.blockContext(new Date(1)));
+    const vtx2 = tx2.wellFormed(ledgerState, strictness, new Date(1));
+    const { events: events2 } = ledgerState.apply(vtx2, ctx2)[1];
+    localState = localState.replayEvents(secretKeys, events2);
+    const root2 = localState.merkleTreeRoot;
+
+    expect(root1).toBeDefined();
+    expect(root2).toBeDefined();
+    expect(root1).not.toEqual(root2);
+  });
+
+  test('insertCoin - adds coin to wallet, advances firstFree, serializes', () => {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    const localState = new ZswapLocalState();
+
+    const coinInfo = Static.shieldedCoinInfo(42n);
+    const updated = localState.insertCoin(secretKeys, coinInfo);
+
+    expect(updated.coins.size).toEqual(1);
+    expect(updated.firstFree).toEqual(1n);
+    expect(updated.merkleTreeRoot).toBeDefined();
+    assertSerializationSuccess(updated);
+  });
+
+  test('insertCoin - assigns mt_index = firstFree at the moment of insertion', () => {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    let localState = new ZswapLocalState();
+
+    localState = localState.insertCoin(secretKeys, Static.shieldedCoinInfo(10n));
+    localState = localState.insertCoin(secretKeys, Static.shieldedCoinInfo(20n));
+
+    expect(localState.coins.size).toEqual(2);
+    expect(localState.firstFree).toEqual(2n);
+
+    const storedIndices = Array.from(localState.coins)
+      .map((c) => c.mt_index)
+      .sort();
+    expect(storedIndices).toEqual([0n, 1n]);
+  });
+
+  test('insertCoin - inserted coin is immediately spendable', () => {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    const localState = new ZswapLocalState();
+
+    const coinInfo = Static.shieldedCoinInfo(42n);
+    const withCoin = localState.insertCoin(secretKeys, coinInfo);
+    const storedCoin = Array.from(withCoin.coins)[0];
+    expect(storedCoin.mt_index).toEqual(0n);
+
+    const [spentState, spendInput] = withCoin.spend(secretKeys, storedCoin, 0);
+    expect(spentState.pendingSpends.size).toEqual(1);
+    expect(spendInput.nullifier).toBeDefined();
+  });
+
+  test('removeCoinByNullifier - removes the coin from tracking; firstFree stays advanced because the tree slot is permanent', () => {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    const coinInfo = Static.shieldedCoinInfo(42n);
+
+    const withCoin = new ZswapLocalState().insertCoin(secretKeys, coinInfo);
+    const nullifier = coinNullifier(coinInfo, secretKeys.coinSecretKey);
+    const withoutCoin = withCoin.removeCoinByNullifier(nullifier);
+
+    expect(withoutCoin.coins.size).toEqual(0);
+    expect(withoutCoin.firstFree).toEqual(1n);
+    assertSerializationSuccess(withoutCoin);
+  });
+
+  test('removeCoinByNullifier - is a no-op for unknown nullifier', () => {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    const withCoin = new ZswapLocalState().insertCoin(secretKeys, Static.shieldedCoinInfo(42n));
+
+    const afterRemove = withCoin.removeCoinByNullifier('0'.repeat(64));
+
+    expect(afterRemove.coins.size).toEqual(1);
+  });
+
+  test('removeCoinByNullifier - leaves other coins untouched', () => {
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    const coin1 = Static.shieldedCoinInfo(10n);
+    const coin2 = Static.shieldedCoinInfo(20n);
+
+    let localState = new ZswapLocalState().insertCoin(secretKeys, coin1).insertCoin(secretKeys, coin2);
+
+    localState = localState.removeCoinByNullifier(coinNullifier(coin1, secretKeys.coinSecretKey));
+
+    expect(localState.coins.size).toEqual(1);
+    expect(Array.from(localState.coins)[0].value).toEqual(20n);
+  });
+
+  test('removeCoinByNullifier - also clears matching pending spend', () => {
+    const { secretKeys, events } = setupWithCoin(100n);
+    const localState = new ZswapLocalState().replayEvents(secretKeys, events);
+
+    const coin = Array.from(localState.coins)[0];
+    const [stateWithPending] = localState.spend(secretKeys, coin, 0);
+    expect(stateWithPending.pendingSpends.size).toEqual(1);
+
+    const nullifier = coinNullifier(
+      { type: coin.type, nonce: coin.nonce, value: coin.value },
+      secretKeys.coinSecretKey
+    );
+    const afterRemove = stateWithPending.removeCoinByNullifier(nullifier);
+
+    expect(afterRemove.pendingSpends.size).toEqual(0);
+  });
+
+  test('replayRawEvents - produces same state as replayEventsWithChanges', () => {
+    const { secretKeys, events } = setupWithCoin(50n);
+    const localState = new ZswapLocalState();
+
+    const rawBytes = serializeEvents(events);
+
+    const withChanges = localState.replayEventsWithChanges(secretKeys, events);
+    const rawResult = localState.replayRawEvents(secretKeys, rawBytes);
+
+    expect(rawResult.state.firstFree).toEqual(withChanges.state.firstFree);
+    expect(rawResult.state.coins.size).toEqual(withChanges.state.coins.size);
+    expect(rawResult.state.merkleTreeRoot).toEqual(withChanges.state.merkleTreeRoot);
+
+    const normalReceived = withChanges.changes.flatMap((c) => c.receivedCoins);
+    const rawReceived = rawResult.changes.flatMap((c) => c.receivedCoins);
+    expect(rawReceived).toEqual(normalReceived);
+  });
+
+  test('replayRawEvents - empty raw bytes return unchanged state', () => {
+    const { secretKeys, events } = setupWithCoin(100n);
+    const localState = new ZswapLocalState().replayEvents(secretKeys, events);
+
+    const emptyResult = localState.replayRawEvents(secretKeys, new Uint8Array(0));
+
+    expect(emptyResult.state.firstFree).toEqual(localState.firstFree);
+    expect(emptyResult.state.coins.size).toEqual(localState.coins.size);
+    expect(emptyResult.changes.length).toEqual(0);
+  });
+
+  test('applyWithChanges - output-only offer matches apply and reports received coin', () => {
+    const { secretKeys, events } = setupWithCoin(100n);
+    const localState = new ZswapLocalState().replayEvents(secretKeys, events);
+
+    const newCoin = Static.shieldedCoinInfo(50n);
+    const offer = ZswapOffer.fromOutput(
+      ZswapOutput.new(newCoin, 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey),
+      newCoin.type,
+      newCoin.value
+    );
+
+    const afterApply = localState.apply(secretKeys, offer);
+    const withChanges = localState.applyWithChanges(secretKeys, offer);
+
+    expect(withChanges.state.firstFree).toEqual(afterApply.firstFree);
+    expect(withChanges.state.coins.size).toEqual(afterApply.coins.size);
+    expect(withChanges.state.merkleTreeRoot).toEqual(afterApply.merkleTreeRoot);
+
+    const receivedCoins = withChanges.changes.flatMap((c) => c.receivedCoins);
+    expect(receivedCoins.length).toEqual(1);
+    expect(receivedCoins[0].value).toEqual(50n);
+  });
+
+  test('applyWithChanges - transfer reports both spent and received coins', () => {
+    const { secretKeys, events } = setupWithCoin(100n);
+    const localState = new ZswapLocalState().replayEvents(secretKeys, events);
+
+    const coinToSpend = Array.from(localState.coins)[0];
+    const [stateWithPending, input] = localState.spend(secretKeys, coinToSpend, 0);
+
+    const changeCoin = Static.shieldedCoinInfo(30n);
+    const changeOutput = ZswapOutput.new(changeCoin, 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey);
+    const transferOffer = ZswapOffer.fromInput(input, coinToSpend.type, coinToSpend.value).merge(
+      ZswapOffer.fromOutput(changeOutput, coinToSpend.type, 30n)
+    );
+
+    const withChanges = stateWithPending.applyWithChanges(secretKeys, transferOffer);
+
+    const receivedCoins = withChanges.changes.flatMap((c) => c.receivedCoins);
+    const spentCoins = withChanges.changes.flatMap((c) => c.spentCoins);
+
+    expect(spentCoins.length).toEqual(1);
+    expect(spentCoins[0].value).toEqual(coinToSpend.value);
+
+    expect(receivedCoins.length).toEqual(1);
+    expect(receivedCoins[0].value).toEqual(30n);
+  });
+
+  test('applyWithChanges - input-only offer matches apply', () => {
+    const { secretKeys, events } = setupWithCoin(100n);
+    const localState = new ZswapLocalState().replayEvents(secretKeys, events);
+
+    const coin = Array.from(localState.coins)[0];
+    const [stateWithPending, input] = localState.spend(secretKeys, coin, 0);
+    const spendOnlyOffer = ZswapOffer.fromInput(input, coin.type, coin.value);
+
+    const afterApply = stateWithPending.apply(secretKeys, spendOnlyOffer);
+    const afterApplyWithChanges = stateWithPending.applyWithChanges(secretKeys, spendOnlyOffer);
+
+    expect(afterApplyWithChanges.state.coins.size).toEqual(afterApply.coins.size);
+    expect(afterApplyWithChanges.state.firstFree).toEqual(afterApply.firstFree);
+    expect(afterApplyWithChanges.state.pendingSpends.size).toEqual(afterApply.pendingSpends.size);
+  });
+
+  test('applyWithChanges - transient (input + output of same coin) matches apply', () => {
+    const { secretKeys, events } = setupWithCoin(100n);
+    const localState = new ZswapLocalState().replayEvents(secretKeys, events);
+
+    const coin = Array.from(localState.coins)[0];
+    const [stateWithPending, transient] = localState.spendFromOutput(
+      secretKeys,
+      coin,
+      0,
+      ZswapOutput.new(Static.shieldedCoinInfo(50n), 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey)
+    );
+
+    const newOutput = ZswapOutput.new(
+      Static.shieldedCoinInfo(30n),
+      0,
+      secretKeys.coinPublicKey,
+      secretKeys.encryptionPublicKey
+    );
+    const offer = ZswapOffer.fromTransient(transient).merge(ZswapOffer.fromOutput(newOutput, coin.type, 30n));
+
+    const afterApply = stateWithPending.apply(secretKeys, offer);
+    const afterApplyWithChanges = stateWithPending.applyWithChanges(secretKeys, offer);
+
+    expect(afterApplyWithChanges.state.coins.size).toEqual(afterApply.coins.size);
+    expect(afterApplyWithChanges.state.firstFree).toEqual(afterApply.firstFree);
+    expect(afterApplyWithChanges.state.merkleTreeRoot).toEqual(afterApply.merkleTreeRoot);
+  });
+
+  test('applyWithChanges - mixed 1 input + 2 outputs assigns sequential mt_indices', () => {
+    const { secretKeys, events } = setupWithCoin(100n);
+    const localState = new ZswapLocalState().replayEvents(secretKeys, events);
+
+    const coin = Array.from(localState.coins)[0];
+    const [stateWithPending, input] = localState.spend(secretKeys, coin, 0);
+
+    const out1 = ZswapOutput.new(
+      createShieldedCoinInfo(coin.type, 40n),
+      0,
+      secretKeys.coinPublicKey,
+      secretKeys.encryptionPublicKey
+    );
+    const out2 = ZswapOutput.new(
+      createShieldedCoinInfo(coin.type, 60n),
+      0,
+      secretKeys.coinPublicKey,
+      secretKeys.encryptionPublicKey
+    );
+    const offer = ZswapOffer.fromInput(input, coin.type, coin.value)
+      .merge(ZswapOffer.fromOutput(out1, coin.type, 40n))
+      .merge(ZswapOffer.fromOutput(out2, coin.type, 60n));
+
+    const afterApply = stateWithPending.apply(secretKeys, offer);
+    const afterApplyWithChanges = stateWithPending.applyWithChanges(secretKeys, offer);
+
+    expect(afterApplyWithChanges.state.coins.size).toEqual(afterApply.coins.size);
+    expect(afterApplyWithChanges.state.firstFree).toEqual(afterApply.firstFree);
+    expect(afterApplyWithChanges.state.merkleTreeRoot).toEqual(afterApply.merkleTreeRoot);
+
+    const receivedCoins = afterApplyWithChanges.changes.flatMap((c) => c.receivedCoins);
+    expect(receivedCoins.length).toEqual(2);
+    const mtIndices = receivedCoins.map((c) => c.mt_index).sort();
+    expect(mtIndices[1] - mtIndices[0]).toEqual(1n);
+  });
+
+  test('Event.source - exposes transaction metadata', () => {
+    const { events } = setupWithCoin();
+
+    expect(events.length).toBeGreaterThan(0);
+
+    const { source } = events[0];
+
+    expect(source).toBeDefined();
+    expect(source.transactionHash).toBeDefined();
+    expect(typeof source.transactionHash).toBe('string');
+    expect(typeof source.logicalSegment).toBe('number');
+    expect(typeof source.physicalSegment).toBe('number');
+  });
+
+  test('Event.source - all events from the same transaction share transactionHash', () => {
+    const { events } = setupWithCoin();
+
+    if (events.length > 1) {
+      const { transactionHash } = events[0].source;
+      events.forEach((event) => {
+        expect(event.source.transactionHash).toEqual(transactionHash);
+      });
+    }
+  });
+
+  test('Event.content - exposes a tagged union (zswapInput / zswapOutput / etc.)', () => {
+    const { events } = setupWithCoin();
+
+    expect(events.length).toBeGreaterThan(0);
+    events.forEach((event) => {
+      const { content } = event as Event & { content: { tag: string } };
+      expect(content).toBeDefined();
+      expect(typeof content.tag).toBe('string');
+    });
+
+    const tags = events.map((e) => (e as Event & { content: { tag: string } }).content.tag);
+    expect(tags).toContain('zswapOutput');
+  });
+
+  test('Event - serialize and deserialize round-trip', () => {
+    const { events } = setupWithCoin();
+
+    expect(events.length).toBeGreaterThan(0);
+    events.forEach((event) => {
+      const serialized = event.serialize();
+      expect(serialized).toBeInstanceOf(Uint8Array);
+      expect(serialized.length).toBeGreaterThan(0);
+
+      const EventClass = event.constructor as unknown as { deserialize(raw: Uint8Array): Event };
+      const deserialized = EventClass.deserialize(serialized);
+
+      expect(deserialized.source).toBeDefined();
+      expect(deserialized.source.transactionHash).toEqual(event.source.transactionHash);
+      expect(deserialized.source.logicalSegment).toEqual(event.source.logicalSegment);
+      expect(deserialized.source.physicalSegment).toEqual(event.source.physicalSegment);
+    });
+  });
+
+  test('realistic scenario - rewardsShielded + insertCoin + removeCoinByNullifier on a TestState wallet', () => {
+    const state = TestState.new();
+    const token: ShieldedTokenType = Static.defaultShieldedTokenType();
+
+    const firstReward = 100_000n;
+    state.rewardsShielded(token, firstReward);
+
+    const rootAfterFirstReward = state.zswap.merkleTreeRoot;
+    expect(rootAfterFirstReward).toBeDefined();
+    expect(state.zswap.coins.size).toBeGreaterThan(0);
+
+    const secondReward = 250_000n;
+    state.rewardsShielded(token, secondReward);
+
+    expect(state.zswap.merkleTreeRoot).not.toEqual(rootAfterFirstReward);
+
+    const totalFunds = Array.from(state.zswap.coins)
+      .filter((c) => c.type === token.raw)
+      .reduce((acc, c) => acc + c.value, 0n);
+    expect(totalFunds).toBeGreaterThanOrEqual(firstReward + secondReward);
+
+    const manualCoin = createShieldedCoinInfo(token.raw, 999n);
+    const coinsBeforeInsert = state.zswap.coins.size;
+    const firstFreeBeforeInsert = state.zswap.firstFree;
+    const stateAfterInsert = state.zswap.insertCoin(state.zswapKeys, manualCoin);
+
+    expect(stateAfterInsert.coins.size).toEqual(coinsBeforeInsert + 1);
+    expect(stateAfterInsert.firstFree).toEqual(firstFreeBeforeInsert + 1n);
+
+    const nullifier = coinNullifier(manualCoin, state.zswapKeys.coinSecretKey);
+    const stateAfterRemove = stateAfterInsert.removeCoinByNullifier(nullifier);
+
+    expect(stateAfterRemove.coins.size).toEqual(coinsBeforeInsert);
+    expect(stateAfterRemove.firstFree).toEqual(stateAfterInsert.firstFree);
+
+    assertSerializationSuccess(stateAfterRemove);
+  });
+
+  test('realistic scenario - sender/receiver transfer with collapsed update and event replay', () => {
+    const senderKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    const receiverKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(2));
+
+    let ledgerState = new LedgerState(LOCAL_TEST_NETWORK_ID, new ZswapChainState());
+    let senderState = new ZswapLocalState();
+    let receiverState = new ZswapLocalState();
+    const strictness = new WellFormedStrictness();
+    strictness.enforceBalancing = false;
+
+    const initialCoin = Static.shieldedCoinInfo(1000n);
+    const initialOffer = ZswapOffer.fromOutput(
+      ZswapOutput.new(initialCoin, 0, senderKeys.coinPublicKey, senderKeys.encryptionPublicKey),
+      initialCoin.type,
+      initialCoin.value
+    );
+    const tx1 = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, initialOffer);
+    const ctx1 = new TransactionContext(ledgerState, Static.blockContext(new Date(0)));
+    const vtx1 = tx1.wellFormed(ledgerState, strictness, new Date(0));
+    const [ledger2, result1] = ledgerState.apply(vtx1, ctx1);
+    ledgerState = ledger2.postBlockUpdate(new Date(0));
+    senderState = senderState.replayEvents(senderKeys, result1.events);
+
+    const collapsedUpdate = new MerkleTreeCollapsedUpdate(ledgerState.zswap, 0n, 0n);
+    receiverState = receiverState.applyCollapsedUpdate(collapsedUpdate);
+
+    const senderCoin = Array.from(senderState.coins)[0];
+    const [, input] = senderState.spend(senderKeys, senderCoin, 0);
+
+    const transferValue = 300n;
+    const transferCoin = Static.shieldedCoinInfo(transferValue);
+    const receiverOutput = ZswapOutput.new(
+      transferCoin,
+      0,
+      receiverKeys.coinPublicKey,
+      receiverKeys.encryptionPublicKey
+    );
+    const changeCoin = Static.shieldedCoinInfo(senderCoin.value - transferValue);
+    const changeOutput = ZswapOutput.new(changeCoin, 0, senderKeys.coinPublicKey, senderKeys.encryptionPublicKey);
+
+    const transferOffer = ZswapOffer.fromInput(input, senderCoin.type, senderCoin.value)
+      .merge(ZswapOffer.fromOutput(receiverOutput, senderCoin.type, transferValue))
+      .merge(ZswapOffer.fromOutput(changeOutput, senderCoin.type, senderCoin.value - transferValue));
+
+    const tx2 = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, transferOffer);
+    const ctx2 = new TransactionContext(ledgerState, Static.blockContext(new Date(1)));
+    const vtx2 = tx2.wellFormed(ledgerState, strictness, new Date(1));
+    const { events: transferEvents } = ledgerState.apply(vtx2, ctx2)[1];
+
+    expect(transferEvents.length).toBeGreaterThan(0);
+    const { source } = transferEvents[0];
+    expect(source.transactionHash).toBeDefined();
+    expect(source.logicalSegment).toEqual(0);
+
+    const receiverResult = receiverState.replayEventsWithChanges(receiverKeys, transferEvents);
+
+    const receivedCoins = receiverResult.changes.flatMap((c) => c.receivedCoins);
+    expect(receivedCoins.length).toEqual(1);
+    expect(receivedCoins[0].value).toEqual(transferValue);
+
+    const receiverCoin = Array.from(receiverResult.state.coins)[0];
+    expect(receiverCoin.value).toEqual(transferValue);
+    expect(receiverCoin.mt_index).toBeDefined();
+  });
+});

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -266,7 +266,6 @@ export type EventDetails =
   } | {
     tag: 'zswapOutput',
     commitment: CoinCommitment,
-    preimageEvidence: ZswapPreimageEvidence,
     contract: ContractAddress | undefined,
     mtIndex: bigint,
   } | {
@@ -289,6 +288,24 @@ export type EventDetails =
   } |
   // Other variants may be added and some events are not yet supported in this API.
   { tag: string };
+
+/**
+ * A path evidencing how to insert an entry into a Merkle tree, even if it is
+ * collapsed.
+ */
+export type TreeInsertionPath<A> = {
+  leafHash: string,
+  annotation: A,
+  path: TreeInsertionPathEntry[],
+};
+
+/**
+ * A single entry in a {@link TreeInsertionPath}.
+ */
+export type TreeInsertionPathEntry = {
+  hash: bigint | undefined,
+  goesLeft: boolean,
+};
 
 /**
  * A secret key for the Dust, used to derive Dust UTxO nonces and prove credentials to spend Dust UTxOs
@@ -418,8 +435,8 @@ export class DustGenerationState {
 
 export class DustStateMerkleTreeCollapsedUpdate {
   private constructor();
-  static newFromGenerationTree(state: DustGenerationState, start: bigint, end: bigint);
-  static newFromCommitmentTree(state: DustUtxoState, start: bigint, end: bigint);
+  static newFromGenerationTree(state: DustGenerationState, start: bigint, end: bigint): DustStateMerkleTreeCollapsedUpdate;
+  static newFromCommitmentTree(state: DustUtxoState, start: bigint, end: bigint): DustStateMerkleTreeCollapsedUpdate;
   serialize(): Uint8Array;
   static deserialize(raw: Uint8Array): DustStateMerkleTreeCollapsedUpdate;
   toString(compact?: boolean): string;
@@ -1747,7 +1764,7 @@ export class ZswapLocalState {
    * This function requires secret keys as coins are indexed by nullifier, and
    * secret keys are required to compute this.
    */
-  insertCoin(secretKeys: ZswapSecretKeys, coin: QualifiedCoinInfo): ZswapLocalState;
+  insertCoin(secretKeys: ZswapSecretKeys, coin: QualifiedShieldedCoinInfo): ZswapLocalState;
 
   /**
    * Removes a given coin from the tracked coins by its nullifier.

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -232,7 +232,7 @@ export class Event {
   static deserialize(raw: Uint8Array): Event;
   toString(compact?: boolean): string;
   readonly source: EventSource;
-  readonly details: EventDetails;
+  readonly content: EventDetails;
 }
 
 /**
@@ -1764,7 +1764,7 @@ export class ZswapLocalState {
    * This function requires secret keys as coins are indexed by nullifier, and
    * secret keys are required to compute this.
    */
-  insertCoin(secretKeys: ZswapSecretKeys, coin: QualifiedShieldedCoinInfo): ZswapLocalState;
+  insertCoin(secretKeys: ZswapSecretKeys, coin: ShieldedCoinInfo): ZswapLocalState;
 
   /**
    * Removes a given coin from the tracked coins by its nullifier.

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -231,7 +231,64 @@ export class Event {
   serialize(): Uint8Array;
   static deserialize(raw: Uint8Array): Event;
   toString(compact?: boolean): string;
+  readonly source: EventSource;
+  readonly details: EventDetails;
 }
+
+/**
+ * Where an event originated from
+ */
+export type EventSource = {
+  /**
+   * The hash of the originating transaction.
+   */
+  transactionHash: TransactionHash,
+  /**
+   * The logical event segment, that is, during which segment's execution the
+   * event was emitted.
+   */
+  logicalSegment: number,
+  /**
+   * The physical event segment, that is, the segment of the transaction this
+   * event's trigger is contained in.
+   */
+  physicalSegment: number,
+};
+
+/**
+ * Details of the event emitted
+ */
+export type EventDetails =
+  {
+    tag: 'zswapInput',
+    nullifier: Nullifier,
+    contract: ContractAddress | undefined,
+  } | {
+    tag: 'zswapOutput',
+    commitment: CoinCommitment,
+    preimageEvidence: ZswapPreimageEvidence,
+    contract: ContractAddress | undefined,
+    mtIndex: bigint,
+  } | {
+    tag: 'dustInitialUtxo',
+    generation: DustGenerationInfo,
+    generationIndex: bigint,
+    blockTime: Date,
+  } | {
+    tag: 'dustGenerationDtimeUpdate',
+    update: TreeInsertionPath<DustGenerationInfo>,
+    blockTime: Date,
+  } | {
+    tag: 'dustSpendProcessed',
+    commitment: DustCommitment,
+    commitmentIndex: bigint,
+    nullifier: DustNullifier,
+    vFee: bigint,
+    declaredTime: Date,
+    blockTime: Date,
+  } |
+  // Other variants may be added and some events are not yet supported in this API.
+  { tag: string };
 
 /**
  * A secret key for the Dust, used to derive Dust UTxO nonces and prove credentials to spend Dust UTxOs
@@ -423,6 +480,10 @@ export class DustLocalState {
   processTtls(time: Date): DustLocalState;
   replayEvents(sk: DustSecretKey, events: Event[]): DustLocalState;
   replayEventsWithChanges(sk: DustSecretKey, events: Event[]): DustLocalStateWithChanges;
+  /**
+   * Replays a direct concatenation of serialized ledger events. Otherwise acts as `replayEventsWithChanges`.
+   */
+  replayRawEvents(sk: DustSecretKey, rawEvents: Uint8Array): DustLocalStateWithChanges;
   addUtxo(nullifier: DustNullifier, utxo: QualifiedDustOutput, pendingUntil?: Date): DustLocalState;
   findUtxoByNullifier(nullifier: DustNullifier): QualifiedDustOutput | undefined;
   removeUtxo(nullifier: DustNullifier): DustLocalState;
@@ -1704,9 +1765,17 @@ export class ZswapLocalState {
    */
   replayEventsWithChanges(secretKeys: ZswapSecretKeys, events: Event[]): ZswapLocalStateWithChanges;
   /**
+   * Replays a direct concatenation of serialized ledger events. Otherwise acts as `replayEventsWithChanges`.
+   */
+  replayRawEvents(sk: ZswapSecretKeys, rawEvents: Uint8Array): ZswapLocalStateWithChanges;
+  /**
    * Locally applies an offer to the current state, returning the updated state
    */
   apply<P extends Proofish>(secretKeys: ZswapSecretKeys, offer: ZswapOffer<P>): ZswapLocalState;
+  /**
+   * Locally applies an offer to the current state, returning both the updated state and the state changes.
+   */
+  applyWithChanges<P extends Proofish>(secretKeys: ZswapSecretKeys, offer: ZswapOffer<P>): ZswapLocalStateWithChanges;
   /**
    * Locally reverts pending outputs/spends from an offer known to have failed
    * or which has been discarded.
@@ -1778,6 +1847,10 @@ export class ZswapLocalState {
    * future. Each has an optional TTL attached.
    */
   readonly pendingSpends: Map<Nullifier, [QualifiedShieldedCoinInfo, Date | undefined]>;
+  /**
+   * The root of the commitment Merkle tree.
+   */
+  readonly merkleTreeRoot: bigint | undefined;
 }
 
 /**

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -1681,6 +1681,19 @@ export class ZswapLocalState {
   applyCollapsedUpdate(update: MerkleTreeCollapsedUpdate): ZswapLocalState;
 
   /**
+   * Directly inserts a coin owned by this wallet into the state at `this.first_free`.
+   *
+   * This function requires secret keys as coins are indexed by nullifier, and
+   * secret keys are required to compute this.
+   */
+  insertCoin(secretKeys: ZswapSecretKeys, coin: QualifiedCoinInfo): ZswapLocalState;
+
+  /**
+   * Removes a given coin from the tracked coins by its nullifier.
+   */
+  removeCoinByNullifier(nullifier: Nullifier): ZswapLocalState;
+
+  /**
    * Replays observed events against the current local state. These *must* be replayed
    * in the same order as emitted by the chain being followed.
    */

--- a/ledger-wasm/src/conversions.rs
+++ b/ledger-wasm/src/conversions.rs
@@ -18,6 +18,7 @@ use coin_structure::coin::{Info as ShieldedCoinInfo, QualifiedInfo as QualifiedS
 use coin_structure::coin::{ShieldedTokenType, UnshieldedTokenType};
 use hex::{FromHex, ToHex};
 use js_sys::{BigInt, Date, Function, JsString, Map, Number};
+use ledger::events::{EventDetails, EventSource};
 use ledger::structure::UtxoMeta;
 use ledger::structure::{ClaimKind, SignatureKind};
 use serde::{Deserialize, Serialize};
@@ -27,6 +28,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use storage::storage::HashMap;
 use transient_crypto::curve::Fr;
+use transient_crypto::merkle_tree::{TreeInsertionPath, TreeInsertionPathEntry};
 use wasm_bindgen::convert::RefFromWasmAbi;
 use wasm_bindgen::{JsCast, JsError, JsValue};
 
@@ -314,6 +316,69 @@ struct PreDustParameters {
     dust_grace_period_seconds: BigInt,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PreEventSource {
+    transaction_hash: String,
+    logical_segment: u16,
+    physical_segment: u16,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "tag")]
+struct PreTreeInsertionPath<A> {
+    leaf_hash: String,
+    annotation: A,
+    path: Vec<PreTreeInsertionPathEntry>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "tag")]
+struct PreTreeInsertionPathEntry {
+    #[serde(with = "serde_wasm_bindgen::preserve")]
+    hash: JsValue,
+    goes_left: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase", tag = "tag")]
+enum PreEventDetails {
+    ZswapInput {
+        nullifier: String,
+        contract: Option<String>,
+    },
+    ZswapOutput {
+        commitment: String,
+        contract: Option<String>,
+        mt_index: u64,
+    },
+    DustInitialUtxo {
+        output: PreQualifiedDustOutput,
+        generation: PreDustGenerationInfo,
+        generation_index: u64,
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        block_time: Date,
+    },
+    DustGenerationDtimeUpdate {
+        update: PreTreeInsertionPath<PreDustGenerationInfo>,
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        block_time: Date,
+    },
+    DustSpendProcessed {
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        commitment: BigInt,
+        commitment_index: u64,
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        nullifier: BigInt,
+        v_fee: u128,
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        declared_time: Date,
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        block_time: Date,
+    },
+    NotYetSupportedEventType,
+}
+
 pub fn value_to_shielded_coininfo(value: JsValue) -> Result<ShieldedCoinInfo, JsError> {
     let pre: PreShieldedCoinInfo = from_value(value)?;
     Ok(ShieldedCoinInfo {
@@ -420,16 +485,23 @@ pub fn value_to_utxo_meta(value: JsValue) -> Result<UtxoMeta, JsError> {
     })
 }
 
+impl TryFrom<&QualifiedDustOutput> for PreQualifiedDustOutput {
+    type Error = JsError;
+    fn try_from(qdo: &QualifiedDustOutput) -> Result<Self, JsError> {
+        Ok(PreQualifiedDustOutput {
+            initial_value: qdo.initial_value,
+            owner: fr_to_bigint(qdo.owner.0),
+            nonce: fr_to_bigint(qdo.nonce),
+            seq: qdo.seq,
+            ctime: seconds_to_js_date(qdo.ctime.to_secs()),
+            backing_night: to_hex_ser(&qdo.backing_night.0)?,
+            mt_index: qdo.mt_index,
+        })
+    }
+}
+
 pub fn qdo_to_value(qdo: &QualifiedDustOutput) -> Result<JsValue, JsError> {
-    Ok(to_value(&PreQualifiedDustOutput {
-        initial_value: qdo.initial_value,
-        owner: fr_to_bigint(qdo.owner.0),
-        nonce: fr_to_bigint(qdo.nonce),
-        seq: qdo.seq,
-        ctime: seconds_to_js_date(qdo.ctime.to_secs()),
-        backing_night: to_hex_ser(&qdo.backing_night.0)?,
-        mt_index: qdo.mt_index,
-    })?)
+    Ok(to_value(&PreQualifiedDustOutput::try_from(qdo)?)?)
 }
 
 pub fn value_to_qdo(value: JsValue) -> Result<QualifiedDustOutput, JsError> {
@@ -445,17 +517,24 @@ pub fn value_to_qdo(value: JsValue) -> Result<QualifiedDustOutput, JsError> {
     })
 }
 
+impl TryFrom<&DustGenerationInfo> for PreDustGenerationInfo {
+    type Error = JsError;
+    fn try_from(gen_info: &DustGenerationInfo) -> Result<Self, Self::Error> {
+        Ok(PreDustGenerationInfo {
+            value: gen_info.value,
+            owner: fr_to_bigint(gen_info.owner.0),
+            nonce: to_hex_ser(&gen_info.nonce.0)?,
+            dtime: if gen_info.dtime == Timestamp::MAX {
+                None
+            } else {
+                Some(seconds_to_js_date(gen_info.dtime.to_secs()))
+            },
+        })
+    }
+}
+
 pub fn dust_gen_info_to_value(gen_info: &DustGenerationInfo) -> Result<JsValue, JsError> {
-    Ok(to_value(&PreDustGenerationInfo {
-        value: gen_info.value,
-        owner: fr_to_bigint(gen_info.owner.0),
-        nonce: to_hex_ser(&gen_info.nonce.0)?,
-        dtime: if gen_info.dtime == Timestamp::MAX {
-            None
-        } else {
-            Some(seconds_to_js_date(gen_info.dtime.to_secs()))
-        },
-    })?)
+    Ok(to_value(&PreDustGenerationInfo::try_from(gen_info)?)?)
 }
 
 pub fn value_to_dust_gen_info(value: JsValue) -> Result<DustGenerationInfo, JsError> {
@@ -479,6 +558,104 @@ pub fn value_to_dust_params(value: JsValue) -> Result<DustParameters, JsError> {
         pre.generation_decay_rate,
         pre.dust_grace_period_seconds,
     )
+}
+
+pub fn event_source_to_value(event_source: &EventSource) -> Result<JsValue, JsError> {
+    Ok(to_value(&PreEventSource {
+        transaction_hash: to_hex_ser(&event_source.transaction_hash)?,
+        logical_segment: event_source.logical_segment,
+        physical_segment: event_source.physical_segment,
+    })?)
+}
+
+pub fn event_details_to_value(
+    event_details: &EventDetails<InMemoryDB>,
+) -> Result<JsValue, JsError> {
+    use EventDetails as L;
+    use PreEventDetails as P;
+    let details = match event_details {
+        L::ZswapInput {
+            nullifier,
+            contract,
+        } => P::ZswapInput {
+            nullifier: to_hex_ser(nullifier)?,
+            contract: contract.as_ref().map(|c| to_hex_ser(&**c)).transpose()?,
+        },
+        L::ZswapOutput {
+            commitment,
+            preimage_evidence: _,
+            contract,
+            mt_index,
+        } => P::ZswapOutput {
+            commitment: to_hex_ser(commitment)?,
+            contract: contract.as_ref().map(|c| to_hex_ser(&**c)).transpose()?,
+            mt_index: *mt_index,
+        },
+        L::DustInitialUtxo {
+            output,
+            generation,
+            generation_index,
+            block_time,
+        } => P::DustInitialUtxo {
+            output: PreQualifiedDustOutput::try_from(output)?,
+            generation: PreDustGenerationInfo::try_from(generation)?,
+            generation_index: *generation_index,
+            block_time: seconds_to_js_date(block_time.to_secs()),
+        },
+        L::DustGenerationDtimeUpdate { update, block_time } => P::DustGenerationDtimeUpdate {
+            update: PreTreeInsertionPath::try_from(update)?,
+            block_time: seconds_to_js_date(block_time.to_secs()),
+        },
+        L::DustSpendProcessed {
+            commitment,
+            commitment_index,
+            nullifier,
+            v_fee,
+            declared_time,
+            block_time,
+        } => P::DustSpendProcessed {
+            commitment: fr_to_bigint(commitment.0),
+            commitment_index: *commitment_index,
+            nullifier: fr_to_bigint(nullifier.0),
+            v_fee: *v_fee,
+            declared_time: seconds_to_js_date(declared_time.to_secs()),
+            block_time: seconds_to_js_date(block_time.to_secs()),
+        },
+        _ => P::NotYetSupportedEventType,
+    };
+    Ok(to_value(&details)?)
+}
+
+impl<
+    A: Serializable + Deserializable + Send + Sync + Clone,
+    B: for<'a> TryFrom<&'a A, Error = JsError>,
+> TryFrom<&TreeInsertionPath<A>> for PreTreeInsertionPath<B>
+{
+    type Error = JsError;
+    fn try_from(value: &TreeInsertionPath<A>) -> Result<Self, Self::Error> {
+        Ok(PreTreeInsertionPath {
+            leaf_hash: to_hex_ser(&value.leaf.0)?,
+            annotation: B::try_from(&value.leaf.1)?,
+            path: value
+                .path
+                .iter()
+                .map(PreTreeInsertionPathEntry::try_from)
+                .collect::<Result<_, JsError>>()?,
+        })
+    }
+}
+
+impl TryFrom<&TreeInsertionPathEntry> for PreTreeInsertionPathEntry {
+    type Error = JsError;
+    fn try_from(value: &TreeInsertionPathEntry) -> Result<Self, Self::Error> {
+        Ok(PreTreeInsertionPathEntry {
+            hash: value
+                .hash
+                .map(|h| JsValue::from(fr_to_bigint(h.0)))
+                .unwrap_or(JsValue::UNDEFINED),
+            goes_left: value.goes_left,
+        })
+    }
 }
 
 pub fn construct_dust_parameters(

--- a/ledger-wasm/src/dust.rs
+++ b/ledger-wasm/src/dust.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 use crate::conversions::*;
+use crate::events::Event;
 use crate::state_changes::DustStateChanges;
 use base_crypto::signatures;
 use base_crypto::signatures::Signature;
@@ -26,11 +27,10 @@ use ledger::dust::{
     DustUtxoState as LedgerDustUtxoState, InitialNonce,
     WithDustStateChanges as LedgerWithDustStateChanges,
 };
-use ledger::events::Event as LedgerEvent;
 use ledger::structure::{ProofMarker, ProofPreimageMarker, UtxoMeta as LedgerUtxoMeta};
 use onchain_runtime_wasm::{from_value_hex_ser, from_value_ser, to_value_hex_ser};
 use rand::rngs::OsRng;
-use serialize::tagged_serialize;
+use serialize::{tagged_deserialize_sequence, tagged_serialize};
 use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
@@ -39,45 +39,6 @@ use storage::db::InMemoryDB;
 use transient_crypto::merkle_tree;
 use wasm_bindgen::JsError;
 use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen]
-#[derive(Debug)]
-pub struct Event(pub(crate) LedgerEvent<InMemoryDB>);
-
-impl From<LedgerEvent<InMemoryDB>> for Event {
-    fn from(inner: LedgerEvent<InMemoryDB>) -> Event {
-        Event(inner)
-    }
-}
-
-#[wasm_bindgen]
-impl Event {
-    #[wasm_bindgen(constructor)]
-    pub fn new() -> Result<Event, JsError> {
-        Err(JsError::new(
-            "Event cannot be constructed directly through the WASM API.",
-        ))
-    }
-
-    pub fn serialize(&self) -> Result<Uint8Array, JsError> {
-        let mut res = Vec::new();
-        tagged_serialize(&self.0, &mut res)?;
-        Ok(Uint8Array::from(&res[..]))
-    }
-
-    pub fn deserialize(raw: Uint8Array) -> Result<Event, JsError> {
-        Ok(Event(from_value_ser(raw, "Event")?))
-    }
-
-    #[wasm_bindgen(js_name = "toString")]
-    pub fn to_string(&self, compact: Option<bool>) -> String {
-        if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
-        } else {
-            format!("{:#?}", &self.0)
-        }
-    }
-}
 
 #[derive(Clone)]
 pub enum DustSpendTypes {
@@ -1494,6 +1455,18 @@ impl DustLocalState {
         let sk = sk.try_unwrap()?;
         let events = events.iter().map(|event| &event.0);
         let with_changes = self.0.replay_events_with_changes(&sk, events)?;
+        Ok(DustLocalStateWithChanges::from(with_changes))
+    }
+
+    #[wasm_bindgen(js_name = "replayRawEvents")]
+    pub fn replay_raw_events(
+        &self,
+        sk: &DustSecretKey,
+        raw_events: &[u8],
+    ) -> Result<DustLocalStateWithChanges, JsError> {
+        let sk = sk.try_unwrap()?;
+        let events = tagged_deserialize_sequence(raw_events)?;
+        let with_changes = self.0.replay_events_with_changes(&sk, events.iter())?;
         Ok(DustLocalStateWithChanges::from(with_changes))
     }
 

--- a/ledger-wasm/src/events.rs
+++ b/ledger-wasm/src/events.rs
@@ -1,3 +1,4 @@
+use crate::conversions::event_details_to_value;
 use crate::conversions::event_source_to_value;
 use js_sys::Uint8Array;
 use ledger::events::Event as LedgerEvent;
@@ -48,5 +49,10 @@ impl Event {
     #[wasm_bindgen(getter = "source")]
     pub fn source(&self) -> Result<JsValue, JsError> {
         event_source_to_value(&self.0.source)
+    }
+
+    #[wasm_bindgen(getter = "content")]
+    pub fn content(&self) -> Result<JsValue, JsError> {
+        event_details_to_value(&self.0.content)
     }
 }

--- a/ledger-wasm/src/events.rs
+++ b/ledger-wasm/src/events.rs
@@ -1,0 +1,52 @@
+use crate::conversions::event_source_to_value;
+use js_sys::Uint8Array;
+use ledger::events::Event as LedgerEvent;
+use onchain_runtime_wasm::from_value_ser;
+use serialize::tagged_serialize;
+use storage::db::InMemoryDB;
+use wasm_bindgen::JsError;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct Event(pub(crate) LedgerEvent<InMemoryDB>);
+
+impl From<LedgerEvent<InMemoryDB>> for Event {
+    fn from(inner: LedgerEvent<InMemoryDB>) -> Event {
+        Event(inner)
+    }
+}
+
+#[wasm_bindgen]
+impl Event {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Result<Event, JsError> {
+        Err(JsError::new(
+            "Event cannot be constructed directly through the WASM API.",
+        ))
+    }
+
+    pub fn serialize(&self) -> Result<Uint8Array, JsError> {
+        let mut res = Vec::new();
+        tagged_serialize(&self.0, &mut res)?;
+        Ok(Uint8Array::from(&res[..]))
+    }
+
+    pub fn deserialize(raw: Uint8Array) -> Result<Event, JsError> {
+        Ok(Event(from_value_ser(raw, "Event")?))
+    }
+
+    #[wasm_bindgen(js_name = "toString")]
+    pub fn to_string(&self, compact: Option<bool>) -> String {
+        if compact.unwrap_or(false) {
+            format!("{:?}", &self.0)
+        } else {
+            format!("{:#?}", &self.0)
+        }
+    }
+
+    #[wasm_bindgen(getter = "source")]
+    pub fn source(&self) -> Result<JsValue, JsError> {
+        event_source_to_value(&self.0.source)
+    }
+}

--- a/ledger-wasm/src/lib.rs
+++ b/ledger-wasm/src/lib.rs
@@ -16,6 +16,7 @@ pub mod contract;
 pub mod conversions;
 pub mod crypto;
 pub mod dust;
+pub mod events;
 pub mod intent;
 pub mod state;
 pub mod state_changes;

--- a/ledger-wasm/src/state.rs
+++ b/ledger-wasm/src/state.rs
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 use crate::conversions::*;
-use crate::dust::Event;
 use crate::dust::{DustState, UtxoMeta};
+use crate::events::Event;
 use crate::onchain_runtime::{ContractState, value_to_token_type};
 use crate::tx::{SystemTransaction, TransactionContext, TransactionResult, VerifiedTransaction};
 use crate::zswap_state::*;

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use crate::conversions::*;
-use crate::dust::Event;
+use crate::events::Event;
 use crate::intent::{Intent, IntentTypes};
 use crate::state::LedgerState;
 use crate::transcript::PreTranscript;

--- a/ledger-wasm/src/zswap_state.rs
+++ b/ledger-wasm/src/zswap_state.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use crate::conversions::*;
-use crate::dust::Event;
+use crate::events::Event;
 use crate::state_changes::ZswapStateChanges;
 use crate::tx::{Transaction, get_dyn_transaction};
 use crate::zswap_keys::ZswapSecretKeys;
@@ -31,7 +31,7 @@ use ledger::zswap::WithZswapStateChanges;
 use onchain_runtime_wasm::from_value_ser;
 use rand::Rng;
 use rand::rngs::OsRng;
-use serialize::tagged_serialize;
+use serialize::{tagged_deserialize_sequence, tagged_serialize};
 use std::ops::Deref;
 use storage::{db::InMemoryDB, storage::Map as SMap};
 use transient_crypto::merkle_tree;
@@ -154,6 +154,15 @@ impl ZswapLocalState {
         Ok(res)
     }
 
+    #[wasm_bindgen(getter = "merkleTreeRoot")]
+    pub fn merkle_tree_root(&self) -> JsValue {
+        self.0
+            .merkle_tree
+            .root()
+            .map(|r| JsValue::from(fr_to_bigint(r.0)))
+            .unwrap_or(JsValue::UNDEFINED)
+    }
+
     // pendingSpends: Map<Uint8Array, [QualifiedShieldedCoinInfo, Date | undefined]>
     #[wasm_bindgen(getter, js_name = "pendingSpends")]
     pub fn pending_spends(&self) -> Result<Map, JsError> {
@@ -209,6 +218,19 @@ impl ZswapLocalState {
         Ok(ZswapLocalStateWithChanges::from(with_changes))
     }
 
+    #[wasm_bindgen(js_name = "replayRawEvents")]
+    pub fn replay_raw_events(
+        &self,
+        secret_keys: &ZswapSecretKeys,
+        raw_events: &[u8],
+    ) -> Result<ZswapLocalStateWithChanges, JsError> {
+        let events = tagged_deserialize_sequence(raw_events)?;
+        let with_changes = self
+            .0
+            .replay_events_with_changes(&secret_keys.try_into()?, events.iter())?;
+        Ok(ZswapLocalStateWithChanges::from(with_changes))
+    }
+
     pub fn apply(
         &self,
         secret_keys: &ZswapSecretKeys,
@@ -223,6 +245,28 @@ impl ZswapLocalState {
                 ProofErasedOffer(val) => self.0.apply(&sk_unwrapped, val),
             })?,
         ))
+    }
+
+    #[wasm_bindgen(js_name = "applyWithChanges")]
+    pub fn apply_with_changes(
+        &self,
+        secret_keys: &ZswapSecretKeys,
+        offer: &ZswapOffer,
+    ) -> Result<ZswapLocalStateWithChanges, JsError> {
+        use ZswapOfferTypes::*;
+        let sk_unwrapped = secret_keys.try_into()?;
+        let state = match &offer.0 {
+            ProvenOffer(val) => self.0.apply(&sk_unwrapped, val),
+            UnprovenOffer(val) => self.0.apply(&sk_unwrapped, val),
+            ProofErasedOffer(val) => self.0.apply(&sk_unwrapped, val),
+        }?;
+        let with_changes = WithZswapStateChanges {
+            result: state,
+            // FIXME: This ain't good. But also actually extracting the changes needs to be done
+            // *while* executing, which isn't really supported rn.
+            changes: vec![],
+        };
+        Ok(with_changes.into())
     }
 
     #[wasm_bindgen(js_name = "applyCollapsedUpdate")]

--- a/ledger-wasm/src/zswap_state.rs
+++ b/ledger-wasm/src/zswap_state.rs
@@ -235,6 +235,24 @@ impl ZswapLocalState {
         ))
     }
 
+    #[wasm_bindgen(js_name = "insertCoin")]
+    pub fn insert_coin(
+        &self,
+        secret_keys: &ZswapSecretKeys,
+        coin: JsValue,
+    ) -> Result<ZswapLocalState, JsError> {
+        Ok(ZswapLocalState(self.0.insert_coin(
+            &secret_keys.try_into()?,
+            value_to_qualified_shielded_coininfo(coin)?,
+        )?))
+    }
+
+    #[wasm_bindgen(js_name = "removeCoinByNullifier")]
+    pub fn remove_coin_by_nullifier(&self, nullifier: &str) -> Result<ZswapLocalState, JsError> {
+        let nullifier = from_hex_ser(nullifier)?;
+        Ok(ZswapLocalState(self.0.remove_coin_by_nullifier(nullifier)))
+    }
+
     #[wasm_bindgen(js_name = "applyFailed")]
     pub fn apply_failed(&self, offer: &ZswapOffer) -> ZswapLocalState {
         use ZswapOfferTypes::*;

--- a/ledger-wasm/src/zswap_state.rs
+++ b/ledger-wasm/src/zswap_state.rs
@@ -26,6 +26,7 @@ use coin_structure::{
     contract::ContractAddress as Address,
 };
 use js_sys::{Array, Date, JsString, Map, Set, Uint8Array};
+use ledger::events::{EventDetails, EventSource};
 use ledger::semantics::ZswapLocalStateExt;
 use ledger::zswap::WithZswapStateChanges;
 use onchain_runtime_wasm::from_value_ser;
@@ -254,19 +255,52 @@ impl ZswapLocalState {
         offer: &ZswapOffer,
     ) -> Result<ZswapLocalStateWithChanges, JsError> {
         use ZswapOfferTypes::*;
-        let sk_unwrapped = secret_keys.try_into()?;
-        let state = match &offer.0 {
-            ProvenOffer(val) => self.0.apply(&sk_unwrapped, val),
-            UnprovenOffer(val) => self.0.apply(&sk_unwrapped, val),
-            ProofErasedOffer(val) => self.0.apply(&sk_unwrapped, val),
-        }?;
-        let with_changes = WithZswapStateChanges {
-            result: state,
-            // FIXME: This ain't good. But also actually extracting the changes needs to be done
-            // *while* executing, which isn't really supported rn.
-            changes: vec![],
+        let erased = match &offer.0 {
+            ProvenOffer(val) => val.erase_proofs(),
+            UnprovenOffer(val) => val.erase_proofs(),
+            ProofErasedOffer(val) => val.erase_proofs(),
         };
-        Ok(with_changes.into())
+        let inputs = erased
+            .inputs
+            .iter()
+            .map(|i| (*i).clone())
+            .chain(erased.transient.iter().map(|t| t.as_input()));
+        let outputs = erased
+            .outputs
+            .iter()
+            .map(|o| (*o).clone())
+            .chain(erased.transient.iter().map(|t| t.as_output()));
+        let dummy_source = EventSource {
+            transaction_hash: Default::default(),
+            logical_segment: 0,
+            physical_segment: 0,
+        };
+        let details = inputs
+            .map(|i| EventDetails::ZswapInput {
+                nullifier: i.nullifier,
+                contract: i.contract_address,
+            })
+            .chain(outputs.enumerate().map(|(i, o)| EventDetails::ZswapOutput {
+                commitment: o.coin_com,
+                preimage_evidence: match o.ciphertext {
+                    Some(ciph) => {
+                        ledger::events::ZswapPreimageEvidence::Ciphertext(Box::new((*ciph).clone()))
+                    }
+                    None => ledger::events::ZswapPreimageEvidence::None,
+                },
+                contract: o.contract_address,
+                mt_index: i as u64 + self.0.first_free,
+            }));
+        let events = details
+            .map(|content| ledger::events::Event {
+                source: dummy_source.clone(),
+                content,
+            })
+            .collect::<Vec<_>>();
+        let with_changes = self
+            .0
+            .replay_events_with_changes(&secret_keys.try_into()?, events.iter())?;
+        Ok(ZswapLocalStateWithChanges::from(with_changes))
     }
 
     #[wasm_bindgen(js_name = "applyCollapsedUpdate")]

--- a/ledger-wasm/src/zswap_state.rs
+++ b/ledger-wasm/src/zswap_state.rs
@@ -321,7 +321,7 @@ impl ZswapLocalState {
     ) -> Result<ZswapLocalState, JsError> {
         Ok(ZswapLocalState(self.0.insert_coin(
             &secret_keys.try_into()?,
-            value_to_qualified_shielded_coininfo(coin)?,
+            value_to_shielded_coininfo(coin)?,
         )?))
     }
 

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-serialize"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -69,10 +69,14 @@ fn tagged_deserialize_inner<T: Deserializable + Tagged>(
     }
     let value = <T as Deserializable>::deserialize(&mut reader, 0)?;
 
+    if !ensure_consumed {
+        return Ok(value);
+    }
+
     #[allow(clippy::unbuffered_bytes)] // we can permit a potentally inefficient count here, as in
     let count = reader.bytes().count(); // the happy path it should be 0
 
-    if count == 0 || !ensure_consumed {
+    if count == 0 {
         return Ok(value);
     }
 

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -15,7 +15,7 @@ use crate::VecExt;
 use crate::serializable::GLOBAL_TAG;
 use crate::tagged::Tagged;
 use std::borrow::Cow;
-use std::io::Read;
+use std::io::{BufRead, Read};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{collections::HashMap, collections::HashSet, hash::Hash};
@@ -27,6 +27,23 @@ pub const RECURSION_LIMIT: u32 = 250;
 
 // Top-level deserialization function
 pub fn tagged_deserialize<T: Deserializable + Tagged>(mut reader: impl Read) -> std::io::Result<T> {
+    tagged_deserialize_inner(reader, true)
+}
+
+pub fn tagged_deserialize_sequence<T: Deserializable + Tagged>(
+    mut reader: impl BufRead,
+) -> std::io::Result<Vec<T>> {
+    let mut res = vec![];
+    while reader.has_data_left()? {
+        res.push(tagged_deserialize_inner(reader, false)?);
+    }
+    Ok(res)
+}
+
+fn tagged_deserialize_inner<T: Deserializable + Tagged>(
+    mut reader: impl Read,
+    ensure_consumed: bool,
+) -> std::io::Result<T> {
     let tag_expected = format!("{GLOBAL_TAG}{}:", T::tag());
     let mut read_tag = vec![0u8; tag_expected.len()];
     let mut remaining_tag_buf = &mut read_tag[..];
@@ -55,7 +72,7 @@ pub fn tagged_deserialize<T: Deserializable + Tagged>(mut reader: impl Read) -> 
     #[allow(clippy::unbuffered_bytes)] // we can permit a potentally inefficient count here, as in
     let count = reader.bytes().count(); // the happy path it should be 0
 
-    if count == 0 {
+    if count == 0 || !ensure_consumed {
         return Ok(value);
     }
 

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -26,7 +26,7 @@ pub const RECURSION_LIMIT: u32 = 50;
 pub const RECURSION_LIMIT: u32 = 250;
 
 // Top-level deserialization function
-pub fn tagged_deserialize<T: Deserializable + Tagged>(mut reader: impl Read) -> std::io::Result<T> {
+pub fn tagged_deserialize<T: Deserializable + Tagged>(reader: impl Read) -> std::io::Result<T> {
     tagged_deserialize_inner(reader, true)
 }
 
@@ -34,8 +34,8 @@ pub fn tagged_deserialize_sequence<T: Deserializable + Tagged>(
     mut reader: impl BufRead,
 ) -> std::io::Result<Vec<T>> {
     let mut res = vec![];
-    while reader.has_data_left()? {
-        res.push(tagged_deserialize_inner(reader, false)?);
+    while !reader.fill_buf()?.is_empty() {
+        res.push(tagged_deserialize_inner(&mut reader, false)?);
     }
     Ok(res)
 }

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -21,7 +21,7 @@ mod serializable;
 mod tagged;
 mod util;
 
-pub use crate::deserializable::{Deserializable, RECURSION_LIMIT, tagged_deserialize};
+pub use crate::deserializable::{Deserializable, RECURSION_LIMIT, tagged_deserialize, tagged_deserialize_sequence};
 pub use crate::serializable::{GLOBAL_TAG, Serializable, tagged_serialize, tagged_serialized_size};
 pub use crate::tagged::Tagged;
 #[cfg(feature = "proptest")]

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -21,7 +21,9 @@ mod serializable;
 mod tagged;
 mod util;
 
-pub use crate::deserializable::{Deserializable, RECURSION_LIMIT, tagged_deserialize, tagged_deserialize_sequence};
+pub use crate::deserializable::{
+    Deserializable, RECURSION_LIMIT, tagged_deserialize, tagged_deserialize_sequence,
+};
 pub use crate::serializable::{GLOBAL_TAG, Serializable, tagged_serialize, tagged_serialized_size};
 pub use crate::tagged::Tagged;
 #[cfg(feature = "proptest")]

--- a/zswap/src/local.rs
+++ b/zswap/src/local.rs
@@ -83,6 +83,39 @@ impl<D: DB> State<D> {
         })
     }
 
+    pub fn insert_coin(
+        &self,
+        secret_keys: &SecretKeys,
+        qcoin: QualifiedCoinInfo,
+    ) -> Result<Self, InvalidUpdate> {
+        let coin = CoinInfo::from(&qcoin);
+        let nullifier = coin.nullifier(&SenderEvidence::User(Cow::Borrowed(
+            &secret_keys.coin_secret_key,
+        )));
+        Ok(Self {
+            coins: self.coins.insert(nullifier, qcoin),
+            merkle_tree: self
+                .merkle_tree
+                .update_hash(
+                    self.first_free,
+                    coin.commitment(&Recipient::User(secret_keys.coin_public_key()))
+                        .0,
+                    (),
+                )?
+                .rehash(),
+            first_free: self.first_free + 1,
+            ..self.clone()
+        })
+    }
+
+    pub fn remove_coin_by_nullifier(&self, nullifier: Nullifier) -> Self {
+        Self {
+            coins: self.coins.remove(&nullifier),
+            pending_spends: self.pending_spends.remove(&nullifier),
+            ..self.clone()
+        }
+    }
+
     pub fn apply_claim<P: Storable<D>>(
         &self,
         secret_keys: &SecretKeys,

--- a/zswap/src/local.rs
+++ b/zswap/src/local.rs
@@ -86,9 +86,9 @@ impl<D: DB> State<D> {
     pub fn insert_coin(
         &self,
         secret_keys: &SecretKeys,
-        qcoin: QualifiedCoinInfo,
+        coin: CoinInfo,
     ) -> Result<Self, InvalidUpdate> {
-        let coin = CoinInfo::from(&qcoin);
+        let qcoin = coin.qualify(self.first_free);
         let nullifier = coin.nullifier(&SenderEvidence::User(Cow::Borrowed(
             &secret_keys.coin_secret_key,
         )));


### PR DESCRIPTION
## Description

<!-- describe what this PR does, and why it is needed -->
Adds a swathe of endpoints for the wallet to more granularly modify its internal state, as well as the ability to inspect Zswap/Dust events directly.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
