### PR TITLE
Use correct fees during transaction application

### DIFF
--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -934,6 +934,7 @@ impl<D: DB> LedgerState<D> {
         &self,
         tx: &StandardTransaction<S, P, B, D>,
         transaction_hash: TransactionHash,
+        fees: u128,
         segment: u16,
         context: &TransactionContext<D>,
     ) -> Result<ApplySectionResult<D>, TransactionInvalid<D>> {
@@ -1015,9 +1016,7 @@ impl<D: DB> LedgerState<D> {
                 //
                 // NOTE: The `unwrap_or` is safe here, as fees have already been
                 // checked during well-formedness.
-                let mut fees_remaining = Transaction::Standard(tx.clone())
-                    .fees(&self.parameters, true)
-                    .unwrap_or(0);
+                let mut fees_remaining = fees;
                 // apply spends first, to make sure registration outputs get the maximum dust they can.
                 let intents = tx.intents.sorted_iter().collect::<Vec<_>>();
                 for (phys_seg, time, dust_spend) in intents.iter().flat_map(|(phys_seg, i)| {
@@ -1217,7 +1216,7 @@ impl<D: DB> LedgerState<D> {
                 let mut total_success = true;
                 let mut new_st = self.clone();
                 for &segment in segments.iter() {
-                    match new_st.apply_section(stx, tx.hash, segment, context) {
+                    match new_st.apply_section(stx, tx.hash, tx.fees, segment, context) {
                         Ok(state) => {
                             new_st = state.0;
                             events.extend(state.1);
@@ -2175,7 +2174,11 @@ mod tests {
             .apply_system_tx(
                 &SystemTransaction::DistributeNight(
                     ClaimKind::CardanoBridge,
-                    vec![OutputInstructionUnshielded { amount, target_address, nonce }],
+                    vec![OutputInstructionUnshielded {
+                        amount,
+                        target_address,
+                        nonce,
+                    }],
                 ),
                 Timestamp::from_secs(1),
             )
@@ -2189,8 +2192,22 @@ mod tests {
             INITIAL_PARAMETERS.cardano_to_midnight_bridge_fee_basis_points,
             amount,
         );
-        assert_eq!(new_state.bridge_receiving.get(&target_address).copied().unwrap_or(0), amount - expected_fee);
-        assert_eq!(new_state.treasury.get(&TokenType::Unshielded(NIGHT)).copied().unwrap_or(0), expected_fee);
+        assert_eq!(
+            new_state
+                .bridge_receiving
+                .get(&target_address)
+                .copied()
+                .unwrap_or(0),
+            amount - expected_fee
+        );
+        assert_eq!(
+            new_state
+                .treasury
+                .get(&TokenType::Unshielded(NIGHT))
+                .copied()
+                .unwrap_or(0),
+            expected_fee
+        );
         assert_eq!(new_state.locked_pool, 0);
     }
 
@@ -2214,7 +2231,11 @@ mod tests {
             .apply_system_tx(
                 &SystemTransaction::DistributeNight(
                     ClaimKind::CardanoBridge,
-                    vec![OutputInstructionUnshielded { amount, target_address, nonce }],
+                    vec![OutputInstructionUnshielded {
+                        amount,
+                        target_address,
+                        nonce,
+                    }],
                 ),
                 Timestamp::from_secs(1),
             )
@@ -2225,8 +2246,22 @@ mod tests {
             .expect("invariant should hold after sub-minimum bridge transfer");
 
         // Sub-minimum: entire amount goes to treasury as fee, nothing to bridge_receiving
-        assert_eq!(new_state.bridge_receiving.get(&target_address).copied().unwrap_or(0), 0);
-        assert_eq!(new_state.treasury.get(&TokenType::Unshielded(NIGHT)).copied().unwrap_or(0), amount);
+        assert_eq!(
+            new_state
+                .bridge_receiving
+                .get(&target_address)
+                .copied()
+                .unwrap_or(0),
+            0
+        );
+        assert_eq!(
+            new_state
+                .treasury
+                .get(&TokenType::Unshielded(NIGHT))
+                .copied()
+                .unwrap_or(0),
+            amount
+        );
         assert_eq!(new_state.locked_pool, 0);
     }
 }

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -1291,6 +1291,7 @@ tag_enforcement_test!(Transaction<(), (), Pedersen, InMemoryDB>);
 pub struct VerifiedTransaction<D: DB> {
     pub(crate) inner: Transaction<(), (), Pedersen, D>,
     pub(crate) hash: TransactionHash,
+    pub(crate) fees: u128,
 }
 
 impl<D: DB> Deref for VerifiedTransaction<D> {

--- a/ledger/src/verify.rs
+++ b/ledger/src/verify.rs
@@ -605,8 +605,9 @@ where
                     stx.pedersen_check()
                 })?;
 
-                ref_state.param_check(false, |params| {
-                    let fees = match self.fees(params, true) {
+                let mut fees = 0;
+                ref_state.param_check(true, |params| {
+                    fees = match self.fees(params, true) {
                         Ok(fees) => fees,
                         Err(e) => {
                             if strictness.enforce_balancing {
@@ -635,6 +636,7 @@ where
                 Ok(VerifiedTransaction {
                     inner: self.erase_proofs().erase_signatures(),
                     hash: self.transaction_hash(),
+                    fees,
                 })
             }
             Transaction::ClaimRewards(mtx) => {
@@ -648,6 +650,7 @@ where
                 Ok(VerifiedTransaction {
                     inner: self.erase_proofs().erase_signatures(),
                     hash: self.transaction_hash(),
+                    fees: 0,
                 })
             }
         }


### PR DESCRIPTION
## Description

Recalculating the fees during application can lead to subtle differences, as these will use proof-erased transaction fees, which use estimates for proof size instead of real proof sizes.
Instead, we reuse the fees calculated during transaction verification. Fixes #298.

## Sanity Checklist

This PR:
- [X] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
