### PR TITLE
feat: add SRS upload workflow with OIDC and dry-run support

### DIFF
--- a/.github/workflows/upload-srs.yml
+++ b/.github/workflows/upload-srs.yml
@@ -1,0 +1,71 @@
+name: Upload SRS Parameters
+
+on:
+  push:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-params:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git rewrite
+        run: |
+          mkdir -p $HOME/.config/git
+          echo '[url "https://github.com/"]' >> $HOME/.config/git/config
+          echo '  insteadOf = "git@github.com:"' >> $HOME/.config/git/config
+          echo '  insteadOf = "git@github.com/"' >> $HOME/.config/git/config
+          echo '  insteadOf = "ssh://git@github.com/"' >> $HOME/.config/git/config
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31.10.2
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
+            accept-flake-config = true
+
+      - name: Cache Nix
+        uses: input-output-hk/actions/attic@6d5d62ad59441a3c869a0e8abee4e1bf8b440c2f
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          endpoint: https://attic.ci.iog.io
+          cache: midnight-public
+
+      - name: Build local-params
+        run: |
+          MIDNIGHT_PP=$(nix build .#local-params --print-out-paths)
+          echo "MIDNIGHT_PP=$MIDNIGHT_PP" >> "$GITHUB_ENV"
+          VERSION=$(cat static/version)
+          echo "Built local-params at $MIDNIGHT_PP for version $VERSION"
+          ls -lh "$MIDNIGHT_PP/zswap/$VERSION/" || echo "No zswap files found"
+          ls -lh "$MIDNIGHT_PP/dust/$VERSION/" || echo "No dust files found"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::903367786860:role/MidnightLedgerSrsUploadRole
+          aws-region: eu-west-1
+
+      - name: Verify S3 access
+        run: aws s3 ls s3://stl-euw1-mainnet-srs-download/ | head -5
+
+      - name: Dry run - show what would be uploaded
+        run: |
+          VERSION=$(cat static/version)
+          echo "=== Would upload from $MIDNIGHT_PP ==="
+          for file in $MIDNIGHT_PP/zswap/$VERSION/*.{prover,verifier,bzkir}; do
+            [ -f "$file" ] && echo "  zswap/$VERSION/$(basename "$file")"
+          done
+          for file in $MIDNIGHT_PP/dust/$VERSION/*.{prover,verifier,bzkir}; do
+            [ -f "$file" ] && echo "  dust/$VERSION/$(basename "$file")"
+          done

--- a/.github/workflows/upload-srs.yml
+++ b/.github/workflows/upload-srs.yml
@@ -1,7 +1,6 @@
 name: Upload SRS Parameters
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/upload-srs.yml
+++ b/.github/workflows/upload-srs.yml
@@ -1,7 +1,12 @@
 name: Upload SRS Parameters
 
 on:
-  push:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run - build and list files without uploading"
+        type: boolean
+        default: true
 
 permissions:
   id-token: write
@@ -11,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-params:
+  upload-srs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure git rewrite
@@ -41,31 +46,13 @@ jobs:
           endpoint: https://attic.ci.iog.io
           cache: midnight-public
 
-      - name: Build local-params
-        run: |
-          MIDNIGHT_PP=$(nix build .#local-params --print-out-paths)
-          echo "MIDNIGHT_PP=$MIDNIGHT_PP" >> "$GITHUB_ENV"
-          VERSION=$(cat static/version)
-          echo "Built local-params at $MIDNIGHT_PP for version $VERSION"
-          ls -lh "$MIDNIGHT_PP/zswap/$VERSION/" || echo "No zswap files found"
-          ls -lh "$MIDNIGHT_PP/dust/$VERSION/" || echo "No dust files found"
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::903367786860:role/MidnightLedgerSrsUploadRole
           aws-region: eu-west-1
 
-      - name: Verify S3 access
-        run: aws s3 ls s3://stl-euw1-mainnet-srs-download/ | head -5
-
-      - name: Dry run - show what would be uploaded
-        run: |
-          VERSION=$(cat static/version)
-          echo "=== Would upload from $MIDNIGHT_PP ==="
-          for file in $MIDNIGHT_PP/zswap/$VERSION/*.{prover,verifier,bzkir}; do
-            [ -f "$file" ] && echo "  zswap/$VERSION/$(basename "$file")"
-          done
-          for file in $MIDNIGHT_PP/dust/$VERSION/*.{prover,verifier,bzkir}; do
-            [ -f "$file" ] && echo "  dust/$VERSION/$(basename "$file")"
-          done
+      - name: Upload SRS parameters
+        env:
+          DRY_RUN: ${{ inputs.dry-run != false && '--dry-run' || '' }}
+        run: bash scripts/upload-keys-s3.sh $DRY_RUN

--- a/.github/workflows/upload-srs.yml
+++ b/.github/workflows/upload-srs.yml
@@ -1,6 +1,7 @@
 name: Upload SRS Parameters
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/upload-srs.yml
+++ b/.github/workflows/upload-srs.yml
@@ -54,6 +54,11 @@ jobs:
           aws-region: eu-west-1
 
       - name: Upload SRS parameters
-        env:
-          DRY_RUN: ${{ inputs.dry-run != false && '--dry-run' || '' }}
-        run: bash scripts/upload-keys-s3.sh $DRY_RUN
+        run: |
+          if [ "${{ inputs.dry-run }}" = "false" ]; then
+            echo "=== LIVE UPLOAD ==="
+            bash scripts/upload-keys-s3.sh
+          else
+            echo "=== DRY RUN (pass dry-run=false to upload for real) ==="
+            bash scripts/upload-keys-s3.sh --dry-run
+          fi

--- a/scripts/upload-keys-s3.sh
+++ b/scripts/upload-keys-s3.sh
@@ -18,6 +18,13 @@
 # See: .github/workflows/upload-srs.yml
 
 set -e
+
+DRY_RUN=false
+if [ "$1" = "--dry-run" ]; then
+  DRY_RUN=true
+  echo "=== DRY RUN - no files will be uploaded ==="
+fi
+
 VERSION=$(cat static/version)
 MIDNIGHT_PP=$(nix build .#local-params --print-out-paths)
 FILES_ZSWAP=$(echo "$MIDNIGHT_PP/zswap/$VERSION"/*.{prover,verifier,bzkir})
@@ -27,10 +34,14 @@ FILESTORE="s3://stl-euw1-mainnet-srs-download"
 for file in $FILES_ZSWAP; do
   NAME=$(basename "$file")
   echo ":: $file -> $FILESTORE/zswap/$VERSION/$NAME"
-  aws s3 cp "$file" "$FILESTORE/zswap/$VERSION/$NAME"
+  if [ "$DRY_RUN" = false ]; then
+    aws s3 cp "$file" "$FILESTORE/zswap/$VERSION/$NAME"
+  fi
 done
 for file in $FILES_DUST; do
   NAME=$(basename "$file")
   echo ":: $file -> $FILESTORE/dust/$VERSION/$NAME"
-  aws s3 cp "$file" "$FILESTORE/dust/$VERSION/$NAME"
+  if [ "$DRY_RUN" = false ]; then
+    aws s3 cp "$file" "$FILESTORE/dust/$VERSION/$NAME"
+  fi
 done


### PR DESCRIPTION
## Summary

- Adds workflow_dispatch workflow for uploading SRS parameters to s3://stl-euw1-mainnet-srs-download via OIDC -- no personal access keys needed
- Adds --dry-run flag to upload-keys-s3.sh -- lists files without uploading
- Defaults to dry-run for safety; set dry-run=false to upload for real

## Tested

- Dry-run verified: https://github.com/midnightntwrk/midnight-ledger/actions/runs/24555413035
- Full E2E upload verified: https://github.com/midnightntwrk/midnight-ledger/actions/runs/24555157620

## Links

- Ref: SRE-2065
- IAM OIDC role: shieldedtech/shielded-iac#970