### PR TITLE
refactor: introduced type alias for segments

### DIFF
--- a/ledger/src/construct.rs
+++ b/ledger/src/construct.rs
@@ -14,7 +14,7 @@
 use crate::dust::DustActions;
 use crate::error::{MalformedTransaction, PartitionFailure};
 use crate::structure::{
-    ContractAction, ContractCall, ContractDeploy, Intent, Segments,
+    ContractAction, ContractCall, ContractDeploy, GUARANTEED_SEGMENT, Intent,
     LedgerParameters, MIN_PROOF_SIZE, MaintenanceUpdate, ProofPreimageMarker, ProofPreimageVersioned,
     SignatureKind, SignaturesValue, SingleUpdate, StandardTransaction, Transaction,
     UnshieldedOffer, UtxoOutput, UtxoSpend,
@@ -128,7 +128,7 @@ impl<S: SignatureKind<D>, D: DB>
                 return Err(PartitionFailure::GuaranteedOnlyUnsatisfied);
             }
             SegmentSpecifier::GuaranteedOnly | SegmentSpecifier::Random => rng.r#gen(),
-            SegmentSpecifier::Specific(Segments::GUARANTEED) => {
+            SegmentSpecifier::Specific(GUARANTEED_SEGMENT) => {
                 return Err(PartitionFailure::IllegalSegmentZero);
             }
             SegmentSpecifier::Specific(seg) => seg,
@@ -215,7 +215,7 @@ impl<S: SignatureKind<D>, D: DB>
                 .map(|(t, _)| t.clone())
                 .collect(),
         )
-        .map(|o| o.retarget_segment(Segments::GUARANTEED));
+        .map(|o| o.retarget_segment(GUARANTEED_SEGMENT));
         let fallible_coins = ZswapOffer::new(
             zswap_inputs
                 .iter()
@@ -454,7 +454,7 @@ impl<S: SignatureKind<D>, D: DB> Transaction<S, ProofPreimageMarker, PedersenRan
             intents,
             guaranteed_coins: guaranteed_coins.map(|x| {
                 Sp::new(
-                    x.retarget_segment(Segments::GUARANTEED),
+                    x.retarget_segment(GUARANTEED_SEGMENT),
                 )
             }),
             fallible_coins: fallible_coins

--- a/ledger/src/construct.rs
+++ b/ledger/src/construct.rs
@@ -14,9 +14,10 @@
 use crate::dust::DustActions;
 use crate::error::{MalformedTransaction, PartitionFailure};
 use crate::structure::{
-    ContractAction, ContractCall, ContractDeploy, Intent, LedgerParameters, MIN_PROOF_SIZE,
-    MaintenanceUpdate, ProofPreimageMarker, ProofPreimageVersioned, SignatureKind, SignaturesValue,
-    SingleUpdate, StandardTransaction, Transaction, UnshieldedOffer, UtxoOutput, UtxoSpend,
+    ContractAction, ContractCall, ContractDeploy, Intent, Segments,
+    LedgerParameters, MIN_PROOF_SIZE, MaintenanceUpdate, ProofPreimageMarker, ProofPreimageVersioned,
+    SignatureKind, SignaturesValue, SingleUpdate, StandardTransaction, Transaction,
+    UnshieldedOffer, UtxoOutput, UtxoSpend,
 };
 use crate::structure::{
     EXPECTED_CONTRACT_DEPTH, EXPECTED_OPERATIONS_DEPTH, SegIntent, VERIFIER_KEY_SIZE,
@@ -127,7 +128,9 @@ impl<S: SignatureKind<D>, D: DB>
                 return Err(PartitionFailure::GuaranteedOnlyUnsatisfied);
             }
             SegmentSpecifier::GuaranteedOnly | SegmentSpecifier::Random => rng.r#gen(),
-            SegmentSpecifier::Specific(0) => return Err(PartitionFailure::IllegalSegmentZero),
+            SegmentSpecifier::Specific(Segments::GUARANTEED) => {
+                return Err(PartitionFailure::IllegalSegmentZero);
+            }
             SegmentSpecifier::Specific(seg) => seg,
         };
         let prototypes = calls
@@ -212,7 +215,7 @@ impl<S: SignatureKind<D>, D: DB>
                 .map(|(t, _)| t.clone())
                 .collect(),
         )
