### PR TITLE
Change the `Result`-based MT updates to be backwards compatible.

### DIFF
--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -965,7 +965,7 @@ impl<D: DB> DustState<D> {
         state.utxo.commitments = state
             .utxo
             .commitments
-            .update_hash(
+            .try_update_hash(
                 self.utxo.commitments_first_free,
                 spend.new_commitment.into(),
                 (),
@@ -1097,7 +1097,7 @@ impl<D: DB> DustState<D> {
         state.utxo.commitments = state
             .utxo
             .commitments
-            .update_hash(
+            .try_update_hash(
                 state.utxo.commitments_first_free,
                 dust_commitment.into(),
                 (),
@@ -1118,7 +1118,7 @@ impl<D: DB> DustState<D> {
         state.generation.generating_tree = state
             .generation
             .generating_tree
-            .update_hash(
+            .try_update_hash(
                 state.generation.generating_tree_first_free,
                 gen_info.merkle_hash(),
                 gen_info,
@@ -1220,7 +1220,7 @@ impl<D: DB> DustState<D> {
             state.generation.generating_tree = state
                 .generation
                 .generating_tree
-                .update_hash(*idx, gen_info.merkle_hash(), gen_info)
+                .try_update_hash(*idx, gen_info.merkle_hash(), gen_info)
                 .map_err(TransactionInvalid::MerkleTreeError)?
                 .rehash();
             event_push(EventDetails::DustGenerationDtimeUpdate {
@@ -1544,7 +1544,7 @@ impl<D: DB> DustLocalState<D> {
 
         state.generating_tree = state
             .generating_tree
-            .update_hash(generation_index, gen_info.merkle_hash(), gen_info)
+            .try_update_hash(generation_index, gen_info.merkle_hash(), gen_info)
             .map_err(DustLocalStateError::MerkleTreeError)?;
         state.generating_tree_first_free += 1;
         if let Some(initial_nonce) = initial_nonce {
@@ -1627,7 +1627,7 @@ impl<D: DB> DustLocalState<D> {
 
         state.commitment_tree = state
             .commitment_tree
-            .update_hash(commitment_index, qdo.commitment().into(), ())
+            .try_update_hash(commitment_index, qdo.commitment().into(), ())
             .map_err(DustLocalStateError::MerkleTreeError)?;
         state.commitment_tree_first_free += 1;
         if !own_qdo {
@@ -1887,7 +1887,11 @@ impl<D: DB> DustLocalState<D> {
                         acc.result.generating_tree = acc
                             .result
                             .generating_tree
-                            .update_hash(*generation_index, generation.merkle_hash(), *generation)
+                            .try_update_hash(
+                                *generation_index,
+                                generation.merkle_hash(),
+                                *generation,
+                            )
                             .map_err(EventReplayError::MerkleTreeError)?;
                         acc.result.generating_tree_first_free += 1;
                         if output.mt_index != acc.result.commitment_tree_first_free {
@@ -1900,7 +1904,7 @@ impl<D: DB> DustLocalState<D> {
                         acc.result.commitment_tree = acc
                             .result
                             .commitment_tree
-                            .update_hash(output.mt_index, output.commitment().into(), ())
+                            .try_update_hash(output.mt_index, output.commitment().into(), ())
                             .map_err(EventReplayError::MerkleTreeError)?;
                         acc.result.commitment_tree_first_free += 1;
                         let maybe_change = if pk == output.owner {
@@ -1963,7 +1967,7 @@ impl<D: DB> DustLocalState<D> {
                         acc.result.commitment_tree = acc
                             .result
                             .commitment_tree
-                            .update_hash(*commitment_index, (*commitment).into(), ())
+                            .try_update_hash(*commitment_index, (*commitment).into(), ())
                             .map_err(EventReplayError::MerkleTreeError)?;
                         acc.result.commitment_tree_first_free += 1;
                         let maybe_change = if let Some(utxo) = acc.result.dust_utxos.get(nullifier)

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -294,7 +294,7 @@ impl<D: DB> ZswapLocalStateExt<D> for ZswapLocalState<D> {
                     acc.result.merkle_tree =
                         acc.result
                             .merkle_tree
-                            .update_hash(*mt_index, commitment.0, ())?;
+                            .try_update_hash(*mt_index, commitment.0, ())?;
                     acc.result.first_free += 1;
                     let maybe_change = if let Some(ci) = acc.result.pending_outputs.get(commitment)
                     {
@@ -427,7 +427,7 @@ impl<D: DB> LedgerState<D> {
                 coin_coms: self
                     .zswap
                     .coin_coms
-                    .update(self.zswap.first_free, &cm, None)
+                    .try_update(self.zswap.first_free, &cm, None)
                     .map_err(SystemTransactionError::MerkleTreeError)?,
                 coin_coms_set: self.zswap.coin_coms_set.insert(cm, ()),
                 first_free: self.zswap.first_free + 1,
@@ -861,7 +861,7 @@ impl<D: DB> LedgerState<D> {
                             dust_state.generation.generating_tree = dust_state
                                 .generation
                                 .generating_tree
-                                .update_hash(*idx, gen_info.merkle_hash(), gen_info)
+                                .try_update_hash(*idx, gen_info.merkle_hash(), gen_info)
                                 .map_err(SystemTransactionError::MerkleTreeError)?
                                 .rehash();
                             event_push(EventDetails::DustGenerationDtimeUpdate {

--- a/onchain-runtime-wasm/src/state.rs
+++ b/onchain-runtime-wasm/src/state.rs
@@ -147,7 +147,7 @@ impl StateBoundedMerkleTree {
     // update(index: number, leaf: AlignedValue): MerkleTree
     pub fn update(&self, index: u64, leaf: JsValue) -> Result<StateBoundedMerkleTree, JsError> {
         let leaf: AlignedValue = from_value(leaf)?;
-        Ok(StateBoundedMerkleTree(self.0.update(
+        Ok(StateBoundedMerkleTree(self.0.try_update(
             index,
             &ValueReprAlignedValue(leaf),
             (),

--- a/onchain-runtime/benches/benchmarking.rs
+++ b/onchain-runtime/benches/benchmarking.rs
@@ -217,7 +217,7 @@ fn gen_bmts(log_sizes: &[usize]) -> Vec<StateValueMerkleTree> {
         for path in 0u64..(1 << height) {
             // Also use the path as the value to hash.
             bmt = bmt
-                .update(path, &path, ())
+                .try_update(path, &path, ())
                 .expect("updating hash on non-collapsed tree should always succeed");
         }
         bmt = bmt.rehash();
@@ -448,7 +448,7 @@ impl BenchWithArgs {
                     let bmt = if present == 0 {
                         bmt.clone()
                     } else {
-                        bmt.update(raw_key, &raw_key, ()).unwrap()
+                        bmt.try_update(raw_key, &raw_key, ()).unwrap()
                     };
                     let container = mk_vm_val(StateValue::BoundedMerkleTree(bmt));
                     let container_log_size = container.log_size();

--- a/onchain-runtime/generate-rust-macros.ss
+++ b/onchain-runtime/generate-rust-macros.ss
@@ -65,7 +65,7 @@
     [(_ (state-value 'array (entries ...)))
       (format "StateValue::Array(vec![~{~a~^, ~}].into())" (list (rt-arg entries) ...))]
     [(_ (state-value 'merkle-tree nat ([key value] ...)))
-      (format "StateValue::BoundedMerkleTree(MerkleTree::blank(~a)~{.update(~a)~})"
+      (format "StateValue::BoundedMerkleTree(MerkleTree::blank(~a)~{.try_update(~a).unwrap()~})"
               (rt-arg nat)
               (list (format "~a, ~a.into()" (rt-arg key) (rt-arg value)) ...))]
     [(_ (state-value 'ADT value value_type))

--- a/onchain-state/src/state.rs
+++ b/onchain-state/src/state.rs
@@ -356,7 +356,7 @@ macro_rules! stval {
         StateValue::Cell(Sp::new($val.into()))
     };
     ({MT($height:expr_2021) {$($key:expr_2021 => $val:expr_2021),*}}) => {
-        StateValue::BoundedMerkleTree(MerkleTree::blank($height)$(.update_hash($key, $val, ()).expect("updating hash on `StateValue` should always succeed, as these should not be collapsed"))*.rehash())
+        StateValue::BoundedMerkleTree(MerkleTree::blank($height)$(.try_update_hash($key, $val, ()).expect("updating hash on `StateValue` should always succeed, as these should not be collapsed"))*.rehash())
     };
     ({$($key:expr_2021 => $val:tt),*}) => {
         StateValue::Map(HashMap::new()$(.insert($key.into(), stval!($val)))*)

--- a/onchain-vm/src/vm.rs
+++ b/onchain-vm/src/vm.rs
@@ -739,7 +739,7 @@ fn run_program_internal<M: ResultMode<D>, D: DB>(
                 let container_nxt = match &container.0.value {
                     StateValue::Map(m) => StateValue::Map(m.remove(&key)),
                     StateValue::BoundedMerkleTree(t) => StateValue::BoundedMerkleTree(
-                        t.update_hash((&*key.value).try_into()?, Default::default(), ())
+                        t.try_update_hash((&*key.value).try_into()?, Default::default(), ())
                             .map_err(OnchainProgramError::MerkleTreeError)?
                             .rehash(),
                     ),
@@ -990,7 +990,7 @@ fn run_program_internal<M: ResultMode<D>, D: DB>(
                                     ))
                                 })?;
                                 StateValue::BoundedMerkleTree(
-                                    t.update_hash(idx, hash, ())
+                                    t.try_update_hash(idx, hash, ())
                                         .map_err(OnchainProgramError::MerkleTreeError)?
                                         .rehash(),
                                 )

--- a/transient-crypto/src/merkle_tree.rs
+++ b/transient-crypto/src/merkle_tree.rs
@@ -458,7 +458,7 @@ impl<'de, A: Deserialize<'de> + Storable<D>, D: DB> Deserialize<'de> for MerkleT
             Deserialize::deserialize(de)?;
         data.into_iter()
             .try_fold(MerkleTree::blank(height), |mt, (k, (v, a))| {
-                MerkleTree::update_hash(&mt, k, v, a)
+                MerkleTree::try_update_hash(&mt, k, v, a)
                     .map_err(<D2::Error as serde::de::Error>::custom)
             })
     }
@@ -510,10 +510,10 @@ impl<Faker, D: DB> fake::Dummy<Faker> for MerkleTree<(), D> {
         // TODO: make random trees!
         let mut mt = MerkleTree::<(), D>::blank(32);
         if let Ok(updated) = mt
-            .update(0, &Fr::from(42u64), ())
-            .and_then(|mt| mt.update(0, &Fr::from(41u64), ()))
-            .and_then(|mt| mt.update(3, &Fr::from(43u64), ()))
-            .and_then(|mt| mt.update(62, &Fr::from(12u64), ()))
+            .try_update(0, &Fr::from(42u64), ())
+            .and_then(|mt| mt.try_update(0, &Fr::from(41u64), ()))
+            .and_then(|mt| mt.try_update(3, &Fr::from(43u64), ()))
+            .and_then(|mt| mt.try_update(62, &Fr::from(12u64), ()))
         {
             mt = updated;
         }
@@ -928,7 +928,15 @@ impl<A: Storable<D>, D: DB> MerkleTreeNode<A, D> {
 
     /// Inserts a hash value at a specific index, returning the resulting tree.
     /// `index` *must* be within range of the tree height.
-    pub fn update_hash(
+    #[deprecated = "This version panics rather than throwing errors. Prefer `try_update_hash`."]
+    pub fn update_hash(&self, index: u64, new_leaf: HashOutput, new_aux: A) -> Sp<Self, D> {
+        self.try_update_hash(index, new_leaf, new_aux)
+            .expect("attempted update into collapsed tree")
+    }
+
+    /// Inserts a hash value at a specific index, returning the resulting tree.
+    /// `index` *must* be within range of the tree height.
+    pub fn try_update_hash(
         &self,
         index: u64,
         new_leaf: HashOutput,
@@ -966,11 +974,14 @@ impl<A: Storable<D>, D: DB> MerkleTreeNode<A, D> {
             // Here `index < cmp` is the same as `index & cmp == 0`, i.e. we're
             // checking if the height `h` bit in the path is set or not.
             let (left, right) = if index < cmp {
-                (left.update_hash(index, new_leaf, new_aux)?, right.clone())
+                (
+                    left.try_update_hash(index, new_leaf, new_aux)?,
+                    right.clone(),
+                )
             } else {
                 (
                     left.clone(),
-                    right.update_hash(index - cmp, new_leaf, new_aux)?,
+                    right.try_update_hash(index - cmp, new_leaf, new_aux)?,
                 )
             };
             Ok(Sp::new(Node {
@@ -1017,13 +1028,21 @@ impl<A: Storable<D>, D: DB> MerkleTree<A, D> {
 
     /// Inserts a hash value at a specific index, returning the resulting tree.
     /// `index` *must* be within range of the tree height.
-    pub fn update_hash(
+    #[deprecated = "This version panics rather than throwing errors. Prefer `try_update_hash`."]
+    pub fn update_hash(&self, index: u64, new_leaf: HashOutput, aux: A) -> Self {
+        #[allow(deprecated)]
+        MerkleTree(self.0.update_hash(index, new_leaf, aux))
+    }
+
+    /// Inserts a hash value at a specific index, returning the resulting tree.
+    /// `index` *must* be within range of the tree height.
+    pub fn try_update_hash(
         &self,
         index: u64,
         new_leaf: HashOutput,
         aux: A,
     ) -> Result<Self, InvalidUpdate> {
-        Ok(MerkleTree(self.0.update_hash(index, new_leaf, aux)?))
+        Ok(MerkleTree(self.0.try_update_hash(index, new_leaf, aux)?))
     }
 
     /// Inserts a value into a specific index of the tree.
@@ -1032,16 +1051,20 @@ impl<A: Storable<D>, D: DB> MerkleTree<A, D> {
     ///
     /// May panic if this index was previously in a range passed to
     /// [`collapse`](crate::merkle_tree::MerkleTree::collapse).
-    pub fn update<T: BinaryHashRepr + ?Sized>(
+    #[deprecated = "This version panics rather than throwing errors. Prefer `try_update_hash`."]
+    pub fn update<T: BinaryHashRepr + ?Sized>(&self, index: u64, value: &T, aux: A) -> Self {
+        #[allow(deprecated)]
+        self.update_hash(index, crate::merkle_tree::leaf_hash(value), aux)
+    }
+
+    /// Inserts a value into a specific index of the tree.
+    pub fn try_update<T: BinaryHashRepr + ?Sized>(
         &self,
         index: u64,
         value: &T,
         aux: A,
-    ) -> Result<Self, InvalidUpdate>
-    where
-        Self: Sized,
-    {
-        self.update_hash(index, crate::merkle_tree::leaf_hash(value), aux)
+    ) -> Result<Self, InvalidUpdate> {
+        self.try_update_hash(index, crate::merkle_tree::leaf_hash(value), aux)
     }
 
     /// Collapses the tree between `start` and `end` (inclusive) into their
@@ -1333,7 +1356,7 @@ where
         let mut mt = MerkleTree::blank(height);
 
         for i in 0..height {
-            if let Ok(updated) = mt.update(i.into(), &rng.r#gen::<Fr>(), rng.r#gen()) {
+            if let Ok(updated) = mt.try_update(i.into(), &rng.r#gen::<Fr>(), rng.r#gen()) {
                 mt = updated;
             }
         }
@@ -1357,10 +1380,10 @@ mod tests {
     #[test]
     fn test_membership() {
         let tree = new_mt::<()>(32)
-            .update(0, &Fr::from(42u64), ())
-            .and_then(|mt| mt.update(0, &Fr::from(41u64), ()))
-            .and_then(|mt| mt.update(3, &Fr::from(43u64), ()))
-            .and_then(|mt| mt.update(62, &Fr::from(12u64), ()))
+            .try_update(0, &Fr::from(42u64), ())
+            .and_then(|mt| mt.try_update(0, &Fr::from(41u64), ()))
+            .and_then(|mt| mt.try_update(3, &Fr::from(43u64), ()))
+            .and_then(|mt| mt.try_update(62, &Fr::from(12u64), ()))
             .unwrap()
             .rehash();
         assert_eq!(
@@ -1380,10 +1403,10 @@ mod tests {
     #[test]
     fn test_collapse_good() {
         let tree = new_mt::<()>(32)
-            .update(0, &Fr::from(42u64), ())
-            .and_then(|mt| mt.update(0, &Fr::from(41u64), ()))
-            .and_then(|mt| mt.update(3, &Fr::from(43u64), ()))
-            .and_then(|mt| mt.update(62, &Fr::from(12u64), ()))
+            .try_update(0, &Fr::from(42u64), ())
+            .and_then(|mt| mt.try_update(0, &Fr::from(41u64), ()))
+            .and_then(|mt| mt.try_update(3, &Fr::from(43u64), ()))
+            .and_then(|mt| mt.try_update(62, &Fr::from(12u64), ()))
             .unwrap()
             .collapse(0, 61)
             .rehash();
@@ -1396,10 +1419,10 @@ mod tests {
     #[test]
     fn test_collapse_bad_proof() {
         let tree = new_mt::<()>(32)
-            .update(0, &Fr::from(42u64), ())
-            .and_then(|mt| mt.update(0, &Fr::from(41u64), ()))
-            .and_then(|mt| mt.update(3, &Fr::from(43u64), ()))
-            .and_then(|mt| mt.update(62, &Fr::from(12u64), ()))
+            .try_update(0, &Fr::from(42u64), ())
+            .and_then(|mt| mt.try_update(0, &Fr::from(41u64), ()))
+            .and_then(|mt| mt.try_update(3, &Fr::from(43u64), ()))
+            .and_then(|mt| mt.try_update(62, &Fr::from(12u64), ()))
             .unwrap()
             .collapse(0, 61)
             .rehash();
@@ -1409,39 +1432,39 @@ mod tests {
     #[test]
     fn test_collapse_bad_update() {
         let tree = new_mt::<()>(32)
-            .update(0, &Fr::from(42u64), ())
-            .and_then(|mt| mt.update(0, &Fr::from(41u64), ()))
-            .and_then(|mt| mt.update(3, &Fr::from(43u64), ()))
-            .and_then(|mt| mt.update(62, &Fr::from(12u64), ()))
+            .try_update(0, &Fr::from(42u64), ())
+            .and_then(|mt| mt.try_update(0, &Fr::from(41u64), ()))
+            .and_then(|mt| mt.try_update(3, &Fr::from(43u64), ()))
+            .and_then(|mt| mt.try_update(62, &Fr::from(12u64), ()))
             .unwrap()
             .collapse(0, 61)
-            .update(61, &Fr::from(0xdeadbeefu64), ());
+            .try_update(61, &Fr::from(0xdeadbeefu64), ());
         assert_eq!(tree, Err(InvalidUpdate::CollapsedIndex(1, 1)));
     }
 
     #[test]
     fn test_incremental_collapse() {
         let tree = new_mt::<()>(3)
-            .update(0, &Fr::from(42u64), ())
+            .try_update(0, &Fr::from(42u64), ())
             .unwrap()
             .collapse(0, 0)
-            .update(1, &Fr::from(42u64), ())
+            .try_update(1, &Fr::from(42u64), ())
             .unwrap()
             .collapse(1, 1)
-            .update(2, &Fr::from(42u64), ())
+            .try_update(2, &Fr::from(42u64), ())
             .unwrap()
             .collapse(2, 2)
-            .update(3, &Fr::from(42u64), ())
+            .try_update(3, &Fr::from(42u64), ())
             .unwrap()
-            .update(4, &Fr::from(42u64), ())
+            .try_update(4, &Fr::from(42u64), ())
             .unwrap()
             .collapse(4, 4);
         let tree2 = new_mt::<()>(3)
-            .update(0, &Fr::from(42u64), ())
-            .and_then(|mt| mt.update(1, &Fr::from(42u64), ()))
-            .and_then(|mt| mt.update(2, &Fr::from(42u64), ()))
-            .and_then(|mt| mt.update(3, &Fr::from(42u64), ()))
-            .and_then(|mt| mt.update(4, &Fr::from(42u64), ()))
+            .try_update(0, &Fr::from(42u64), ())
+            .and_then(|mt| mt.try_update(1, &Fr::from(42u64), ()))
+            .and_then(|mt| mt.try_update(2, &Fr::from(42u64), ()))
+            .and_then(|mt| mt.try_update(3, &Fr::from(42u64), ()))
+            .and_then(|mt| mt.try_update(4, &Fr::from(42u64), ()))
             .unwrap()
             .collapse(0, 2)
             .collapse(4, 4);
@@ -1451,16 +1474,18 @@ mod tests {
     #[test]
     fn test_collapsed_update() {
         let t = new_mt::<()>(6)
-            .update(0, &Fr::from(42u64), ())
+            .try_update(0, &Fr::from(42u64), ())
             .unwrap()
-            .update(1, &Fr::from(42u64), ())
+            .try_update(1, &Fr::from(42u64), ())
             .unwrap();
         let t2 = (2..=32)
-            .fold(t.clone(), |t, i| t.update(i, &Fr::from(42u64), ()).unwrap())
+            .fold(t.clone(), |t, i| {
+                t.try_update(i, &Fr::from(42u64), ()).unwrap()
+            })
             .rehash();
         let upd1 = MerkleTreeCollapsedUpdate::new(&t2, 2, 2).unwrap();
         let upd2 = MerkleTreeCollapsedUpdate::new(&t2, 3, 31).unwrap();
-        let t3 = t.update(32, &Fr::from(42u64), ()).unwrap();
+        let t3 = t.try_update(32, &Fr::from(42u64), ()).unwrap();
         let t4 = t3
             .apply_collapsed_update(&upd1)
             .unwrap()
@@ -1474,10 +1499,10 @@ mod tests {
     fn test_insertion_evidence() {
         let t = (0..=32)
             .fold(new_mt::<()>(6), |t, i| {
-                t.update(i, &Fr::from(42u64), ()).unwrap()
+                t.try_update(i, &Fr::from(42u64), ()).unwrap()
             })
             .rehash();
-        let t2 = t.update(12, &Fr::from(43u64), ()).unwrap().rehash();
+        let t2 = t.try_update(12, &Fr::from(43u64), ()).unwrap().rehash();
         let evidence = t2.insertion_evidence(12).unwrap();
         assert_eq!(
             t.update_from_evidence(evidence.clone()).unwrap().rehash(),
@@ -1493,8 +1518,8 @@ mod tests {
         );
         // test *not* rehashing the tree first
         let t3 = (33..=64).fold(
-            t.update(12, &Fr::from(43u64), ()).unwrap().rehash(),
-            |t, i| t.update(i, &Fr::from(42u64), ()).unwrap(),
+            t.try_update(12, &Fr::from(43u64), ()).unwrap().rehash(),
+            |t, i| t.try_update(i, &Fr::from(42u64), ()).unwrap(),
         );
         let evidence = t3.insertion_evidence(12).unwrap();
         dbg!(&evidence);
@@ -1512,7 +1537,7 @@ mod tests {
     #[test]
     fn test_singleton_collapsed_update() {
         let t = new_mt::<()>(6)
-            .update(0, &Fr::from(42u64), ())
+            .try_update(0, &Fr::from(42u64), ())
             .unwrap()
             .rehash();
         let upd = MerkleTreeCollapsedUpdate::new(&t, 0, 0).unwrap();
@@ -1526,18 +1551,20 @@ mod tests {
     #[test]
     fn test_tiny_trees() {
         let t = new_mt::<()>(1)
-            .update(0, &Fr::from(42u64), ())
+            .try_update(0, &Fr::from(42u64), ())
             .unwrap()
-            .update(1, &Fr::from(42u64), ())
+            .try_update(1, &Fr::from(42u64), ())
             .unwrap();
         t.path_for_leaf(0, Fr::from(42u64)).unwrap();
-        let t = new_mt::<()>(0).update(0, &Fr::from(42u64), ()).unwrap();
+        let t = new_mt::<()>(0).try_update(0, &Fr::from(42u64), ()).unwrap();
         t.path_for_leaf(0, Fr::from(42u64)).unwrap();
     }
 
     #[test]
     fn test_aux_data() {
-        let t = new_mt::<u8>(32).update(0, &Fr::from(42u64), 10).unwrap();
+        let t = new_mt::<u8>(32)
+            .try_update(0, &Fr::from(42u64), 10)
+            .unwrap();
         for (_index, (_hash, aux)) in t.iter_aux() {
             assert_eq!(aux, 10);
         }
@@ -1546,9 +1573,9 @@ mod tests {
     #[test]
     fn test_find_path_for_leaf_within_range() {
         let tree = new_mt::<()>(32)
-            .update(0, &Fr::from(10u64), ())
-            .and_then(|mt| mt.update(5, &Fr::from(20u64), ()))
-            .and_then(|mt| mt.update(10, &Fr::from(30u64), ()))
+            .try_update(0, &Fr::from(10u64), ())
+            .and_then(|mt| mt.try_update(5, &Fr::from(20u64), ()))
+            .and_then(|mt| mt.try_update(10, &Fr::from(30u64), ()))
             .unwrap()
             .rehash();
 
@@ -1584,8 +1611,8 @@ mod tests {
     #[test]
     fn test_find_path_for_hashed_leaf_within_range() {
         let tree = new_mt::<()>(32)
-            .update(0, &Fr::from(10u64), ())
-            .and_then(|mt| mt.update(5, &Fr::from(20u64), ()))
+            .try_update(0, &Fr::from(10u64), ())
+            .and_then(|mt| mt.try_update(5, &Fr::from(20u64), ()))
             .unwrap()
             .rehash();
 
@@ -1611,9 +1638,9 @@ mod tests {
     #[test]
     fn test_find_within_range_with_collapsed() {
         let tree = new_mt::<()>(6)
-            .update(0, &Fr::from(10u64), ())
-            .and_then(|mt| mt.update(5, &Fr::from(20u64), ()))
-            .and_then(|mt| mt.update(10, &Fr::from(30u64), ()))
+            .try_update(0, &Fr::from(10u64), ())
+            .and_then(|mt| mt.try_update(5, &Fr::from(20u64), ()))
+            .and_then(|mt| mt.try_update(10, &Fr::from(30u64), ()))
             .unwrap()
             .collapse(0, 4)
             .rehash();
@@ -1641,9 +1668,9 @@ mod tests {
     fn test_find_within_range_duplicate_leaves() {
         let val = Fr::from(42u64);
         let tree = new_mt::<()>(6)
-            .update(2, &val, ())
-            .and_then(|mt| mt.update(5, &val, ()))
-            .and_then(|mt| mt.update(8, &val, ()))
+            .try_update(2, &val, ())
+            .and_then(|mt| mt.try_update(5, &val, ()))
+            .and_then(|mt| mt.try_update(8, &val, ()))
             .unwrap()
             .rehash();
 

--- a/zswap/src/construct.rs
+++ b/zswap/src/construct.rs
@@ -392,7 +392,7 @@ impl<D: DB> Transient<ProofPreimage, D> {
         output: Output<ProofPreimage, D>,
     ) -> Result<Self, OfferCreationFailed> {
         let tree = MerkleTree::<(), InMemoryDB>::blank(ZSWAP_TREE_HEIGHT)
-            .update_hash(0, output.coin_com.0, ())
+            .try_update_hash(0, output.coin_com.0, ())
             .map_err(OfferCreationFailed::MerkleTreeError)?
             .rehash();
         let addr = output

--- a/zswap/src/ledger.rs
+++ b/zswap/src/ledger.rs
@@ -105,7 +105,7 @@ impl<D: DB> State<D> {
         let first_free = self.first_free;
         self.coin_coms = self
             .coin_coms
-            .update_hash(
+            .try_update_hash(
                 first_free,
                 out.coin_com.0,
                 out.contract_address.as_ref().map(|x| Sp::new(*x.deref())),
@@ -146,7 +146,7 @@ impl<D: DB> State<D> {
         let first_free = self.first_free;
         self.coin_coms = self
             .coin_coms
-            .update_hash(
+            .try_update_hash(
                 first_free,
                 trans.coin_com.0,
                 trans.contract_address.as_ref().map(|x| Sp::new(*x.deref())),

--- a/zswap/src/local.rs
+++ b/zswap/src/local.rs
@@ -96,7 +96,7 @@ impl<D: DB> State<D> {
             coins: self.coins.insert(nullifier, qcoin),
             merkle_tree: self
                 .merkle_tree
-                .update_hash(
+                .try_update_hash(
                     self.first_free,
                     coin.commitment(&Recipient::User(secret_keys.coin_public_key()))
                         .0,
@@ -124,7 +124,7 @@ impl<D: DB> State<D> {
         let mut res = self.clone();
         res.merkle_tree = res
             .merkle_tree
-            .update_hash(
+            .try_update_hash(
                 res.first_free,
                 tx.coin.commitment(&Recipient::User(tx.recipient)).0,
                 (),
@@ -185,7 +185,7 @@ impl<D: DB> State<D> {
         {
             res.merkle_tree = res
                 .merkle_tree
-                .update_hash(res.first_free, coin_com.0, ())?;
+                .try_update_hash(res.first_free, coin_com.0, ())?;
             if let Some(ci) = ciph.as_ref().and_then(|ciph| secret_keys.try_decrypt(ciph)) {
                 info!(coin=?ci, "received coin");
                 let qci = ci.qualify(res.first_free);
@@ -279,7 +279,7 @@ impl<D: DB> State<D> {
         output: Output<ProofPreimage, D>,
     ) -> Result<(State<D>, Transient<ProofPreimage, D>), OfferCreationFailed> {
         let tree = MerkleTree::blank(ZSWAP_TREE_HEIGHT)
-            .update_hash(0, output.coin_com.0, ())
+            .try_update_hash(0, output.coin_com.0, ())
             .map_err(OfferCreationFailed::MerkleTreeError)?
             .rehash();
         let (res, input) = self.spend_from_tree(rng, secret_keys, coin, segment, &tree)?;

--- a/zswap/src/prove.rs
+++ b/zswap/src/prove.rs
@@ -238,7 +238,7 @@ mod tests {
         let coin = CoinInfo::from(&qcoin);
         let recipient = Recipient::Contract(Default::default());
         let tree = MerkleTree::<(), InMemoryDB>::blank(32)
-            .update_hash(0, coin.commitment(&recipient).0, ())
+            .try_update_hash(0, coin.commitment(&recipient).0, ())
             .expect("updating hash on non-collapsed tree should always succeed")
             .rehash();
 

--- a/zswap/src/structure.rs
+++ b/zswap/src/structure.rs
@@ -421,7 +421,7 @@ impl<P: Clone + Storable<D>, D: DB> Transient<P, D> {
             value_commitment: self.value_commitment_input,
             contract_address: self.contract_address.clone(),
             merkle_tree_root: MerkleTree::<_>::blank(ZSWAP_TREE_HEIGHT)
-                .update_hash(0, self.coin_com.0, ())
+                .try_update_hash(0, self.coin_com.0, ())
                 .expect("updating hash on non-collapsed tree should always succeed")
                 .rehash()
                 .root()


### PR DESCRIPTION
## Description

<!-- describe what this PR does, and why it is needed -->
Reverts the signature change on `update`/`update_hash`, in favour of deprecating these in favour of two new methods, `try_update`/`try_update_hash`. This resolves complications around the 8.1.0 release strategy.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [X] contains breaking API changes [^1][^2]*
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

* Kinda, it reverts a breaking change into a non-breaking one, which is itself breaking.

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.
