### PR TITLE
Gas estimation revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 - fix: fix potential panic in MPT path removal, unlikely to be currently triggerable.
 - fix: fix potential panic in bridge fee processing
 - fix: address non-associativity of Dust event processing.
+- fix: tighten cost heuristic, no longer being overly conservative, moving less transactions to the fallible section.
 
 ## 8.1.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -4944,7 +4944,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 

--- a/integration-tests/src/test/no-proving/MicroDao.test.ts
+++ b/integration-tests/src/test/no-proving/MicroDao.test.ts
@@ -652,10 +652,14 @@ describe('Ledger API - MicroDao', () => {
         BUY_IN
       );
 
+      const isGuaranteed = transcripts[0][0] !== undefined;
+      const guaranteedOffer = isGuaranteed ? offer : undefined;
+      const fallibleOffer = isGuaranteed ? undefined : offer;
+
       const tx = Transaction.fromParts(
         LOCAL_TEST_NETWORK_ID,
-        undefined,
-        offer,
+        guaranteedOffer,
+        fallibleOffer,
         testIntents([call], [], [], state.time)
       );
       tx.wellFormed(state.ledger, unbalancedStrictness, state.time);
@@ -1219,7 +1223,7 @@ describe('Ledger API - MicroDao', () => {
     const s = state;
     s.zswap = s.zswap.watchFor(s.zswapKeys.coinPublicKey, newCoin);
 
-    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, undefined, offer, testIntents([call], [], [], s.time));
+    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, offer, undefined, testIntents([call], [], [], s.time));
     tx.wellFormed(s.ledger, unbalancedStrictness, s.time);
     const balanced = s.balanceTx(tx.eraseProofs());
     s.assertApply(balanced, balancedStrictness);

--- a/integration-tests/src/test/no-proving/TokenVaultUnshielded.test.ts
+++ b/integration-tests/src/test/no-proving/TokenVaultUnshielded.test.ts
@@ -367,7 +367,7 @@ describe('Ledger API - TokenVault Unshielded', () => {
     };
 
     const intent = testIntents([call], [], [], state.time);
-    intent.fallibleUnshieldedOffer = UnshieldedOffer.new(
+    intent.guaranteedUnshieldedOffer = UnshieldedOffer.new(
       [utxoSpend], // Input: spend the full UTXO
       [changeOutput], // Output: change back to user
       [] // Signatures added later
@@ -485,7 +485,7 @@ describe('Ledger API - TokenVault Unshielded', () => {
 
     const depositIntent = testIntents([depositCall], [], [], state.time);
     // No outputs - entire UTXO value goes to contract
-    depositIntent.fallibleUnshieldedOffer = UnshieldedOffer.new([depositUtxoSpend], [], []);
+    depositIntent.guaranteedUnshieldedOffer = UnshieldedOffer.new([depositUtxoSpend], [], []);
 
     const depositTx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, undefined, undefined, depositIntent);
 
@@ -598,7 +598,7 @@ describe('Ledger API - TokenVault Unshielded', () => {
     };
 
     const withdrawIntent = testIntents([withdrawCall], [], [], state.time);
-    withdrawIntent.fallibleUnshieldedOffer = UnshieldedOffer.new(
+    withdrawIntent.guaranteedUnshieldedOffer = UnshieldedOffer.new(
       [], // No inputs - tokens come from contract
       [withdrawOutput], // Output: new UTXO for user
       []
@@ -672,7 +672,7 @@ describe('Ledger API - TokenVault Unshielded', () => {
     );
 
     const gasA = transcriptsA[0][0]!.gas;
-    const gasB = transcriptsB[0][1]!.gas;
+    const gasB = transcriptsB[0][0]!.gas;
 
     const totalGasA = gasA.computeTime + gasA.readTime + gasA.bytesWritten + gasA.bytesDeleted;
     const totalGasB = gasB.computeTime + gasB.readTime + gasB.bytesWritten + gasB.bytesDeleted;
@@ -777,8 +777,8 @@ describe('Ledger API - TokenVault Unshielded', () => {
       LedgerParameters.initialParameters()
     );
 
-    const gasA = transcriptsA[0][1]!.gas;
-    const gasB = transcriptsB[0][1]!.gas;
+    const gasA = transcriptsA[0][0]!.gas;
+    const gasB = transcriptsB[0][0]!.gas;
 
     const totalGasA = gasA.computeTime + gasA.readTime + gasA.bytesWritten + gasA.bytesDeleted;
     const totalGasB = gasB.computeTime + gasB.readTime + gasB.bytesWritten + gasB.bytesDeleted;

--- a/integration-tests/src/test/no-proving/functions.test.ts
+++ b/integration-tests/src/test/no-proving/functions.test.ts
@@ -270,8 +270,8 @@ describe('Ledger API - functions', () => {
     expect(transcripts).toHaveLength(2);
     expect(transcripts.at(0)).toBeDefined();
     expect(transcripts.at(1)).toBeDefined();
-    expect(transcripts.at(0)?.at(1)?.program).toEqual([{ noop: { n: 0 } }]);
-    expect(transcripts.at(0)?.at(1)?.effects).toEqual({
+    expect(transcripts.at(0)?.at(0)?.program).toEqual([{ noop: { n: 0 } }]);
+    expect(transcripts.at(0)?.at(0)?.effects).toEqual({
       claimedContractCalls: [],
       claimedNullifiers: [],
       claimedShieldedReceives: [],
@@ -282,9 +282,9 @@ describe('Ledger API - functions', () => {
       unshieldedOutputs: new Map(),
       claimedUnshieldedSpends: new Map()
     });
-    expect(transcripts.at(0)?.at(1)?.gas.computeTime).toBeGreaterThanOrEqual(1n);
-    expect(transcripts.at(1)?.at(1)?.program).toEqual([{ noop: { n: 1 } }]);
-    expect(transcripts.at(1)?.at(1)?.effects).toEqual({
+    expect(transcripts.at(0)?.at(0)?.gas.computeTime).toBeGreaterThanOrEqual(1n);
+    expect(transcripts.at(1)?.at(0)?.program).toEqual([{ noop: { n: 1 } }]);
+    expect(transcripts.at(1)?.at(0)?.effects).toEqual({
       claimedContractCalls: [],
       claimedNullifiers: [],
       claimedShieldedReceives: [],
@@ -295,7 +295,7 @@ describe('Ledger API - functions', () => {
       unshieldedOutputs: new Map(),
       claimedUnshieldedSpends: new Map()
     });
-    expect(transcripts.at(1)?.at(1)?.gas.computeTime).toBeGreaterThanOrEqual(1n);
+    expect(transcripts.at(1)?.at(0)?.gas.computeTime).toBeGreaterThanOrEqual(1n);
   });
 
   /**

--- a/ledger/src/construct.rs
+++ b/ledger/src/construct.rs
@@ -11,25 +11,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::dust::DustActions;
+use crate::dust::{DUST_GENERATION_INFO_SIZE, DustActions};
 use crate::error::{MalformedTransaction, PartitionFailure};
 use crate::structure::{
     ContractAction, ContractCall, ContractDeploy, GUARANTEED_SEGMENT, Intent, LedgerParameters,
     MIN_PROOF_SIZE, MaintenanceUpdate, ProofPreimageMarker, ProofPreimageVersioned, SignatureKind,
-    SignaturesValue, SingleUpdate, StandardTransaction, Transaction, UnshieldedOffer, UtxoOutput,
-    UtxoSpend,
+    SignaturesValue, SingleUpdate, StandardTransaction, Transaction, TransactionCostModel,
+    UnshieldedOffer,
 };
 use crate::structure::{
-    EXPECTED_CONTRACT_DEPTH, EXPECTED_OPERATIONS_DEPTH, SegIntent, VERIFIER_KEY_SIZE,
+    EXPECTED_CONTRACT_DEPTH, EXPECTED_OPERATIONS_DEPTH, EXPECTED_UTXO_DEPTH,
+    FRESH_DUST_COMMITMENT_HASHES, SegIntent, UTXO_SIZE, VERIFIER_KEY_SIZE,
 };
 use crate::structure::{PedersenDowngradeable, ProofKind};
 use base_crypto::cost_model::CostDuration;
 use base_crypto::cost_model::RunningCost;
 use base_crypto::fab::AlignedValue;
+use base_crypto::hash::PERSISTENT_HASH_BYTES;
 use base_crypto::signatures::Signature;
 use base_crypto::signatures::SigningKey;
 use base_crypto::time::Timestamp;
-use coin_structure::coin::TokenType;
+use coin_structure::coin::{NIGHT, TokenType};
 use coin_structure::contract::ContractAddress;
 use itertools::Itertools;
 use onchain_runtime::context::{Effects, QueryContext, QueryResults};
@@ -47,7 +49,7 @@ use storage::Storable;
 use storage::arena::Sp;
 use storage::db::DB;
 use transient_crypto::commitment::PedersenRandomness;
-use transient_crypto::curve::Fr;
+use transient_crypto::curve::{FR_BYTES, Fr};
 use transient_crypto::fab::{AlignedValueExt, ValueReprAlignedValue};
 use transient_crypto::hash::transient_commit;
 use transient_crypto::proofs::{KeyLocation, ProofPreimage};
@@ -819,22 +821,37 @@ trait QueryResultsExt {
     ) -> RunningCost;
 }
 
-fn test_tx_from_unshielded_offer<D: DB>(
-    offer: UnshieldedOffer<Signature, D>,
-) -> Transaction<Signature, ProofPreimageMarker, PedersenRandomness, D> {
-    use rand::{SeedableRng, rngs::StdRng};
-    let intent = Intent::new(
-        &mut StdRng::seed_from_u64(0x42),
-        Some(offer),
-        None,
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        None,
-        Timestamp::from_secs(0),
-    );
-    Transaction::from_intents("local-test", [(1, intent)].into_iter().collect())
-}
+// gas_heuristic and per_tx_cost_reserve together approximate
+// Transaction::cost() (= validation_cost + application_cost, defined in
+// structure.rs) for use during transcript partitioning, before the final
+// Transaction exists. They must be kept in sync when validation_cost or
+// application_cost change.
+//
+// The costs are split into per-call (in gas_heuristic, summed across calls)
+// and per-transaction (in per_tx_cost_reserve, subtracted from the budget
+// once) to avoid double-counting in multi-call transactions.
+//
+// gas_heuristic covers:
+//   From validation_cost: VK reads (cell_read + map_index for contract and
+//     operations depth, once per unique call), and ContractAction::Call proof
+//     verification (proof_verify + verifier_key_load). Parallelism is applied
+//     to the validation compute_time as in Transaction::cost.
+//   From application_cost: ContractAction::Call state fetch/store (map_index
+//     + map_insert for contract depth and sequence number) and
+//     stack_setup_cost for the call's effects.
+//
+// per_tx_cost_reserve covers:
+//   From validation_cost: baseline_cost, zswap input/output proof
+//     verifications (approximated via claimed_nullifiers/receives counts),
+//     Pedersen binding check + final ec_mul (deltas assumed balanced),
+//     unshielded offer signature verifications, and one heuristic dust spend
+//     proof. Parallelism applied.
+//   From application_cost: baseline_cost, replay protection, unshielded UTXO
+//     membership/removal/insertion, NIGHT-specific dust generation costs
+//     (dtime update, address table, generation tree, night indices,
+//     commitment tree, commitment hash), and one heuristic dust spend's
+//     nullifier + commitment processing.
+
 impl<D: DB> QueryResultsExt for QueryResults<ResultModeVerify, D> {
     fn gas_heuristic(
         &self,
@@ -846,72 +863,135 @@ impl<D: DB> QueryResultsExt for QueryResults<ResultModeVerify, D> {
         if !include_external {
             return transcript_gas_cost_with_overhead;
         }
-        let expected_unshielded_inputs_overhead = self
-            .context
+        let model = &params.cost_model;
+
+        let mut validation = RunningCost::ZERO;
+        validation += model.cell_read(VERIFIER_KEY_SIZE as u64)
+            + model.map_index(EXPECTED_CONTRACT_DEPTH)
+            + model.map_index(EXPECTED_OPERATIONS_DEPTH);
+        if public_input_count > 0 {
+            validation += model.proof_verify(public_input_count);
+            validation.compute_time += model.runtime_cost_model.verifier_key_load;
+        }
+        validation.compute_time = validation.compute_time / model.parallelism_factor;
+
+        let mut application = RunningCost::ZERO;
+        application += model.map_index(EXPECTED_CONTRACT_DEPTH)
+            + model.map_insert(EXPECTED_CONTRACT_DEPTH, true)
+            + model.map_index(1)
+            + model.map_insert(1, true);
+        application += model.stack_setup_cost_for_effects(&self.context.effects);
+
+        transcript_gas_cost_with_overhead + validation + application
+    }
+}
+
+/// Estimate per-transaction non-contract costs from the union of all calls'
+/// effects. Subtracted from the partition budget in `partition_transcripts`.
+///
+/// Effect sizes are summed across calls: exact for nullifiers/receives
+/// (disjoint), conservative overestimate for token types if calls overlap.
+fn per_tx_cost_reserve<D: DB>(
+    full_runs: &[QueryResults<ResultModeVerify, D>],
+    model: &TransactionCostModel,
+) -> CostDuration {
+    let zswap_inputs: usize = full_runs
+        .iter()
+        .map(|r| r.context.effects.claimed_nullifiers.size())
+        .sum();
+    let zswap_outputs: usize = full_runs
+        .iter()
+        .map(|r| r.context.effects.claimed_shielded_receives.size())
+        .sum();
+    let unshielded_inputs: usize = full_runs
+        .iter()
+        .map(|r| r.context.effects.unshielded_inputs.size())
+        .sum();
+    let unshielded_outputs: usize = full_runs
+        .iter()
+        .map(|r| {
+            r.context.effects.unshielded_outputs.size() + r.context.effects.unshielded_mints.size()
+        })
+        .sum();
+    let has_night_input = full_runs.iter().any(|r| {
+        r.context
             .effects
             .unshielded_inputs
             .keys()
-            .map(|tt| {
-                let TokenType::Unshielded(tt) = tt else {
-                    unreachable!()
-                };
-                let input = UtxoSpend {
-                    intent_hash: Default::default(),
-                    output_no: 0,
-                    owner: Default::default(),
-                    type_: tt,
-                    value: 1,
-                };
-                let output = UtxoOutput {
-                    owner: Default::default(),
-                    type_: tt,
-                    value: 1,
-                };
-                let offer = UnshieldedOffer::<_, D> {
-                    inputs: vec![input].into(),
-                    outputs: vec![output].into(),
-                    signatures: Default::default(),
-                };
-                let tx = test_tx_from_unshielded_offer(offer);
-                tx.cost(params, false)
-                    .map(RunningCost::from)
-                    .unwrap_or(RunningCost::ZERO)
-            })
-            .sum();
-        let expected_unshielded_outputs_overhead = self
-            .context
+            .any(|tt| tt == TokenType::Unshielded(NIGHT))
+    });
+    let has_night_output = full_runs.iter().any(|r| {
+        r.context
             .effects
             .unshielded_outputs
             .keys()
-            .map(|tt| {
-                let TokenType::Unshielded(tt) = tt else {
-                    unreachable!()
-                };
-                let output = UtxoOutput {
-                    owner: Default::default(),
-                    type_: tt,
-                    value: 1,
-                };
-                let offer = UnshieldedOffer::<_, D> {
-                    inputs: Default::default(),
-                    outputs: vec![output].into(),
-                    signatures: Default::default(),
-                };
-                let tx = test_tx_from_unshielded_offer(offer);
-                tx.cost(params, false)
-                    .map(RunningCost::from)
-                    .unwrap_or(RunningCost::ZERO)
-            })
-            .sum();
-        let proof_verify = params.cost_model.proof_verify(public_input_count)
-            + params.cost_model.cell_read(VERIFIER_KEY_SIZE as u64)
-            + params.cost_model.map_index(EXPECTED_CONTRACT_DEPTH)
-            + params.cost_model.map_index(EXPECTED_OPERATIONS_DEPTH);
-        transcript_gas_cost_with_overhead
-            + expected_unshielded_inputs_overhead
-            + expected_unshielded_outputs_overhead
-            + proof_verify
+            .any(|tt| tt == TokenType::Unshielded(NIGHT))
+    });
+    let night_inputs = has_night_input as usize;
+    let night_outputs = has_night_output as usize;
+
+    // === Validation cost (parallelized) ===
+    let mut validation = model.baseline_cost;
+    // Zswap proof verifications
+    validation += model.proof_verify(zswap::INPUT_PIS) * zswap_inputs;
+    validation += model.proof_verify(zswap::OUTPUT_PIS) * zswap_outputs;
+    // Pedersen binding commitment check
+    if zswap_inputs + zswap_outputs > 0 {
+        validation.compute_time += model.runtime_cost_model.pedersen_valid;
+        validation.compute_time += model.runtime_cost_model.ec_mul;
     }
+    // Unshielded offer signature verifications
+    validation.compute_time +=
+        model.runtime_cost_model.signature_verify_constant * unshielded_inputs;
+    // Dust spend proof verification (heuristically assume 1)
+    validation += model.proof_verify(crate::dust::DUST_SPEND_PIS);
+    validation.compute_time = validation.compute_time / model.parallelism_factor;
+
+    // === Application cost ===
+    let mut application = model.baseline_cost;
+    // Replay protection
+    application += model.time_filter_map_lookup() + model.cell_read(PERSISTENT_HASH_BYTES as u64);
+    application +=
+        model.time_filter_map_insert(false) + model.cell_write(PERSISTENT_HASH_BYTES as u64, false);
+    // Unshielded UTXO processing
+    application += (model.map_index(EXPECTED_UTXO_DEPTH)
+        + model.map_remove(EXPECTED_UTXO_DEPTH, true)
+        + model.cell_delete(UTXO_SIZE as u64))
+        * unshielded_inputs;
+    application += (model.map_insert(EXPECTED_UTXO_DEPTH, false)
+        + model.cell_write(UTXO_SIZE as u64, false))
+        * unshielded_outputs;
+    // NIGHT-specific dust generation costs
+    application += (model.merkle_tree_insert_unamortized(32, false)
+        + model.cell_write(DUST_GENERATION_INFO_SIZE as u64, false))
+        * night_inputs;
+    application +=
+        (model.map_index(EXPECTED_UTXO_DEPTH) + model.cell_read(FR_BYTES as u64)) * night_outputs;
+    application += (model.cell_read(8) + model.cell_write(8, true)) * night_outputs;
+    application += (model.merkle_tree_insert_amortized(32, false)
+        + model.cell_write(DUST_GENERATION_INFO_SIZE as u64, false))
+        * night_outputs;
+    application +=
+        (model.map_insert(EXPECTED_UTXO_DEPTH, false) + model.cell_write(8, false)) * night_outputs;
+    application += (model.cell_read(8) + model.cell_write(8, true)) * night_outputs;
+    application += (model.merkle_tree_insert_amortized(EXPECTED_UTXO_DEPTH, false)
+        + model.cell_write(FR_BYTES as u64, false))
+        * night_outputs;
+    application += RunningCost::compute(
+        model.runtime_cost_model.transient_hash * FRESH_DUST_COMMITMENT_HASHES * night_outputs,
+    );
+    // Dust spend application costs (1 spend)
+    application += model.map_index(32)
+        + model.map_insert(EXPECTED_UTXO_DEPTH, false)
+        + model.cell_write(FR_BYTES as u64, false)
+        + model.cell_read(8)
+        + model.cell_write(8, true)
+        + model.merkle_tree_insert_amortized(EXPECTED_UTXO_DEPTH, false)
+        + model.cell_write(FR_BYTES as u64, false)
+        + model.time_filter_map_lookup() * 2u64;
+
+    let total = validation + application;
+    CostDuration::max(total.compute_time, total.read_time)
 }
 
 pub fn communication_commitment(input: AlignedValue, output: AlignedValue, rand: Fr) -> Fr {
@@ -1015,9 +1095,12 @@ pub fn partition_transcripts<D: DB>(
                 .sum::<CostDuration>()
         })
         .collect::<Vec<_>>();
-    // Allow creep-up to the min time to dismiss, up to 70% usage
+    // Reserve budget for per-transaction costs (validation baseline, zswap
+    // proofs, pedersen, replay protection, unshielded UTXO processing, dust).
+    // These don't scale per-call and are not included in the per-call heuristic.
+    let tx_reserve = per_tx_cost_reserve(&full_runs, &params.cost_model);
     let spare_min_time_to_dismiss =
-        params.limits.min_time_to_dismiss * 0.7f64 - closure_budgets.iter().copied().sum();
+        params.limits.min_time_to_dismiss - tx_reserve - closure_budgets.iter().copied().sum();
     for budget in closure_budgets.iter_mut() {
         *budget += spare_min_time_to_dismiss * (1.0 / closures.len() as f64);
     }

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -39,7 +39,7 @@ use coin_structure::contract::ContractAddress;
 use derive_where::derive_where;
 use fake::Dummy;
 use introspection_derive::Introspection;
-use onchain_runtime::context::{BlockContext, CallContext, ClaimedContractCallsValue};
+use onchain_runtime::context::{BlockContext, CallContext, ClaimedContractCallsValue, Effects};
 use onchain_runtime::state::ChargedState;
 use onchain_runtime::state::ContractOperation;
 use onchain_runtime::state::{ContractMaintenanceAuthority, ContractState, EntryPointBuf};
@@ -1025,14 +1025,14 @@ impl TransactionCostModel {
     pub(crate) fn cell_read(&self, size: u64) -> RunningCost {
         self.runtime_cost_model.read_cell(size, true)
     }
-    fn cell_write(&self, size: u64, overwrite: bool) -> RunningCost {
+    pub(crate) fn cell_write(&self, size: u64, overwrite: bool) -> RunningCost {
         RunningCost {
             bytes_written: size,
             bytes_deleted: if overwrite { size } else { 0 },
             ..RunningCost::ZERO
         }
     }
-    fn cell_delete(&self, size: u64) -> RunningCost {
+    pub(crate) fn cell_delete(&self, size: u64) -> RunningCost {
         RunningCost {
             bytes_deleted: size,
             ..RunningCost::ZERO
@@ -1046,23 +1046,23 @@ impl TransactionCostModel {
             + self.runtime_cost_model.proof_verify_coeff_size * size;
         RunningCost::compute(time)
     }
-    fn map_insert(&self, log_size: usize, overwrite: bool) -> RunningCost {
+    pub(crate) fn map_insert(&self, log_size: usize, overwrite: bool) -> RunningCost {
         let layers = log_size.div_ceil(4);
         self.cell_write(PERSISTENT_HASH_BYTES as u64 * 16, true) * layers as u64
             + self.cell_write(PERSISTENT_HASH_BYTES as u64, overwrite)
     }
-    fn map_remove(&self, log_size: usize, guaranteed_present: bool) -> RunningCost {
+    pub(crate) fn map_remove(&self, log_size: usize, guaranteed_present: bool) -> RunningCost {
         if guaranteed_present {
             self.map_insert(log_size, true)
         } else {
             self.map_insert(log_size, true) + self.map_index(log_size)
         }
     }
-    fn time_filter_map_lookup(&self) -> RunningCost {
+    pub(crate) fn time_filter_map_lookup(&self) -> RunningCost {
         // TODO: This is a good approximation, but not accurate.
         self.map_index(8) * 2u64
     }
-    fn time_filter_map_insert(&self, overwrite: bool) -> RunningCost {
+    pub(crate) fn time_filter_map_insert(&self, overwrite: bool) -> RunningCost {
         // Two map insertions, the 'set' and the 'time_map'.
         self.map_insert(8, overwrite) * 2u64
     }
@@ -1079,11 +1079,19 @@ impl TransactionCostModel {
         let raw_overwrites = self.cell_write((FR_BYTES * 3 + 2) as u64, true) * log_size as u64;
         raw_writes + raw_overwrites
     }
-    fn merkle_tree_insert_unamortized(&self, log_size: usize, overwrite: bool) -> RunningCost {
+    pub(crate) fn merkle_tree_insert_unamortized(
+        &self,
+        log_size: usize,
+        overwrite: bool,
+    ) -> RunningCost {
         let rehashes = RunningCost::compute(self.runtime_cost_model.transient_hash * log_size);
         rehashes + self.merkle_tree_insert_no_rehash(log_size, overwrite)
     }
-    fn merkle_tree_insert_amortized(&self, log_size: usize, overwrite: bool) -> RunningCost {
+    pub(crate) fn merkle_tree_insert_amortized(
+        &self,
+        log_size: usize,
+        overwrite: bool,
+    ) -> RunningCost {
         // The amortization turns n writes into a tree of depth d from
         // nd hashes to n log_2 n + d hashes. That means that the hashes we cost *per insert*
         // isn't constant.
@@ -1098,7 +1106,7 @@ impl TransactionCostModel {
     fn tree_copy<T: Storable<D>, D: DB>(&self, value: Sp<T, D>) -> RunningCost {
         self.runtime_cost_model.tree_copy(value)
     }
-    fn stack_setup_cost<D: DB>(&self, transcript: &Transcript<D>) -> RunningCost {
+    pub(crate) fn stack_setup_cost_for_effects<D: DB>(&self, eff: &Effects<D>) -> RunningCost {
         // There's an additional cost of processing a transcript coming from initializing effects
         // and context stack variables. This accounts for them.
         // The bulk of this is MPT insertions to build up various sets that sit in these values.
@@ -1106,7 +1114,6 @@ impl TransactionCostModel {
         // they are constant by container, and then reduce that to a running cost using map
         // insert VM operations.
         const EXPECTED_COM_INDICES: usize = 16;
-        let eff = &transcript.effects;
         // (amount, key length)
         let maps = [
             (EXPECTED_COM_INDICES, PERSISTENT_HASH_BYTES),
@@ -2073,7 +2080,7 @@ where
                             // VM stack setup / destroy cost
                             // Left out of scope here to avoid going to deep into
                             // stack structure.
-                            *cost += model.stack_setup_cost(transcript);
+                            *cost += model.stack_setup_cost_for_effects(&transcript.effects);
                         }
                     }
                     ContractAction::Deploy(deploy) => {

--- a/ledger/tests/composable.rs
+++ b/ledger/tests/composable.rs
@@ -533,15 +533,12 @@ async fn composable() {
         tx.well_formed(&state.ledger, strictness, state.time)
             .unwrap()
     };
-    match state.ledger.apply(&tx, &state.context()).1 {
-        TransactionResult::PartialSuccess(res, _) => assert!(matches!(
-            res.get(&1),
-            Some(Err(TransactionInvalid::Transcript(
-                TranscriptRejected::Execution(OnchainProgramError::ReadMismatch { .. })
-            )))
-        )),
-        r => panic!("unexpected transaction result: {r:?}"),
-    }
+    assert!(matches!(
+        state.ledger.apply(&tx, &state.context()).1,
+        TransactionResult::Failure(TransactionInvalid::Transcript(
+            TranscriptRejected::Execution(OnchainProgramError::ReadMismatch { .. })
+        ))
+    ));
 
     // Part 7: Rejected (read mismatch & fallibility hacking)
     println!(":: Part 7: Rejected (read mismatch & fallibility hacking)");
@@ -607,13 +604,13 @@ async fn composable() {
             key_location: KeyLocation(Cow::Borrowed("get")),
         };
         dbg!(&transcripts);
-        // Manually move things to the guaranteed section.
+        // Manually move things to the fallible section.
         let call_outer = ContractCallPrototype {
             address: addr_outer,
             entry_point: b"update"[..].into(),
             op: update_op.clone(),
-            guaranteed_public_transcript: transcripts[1].1.clone(),
-            fallible_public_transcript: None,
+            guaranteed_public_transcript: None,
+            fallible_public_transcript: transcripts[1].0.clone(),
             private_transcript_outputs: vec![b"malicious".to_vec().into(), cc_rand.into()],
             input: ().into(),
             output: ().into(),
@@ -634,7 +631,7 @@ async fn composable() {
 
         match tx.well_formed(&state.ledger, strictness, state.time) {
             Err(MalformedTransaction::SequencingCheckFailure(
-                SequencingCheckError::FallibleInGuaranteedContextViolation { .. },
+                SequencingCheckError::GuaranteedInFallibleContextViolation { .. },
             )) => (),
             Err(e) => panic!("{e:?}"),
             Ok(_) => panic!("succeeded unexpectedly"),
@@ -1073,15 +1070,12 @@ async fn guaranteed_in_fallible() {
         tx.well_formed(&ledger_state.ledger, strictness, Timestamp::from_secs(0))
             .unwrap()
     };
-    match ledger_state.ledger.apply(&tx, &ledger_state.context()).1 {
-        TransactionResult::PartialSuccess(res, _) => assert!(matches!(
-            res.get(&1),
-            Some(Err(TransactionInvalid::Transcript(
-                TranscriptRejected::Execution(OnchainProgramError::ReadMismatch { .. })
-            )))
-        )),
-        r => panic!("unexpected transaction result: {r:?}"),
-    }
+    assert!(matches!(
+        ledger_state.ledger.apply(&tx, &ledger_state.context()).1,
+        TransactionResult::Failure(TransactionInvalid::Transcript(
+            TranscriptRejected::Execution(OnchainProgramError::ReadMismatch { .. })
+        ))
+    ));
 
     // Part 7: Rejected (read mismatch & fallibility hacking)
     println!(":: Part 7: Rejected (read mismatch & fallibility hacking)");
@@ -1173,7 +1167,7 @@ async fn guaranteed_in_fallible() {
 
         match tx.well_formed(&ledger_state.ledger, strictness, Timestamp::from_secs(0)) {
             Err(MalformedTransaction::SequencingCheckFailure(
-                SequencingCheckError::FallibleInGuaranteedContextViolation { .. },
+                SequencingCheckError::GuaranteedInFallibleContextViolation { .. },
             )) => (),
             Err(e) => panic!("{e:?}"),
             Ok(_) => panic!("succeeded unexpectedly"),
@@ -1417,8 +1411,8 @@ async fn composable_funded() {
                     Vec::new(),
                     state.time,
                 ),
-                None,
-                [(1, offer)].into_iter().collect(),
+                Some(offer),
+                HashMap::new(),
             );
         dbg!(&pre_tx);
         tx_prove(rng.split(), &pre_tx, &RESOLVER).await.unwrap()

--- a/ledger/tests/micro-dao.rs
+++ b/ledger/tests/micro-dao.rs
@@ -442,6 +442,12 @@ async fn micro_dao_inner(mode: TestMode) {
                     &INITIAL_PARAMETERS,
                 )
                 .unwrap();
+                let is_guaranteed = transcripts[0].0.is_some();
+                let (guaranteed_coins, fallible_coins) = if is_guaranteed {
+                    (Some(offer), HashMap::new())
+                } else {
+                    (None, [(1, offer)].into_iter().collect())
+                };
                 let call = ContractCallPrototype {
                     address: addr,
                     entry_point: b"buyIn"[..].into(),
@@ -457,8 +463,8 @@ async fn micro_dao_inner(mode: TestMode) {
                 let tx = Transaction::new(
                     "local-test",
                     test_intents(&mut rng, vec![call], Vec::new(), Vec::new(), state.time),
-                    None,
-                    [(1, offer)].into_iter().collect(),
+                    guaranteed_coins,
+                    fallible_coins,
                 );
                 let tx = tx_prove_bind(rng.split(), &tx, &RESOLVER).await.unwrap();
                 tx.well_formed(&state.ledger, unbalanced_strictness, state.time)
@@ -939,8 +945,8 @@ async fn micro_dao_inner(mode: TestMode) {
             let tx = Transaction::new(
                 "local-test",
                 test_intents(&mut rng, vec![call], Vec::new(), Vec::new(), state.time),
-                None,
-                [(1, offer)].into_iter().collect(),
+                Some(offer),
+                HashMap::new(),
             );
             let tx = tx_prove_bind(rng.split(), &tx, &RESOLVER).await.unwrap();
             tx.well_formed(&state.ledger, unbalanced_strictness, state.time)

--- a/ledger/tests/token_vault_unshielded.rs
+++ b/ledger/tests/token_vault_unshielded.rs
@@ -282,13 +282,13 @@ async fn test_unshielded_contract_deposit() {
     // Create intent with contract call and unshielded offer
     use midnight_ledger::structure::StandardTransaction;
 
-    let fallible_unshielded_offer: Option<UnshieldedOffer<(), InMemoryDB>> = Some(uso);
+    let guaranteed_unshielded_offer: Option<UnshieldedOffer<(), InMemoryDB>> = Some(uso);
 
     // Create the intent and sign it for UTXO spending
     let intent = Intent::new(
         &mut rng,
+        guaranteed_unshielded_offer,
         None,
-        fallible_unshielded_offer,
         vec![call],
         Vec::new(),
         Vec::new(),
@@ -298,8 +298,8 @@ async fn test_unshielded_contract_deposit() {
     .sign(
         &mut rng,
         1,                          // segment_id
-        &[],                        // No guaranteed signing keys
         &[state.night_key.clone()], // Sign the UTXO spend
+        &[],                        // No fallible signing keys
         &[],                        // No dust registration signing keys
     )
     .unwrap();
@@ -557,15 +557,15 @@ async fn test_unshielded_contract_withdraw() {
     // Create and sign intent (signing required because we're spending a UTXO)
     let deposit_intent = Intent::new(
         &mut rng,
-        None,
         Some(deposit_uso),
+        None,
         vec![deposit_call],
         Vec::new(),
         Vec::new(),
         None,
         state.time + base_crypto::time::Duration::from_secs(3600),
     )
-    .sign(&mut rng, 1, &[], &[state.night_key.clone()], &[])
+    .sign(&mut rng, 1, &[state.night_key.clone()], &[], &[])
     .unwrap();
 
     let mut deposit_intents: storage::storage::HashMap<
@@ -745,8 +745,8 @@ async fn test_unshielded_contract_withdraw() {
     // Create intent - no signing needed since no UTXOs are being spent
     let withdraw_intent = Intent::new(
         &mut rng,
-        None,
         Some(withdraw_uso),
+        None,
         vec![withdraw_call],
         Vec::new(),
         Vec::new(),


### PR DESCRIPTION
## Description
Makes gas estimation a relatively tight replica of actual cost computation. This is largely AI copy-and-paste, which I deemed preferable over mutilating things to try to make them reusable.

This moves a slew of tests back to using the guaranteed section, and hopefully gives contracts a good bit more breathing room.

Addresses #409

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
