### PR TITLE
fix(ci): use absolute path for netrc-file in Nix config

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            netrc-file = ~/.netrc
+            netrc-file = ${{ env.HOME }}/.netrc
             access-tokens = github.com=${{ secrets.GH_PASSWORD }} api.github.com=${{ secrets.GH_PASSWORD }}
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            netrc-file = ~/.netrc
+            netrc-file = ${{ env.HOME }}/.netrc
             access-tokens = github.com=${{ secrets.GH_PASSWORD }} api.github.com=${{ secrets.GH_PASSWORD }}
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache

--- a/.github/workflows/prepare-cost-model-docker.yml
+++ b/.github/workflows/prepare-cost-model-docker.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            netrc-file = ~/.netrc
+            netrc-file = ${{ env.HOME }}/.netrc
             access-tokens = github.com=${{ secrets.GH_PASSWORD }} api.github.com=${{ secrets.GH_PASSWORD }}
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache


### PR DESCRIPTION
## Summary
Three CI workflows (`nightly.yml`, `benchmark.yml`, `prepare-cost-model-docker.yml`) currently fail at the `Cache Nix` step with:

  error: not an absolute path: "~/.netrc"

Newer Nix versions no longer accept tilde-prefixed paths in `netrc-file`. Replace `~/.netrc` with `${{ env.HOME }}/.netrc`, which GitHub Actions substitutes at template time to an absolute runner path.

Example failure run: https://github.com/midnightntwrk/midnight-ledger/actions/runs/24557488146/job/71799274887 (triggered after merging #433 into ledger-8).

## Test plan

- [ ] CI re-runs `nightly.yml` on push to this branch (or after merge) and passes the Nix cache setup step
- [ ] `benchmark.yml` and `prepare-cost-model-docker.yml` can be manually dispatched to verify
