### PR TITLE
chore: updated lru to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,6 +2053,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2729,11 +2734,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]

--- a/storage-core/Cargo.toml
+++ b/storage-core/Cargo.toml
@@ -42,7 +42,7 @@ parking_lot = "^0.12.4"
 # proptest 1.7.0+ rely on rand 0.9.0, which we are not yet updating to.
 proptest = { version = "~1.6.0", optional = true }
 proptest-derive = { version = "0.8", optional = true }
-lru = "0.16.0"
+lru = "0.17.0"
 # The "bundled" feature means rusqlite will build its own libsqlite3 instead of
 # using OS provided version. The latest version of rusqlite, 0.32.1, is not
 # compatible with our rustc version.

--- a/transient-crypto/Cargo.toml
+++ b/transient-crypto/Cargo.toml
@@ -32,7 +32,7 @@ midnight-proofs = { version = "^0.7.0" }
 midnight-circuits = { version = "^6.0.0" }
 midnight-zk-stdlib = { version = "^1.0.0" }
 anyhow = { version = "^1.0.102" }
-lru = "0.16.0"
+lru = "0.17.0"
 
 # rand 0.9.0 is not yet supported by some of our dependencies, we will
 # stick with 0.8.0 for now.


### PR DESCRIPTION
## Description

Updated lru to 0.17.0

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [X] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