-        .map(|o| o.retarget_segment(0));
+        .map(|o| o.retarget_segment(Segments::GUARANTEED));
         let fallible_coins = ZswapOffer::new(
             zswap_inputs
                 .iter()
@@ -449,7 +452,11 @@ impl<S: SignatureKind<D>, D: DB> Transaction<S, ProofPreimageMarker, PedersenRan
         let mut stx = StandardTransaction {
             network_id: network_id.into(),
             intents,
-            guaranteed_coins: guaranteed_coins.map(|x| Sp::new(x.retarget_segment(0))),
+            guaranteed_coins: guaranteed_coins.map(|x| {
+                Sp::new(
+                    x.retarget_segment(Segments::GUARANTEED),
+                )
+            }),
             fallible_coins: fallible_coins
                 .into_iter()
                 .map(|(seg, offer)| (seg, offer.retarget_segment(seg)))

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -20,10 +20,11 @@ use crate::events::{Event, EventDetails, EventSource, ZswapPreimageEvidence};
 use crate::structure::TransactionHash;
 use crate::structure::UtxoMeta;
 use crate::structure::{
-    ClaimKind, ClaimRewardsTransaction, ContractAction, ErasedIntent, Intent, IntentHash,
-    LedgerParameters, LedgerState, MAX_SUPPLY, OutputInstructionUnshielded, PedersenDowngradeable,
-    ProofKind, ReplayProtectionState, SignatureKind, SingleUpdate, StandardTransaction,
-    SystemTransaction, Transaction, UnshieldedOffer, Utxo, UtxoState, VerifiedTransaction,
+    ClaimKind, ClaimRewardsTransaction, ContractAction, ErasedIntent, Segments,
+    Intent, IntentHash, LedgerParameters, LedgerState, MAX_SUPPLY, OutputInstructionUnshielded,
+    PedersenDowngradeable, ProofKind, ReplayProtectionState, SignatureKind, SingleUpdate,
+    StandardTransaction, SystemTransaction, Transaction, UnshieldedOffer, Utxo, UtxoState,
+    VerifiedTransaction,
 };
 use crate::utils::{KeySortedIter, SortedIter};
 use crate::zswap::{WithZswapStateChanges, ZswapStateChanges};
@@ -202,7 +203,9 @@ impl<D: DB> ZswapLocalStateExt<D> for ZswapLocalState<D> {
 
                 segments
                     .iter()
-                    .filter(|(segment, success)| *segment != 0 && *success)
+                    .filter(|(segment, success)| {
+                        *segment != Segments::GUARANTEED && *success
+                    })
                     .map(|(segment, _)| segment)
                     .try_fold(post_guaranteed, |st, segment| {
                         if let Some(fc) = stx.fallible_coins.get(segment) {
@@ -937,7 +940,7 @@ impl<D: DB> LedgerState<D> {
     ) -> Result<ApplySectionResult<D>, TransactionInvalid<D>> {
         let mut events: Vec<Event<D>> = vec![];
         let mut state: LedgerState<D> = self.clone();
-        if segment == 0 {
+        if segment == Segments::GUARANTEED {
             // Apply replay protection
             state.replay_protection = Sp::new(
                 state
@@ -1103,7 +1106,7 @@ impl<D: DB> LedgerState<D> {
                                 events.push(Event {
                                     source: EventSource {
                                         transaction_hash,
-                                        logical_segment: 0,
+                                        logical_segment: Segments::GUARANTEED,
                                         physical_segment: segment,
                                     },
                                     content,
@@ -1121,7 +1124,7 @@ impl<D: DB> LedgerState<D> {
                     &com_indices,
                     EventSource {
                         transaction_hash,
-                        logical_segment: 0,
+                        logical_segment: Segments::GUARANTEED,
                         physical_segment: segment,
                     },
                 )?;
@@ -1222,7 +1225,7 @@ impl<D: DB> LedgerState<D> {
                             segment_success.insert(segment, Ok(()));
                         }
                         Err(e) => {
-                            if segment == 0 {
+                            if segment == Segments::GUARANTEED {
                                 return (self.clone(), TransactionResult::Failure(e));
                             } else {
                                 segment_success.insert(segment, Err(e));
@@ -1828,8 +1831,8 @@ impl SystemTransaction {
     fn event_source(&self) -> EventSource {
         EventSource {
             transaction_hash: self.transaction_hash(),
-            logical_segment: 0,
-            physical_segment: 0,
+            logical_segment: Segments::GUARANTEED,
+            physical_segment: Segments::GUARANTEED,
         }
     }
 }

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -20,8 +20,8 @@ use crate::events::{Event, EventDetails, EventSource, ZswapPreimageEvidence};
 use crate::structure::TransactionHash;
 use crate::structure::UtxoMeta;
 use crate::structure::{
-    ClaimKind, ClaimRewardsTransaction, ContractAction, ErasedIntent, Segments,
-    Intent, IntentHash, LedgerParameters, LedgerState, MAX_SUPPLY, OutputInstructionUnshielded,
+    ClaimKind, ClaimRewardsTransaction, ContractAction, ErasedIntent, GUARANTEED_SEGMENT, Intent,
+    IntentHash, LedgerParameters, LedgerState, MAX_SUPPLY, OutputInstructionUnshielded,
     PedersenDowngradeable, ProofKind, ReplayProtectionState, SignatureKind, SingleUpdate,
     StandardTransaction, SystemTransaction, Transaction, UnshieldedOffer, Utxo, UtxoState,
     VerifiedTransaction,
@@ -204,7 +204,7 @@ impl<D: DB> ZswapLocalStateExt<D> for ZswapLocalState<D> {
                 segments
                     .iter()
                     .filter(|(segment, success)| {
-                        *segment != Segments::GUARANTEED && *success
+                        *segment != GUARANTEED_SEGMENT && *success
                     })
                     .map(|(segment, _)| segment)
                     .try_fold(post_guaranteed, |st, segment| {
@@ -940,7 +940,7 @@ impl<D: DB> LedgerState<D> {
     ) -> Result<ApplySectionResult<D>, TransactionInvalid<D>> {
         let mut events: Vec<Event<D>> = vec![];
         let mut state: LedgerState<D> = self.clone();
-        if segment == Segments::GUARANTEED {
+        if segment == GUARANTEED_SEGMENT {
             // Apply replay protection
             state.replay_protection = Sp::new(
                 state
@@ -1106,7 +1106,7 @@ impl<D: DB> LedgerState<D> {
                                 events.push(Event {
                                     source: EventSource {
                                         transaction_hash,
-                                        logical_segment: Segments::GUARANTEED,
+                                        logical_segment: GUARANTEED_SEGMENT,
                                         physical_segment: segment,
                                     },
                                     content,
@@ -1124,7 +1124,7 @@ impl<D: DB> LedgerState<D> {
                     &com_indices,
                     EventSource {
                         transaction_hash,
-                        logical_segment: Segments::GUARANTEED,
+                        logical_segment: GUARANTEED_SEGMENT,
                         physical_segment: segment,
                     },
                 )?;
@@ -1225,7 +1225,7 @@ impl<D: DB> LedgerState<D> {
                             segment_success.insert(segment, Ok(()));
                         }
                         Err(e) => {
-                            if segment == Segments::GUARANTEED {
+                            if segment == GUARANTEED_SEGMENT {
                                 return (self.clone(), TransactionResult::Failure(e));
                             } else {
                                 segment_success.insert(segment, Err(e));
@@ -1250,8 +1250,8 @@ impl<D: DB> LedgerState<D> {
                 &context.block_context,
                 EventSource {
                     transaction_hash: tx.hash,
-                    logical_segment: 0,
-                    physical_segment: 0,
+                    logical_segment: GUARANTEED_SEGMENT,
+                    physical_segment: GUARANTEED_SEGMENT,
                 },
             ),
         };
@@ -1831,8 +1831,8 @@ impl SystemTransaction {
     fn event_source(&self) -> EventSource {
         EventSource {
             transaction_hash: self.transaction_hash(),
-            logical_segment: Segments::GUARANTEED,
-            physical_segment: Segments::GUARANTEED,
+            logical_segment: GUARANTEED_SEGMENT,
+            physical_segment: GUARANTEED_SEGMENT,
         }
     }
 }

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -1555,13 +1555,8 @@ impl<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> Intent<S, P, B
 /// Logical segment index used in standard transactions and ledger application order.
 pub type Segment = u16;
 
-/// Namespace for [`Segment`] constants.
-pub struct Segments;
-
-impl Segments {
-    /// Segment id for the guaranteed phase (fees, guaranteed coins, guaranteed transcripts).
-    pub const GUARANTEED: Segment = 0;
-}
+/// Segment id for the guaranteed phase (fees, guaranteed coins, guaranteed transcripts).
+pub const GUARANTEED_SEGMENT: Segment = 0;
 
 #[derive(Storable)]
 #[storable(db = D)]
@@ -1716,7 +1711,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: St
     }
 
     pub fn segments(&self) -> Vec<Segment> {
-        let mut segments = once(Segments::GUARANTEED)
+        let mut segments = once(GUARANTEED_SEGMENT)
             .chain(self.intents.iter().map(|seg_intent| *seg_intent.0))
             .chain(self.fallible_coins.iter().map(|seg_offer| *seg_offer.0))
             .collect::<Vec<_>>();
@@ -2114,12 +2109,7 @@ where
                 let offers = stx
                     .guaranteed_coins
                     .iter()
-                    .map(|o| {
-                        (
-                            Segments::GUARANTEED,
-                            (**o).clone(),
-                        )
-                    })
+                    .map(|o| (GUARANTEED_SEGMENT, (**o).clone()))
                     .chain(
                         stx.fallible_coins
                             .iter()
@@ -2146,7 +2136,7 @@ where
                     // Merkle tree insertion
                     offer_cost +=
                         model.merkle_tree_insert_amortized(EXPECTED_UTXO_DEPTH, false) * outputs;
-                    if segment == Segments::GUARANTEED {
+                    if segment == GUARANTEED_SEGMENT {
                         g_cost += offer_cost;
                     } else {
                         f_cost += offer_cost;

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -1522,7 +1522,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> Transaction<S,
 where
     Transaction<S, P, B, D>: Serializable,
 {
-    pub fn segments(&self) -> Vec<u16> {
+    pub fn segments(&self) -> Vec<Segment> {
         match self {
             Self::Standard(stx) => stx.segments(),
             Self::ClaimRewards(_) => Vec::new(),
@@ -1552,15 +1552,26 @@ impl<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> Intent<S, P, B
     }
 }
 
+/// Logical segment index used in standard transactions and ledger application order.
+pub type Segment = u16;
+
+/// Namespace for [`Segment`] constants.
+pub struct Segments;
+
+impl Segments {
+    /// Segment id for the guaranteed phase (fees, guaranteed coins, guaranteed transcripts).
+    pub const GUARANTEED: Segment = 0;
+}
+
 #[derive(Storable)]
 #[storable(db = D)]
 #[derive_where(Clone, Debug; S, P, B)]
 #[tag = "standard-transaction[v9]"]
 pub struct StandardTransaction<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> {
     pub network_id: String,
-    pub intents: HashMap<u16, Intent<S, P, B, D>, D>,
+    pub intents: HashMap<Segment, Intent<S, P, B, D>, D>,
     pub guaranteed_coins: Option<Sp<ZswapOffer<P::LatestProof, D>, D>>,
-    pub fallible_coins: HashMap<u16, ZswapOffer<P::LatestProof, D>, D>,
+    pub fallible_coins: HashMap<Segment, ZswapOffer<P::LatestProof, D>, D>,
     pub binding_randomness: PedersenRandomness,
 }
 tag_enforcement_test!(StandardTransaction<(), (), Pedersen, InMemoryDB>);
@@ -1568,7 +1579,7 @@ tag_enforcement_test!(StandardTransaction<(), (), Pedersen, InMemoryDB>);
 impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: Storable<D>, D: DB>
     StandardTransaction<S, P, B, D>
 {
-    pub fn actions(&self) -> impl Iterator<Item = (u16, ContractAction<P, D>)> {
+    pub fn actions(&self) -> impl Iterator<Item = (Segment, ContractAction<P, D>)> {
         self.intents
             .clone()
             .into_iter()
@@ -1579,7 +1590,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: St
             })
     }
 
-    pub fn deploys(&self) -> impl Iterator<Item = (u16, ContractDeploy<D>)> {
+    pub fn deploys(&self) -> impl Iterator<Item = (Segment, ContractDeploy<D>)> {
         self.intents
             .clone()
             .into_iter()
@@ -1594,7 +1605,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: St
             })
     }
 
-    pub fn updates(&self) -> impl Iterator<Item = (u16, MaintenanceUpdate<D>)> {
+    pub fn updates(&self) -> impl Iterator<Item = (Segment, MaintenanceUpdate<D>)> {
         self.intents
             .clone()
             .into_iter()
@@ -1609,7 +1620,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: St
             })
     }
 
-    pub fn calls(&self) -> impl Iterator<Item = (u16, ContractCall<P, D>)> {
+    pub fn calls(&self) -> impl Iterator<Item = (Segment, ContractCall<P, D>)> {
         self.intents
             .clone()
             .into_iter()
@@ -1626,7 +1637,7 @@ impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: St
             })
     }
 
-    pub fn intents(&'_ self) -> impl Iterator<Item = (u16, Intent<S, P, B, D>)> {
+    pub fn intents(&'_ self) -> impl Iterator<Item = (Segment, Intent<S, P, B, D>)> {
         self.intents.clone().into_iter()
     }
 
@@ -1704,8 +1715,8 @@ impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: St
             .flat_map(|offer| Vec::from(&offer.1.transient).into_iter())
     }
 
-    pub fn segments(&self) -> Vec<u16> {
-        let mut segments = once(0)
+    pub fn segments(&self) -> Vec<Segment> {
+        let mut segments = once(Segments::GUARANTEED)
             .chain(self.intents.iter().map(|seg_intent| *seg_intent.0))
             .chain(self.fallible_coins.iter().map(|seg_offer| *seg_offer.0))
             .collect::<Vec<_>>();
@@ -2103,7 +2114,12 @@ where
                 let offers = stx
                     .guaranteed_coins
                     .iter()
-                    .map(|o| (0, (**o).clone()))
+                    .map(|o| {
+                        (
+                            Segments::GUARANTEED,
+                            (**o).clone(),
+                        )
+                    })
                     .chain(
                         stx.fallible_coins
                             .iter()
@@ -2130,7 +2146,7 @@ where
                     // Merkle tree insertion
                     offer_cost +=
                         model.merkle_tree_insert_amortized(EXPECTED_UTXO_DEPTH, false) * outputs;
-                    if segment == 0 {
+                    if segment == Segments::GUARANTEED {
                         g_cost += offer_cost;
                     } else {
                         f_cost += offer_cost;

--- a/ledger/src/verify.rs
+++ b/ledger/src/verify.rs
@@ -20,9 +20,9 @@ use crate::error::{
 use crate::primitive::MultiSet;
 use crate::structure::{
     BindingKind, ClaimRewardsTransaction, ContractAction, ContractCall, ContractDeploy,
-    ErasedIntent, FEE_TOKEN, Intent, LedgerParameters, LedgerState, MaintenanceUpdate, Segments,
-    PedersenDowngradeable, ProofKind, SingleUpdate, StandardTransaction, Transaction,
-    UnshieldedOffer,
+    ErasedIntent, FEE_TOKEN, GUARANTEED_SEGMENT, Intent, LedgerParameters, LedgerState,
+    MaintenanceUpdate, PedersenDowngradeable, ProofKind, SingleUpdate, StandardTransaction,
+    Transaction, UnshieldedOffer,
 };
 use crate::structure::{SignatureKind, VerifiedTransaction};
 use crate::utils::SortedIter;
@@ -489,7 +489,7 @@ impl<
     where
         UnshieldedOffer<S, D>: Clone,
     {
-        if segment_id == Segments::GUARANTEED {
+        if segment_id == GUARANTEED_SEGMENT {
             return Err(MalformedTransaction::IntentAtGuaranteedSegmentId);
         }
 
@@ -587,13 +587,13 @@ where
                         .map(|x| {
                             P::zswap_well_formed(
                                 x,
-                                Segments::GUARANTEED,
+                                GUARANTEED_SEGMENT,
                             )
                             .map_err(MalformedTransaction::<D>::from)
                         })
                         .transpose()?;
                     for seg_x_offer in stx.fallible_coins.iter() {
-                        if *seg_x_offer.0 == Segments::GUARANTEED {
+                        if *seg_x_offer.0 == GUARANTEED_SEGMENT {
                             return Err(MalformedTransaction::IllegallyDeclaredGuaranteed);
                         }
                         P::zswap_well_formed(&seg_x_offer.1.clone(), *seg_x_offer.0.deref())
@@ -622,7 +622,7 @@ where
                 })?;
 
                 for segment_intent in stx.intents.sorted_iter() {
-                    if *segment_intent.0 == Segments::GUARANTEED {
+                    if *segment_intent.0 == GUARANTEED_SEGMENT {
                         return Err(MalformedTransaction::IllegallyDeclaredGuaranteed);
                     }
                     segment_intent.1.well_formed(

--- a/ledger/src/verify.rs
+++ b/ledger/src/verify.rs
@@ -20,7 +20,7 @@ use crate::error::{
 use crate::primitive::MultiSet;
 use crate::structure::{
     BindingKind, ClaimRewardsTransaction, ContractAction, ContractCall, ContractDeploy,
-    ErasedIntent, FEE_TOKEN, Intent, LedgerParameters, LedgerState, MaintenanceUpdate,
+    ErasedIntent, FEE_TOKEN, Intent, LedgerParameters, LedgerState, MaintenanceUpdate, Segments,
     PedersenDowngradeable, ProofKind, SingleUpdate, StandardTransaction, Transaction,
     UnshieldedOffer,
 };
@@ -489,7 +489,7 @@ impl<
     where
         UnshieldedOffer<S, D>: Clone,
     {
-        if segment_id == SEGMENT_GUARANTEED {
+        if segment_id == Segments::GUARANTEED {
             return Err(MalformedTransaction::IntentAtGuaranteedSegmentId);
         }
 
@@ -525,8 +525,6 @@ impl<
         Ok(())
     }
 }
-
-const SEGMENT_GUARANTEED: u16 = 0;
 
 impl<S: SignatureKind<D>, D: DB> ClaimRewardsTransaction<S, D> {
     fn well_formed(&self) -> Result<(), MalformedTransaction<D>> {
@@ -587,11 +585,15 @@ where
                     stx.guaranteed_coins
                         .as_ref()
                         .map(|x| {
-                            P::zswap_well_formed(x, 0).map_err(MalformedTransaction::<D>::from)
+                            P::zswap_well_formed(
+                                x,
+                                Segments::GUARANTEED,
+                            )
+                            .map_err(MalformedTransaction::<D>::from)
                         })
                         .transpose()?;
                     for seg_x_offer in stx.fallible_coins.iter() {
-                        if *seg_x_offer.0 == 0 {
+                        if *seg_x_offer.0 == Segments::GUARANTEED {
                             return Err(MalformedTransaction::IllegallyDeclaredGuaranteed);
                         }
                         P::zswap_well_formed(&seg_x_offer.1.clone(), *seg_x_offer.0.deref())
@@ -620,7 +622,7 @@ where
                 })?;
 
                 for segment_intent in stx.intents.sorted_iter() {
-                    if *segment_intent.0 == 0 {
+                    if *segment_intent.0 == Segments::GUARANTEED {
                         return Err(MalformedTransaction::IllegallyDeclaredGuaranteed);
                     }
                     segment_intent.1.well_formed(

--- a/spec/intents-transactions.md
+++ b/spec/intents-transactions.md
@@ -724,7 +724,7 @@ impl LedgerState {
                     self = state;
                     segment_success = segment_success.insert(segment, true);
                 }
-                Err(e) => if segment == 0 {
+                Err(e) => if segment == Segments::GUARANTEED {
                     return (self, TransactionResult::FailEntirely);
                 } else {
                     segment_success = segment_success.insert(segment, false);
@@ -747,7 +747,7 @@ impl LedgerState {
         segment: u16,
         context: TransactionContext,
     ) -> Result<Self> {
-        if segment == 0 {
+        if segment == Segments::GUARANTEED {
             // Apply replay protection
             self.replay_protection = self.replay_protection.apply_tx(
                 tx,

--- a/spec/intents-transactions.md
+++ b/spec/intents-transactions.md
@@ -724,7 +724,7 @@ impl LedgerState {
                     self = state;
                     segment_success = segment_success.insert(segment, true);
                 }
-                Err(e) => if segment == Segments::GUARANTEED {
+                Err(e) => if segment == GUARANTEED_SEGMENT {
                     return (self, TransactionResult::FailEntirely);
                 } else {
                     segment_success = segment_success.insert(segment, false);
@@ -747,7 +747,7 @@ impl LedgerState {
         segment: u16,
         context: TransactionContext,
     ) -> Result<Self> {
-        if segment == Segments::GUARANTEED {
+        if segment == GUARANTEED_SEGMENT {
             // Apply replay protection
             self.replay_protection = self.replay_protection.apply_tx(
                 tx,


### PR DESCRIPTION
## Description

Introduced type alias for segment and guaranteed segment associated constant

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [X] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
