### PR TITLE
Fix audit issue C of the second-round audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 # Change Log
 
+## Unreleased
+
+- fix: correctly exclude the identity point during coin ciphertext decryption
+
 ## 8.1.0
 
 - feat: expose finer-grained control for the wallet in wasm bindings.

--- a/zswap/src/structure.rs
+++ b/zswap/src/structure.rs
@@ -131,9 +131,9 @@ impl Deserializable for CoinCiphertext {
         recursive_depth: u32,
     ) -> Result<Self, std::io::Error> {
         let c = EmbeddedGroupAffine::deserialize(reader, recursive_depth)?;
-        // See note in `transient_crypto::encryption::SecretKey::decrypt` for why the point at
-        // infinity is excluded.
-        if c.is_infinity() {
+        // See note in `transient_crypto::encryption::SecretKey::decrypt` for why the identity
+        // element is excluded.
+        if c.is_identity() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "ciphertext challenge may not be the point at infinity",


### PR DESCRIPTION
## Description

This instance of `is_infinity` was intended to check for the identity elements. This is technically a hard fork due to its change on transaction validation.

## Sanity Checklist

This PR:
- [X] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
