### PR TITLE
fix: include bridge_receiving in NIGHT balance invariant

### DIFF
--- a/.tag-decompositions/ledger-state[v14]
+++ b/.tag-decompositions/ledger-state[v14]
@@ -1,0 +1,1 @@
+((string,#ledger-parameters[v5],u128,mpt-map(user-address[v1],u128,night-annotation),u128,u128,mpt-map(user-address[v1],u128,night-annotation),mpt-map(token-type[v1],u128,size-annotation),#zswap-ledger-state[v5],mpt-map(contract-address[v2],contract-state[v6],night-annotation),#unshielded-utxo-state[v2],replay-protection-state[v1],#dust-state[v1]))

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -464,6 +464,7 @@ impl<D: DB> LedgerState<D> {
             .copied()
             .unwrap_or(0);
         let unclaimed_rewards = self.unclaimed_block_rewards.ann().value;
+        let bridge_receiving = self.bridge_receiving.ann().value;
         let contract_value = self.contract.ann().value;
 
         // Ensure the total supply of NIGHT is conserved.
@@ -473,6 +474,7 @@ impl<D: DB> LedgerState<D> {
             + self.block_reward_pool
             + treasury_night
             + unclaimed_rewards
+            + bridge_receiving
             + contract_value;
 
         if total_night != MAX_SUPPLY {
@@ -2147,5 +2149,79 @@ mod tests {
 
         assert!(!state.utxos.contains_key(&a));
         assert!(state.utxos.contains_key(&b));
+    }
+
+    #[test]
+    fn bridge_transfer_passes_invariant() {
+        let mut rng = StdRng::seed_from_u64(0x42);
+        let target_address = UserAddress::from(rng.r#gen::<VerifyingKey>());
+        let nonce = coin_structure::coin::Nonce(HashOutput(rng.r#gen()));
+        let amount: u128 = 10_000_000_000;
+
+        let state: LedgerState<InMemoryDB> = LedgerState::with_genesis_settings(
+            "test",
+            INITIAL_PARAMETERS,
+            amount,
+            MAX_SUPPLY - amount,
+            0,
+        )
+        .expect("valid genesis");
+
+        let (new_state, _) = state
+            .apply_system_tx(
+                &SystemTransaction::DistributeNight(
+                    ClaimKind::CardanoBridge,
+                    vec![OutputInstructionUnshielded { amount, target_address, nonce }],
+                ),
+                Timestamp::from_secs(1),
+            )
+            .expect("bridge transfer should succeed");
+
+        new_state
+            .check_night_balance_invariant()
+            .expect("invariant should hold after bridge transfer");
+
+        let expected_fee = basis_points_of(
+            INITIAL_PARAMETERS.cardano_to_midnight_bridge_fee_basis_points,
+            amount,
+        );
+        assert_eq!(new_state.bridge_receiving.get(&target_address).copied().unwrap_or(0), amount - expected_fee);
+        assert_eq!(new_state.treasury.get(&TokenType::Unshielded(NIGHT)).copied().unwrap_or(0), expected_fee);
+        assert_eq!(new_state.locked_pool, 0);
+    }
+
+    #[test]
+    fn bridge_transfer_sub_minimum_passes_invariant() {
+        let mut rng = StdRng::seed_from_u64(0x42);
+        let target_address = UserAddress::from(rng.r#gen::<VerifyingKey>());
+        let nonce = coin_structure::coin::Nonce(HashOutput(rng.r#gen()));
+        let amount: u128 = INITIAL_PARAMETERS.c_to_m_bridge_min_amount - 1;
+
+        let state: LedgerState<InMemoryDB> = LedgerState::with_genesis_settings(
+            "test",
+            INITIAL_PARAMETERS,
+            amount,
+            MAX_SUPPLY - amount,
+            0,
+        )
+        .expect("valid genesis");
+
+        let (new_state, _) = state
+            .apply_system_tx(
+                &SystemTransaction::DistributeNight(
+                    ClaimKind::CardanoBridge,
+                    vec![OutputInstructionUnshielded { amount, target_address, nonce }],
+                ),
+                Timestamp::from_secs(1),
+            )
+            .expect("sub-minimum bridge transfer should succeed");
+
+        new_state
+            .check_night_balance_invariant()
+            .expect("invariant should hold for sub-minimum transfer");
+
+        // 100% fee to treasury, nothing to bridge_receiving.
+        assert_eq!(new_state.bridge_receiving.get(&target_address).copied().unwrap_or(0), 0);
+        assert_eq!(new_state.treasury.get(&TokenType::Unshielded(NIGHT)).copied().unwrap_or(0), amount);
     }
 }

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -2970,14 +2970,14 @@ impl<D: DB> Default for UtxoState<D> {
 #[derive(Storable)]
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 #[storable(db = D)]
-#[tag = "ledger-state[v13]"]
+#[tag = "ledger-state[v14]"]
 #[must_use]
 pub struct LedgerState<D: DB> {
     pub network_id: String,
     #[storable(child)]
     pub parameters: Sp<LedgerParameters, D>,
     pub locked_pool: u128,
-    pub bridge_receiving: Map<UserAddress, u128, D>,
+    pub bridge_receiving: Map<UserAddress, u128, D, NightAnn>,
     pub reserve_pool: u128,
     pub block_reward_pool: u128,
     pub unclaimed_block_rewards: Map<UserAddress, u128, D, NightAnn>,


### PR DESCRIPTION
## Summary
`bridge_receiving` Map was excluded from `check_night_balance_invariant`, causing `DistributeNight(CardanoBridge)` system transactions to fail with an invariant violation. This blocks all Cardano-to-Midnight bridge transfers at or above the minimum threshold.

## Notes
- Existing bridge claim tests (`simple_bridge_claim`, `bridge_claim_not_enough_available`) continue to pass
- Thomas milestoned #411 to ledger-9.0.0 but the fix is identical on both branches. Targeting ledger-8 to potentially unblock bridge work sooner. Happy to retarget to ledger-9 if preferred.
- The serialization tag change (v13 to v14) means existing serialized state with `bridge_receiving` using `SizeAnn` would need migration. Since `bridge_receiving` is empty on all live networks (bridge has never been active), migration should be straightforward.

Fixes: #411