### PR TITLE
ZKIRv2 backwards compatibility

### DIFF
--- a/.tag-decompositions/ir-source[v2-generic]
+++ b/.tag-decompositions/ir-source[v2-generic]
@@ -1,0 +1,1 @@
+((ir-minor-version[v2],u32,bool,vec(ir-instruction[v2])))

--- a/.tag-decompositions/ir-source[v3-generic]
+++ b/.tag-decompositions/ir-source[v3-generic]
@@ -1,0 +1,1 @@
+((ir-minor-version[v3],vec(zkir-typed-identifier[v1]),bool,vec(ir-instruction[v3])))

--- a/.tag-decompositions/prover-key[v7](ir-source[v2-generic])
+++ b/.tag-decompositions/prover-key[v7](ir-source[v2-generic])
@@ -1,0 +1,1 @@
+prover-key[v7](ir-source[v2-generic])

--- a/.tag-decompositions/prover-key[v7](ir-source[v3-generic])
+++ b/.tag-decompositions/prover-key[v7](ir-source[v3-generic])
@@ -1,0 +1,1 @@
+prover-key[v7](ir-source[v3-generic])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,6 +3331,7 @@ dependencies = [
  "midnight-transient-crypto",
  "midnight-zk-stdlib",
  "midnight-zkir",
+ "num-bigint",
  "pastey",
  "proptest",
  "proptest-derive",
@@ -3339,6 +3340,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_repr",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3376,6 +3378,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_repr",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4765,6 +4768,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/proof-server/src/versioned_ir.rs
+++ b/proof-server/src/versioned_ir.rs
@@ -15,7 +15,9 @@ use std::sync::Arc;
 
 use ledger::prove::Resolver;
 use rand::rngs::OsRng;
+#[allow(unused_imports)]
 use serialize::tagged_deserialize;
+use std::io::Cursor;
 use transient_crypto::proofs::{Proof, ProofPreimage, Zkir};
 use zkir as zkir_v2;
 
@@ -23,7 +25,7 @@ use crate::endpoints::PUBLIC_PARAMS;
 
 #[cfg(feature = "experimental")]
 pub(crate) fn k(request: &[u8]) -> Result<u8, &'static str> {
-    if let Ok(ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(request) {
+    if let Ok(ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(request)) {
         Ok(ir_v2.k())
     } else if let Ok(ir_v3) = tagged_deserialize::<zkir_v3::IrSource>(request) {
         Ok(ir_v3.k())
@@ -34,7 +36,7 @@ pub(crate) fn k(request: &[u8]) -> Result<u8, &'static str> {
 
 #[cfg(not(feature = "experimental"))]
 pub(crate) fn k(request: &[u8]) -> Result<u8, &'static str> {
-    if let Ok(ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(request) {
+    if let Ok(ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(request)) {
         Ok(ir_v2.k())
     } else {
         Err("Unsupported ZKIR version")
@@ -43,7 +45,7 @@ pub(crate) fn k(request: &[u8]) -> Result<u8, &'static str> {
 
 #[cfg(feature = "experimental")]
 pub(crate) fn check(ppi: Arc<ProofPreimage>, ir: &[u8]) -> Result<Vec<Option<usize>>, String> {
-    if let Ok(ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(ir) {
+    if let Ok(ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(ir)) {
         ppi.check(&ir_v2).map_err(|e| e.to_string())
     } else if let Ok(ir_v3) = tagged_deserialize::<zkir_v3::IrSource>(ir) {
         ppi.check(&ir_v3).map_err(|e| e.to_string())
@@ -54,7 +56,7 @@ pub(crate) fn check(ppi: Arc<ProofPreimage>, ir: &[u8]) -> Result<Vec<Option<usi
 
 #[cfg(not(feature = "experimental"))]
 pub(crate) fn check(ppi: Arc<ProofPreimage>, ir: &[u8]) -> Result<Vec<Option<usize>>, String> {
-    if let Ok(ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(ir) {
+    if let Ok(ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(ir)) {
         ppi.check(&ir_v2).map_err(|e| e.to_string())
     } else {
         Err("Unsupported ZKIR version".to_string())
@@ -67,7 +69,7 @@ pub(crate) async fn prove(
     ir_source: &[u8],
     resolver: &Resolver,
 ) -> Result<(Proof, Vec<Option<usize>>), String> {
-    if let Ok(_ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(ir_source) {
+    if let Ok(_ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(ir_source)) {
         ppi.prove::<zkir_v2::IrSource>(OsRng, &*PUBLIC_PARAMS, resolver)
             .await
             .map_err(|e| e.to_string())
@@ -86,7 +88,7 @@ pub(crate) async fn prove(
     ir_source: &[u8],
     resolver: &Resolver,
 ) -> Result<(Proof, Vec<Option<usize>>), String> {
-    if let Ok(_ir_v2) = tagged_deserialize::<zkir_v2::IrSource>(ir_source) {
+    if let Ok(_ir_v2) = zkir_v2::IrSource::load_from_tagged(Cursor::new(ir_source)) {
         ppi.prove::<zkir_v2::IrSource>(OsRng, &*PUBLIC_PARAMS, resolver)
             .await
             .map_err(|e| e.to_string())

--- a/proof-server/tests/integration_tests.rs
+++ b/proof-server/tests/integration_tests.rs
@@ -627,6 +627,7 @@ mod k_endpoint {
 
     fn create_minimal_ir_source() -> zkir_v2::IrSource {
         zkir_v2::IrSource {
+            version: Default::default(),
             num_inputs: 1,
             do_communications_commitment: false,
             instructions: std::sync::Arc::new(vec![]),

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -69,11 +69,7 @@ pub fn peek_tag(reader: &mut (impl Read + Seek)) -> std::io::Result<String> {
         .enumerate()
         .filter(|(_, b)| **b == b':')
         .nth(1)
-        .ok_or_else(|| {
-            err(format!(
-                "tagged data does not begin with a colon-separated tag"
-            ))
-        })?
+        .ok_or_else(|| err("tagged data does not begin with a colon-separated tag".to_string()))?
         .0;
     let raw_tag = &buf[GLOBAL_TAG.len()..second_colon];
     String::from_utf8(raw_tag.to_owned())

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -15,7 +15,7 @@ use crate::VecExt;
 use crate::serializable::GLOBAL_TAG;
 use crate::tagged::Tagged;
 use std::borrow::Cow;
-use std::io::{BufRead, Read};
+use std::io::{self, BufRead, Read, Seek};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{collections::HashMap, collections::HashSet, hash::Hash};
@@ -38,6 +38,52 @@ pub fn tagged_deserialize_sequence<T: Deserializable + Tagged>(
         res.push(tagged_deserialize_inner(&mut reader, false)?);
     }
     Ok(res)
+}
+
+/// Attempts to identify the tag a stream starts with without consuming it, allowing determining a
+/// stream's type *before* deserializing it.
+pub fn peek_tag(reader: &mut (impl Read + Seek)) -> std::io::Result<String> {
+    let position = reader.stream_position()?;
+    // Note that colons are special-cased -- we should expect two, one for `GLOBAL_TAG`, and one
+    // for the end of the read tag. We read up to a limit of 512 bytes, and then take up to the
+    // second b':', converting to string, returning an error if not possible.
+    const READ_LIMIT: usize = 512;
+    let mut buf = [0u8; READ_LIMIT];
+    let mut offset = 0;
+    while offset < READ_LIMIT {
+        let read = reader.read(&mut buf[offset..])?;
+        if read == 0 {
+            break;
+        }
+        offset += read;
+    }
+    reader.seek(std::io::SeekFrom::Start(position))?;
+    let err = |msg| io::Error::new(io::ErrorKind::InvalidData, msg);
+    if !buf.starts_with(GLOBAL_TAG.as_bytes()) {
+        return Err(err(format!(
+            "tagged data does not begin with '{GLOBAL_TAG}'"
+        )));
+    }
+    let second_colon = buf
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| **b == b':')
+        .nth(1)
+        .ok_or_else(|| {
+            err(format!(
+                "tagged data does not begin with a colon-separated tag"
+            ))
+        })?
+        .0;
+    let raw_tag = &buf[GLOBAL_TAG.len()..second_colon];
+    String::from_utf8(raw_tag.to_owned())
+        .map_err(|e| err(format!("tag not utf-8: {e}")))
+        .map(|s| {
+            s.replace(
+                |c: char| -> bool { !c.is_ascii_alphanumeric() && !":_-()[],".contains(c) },
+                "�",
+            )
+        })
 }
 
 fn tagged_deserialize_inner<T: Deserializable + Tagged>(

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -22,7 +22,7 @@ mod tagged;
 mod util;
 
 pub use crate::deserializable::{
-    Deserializable, RECURSION_LIMIT, tagged_deserialize, tagged_deserialize_sequence,
+    Deserializable, RECURSION_LIMIT, peek_tag, tagged_deserialize, tagged_deserialize_sequence,
 };
 pub use crate::serializable::{GLOBAL_TAG, Serializable, tagged_serialize, tagged_serialized_size};
 pub use crate::tagged::Tagged;

--- a/storage-core/src/db/sql.rs
+++ b/storage-core/src/db/sql.rs
@@ -674,9 +674,7 @@ impl<H: WellBehavedHasher> DB for SqlDB<H> {
         self.with_tx(Deferred, |tx| {
             let sql = "SELECT COUNT(*) FROM node";
             let mut stmt = tx.prepare(sql).unwrap();
-            let result = stmt
-                .query_row([], |row| row.get::<_, i64>(0))
-                .unwrap() as usize;
+            let result = stmt.query_row([], |row| row.get::<_, i64>(0)).unwrap() as usize;
             stmt.finalize().unwrap();
             result
         })

--- a/transient-crypto/benches/benchmarking.rs
+++ b/transient-crypto/benches/benchmarking.rs
@@ -23,7 +23,7 @@ use midnight_zk_stdlib::Relation;
 use rand::RngCore;
 use rand::{Rng, rngs::OsRng};
 use serde_json::json;
-use serialize::tagged_serialize;
+use serialize::{tagged_deserialize, tagged_serialize};
 
 /// Helper function to run benchmarks with multiple data points for zero-parameter operations.
 fn with_json_iter<F>(group_name: &str, c: &mut Criterion, mut benchmark_fn: F)
@@ -152,6 +152,16 @@ pub fn proof_verification(c: &mut Criterion) {
                 preimage.public_transcript_inputs.clone(),
                 vec![],
             ))
+        }
+        fn load_ir_from_tagged(
+            reader: impl std::io::Read + std::io::Seek,
+        ) -> std::io::Result<Self> {
+            tagged_deserialize(reader)
+        }
+        fn load_prover_key_from_tagged(
+            reader: impl std::io::Read + std::io::Seek,
+        ) -> std::io::Result<midnight_transient_crypto::proofs::ProverKey<Self>> {
+            tagged_deserialize(reader)
         }
     }
 

--- a/transient-crypto/src/mock_verify.rs
+++ b/transient-crypto/src/mock_verify.rs
@@ -35,7 +35,7 @@ use midnight_zk_stdlib::Relation;
 use rand::Rng;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use serialize::{Deserializable, Serializable, Tagged, tagged_serialize};
+use serialize::{Deserializable, Serializable, Tagged, tagged_deserialize, tagged_serialize};
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use std::fs;
@@ -376,6 +376,14 @@ impl Zkir for TestIr {
             preimage.public_transcript_inputs.clone(),
             vec![],
         ))
+    }
+    fn load_ir_from_tagged(reader: impl std::io::Read + std::io::Seek) -> std::io::Result<Self> {
+        tagged_deserialize(reader)
+    }
+    fn load_prover_key_from_tagged(
+        reader: impl std::io::Read + std::io::Seek,
+    ) -> std::io::Result<ProverKey<Self>> {
+        tagged_deserialize(reader)
     }
 }
 

--- a/transient-crypto/src/proofs.rs
+++ b/transient-crypto/src/proofs.rs
@@ -37,7 +37,6 @@ use serialize::{
 };
 #[cfg(feature = "proptest")]
 use serialize::{NoStrategy, simple_arbitrary};
-use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::io::{self, Read};
@@ -46,6 +45,7 @@ use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 use std::{any::Any, cmp::Ordering};
 use std::{borrow::Cow, num::NonZeroUsize};
+use std::{fmt::Debug, io::Seek};
 use storage_core::Storable;
 use storage_core::arena::ArenaKey;
 use storage_core::db::DB;
@@ -149,7 +149,7 @@ impl<T: Zkir> From<MidnightPK<T>> for ProverKey<T> {
 
 /// An intermediate representation for Midnight's circuits.
 #[allow(async_fn_in_trait)]
-pub trait Zkir: Relation + Tagged + Deserializable + Any + Send + Sync + Debug {
+pub trait Zkir: Relation + Any + Send + Sync + Debug {
     /// Check that a proof preimage satisfies the circuit
     ///
     /// Returns which outputs were skipped in the proof preimage, and how many
@@ -206,6 +206,14 @@ pub trait Zkir: Relation + Tagged + Deserializable + Any + Send + Sync + Debug {
 
         Ok((ProverKey::from(pk), VerifierKey::from(vk)))
     }
+
+    /// Loads IR from a tagged serialization. Separated from `Deserializable` to allow for
+    /// backwards-compatible deserialization of old variants.
+    fn load_ir_from_tagged(reader: impl Read + Seek) -> io::Result<Self>;
+
+    /// Loads a prover key from a tagged serialization. Separated from `Deserializable` to allow
+    /// for backwards-compatible deserialization of old variants.
+    fn load_prover_key_from_tagged(reader: impl Read + Seek) -> io::Result<ProverKey<Self>>;
 }
 
 impl<T: Zkir> PartialEq for ProverKey<T> {
@@ -237,7 +245,7 @@ pub(crate) enum InnerProverKey<T: Zkir> {
     Initialized(Arc<MidnightPK<T>>),
 }
 
-impl<T: Zkir> Tagged for ProverKey<T> {
+impl<T: Zkir + Tagged> Tagged for ProverKey<T> {
     fn tag() -> Cow<'static, str> {
         Cow::Owned(format!("prover-key[v7]({})", T::tag()))
     }
@@ -744,9 +752,10 @@ impl ProofPreimage {
                 "failed to find proving key for '{}'",
                 &self.key_location.0
             )))?;
-        let ir = tagged_deserialize::<Z>(&mut &proof_data.ir_source[..])?;
+        let ir = Z::load_ir_from_tagged(io::Cursor::new(&proof_data.ir_source[..]))?;
         let verifier_key = tagged_deserialize::<VerifierKey>(&mut &proof_data.verifier_key[..])?;
-        let prover_key = tagged_deserialize::<ProverKey<Z>>(&mut &proof_data.prover_key[..])?;
+        let prover_key =
+            Z::load_prover_key_from_tagged(io::Cursor::new(&proof_data.prover_key[..]))?;
         let (proof, pis, pi_skips) = ir.prove(rng, params, prover_key, self).await?;
         debug!("proof created; verifying to make sure");
         let k = verifier_key.force_init()?.k();

--- a/zkir-v3/Cargo.toml
+++ b/zkir-v3/Cargo.toml
@@ -37,6 +37,7 @@ const-hex = "^1.14.0"
 serde = { version = "^1.0.0", features = ["derive", "rc"] }
 serde_bytes = { version = "^0.11.0" }
 serde_json = { version = "^1.0.0" }
+serde_repr = "^0.1.0"
 anyhow = "^1.0.102"
 hex = "^0.4.3"
 # rand 0.9.0 is not yet supported by some of our dependencies, we will

--- a/zkir-v3/src/ir.rs
+++ b/zkir-v3/src/ir.rs
@@ -33,7 +33,7 @@ use crate::ir_types::IrType;
 /// A low-level IR allowing the prover to populate circuit witnesses.
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize, Serializable)]
-#[tag = "ir-source[v3]"]
+#[tag = "ir-source[v3-generic]"]
 pub struct IrSource {
     /// The minor version of this IR.
     pub version: IrMinorVersion,
@@ -49,12 +49,19 @@ tag_enforcement_test!(ProverKey<IrSource>);
 
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(
-    Clone, Debug, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, Serializable,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    Serializable,
 )]
 #[tag = "ir-minor-version[v3]"]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IrMinorVersion {
+    #[default]
     V0,
 }
 
@@ -614,8 +621,8 @@ impl IrSource {
     /// Attempts to parse an arbitrary input as IR.
     pub fn load<R: Read>(reader: R) -> io::Result<Self> {
         let value: serde_json::Value = serde_json::from_reader(reader)?;
-        match &value {
-            serde_json::Value::Object(obj) => {
+        match value {
+            serde_json::Value::Object(mut obj) => {
                 let ver = serde_json::from_value(
                     obj.get("version")
                         .ok_or(io::Error::new(
@@ -625,7 +632,16 @@ impl IrSource {
                         .clone(),
                 )?;
                 match ver {
-                    SerdeVersion { major: 3, minor: 0 } => Ok(serde_json::from_value(value)?),
+                    SerdeVersion {
+                        major: 3,
+                        minor: 0..=0,
+                    } => {
+                        obj.insert(
+                            "version".into(),
+                            serde_json::Value::Number(ver.minor.into()),
+                        );
+                        Ok(serde_json::from_value(serde_json::Value::Object(obj))?)
+                    }
                     SerdeVersion { major, minor } => Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("Unhandled version: {major}.{minor}"),

--- a/zkir-v3/src/ir.rs
+++ b/zkir-v3/src/ir.rs
@@ -20,7 +20,7 @@ use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "proptest")]
 use serialize::randomised_serialization_test;
-use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
+use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test, tagged_deserialize};
 use std::io::{self, Read};
 use std::sync::Arc;
 use transient_crypto::curve::Fr;
@@ -35,6 +35,8 @@ use crate::ir_types::IrType;
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize, Serializable)]
 #[tag = "ir-source[v3]"]
 pub struct IrSource {
+    /// The minor version of this IR.
+    pub version: IrMinorVersion,
     /// The list of input identifiers for this circuit
     pub inputs: Vec<TypedIdentifier>,
     /// Whether this IR should compile a communications commitment
@@ -44,6 +46,17 @@ pub struct IrSource {
 }
 tag_enforcement_test!(IrSource);
 tag_enforcement_test!(ProverKey<IrSource>);
+
+#[cfg_attr(feature = "proptest", derive(Arbitrary))]
+#[derive(
+    Clone, Debug, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, Serializable,
+)]
+#[tag = "ir-minor-version[v3]"]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum IrMinorVersion {
+    V0,
+}
 
 impl Zkir for IrSource {
     fn check(
@@ -74,6 +87,14 @@ impl Zkir for IrSource {
         let proof = prove::<_, TranscriptHash>(params_k.as_ref(), &pk, self, &pis, preproc, rng)?;
 
         Ok((Proof(proof), pis.into_iter().map(Fr).collect(), pi_skips))
+    }
+
+    fn load_ir_from_tagged(reader: impl Read + io::Seek) -> io::Result<Self> {
+        tagged_deserialize(reader)
+    }
+
+    fn load_prover_key_from_tagged(reader: impl Read + io::Seek) -> io::Result<ProverKey<Self>> {
+        tagged_deserialize(reader)
     }
 }
 

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -23,7 +23,6 @@ use base_crypto::fab::{Alignment, AlignmentAtom, AlignmentSegment};
 use base_crypto::hash::persistent_hash;
 use base_crypto::repr::BinaryHashRepr;
 use group::Group;
-use midnight_circuits::instructions::RangeCheckInstructions;
 use midnight_circuits::instructions::{
     ArithInstructions, AssertionInstructions, AssignmentInstructions, BinaryInstructions,
     ControlFlowInstructions, ConversionInstructions, DecompositionInstructions, EccInstructions,

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -38,7 +38,7 @@ use midnight_proofs::{
 };
 use midnight_zk_stdlib::{Relation, ZkStdLib, ZkStdLibArch};
 use num_bigint::BigUint;
-use serialize::{Deserializable, Serializable, VecExt};
+use serialize::{Deserializable, Serializable, VecExt, tagged_deserialize, tagged_serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use transient_crypto::curve::outer;
@@ -1105,10 +1105,13 @@ impl Relation for IrSource {
     }
 
     fn write_relation<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        Serializable::serialize(&self, writer)
+        let mut raw = Vec::new();
+        tagged_serialize(&self, &mut raw)?;
+        raw.serialize(writer)
     }
 
     fn read_relation<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        Deserializable::deserialize(reader, 0)
+        let raw: Vec<u8> = Deserializable::deserialize(reader, 0)?;
+        tagged_deserialize(&mut &raw[..])
     }
 }

--- a/zkir-wasm/src/lib.rs
+++ b/zkir-wasm/src/lib.rs
@@ -167,7 +167,7 @@ pub async fn check(ser_preimage: Uint8Array, provider: JsValue) -> Result<Vec<Js
             &preimage.key_location.0
         )));
     };
-    let ir: IrSource = tagged_deserialize(&mut &data.ir_source[..])?;
+    let ir = IrSource::load_from_tagged(std::io::Cursor::new(&data.ir_source[..]))?;
     let res = preimage
         .check(&ir)
         .map_err(|e| JsError::new(&e.to_string()))?;
@@ -244,7 +244,7 @@ impl Zkir {
 
     #[wasm_bindgen]
     pub fn deserialize(bytes: Uint8Array) -> Result<Self, JsError> {
-        let ir: IrSource = tagged_deserialize(&mut &bytes.to_vec()[..])?;
+        let ir = IrSource::load_from_tagged(std::io::Cursor::new(&bytes.to_vec()[..]))?;
         Ok(Self(ir))
     }
 

--- a/zkir-wasm/src/lib.rs
+++ b/zkir-wasm/src/lib.rs
@@ -250,7 +250,7 @@ impl Zkir {
 
     pub fn serialize(&self) -> Result<Uint8Array, JsError> {
         let mut buf = Vec::new();
-        tagged_serialize(&self.0, &mut buf)?;
+        self.0.serialize_to_tagged(&mut buf)?;
         Ok(buf[..].into())
     }
 }

--- a/zkir/Cargo.toml
+++ b/zkir/Cargo.toml
@@ -36,6 +36,7 @@ const-hex = "^1.14.0"
 serde = { version = "^1.0.0", features = ["derive", "rc"] }
 serde_bytes = { version = "^0.11.0" }
 serde_json = { version = "^1.0.0" }
+serde_repr = "^0.1.20"
 anyhow = "^1.0.102"
 hex = "^0.4.3"
 # rand 0.9.0 is not yet supported by some of our dependencies, we will
@@ -43,6 +44,7 @@ hex = "^0.4.3"
 rand = "^0.8.0"
 rand_chacha = "^0.3.1"
 tracing = { version = "^0.1.41" }
+num-bigint = { version = "0.4" }
 
 log = { version = "^0.4.28", optional = true }
 tracing-subscriber = { version = "^0.3.19", optional = true }

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "proptest")]
 use serialize::randomised_serialization_test;
 use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
-use std::io::{self, Read};
+use std::io::{self, Read, Seek};
 use std::sync::Arc;
 use transient_crypto::curve::Fr;
 use transient_crypto::proofs::{
@@ -33,8 +33,10 @@ use transient_crypto::proofs::{
 /// A low-level IR allowing the prover to populate circuit witnesses.
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize, Serializable)]
-#[tag = "ir-source[v2]"]
+#[tag = "ir-source[v2-generic]"]
 pub struct IrSource {
+    /// The minor version of this IR.
+    pub version: IrMinorVersion,
     /// The number of inputs, the initial elements in the memory
     pub num_inputs: u32,
     /// Whether or not this IR should compile a communications commitment
@@ -44,6 +46,53 @@ pub struct IrSource {
 }
 tag_enforcement_test!(IrSource);
 tag_enforcement_test!(ProverKey<IrSource>);
+
+#[derive(Serializable, Clone)]
+#[tag = "ir-source[v2]"]
+pub(crate) struct OldIrSource {
+    pub(crate) num_inputs: u32,
+    pub(crate) do_communications_commitment: bool,
+    pub(crate) instructions: Arc<Vec<Instruction>>,
+}
+
+impl From<OldIrSource> for IrSource {
+    fn from(value: OldIrSource) -> Self {
+        IrSource {
+            version: IrMinorVersion::V0,
+            num_inputs: value.num_inputs,
+            do_communications_commitment: value.do_communications_commitment,
+            instructions: value.instructions,
+        }
+    }
+}
+
+impl From<IrSource> for OldIrSource {
+    fn from(value: IrSource) -> Self {
+        OldIrSource {
+            num_inputs: value.num_inputs,
+            do_communications_commitment: value.do_communications_commitment,
+            instructions: value.instructions,
+        }
+    }
+}
+
+#[cfg_attr(feature = "proptest", derive(Arbitrary))]
+#[derive(
+    Clone, Debug, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, Serializable,
+)]
+#[tag = "ir-minor-version[v2]"]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum IrMinorVersion {
+    V0,
+    V1,
+}
+
+impl Default for IrMinorVersion {
+    fn default() -> Self {
+        IrMinorVersion::V1
+    }
+}
 
 impl Zkir for IrSource {
     fn check(
@@ -74,6 +123,32 @@ impl Zkir for IrSource {
         let proof = prove::<_, TranscriptHash>(params_k.as_ref(), &pk, self, &pis, preproc, rng)?;
 
         Ok((Proof(proof), pis.into_iter().map(Fr).collect(), pi_skips))
+    }
+
+    fn load_ir_from_tagged(reader: impl Read + Seek) -> io::Result<Self> {
+        Self::load_from_tagged(reader)
+    }
+
+    fn load_prover_key_from_tagged(mut reader: impl Read + Seek) -> io::Result<ProverKey<Self>> {
+        let pos = reader.stream_position()?;
+        // We try to first deserialize as the generic version. If this with an 'expected
+        // header tag' error, we rewind, and try again with the old tag.
+        match serialize::tagged_deserialize::<ProverKey<IrSource>>(&mut reader) {
+            Ok(v) => return Ok(v),
+            Err(e) if !e.to_string().contains("expected header tag") => return Err(e),
+            _ => {}
+        }
+        reader.seek(io::SeekFrom::Start(pos))?;
+        #[derive(Serializable)]
+        #[tag = "prover-key[v7](ir-source[v2])"]
+        struct FakeProverKey(Vec<u8>);
+        let FakeProverKey(data) = serialize::tagged_deserialize::<FakeProverKey>(reader)?;
+        let mut header = Vec::new();
+        Serializable::serialize(&(data.len() as u32), &mut header)?;
+        let mut header_cursor = &header[..];
+        let mut data_cursor = &data[..];
+        let mut reader = Read::chain(&mut header_cursor, &mut data_cursor);
+        Deserializable::deserialize(&mut reader, 0)
     }
 }
 
@@ -386,11 +461,28 @@ impl IrSource {
         }
     }
 
+    /// Attempts to load from a tagged source, which may be *either* of
+    /// - `ir-source[v2-generic]`
+    /// - `ir-source[v2]`
+    /// This is due to a need for a backwards-compatible format change.
+    pub fn load_from_tagged<R: Read + Seek>(mut reader: R) -> io::Result<Self> {
+        let pos = reader.stream_position()?;
+        // We try to first deserialize as the generic version. If this with an 'expected
+        // header tag' error, we rewind, and try again with the old tag.
+        match serialize::tagged_deserialize::<IrSource>(&mut reader) {
+            Ok(v) => return Ok(v),
+            Err(e) if !e.to_string().contains("expected header tag") => return Err(e),
+            _ => {}
+        }
+        reader.seek(io::SeekFrom::Start(pos))?;
+        serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
+    }
+
     /// Attempts to parse an arbitrary input as IR.
     pub fn load<R: Read>(reader: R) -> io::Result<Self> {
         let value: serde_json::Value = serde_json::from_reader(reader)?;
-        match &value {
-            serde_json::Value::Object(obj) => {
+        match value {
+            serde_json::Value::Object(mut obj) => {
                 let ver = serde_json::from_value(
                     obj.get("version")
                         .ok_or(io::Error::new(
@@ -400,7 +492,16 @@ impl IrSource {
                         .clone(),
                 )?;
                 match ver {
-                    SerdeVersion { major: 2, minor: 0 } => Ok(serde_json::from_value(value)?),
+                    SerdeVersion {
+                        major: 2,
+                        minor: 0..=1,
+                    } => {
+                        obj.insert(
+                            "version".into(),
+                            serde_json::Value::Number(ver.minor.into()),
+                        );
+                        Ok(serde_json::from_value(serde_json::Value::Object(obj))?)
+                    }
                     SerdeVersion { major, minor } => Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("Unhandled version: {major}.{minor}"),

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "proptest")]
 use serialize::randomised_serialization_test;
 use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
-use std::io::{self, Read, Seek};
+use std::io::{self, Read, Seek, Write};
 use std::sync::Arc;
 use transient_crypto::curve::Fr;
 use transient_crypto::proofs::{
@@ -78,20 +78,22 @@ impl From<IrSource> for OldIrSource {
 
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(
-    Clone, Debug, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, Serializable,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    Serializable,
 )]
 #[tag = "ir-minor-version[v2]"]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IrMinorVersion {
     V0,
+    #[default]
     V1,
-}
-
-impl Default for IrMinorVersion {
-    fn default() -> Self {
-        IrMinorVersion::V1
-    }
 }
 
 impl Zkir for IrSource {
@@ -141,8 +143,8 @@ impl Zkir for IrSource {
         reader.seek(io::SeekFrom::Start(pos))?;
         #[derive(Serializable)]
         #[tag = "prover-key[v7](ir-source[v2])"]
-        struct FakeProverKey(Vec<u8>);
-        let FakeProverKey(data) = serialize::tagged_deserialize::<FakeProverKey>(reader)?;
+        struct FacadeProverKey(Vec<u8>);
+        let FacadeProverKey(data) = serialize::tagged_deserialize::<FacadeProverKey>(reader)?;
         let mut header = Vec::new();
         Serializable::serialize(&(data.len() as u32), &mut header)?;
         let mut header_cursor = &header[..];
@@ -464,6 +466,7 @@ impl IrSource {
     /// Attempts to load from a tagged source, which may be *either* of
     /// - `ir-source[v2-generic]`
     /// - `ir-source[v2]`
+    ///
     /// This is due to a need for a backwards-compatible format change.
     pub fn load_from_tagged<R: Read + Seek>(mut reader: R) -> io::Result<Self> {
         let pos = reader.stream_position()?;
@@ -476,6 +479,15 @@ impl IrSource {
         }
         reader.seek(io::SeekFrom::Start(pos))?;
         serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
+    }
+
+    /// Writes out with tag, preserving v0's old tag structure.
+    pub fn serialize_to_tagged<W: Write>(&self, writer: W) -> io::Result<()> {
+        if self.version == IrMinorVersion::V0 {
+            serialize::tagged_serialize(&OldIrSource::from(self.clone()), writer)
+        } else {
+            serialize::tagged_serialize(self, writer)
+        }
     }
 
     /// Attempts to parse an arbitrary input as IR.

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -146,9 +146,9 @@ impl Zkir for IrSource {
         let tag = peek_tag(&mut reader)?;
         let expected_tag_new = <ProverKey<IrSource>>::tag();
         let expected_tag_old = FacadeProverKey::tag();
-        if &tag == &expected_tag_new {
+        if tag == expected_tag_new {
             serialize::tagged_deserialize(&mut reader)
-        } else if &tag == &expected_tag_old {
+        } else if tag == expected_tag_old {
             let FacadeProverKey(data) = serialize::tagged_deserialize::<FacadeProverKey>(reader)?;
             let mut header = Vec::new();
             Serializable::serialize(&(data.len() as u32), &mut header)?;
@@ -485,9 +485,9 @@ impl IrSource {
         let tag = peek_tag(&mut reader)?;
         let expected_tag_new = IrSource::tag();
         let expected_tag_old = OldIrSource::tag();
-        if &tag == &expected_tag_new {
+        if tag == expected_tag_new {
             serialize::tagged_deserialize(&mut reader)
-        } else if &tag == &expected_tag_old {
+        } else if tag == expected_tag_old {
             serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
         } else {
             Err(io::Error::new(

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -22,7 +22,9 @@ use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "proptest")]
 use serialize::randomised_serialization_test;
-use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
+use serialize::{
+    Deserializable, Serializable, Tagged, peek_tag, tag_enforcement_test, tagged_serialize,
+};
 use std::io::{self, Read, Seek, Write};
 use std::sync::Arc;
 use transient_crypto::curve::Fr;
@@ -66,12 +68,17 @@ impl From<OldIrSource> for IrSource {
     }
 }
 
-impl From<IrSource> for OldIrSource {
-    fn from(value: IrSource) -> Self {
-        OldIrSource {
-            num_inputs: value.num_inputs,
-            do_communications_commitment: value.do_communications_commitment,
-            instructions: value.instructions,
+impl TryFrom<&IrSource> for OldIrSource {
+    type Error = ();
+    fn try_from(value: &IrSource) -> Result<Self, ()> {
+        if value.version == IrMinorVersion::V0 {
+            Ok(OldIrSource {
+                num_inputs: value.num_inputs,
+                do_communications_commitment: value.do_communications_commitment,
+                instructions: value.instructions.clone(),
+            })
+        } else {
+            Err(())
         }
     }
 }
@@ -95,6 +102,10 @@ pub enum IrMinorVersion {
     #[default]
     V1,
 }
+
+#[derive(Serializable)]
+#[tag = "prover-key[v7](ir-source[v2])"]
+struct FacadeProverKey(Vec<u8>);
 
 impl Zkir for IrSource {
     fn check(
@@ -132,25 +143,27 @@ impl Zkir for IrSource {
     }
 
     fn load_prover_key_from_tagged(mut reader: impl Read + Seek) -> io::Result<ProverKey<Self>> {
-        let pos = reader.stream_position()?;
-        // We try to first deserialize as the generic version. If this with an 'expected
-        // header tag' error, we rewind, and try again with the old tag.
-        match serialize::tagged_deserialize::<ProverKey<IrSource>>(&mut reader) {
-            Ok(v) => return Ok(v),
-            Err(e) if !e.to_string().contains("expected header tag") => return Err(e),
-            _ => {}
+        let tag = peek_tag(&mut reader)?;
+        let expected_tag_new = <ProverKey<IrSource>>::tag();
+        let expected_tag_old = FacadeProverKey::tag();
+        if &tag == &expected_tag_new {
+            serialize::tagged_deserialize(&mut reader)
+        } else if &tag == &expected_tag_old {
+            let FacadeProverKey(data) = serialize::tagged_deserialize::<FacadeProverKey>(reader)?;
+            let mut header = Vec::new();
+            Serializable::serialize(&(data.len() as u32), &mut header)?;
+            let mut header_cursor = &header[..];
+            let mut data_cursor = &data[..];
+            let mut reader = Read::chain(&mut header_cursor, &mut data_cursor);
+            Deserializable::deserialize(&mut reader, 0)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "expected one of '{expected_tag_new}' or '{expected_tag_old}', got '{tag}'."
+                ),
+            ))
         }
-        reader.seek(io::SeekFrom::Start(pos))?;
-        #[derive(Serializable)]
-        #[tag = "prover-key[v7](ir-source[v2])"]
-        struct FacadeProverKey(Vec<u8>);
-        let FacadeProverKey(data) = serialize::tagged_deserialize::<FacadeProverKey>(reader)?;
-        let mut header = Vec::new();
-        Serializable::serialize(&(data.len() as u32), &mut header)?;
-        let mut header_cursor = &header[..];
-        let mut data_cursor = &data[..];
-        let mut reader = Read::chain(&mut header_cursor, &mut data_cursor);
-        Deserializable::deserialize(&mut reader, 0)
     }
 }
 
@@ -469,24 +482,47 @@ impl IrSource {
     ///
     /// This is due to a need for a backwards-compatible format change.
     pub fn load_from_tagged<R: Read + Seek>(mut reader: R) -> io::Result<Self> {
-        let pos = reader.stream_position()?;
-        // We try to first deserialize as the generic version. If this with an 'expected
-        // header tag' error, we rewind, and try again with the old tag.
-        match serialize::tagged_deserialize::<IrSource>(&mut reader) {
-            Ok(v) => return Ok(v),
-            Err(e) if !e.to_string().contains("expected header tag") => return Err(e),
-            _ => {}
+        let tag = peek_tag(&mut reader)?;
+        let expected_tag_new = IrSource::tag();
+        let expected_tag_old = OldIrSource::tag();
+        if &tag == &expected_tag_new {
+            serialize::tagged_deserialize(&mut reader)
+        } else if &tag == &expected_tag_old {
+            serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "expected one of '{expected_tag_new}' or '{expected_tag_old}', got '{tag}'."
+                ),
+            ))
         }
-        reader.seek(io::SeekFrom::Start(pos))?;
-        serialize::tagged_deserialize::<OldIrSource>(reader).map(Into::into)
     }
 
     /// Writes out with tag, preserving v0's old tag structure.
     pub fn serialize_to_tagged<W: Write>(&self, writer: W) -> io::Result<()> {
-        if self.version == IrMinorVersion::V0 {
-            serialize::tagged_serialize(&OldIrSource::from(self.clone()), writer)
+        if let Ok(old_ir) = OldIrSource::try_from(self) {
+            serialize::tagged_serialize(&old_ir, writer)
         } else {
             serialize::tagged_serialize(self, writer)
+        }
+    }
+
+    /// Writes out a prover key with tag, preserving v0's old tag structure.
+    pub fn serialize_prover_key_to_tagged<W: Write>(
+        version: IrMinorVersion,
+        pk: &ProverKey<Self>,
+        writer: W,
+    ) -> io::Result<()> {
+        match version {
+            IrMinorVersion::V0 => {
+                let mut raw = Vec::new();
+                Serializable::serialize(pk, &mut raw)?;
+                let container = <Vec<u8> as Deserializable>::deserialize(&mut &raw[..], 0)?;
+                let facade = FacadeProverKey(container);
+                tagged_serialize(&facade, writer)
+            }
+            IrMinorVersion::V1 => tagged_serialize(pk, writer),
         }
     }
 

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ir::{IrMinorVersion, OldIrSource};
+
 use super::ir::{Instruction as I, IrSource};
 use anyhow::{anyhow, bail};
 use base_crypto::fab::{Alignment, AlignmentAtom, AlignmentSegment};
@@ -31,8 +33,9 @@ use midnight_proofs::{
 };
 use midnight_zk_stdlib::{Relation, ZkStdLib, ZkStdLibArch};
 use num_bigint::BigUint;
-use serialize::{Deserializable, Serializable, VecExt};
+use serialize::{Deserializable, Serializable, VecExt, tagged_deserialize, tagged_serialize};
 use std::cmp::Ordering;
+use std::io::Read;
 use transient_crypto::curve::EmbeddedGroupAffine;
 use transient_crypto::curve::{FR_BITS, FR_BYTES_STORED, Fr};
 use transient_crypto::curve::{embedded, outer};
@@ -601,11 +604,28 @@ impl Relation for IrSource {
         for ins in self.instructions.iter() {
             match ins {
                 I::Assert { cond } => std.assert_non_zero(layouter, idx(&memory, *cond)?)?,
+                I::CondSelect { bit, a, b } if self.version == IrMinorVersion::V0 => {
+                    let bit = std.is_zero(layouter, idx(&memory, *bit)?)?;
+                    // Note that b comes first here, because the is_zero negates the bit.
+                    // The negation is to ensure the bit bound. This may be
+                    // excessive, but user input could violate it otherwise.
+                    let result =
+                        std.select(layouter, &bit, idx(&memory, *b)?, idx(&memory, *a)?)?;
+                    mem_push(result, &mut memory)?;
+                }
                 I::CondSelect { bit, a, b } => {
                     let bit: AssignedBit<_> = std.convert(layouter, idx(&memory, *bit)?)?;
                     let result =
                         std.select(layouter, &bit, idx(&memory, *a)?, idx(&memory, *b)?)?;
                     mem_push(result, &mut memory)?;
+                }
+                I::ConstrainBits { var, bits } if self.version == IrMinorVersion::V0 => {
+                    drop(std.assigned_to_le_bits(
+                        layouter,
+                        idx(&memory, *var)?,
+                        Some(*bits as usize),
+                        *bits as usize >= FR_BITS,
+                    )?)
                 }
                 I::ConstrainBits { var, bits } => {
                     if *bits < FR_BITS as u32 {
@@ -704,6 +724,27 @@ impl Relation for IrSource {
 
                     mem_push(divisor, &mut memory)?;
                     mem_push(modulus, &mut memory)?;
+                }
+                I::ReconstituteField {
+                    divisor,
+                    modulus,
+                    bits,
+                } if self.version == IrMinorVersion::V0 => {
+                    let divisor_bits = std.assigned_to_le_bits(
+                        layouter,
+                        idx(&memory, *divisor)?,
+                        Some(FR_BITS - *bits as usize),
+                        true,
+                    )?;
+                    let modulus_bits = std.assigned_to_le_bits(
+                        layouter,
+                        idx(&memory, *modulus)?,
+                        Some(*bits as usize),
+                        true,
+                    )?;
+                    let reconstituted = std
+                        .assigned_from_le_bits(layouter, &[modulus_bits, divisor_bits].concat())?;
+                    mem_push(reconstituted, &mut memory)?;
                 }
                 I::ReconstituteField {
                     divisor,
@@ -819,6 +860,10 @@ impl Relation for IrSource {
             .instructions
             .iter()
             .any(|op| matches!(op, I::PersistentHash { .. }));
+        let nr_pow2range_cols = match self.version {
+            IrMinorVersion::V0 => 1,
+            IrMinorVersion::V1 => 4,
+        };
         ZkStdLibArch {
             jubjub: jubjub || hash_to_curve,
             poseidon: poseidon || hash_to_curve,
@@ -827,7 +872,7 @@ impl Relation for IrSource {
             sha3_256: false,
             keccak_256: false,
             blake2b: false,
-            nr_pow2range_cols: 4,
+            nr_pow2range_cols,
             secp256k1: false,
             bls12_381: false,
             base64: false,
@@ -836,10 +881,28 @@ impl Relation for IrSource {
     }
 
     fn write_relation<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        Serializable::serialize(&self, writer)
+        if self.version == IrMinorVersion::V0 {
+            Serializable::serialize(&OldIrSource::from(self.clone()), writer)
+        } else {
+            // 0xff is a magic byte indicating non-v0 versions. These are tagged, and in a vec
+            // container. This byte is *not* representable in v0, as it is illegal for a SCALE
+            // encoded u32.
+            writer.write_all(&[0xff])?;
+            let mut raw = Vec::new();
+            tagged_serialize(&self, &mut raw)?;
+            raw.serialize(writer)
+        }
     }
 
     fn read_relation<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        Deserializable::deserialize(reader, 0)
+        let first_byte: u8 = Deserializable::deserialize(reader, 0)?;
+        if first_byte != 0xff {
+            let mut cursor = &[first_byte][..];
+            let mut reader = Read::chain(&mut cursor, reader);
+            OldIrSource::deserialize(&mut reader, 0).map(Into::into)
+        } else {
+            let raw: Vec<u8> = Deserializable::deserialize(reader, 0)?;
+            tagged_deserialize(&mut &raw[..])
+        }
     }
 }

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -610,7 +610,7 @@ impl Relation for IrSource {
                     // The negation is to ensure the bit bound. This may be
                     // excessive, but user input could violate it otherwise.
                     let result =
-                        std.select(layouter, &bit, idx(&memory, *a)?, idx(&memory, *b)?)?;
+                        std.select(layouter, &bit, idx(&memory, *b)?, idx(&memory, *a)?)?;
                     mem_push(result, &mut memory)?;
                 }
                 I::CondSelect { bit, a, b } => {

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -886,8 +886,8 @@ impl Relation for IrSource {
     }
 
     fn write_relation<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        if self.version == IrMinorVersion::V0 {
-            Serializable::serialize(&OldIrSource::from(self.clone()), writer)
+        if let Ok(old_ir) = OldIrSource::try_from(self) {
+            Serializable::serialize(&old_ir, writer)
         } else {
             // 0xff is a magic byte indicating non-v0 versions. These are tagged, and in a vec
             // container. This byte is *not* representable in v0, as it is illegal for a SCALE

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -732,23 +732,19 @@ impl Relation for IrSource {
                 } if self.version == IrMinorVersion::V0 => {
                     let divisor_bits = std.assigned_to_le_bits(
                         layouter,
-                        &divisor,
-                        &(BigUint::from(1u32) << (FR_BITS as u32 - *bits)),
+                        idx(&memory, *divisor)?,
+                        Some(FR_BITS - *bits as usize),
+                        *bits as usize >= FR_BITS,
                     )?;
-                    std.assert_lower_than_fixed(
+                    let modulus_bits = std.assigned_to_le_bits(
                         layouter,
-                        &modulus,
-                        &(BigUint::from(1u32) << *bits),
+                        idx(&memory, *modulus)?,
+                        Some(*bits as usize),
+                        true,
                     )?;
 
-                    let reconstituted = std.linear_combination(
-                        layouter,
-                        &[
-                            (outer::Scalar::from(1), modulus),
-                            (outer::Scalar::from(2).pow([*bits as u64]), divisor),
-                        ],
-                        outer::Scalar::from(0),
-                    )?;
+                    let reconstituted = std
+                        .assigned_from_le_bits(layouter, &[modulus_bits, divisor_bits].concat())?;
                     mem_push(reconstituted, &mut memory)?;
                 }
                 I::ReconstituteField {

--- a/zkir/src/lib.rs
+++ b/zkir/src/lib.rs
@@ -24,7 +24,7 @@ use transient_crypto::proofs::{
 mod ir;
 mod ir_vm;
 
-pub use ir::{Instruction, IrSource};
+pub use ir::{Instruction, IrMinorVersion, IrSource};
 pub use ir_vm::Preprocessed;
 
 /// Implements `ProvingProvider` locally

--- a/zkir/src/lib.rs
+++ b/zkir/src/lib.rs
@@ -16,7 +16,6 @@ extern crate tracing;
 
 use base_crypto::rng::SplittableRng;
 use rand::{CryptoRng, Rng};
-use serialize::tagged_deserialize;
 use transient_crypto::curve::Fr;
 use transient_crypto::proofs::{
     ParamsProverProvider, Proof, ProofPreimage, ProvingProvider, Resolver,
@@ -57,7 +56,7 @@ impl<'a, R: Rng + CryptoRng + SplittableRng, S: Resolver, P: ParamsProverProvide
                     preimage.key_location.0
                 )
             })?;
-        let ir: IrSource = tagged_deserialize(&mut &proving_data.ir_source[..])?;
+        let ir = IrSource::load_from_tagged(std::io::Cursor::new(&proving_data.ir_source[..]))?;
         preimage.check(&ir)
     }
     async fn prove(

--- a/zkir/src/main.rs
+++ b/zkir/src/main.rs
@@ -17,11 +17,12 @@
 use base_crypto::data_provider::{self, MidnightDataProvider};
 use clap::{Parser, Subcommand};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use midnight_zkir::IrSource;
-use serialize::{tagged_deserialize, tagged_serialize};
+use midnight_zkir::{IrMinorVersion, IrSource};
+use serialize::tagged_serialize;
+use serialize::{Deserializable, Serializable, Tagged};
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Write};
+use std::io::{self, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing::info;
@@ -29,7 +30,7 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::Registry;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::prelude::*;
-use transient_crypto::proofs::Zkir;
+use transient_crypto::proofs::{ProverKey, Zkir};
 
 #[derive(Parser)]
 #[clap(version, about, long_about = None)]
@@ -85,10 +86,12 @@ fn maybe_bzkir(path: impl AsRef<Path>) -> anyhow::Result<IrSource> {
         Some(Some("zkir")) => {
             let ir = IrSource::load(BufReader::new(File::open(&path)?))?;
             let mut bzkir = BufWriter::new(File::create(path.as_ref().with_extension("bzkir"))?);
-            tagged_serialize(&ir, &mut bzkir)?;
+            ir.serialize_to_tagged(&mut bzkir)?;
             Ok(ir)
         }
-        _ => Ok(tagged_deserialize(&mut BufReader::new(File::open(path)?))?),
+        _ => Ok(IrSource::load_from_tagged(&mut BufReader::new(
+            File::open(path)?,
+        ))?),
     }
 }
 
@@ -122,6 +125,27 @@ fn extract_files_from_dir(dir: impl AsRef<Path>) -> anyhow::Result<Vec<OsString>
     files.sort();
     files.dedup();
     Ok(files)
+}
+
+fn pk_serialize(
+    version: IrMinorVersion,
+    pk: &ProverKey<IrSource>,
+    writer: impl Write,
+) -> io::Result<()> {
+    match version {
+        IrMinorVersion::V0 => {
+            #[derive(Serializable)]
+            #[tag = "prover-key[v7](ir-source[v2])"]
+            struct FacadeProverKey(Vec<u8>);
+            let mut raw = Vec::new();
+            Serializable::serialize(pk, &mut raw)?;
+            let container = <Vec<u8>>::deserialize(&mut &raw[..], 0)?;
+            let facade = FacadeProverKey(container);
+            tagged_serialize(&facade, writer)
+        }
+        IrMinorVersion::V1 => tagged_serialize(pk, writer),
+        _ => unreachable!(),
+    }
 }
 
 #[tokio::main]
@@ -221,7 +245,7 @@ async fn main() -> anyhow::Result<()> {
                     BufWriter::new(File::create(key_dir.join(file).with_extension("verifier"))?);
                 pb.enable_steady_tick(Duration::from_millis(100));
                 let (pk, vk) = ir.keygen(&pp).await?;
-                tagged_serialize(&pk, &mut pk_file)?;
+                pk_serialize(ir.version, &pk, &mut pk_file)?;
                 tagged_serialize(&vk, &mut vk_file)?;
                 pb.finish();
                 overall.set_message(format!("{n}/{}", data.len()));
@@ -262,7 +286,7 @@ async fn main() -> anyhow::Result<()> {
             pb.set_message(format!("Compiling circuit {ir_file:?} (k={k})"));
             pb.enable_steady_tick(Duration::from_millis(100));
             let (pk, vk) = ir.keygen(&pp).await?;
-            tagged_serialize(&pk, &mut pk_file)?;
+            pk_serialize(ir.version, &pk, &mut pk_file)?;
             tagged_serialize(&vk, &mut vk_file)?;
             pb.finish();
         }

--- a/zkir/src/main.rs
+++ b/zkir/src/main.rs
@@ -17,12 +17,11 @@
 use base_crypto::data_provider::{self, MidnightDataProvider};
 use clap::{Parser, Subcommand};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use midnight_zkir::{IrMinorVersion, IrSource};
+use midnight_zkir::IrSource;
 use serialize::tagged_serialize;
-use serialize::{Deserializable, Serializable, Tagged};
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter, Write};
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing::info;
@@ -30,7 +29,7 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::Registry;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::prelude::*;
-use transient_crypto::proofs::{ProverKey, Zkir};
+use transient_crypto::proofs::Zkir;
 
 #[derive(Parser)]
 #[clap(version, about, long_about = None)]

--- a/zkir/src/main.rs
+++ b/zkir/src/main.rs
@@ -127,27 +127,6 @@ fn extract_files_from_dir(dir: impl AsRef<Path>) -> anyhow::Result<Vec<OsString>
     Ok(files)
 }
 
-fn pk_serialize(
-    version: IrMinorVersion,
-    pk: &ProverKey<IrSource>,
-    writer: impl Write,
-) -> io::Result<()> {
-    match version {
-        IrMinorVersion::V0 => {
-            #[derive(Serializable)]
-            #[tag = "prover-key[v7](ir-source[v2])"]
-            struct FacadeProverKey(Vec<u8>);
-            let mut raw = Vec::new();
-            Serializable::serialize(pk, &mut raw)?;
-            let container = <Vec<u8>>::deserialize(&mut &raw[..], 0)?;
-            let facade = FacadeProverKey(container);
-            tagged_serialize(&facade, writer)
-        }
-        IrMinorVersion::V1 => tagged_serialize(pk, writer),
-        _ => unreachable!(),
-    }
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
@@ -245,7 +224,7 @@ async fn main() -> anyhow::Result<()> {
                     BufWriter::new(File::create(key_dir.join(file).with_extension("verifier"))?);
                 pb.enable_steady_tick(Duration::from_millis(100));
                 let (pk, vk) = ir.keygen(&pp).await?;
-                pk_serialize(ir.version, &pk, &mut pk_file)?;
+                IrSource::serialize_prover_key_to_tagged(ir.version, &pk, &mut pk_file)?;
                 tagged_serialize(&vk, &mut vk_file)?;
                 pb.finish();
                 overall.set_message(format!("{n}/{}", data.len()));
@@ -286,7 +265,7 @@ async fn main() -> anyhow::Result<()> {
             pb.set_message(format!("Compiling circuit {ir_file:?} (k={k})"));
             pb.enable_steady_tick(Duration::from_millis(100));
             let (pk, vk) = ir.keygen(&pp).await?;
-            pk_serialize(ir.version, &pk, &mut pk_file)?;
+            IrSource::serialize_prover_key_to_tagged(ir.version, &pk, &mut pk_file)?;
             tagged_serialize(&vk, &mut vk_file)?;
             pb.finish();
         }

--- a/zkir/tests/proofs.rs
+++ b/zkir/tests/proofs.rs
@@ -422,6 +422,7 @@ mod proof_tests {
            ]
         }"#;
         let ir = IrSource::load(ir_raw.as_bytes()).unwrap();
+        dbg!(&ir);
 
         let (pk, vk) = ir.keygen(&TestParams).await.unwrap();
         let mut pk_data = Vec::new();

--- a/zkir/tests/proofs.rs
+++ b/zkir/tests/proofs.rs
@@ -422,7 +422,6 @@ mod proof_tests {
            ]
         }"#;
         let ir = IrSource::load(ir_raw.as_bytes()).unwrap();
-        dbg!(&ir);
 
         let (pk, vk) = ir.keygen(&TestParams).await.unwrap();
         let mut pk_data = Vec::new();

--- a/zswap/src/prove.rs
+++ b/zswap/src/prove.rs
@@ -196,7 +196,7 @@ mod tests {
             use std::fs::File;
             use std::path::PathBuf;
             let file = PathBuf::from("./static").join(ir).with_extension("bzkir");
-            let ir = tagged_deserialize::<IrSource>(&mut File::open(file).unwrap()).unwrap();
+            let ir = IrSource::load_from_tagged(&mut File::open(file).unwrap()).unwrap();
             ir.instructions
                 .iter()
                 .filter_map(|ins| match ins {


### PR DESCRIPTION
## Description

Extends the proposed optimisation PR with backwards-compatibility fully preserving old circuit behaviour. Most of this is tricky indirections to bypass the non-existence of the version field previously. Also adds this version field to zkir v3 and makes some parallel edits to avoid this much headache in the future.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [X] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
