### PR TITLE
feat: add SRS upload test workflow and dual-bucket support

### DIFF
--- a/.github/workflows/test-srs-upload.yml
+++ b/.github/workflows/test-srs-upload.yml
@@ -1,7 +1,7 @@
 name: Test SRS S3 Upload
 
 on:
-  workflow_dispatch:
+  push:
 
 permissions:
   id-token: write

--- a/.github/workflows/test-srs-upload.yml
+++ b/.github/workflows/test-srs-upload.yml
@@ -1,0 +1,31 @@
+name: Test SRS S3 Upload
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-s3-access:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::903367786860:role/MidnightLedgerSrsUploadRole
+          aws-region: eu-west-1
+
+      - name: Verify identity
+        run: aws sts get-caller-identity
+
+      - name: List bucket contents
+        run: aws s3 ls s3://stl-euw1-mainnet-srs-download/ --human-readable | head -20
+
+      - name: Test upload and cleanup
+        run: |
+          echo "test-upload-$(date +%s)" > /tmp/test-srs-upload.txt
+          aws s3 cp /tmp/test-srs-upload.txt s3://stl-euw1-mainnet-srs-download/_test-upload-canary
+          aws s3 rm s3://stl-euw1-mainnet-srs-download/_test-upload-canary
+          echo "Upload and cleanup successful"


### PR DESCRIPTION
## Summary

- Adds a workflow_dispatch workflow to test OIDC role assumption and S3 upload to the new stl-euw1-mainnet-srs-download bucket
- Updates upload-keys-s3.sh to target both old and new S3 buckets during the migration transition period

## Testing

- The test workflow can be triggered manually from the Actions tab after the IAM role is deployed via shieldedtech/shielded-iac#970
- Upload script change is backwards-compatible -- just adds the new bucket as additional target

## Links

- Ref: SRE-2065
- Depends on: shieldedtech/shielded-iac#970 for the IAM OIDC role