### PR TITLE
Fix panic in Node::remove when path is shorter than Extension's compressed_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 # Change Log
 
+## Unreleased
+
+- fix: fix potential panic in MPT path removal, unlikely to be currently triggerable.
+
 ## 8.1.0
 
 - feat: expose finer-grained control for the wallet in wasm bindings.

--- a/storage/src/merkle_patricia_trie.rs
+++ b/storage/src/merkle_patricia_trie.rs
@@ -1252,21 +1252,16 @@ impl<T: Storable<D>, D: DB, A: Storable<D> + Annotation<T>> Node<T, D, A> {
                 }
             }
             Node::Extension {
-                ann: an,
                 compressed_path,
                 child,
                 ..
             } => {
+                if path.len() < compressed_path.len() {
+                    return (sp.clone(), None);
+                }
                 for i in 0..compressed_path.len() {
                     if compressed_path[i] != path[i] {
-                        return (
-                            sp.arena.alloc(Node::Extension {
-                                ann: an.clone(),
-                                compressed_path: compressed_path.clone(),
-                                child: child.clone(),
-                            }),
-                            None,
-                        );
+                        return (sp.clone(), None);
                     }
                 }
 
@@ -1546,6 +1541,18 @@ mod tests {
         assert_eq!(mpt.size(), 1);
         assert_eq!(mpt.lookup(&([1, 3, 3])), Some(&102));
         assert_eq!(mpt.lookup(&([1, 2, 3])), None);
+    }
+
+    #[test]
+    fn remove_path_shorter_than_extension() {
+        let mut mpt = MerklePatriciaTrie::<u64>::new();
+        // Insert with a path long enough to create an Extension node.
+        mpt = mpt.insert(&[1, 2, 3], 100);
+        // Removing with a path shorter than the Extension's compressed_path
+        // should return the trie unchanged, not panic.
+        mpt = mpt.remove(&[1]);
+        assert_eq!(mpt.lookup(&[1, 2, 3]), Some(&100));
+        assert_eq!(mpt.size(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Add a bounds check before iterating over compressed_path in the Extension arm of Node::remove, matching the existing guard in lookup_with. Without this, a short path causes an index-out-of-bounds panic.

Also simplify the mismatch early-returns to use sp.clone() instead of reconstructing the node.

Note that this *in practice* can't be triggered due to most instances using fixed-length MPT keys, but should be resolved before we accidentally add a way to reach it.

<!-- describe what this PR does, and why it is needed -->

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
