### PR TITLE
Retain collapsed state during processing of insertion evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 ## Unreleased
 
 - fix: fix potential panic in MPT path removal, unlikely to be currently triggerable.
+- fix: address non-associativity of Dust event processing.
 
 ## 8.1.0
 

--- a/transient-crypto/src/merkle_tree.rs
+++ b/transient-crypto/src/merkle_tree.rs
@@ -715,6 +715,21 @@ impl<A: Storable<D>, D: DB> MerkleTreeNode<A, D> {
         leaf: (HashOutput, A),
         path: &[TreeInsertionPathEntry],
     ) -> Result<Self, InvalidUpdate> {
+        if let Collapsed { height, .. } = self {
+            let hash = if path.is_empty() {
+                degrade_to_transient(leaf.0)
+            } else {
+                path.last()
+                    .expect("non-empty")
+                    .hash
+                    .ok_or(InvalidUpdate::BadUpdatePath)?
+                    .0
+            };
+            return Ok(Collapsed {
+                hash,
+                height: *height,
+            });
+        }
         if path.is_empty() {
             return Ok(Leaf {
                 hash: leaf.0,
@@ -723,10 +738,6 @@ impl<A: Storable<D>, D: DB> MerkleTreeNode<A, D> {
         }
         let entry = path.last().expect("non-empty");
         Ok(match self {
-            Collapsed { height, .. } => Collapsed {
-                hash: entry.hash.ok_or(InvalidUpdate::BadUpdatePath)?.0,
-                height: *height,
-            },
             Node {
                 left,
                 right,
@@ -753,7 +764,9 @@ impl<A: Storable<D>, D: DB> MerkleTreeNode<A, D> {
                     }
                 }
             }
-            Stub { .. } | Leaf { .. } => return Err(InvalidUpdate::BadUpdatePath),
+            Stub { .. } | Leaf { .. } | Collapsed { .. } => {
+                return Err(InvalidUpdate::BadUpdatePath);
+            }
         })
     }
 


### PR DESCRIPTION
## Description

Inserting from an `InsertionEvidence` incorrectly re-expands collapsed leaves. This is due to height 0 previously unconditionally creating a non-collapsed leaf entry, even if the point was previously collapsed. This isn't ideal, as it accidentally can restore previous points that are not meant to be retained. Fixes #455 

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
