### PR TITLE
Correctly return `undefined` instead of `null` in `asCell`

### DIFF
--- a/onchain-runtime-wasm/src/state.rs
+++ b/onchain-runtime-wasm/src/state.rs
@@ -289,7 +289,7 @@ impl StateValue {
     pub fn as_cell(&self) -> Result<JsValue, JsError> {
         match &self.0 {
             state::StateValue::Cell(v) => Ok(to_value(v)?),
-            _ => Ok(JsValue::NULL),
+            _ => Ok(JsValue::UNDEFINED),
         }
     }
 


### PR DESCRIPTION
## Description
Fixes a minor bug where we return the wrong object on cast failure.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
