### PR TITLE
Bump zk-stdlib to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,10 +572,11 @@ dependencies = [
 
 [[package]]
 name = "blake2b_halo2"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba44fa3e70871c2bc00d44f08c95be68145ae28a60de8182e649eee2f17a872b"
+checksum = "db0e2335f7864c16821ade9dcc5918780306ca9fdf3876dd2fd2c82d820aa9da"
 dependencies = [
+ "blake2b_simd",
  "ff",
  "hex",
  "midnight-curves",
@@ -646,6 +647,17 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -909,6 +921,18 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -1151,6 +1175,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "group",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1544,6 +1596,7 @@ dependencies = [
  "sec1",
  "serdect",
  "subtle",
+ "tap",
  "zeroize",
 ]
 
@@ -1703,6 +1756,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1972,6 +2031,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "goldenfile"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf39e208efa110ca273f7255aea02485103ffcb7e5dfa5e4196b05a02411618e"
+dependencies = [
+ "scopeguard",
+ "similar-asserts",
+ "tempfile",
+ "yansi",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,20 +2092,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "halo2derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d74794c1b24716c5abf5d6bfd98ee3c2d346bc67da374ba21d80adb38c336c"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote 1.0.45",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2117,6 +2174,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hmac"
@@ -2439,7 +2502,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -2885,13 +2948,13 @@ dependencies = [
 
 [[package]]
 name = "midnight-circuits"
-version = "6.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600f93b06229da9f000d5cb7649ef2d8e3f8058f2eae640b15a3a1d6dd29313b"
+checksum = "1a87ddffe23ec9bc99afd943d69954dcfedf62484836bac5e176a65d72d89074"
 dependencies = [
  "base64 0.13.1",
- "blake2b_halo2",
  "ff",
+ "goldenfile",
  "group",
  "lazy_static",
  "midnight-curves",
@@ -2900,9 +2963,11 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "ripemd",
  "rustc-hash",
+ "serde_json",
  "sha2 0.10.9",
- "sha3-circuit",
  "subtle",
 ]
 
@@ -2927,23 +2992,26 @@ dependencies = [
 
 [[package]]
 name = "midnight-curves"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71df41292a1fd7796bf6c0c6eff7ad717d628406a59a79240e68579716c3566a"
+checksum = "30489f54343b238003dcb58809e7c1ebdd7283494b9d0f54c0a565a6aa3abe5d"
 dependencies = [
  "bitvec",
  "blst",
  "byte-slice-cast",
+ "curve25519-dalek",
  "digest 0.10.7",
  "ff",
  "getrandom 0.2.17",
  "group",
- "halo2derive",
  "hex",
+ "k256",
  "lazy_static",
  "num-bigint",
+ "p256",
  "pairing",
  "paste",
+ "primeorder",
  "rand_core 0.6.4",
  "rayon",
  "serde",
@@ -3173,14 +3241,15 @@ dependencies = [
 
 [[package]]
 name = "midnight-proofs"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b48f199fa4707df5dc443238cd260344f2ad369897fbdc559dacce19b43d2119"
+checksum = "742c98d17c83c48aa2705e0da29b9758f47252af2fc78f6369bb070ba490af0f"
 dependencies = [
  "blake2b_simd",
  "ff",
  "getrandom 0.2.17",
  "group",
+ "itertools 0.14.0",
  "midnight-curves",
  "num-bigint",
  "rand_chacha 0.3.1",
@@ -3344,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "midnight-zk-stdlib"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6171970a8cab445b0b81f2149ec57a7684c934be6e38d6cdbeda0845770a5b8"
+checksum = "67a5fdbe293792eb0b82b800474be642f6d85c719a5be69eb45e9529a5ea2ef9"
 dependencies = [
  "base64 0.13.1",
  "bincode 2.0.1",
@@ -3354,12 +3423,14 @@ dependencies = [
  "blake2b_simd",
  "ff",
  "group",
+ "hex-literal",
  "midnight-circuits",
  "midnight-curves",
  "midnight-proofs",
  "num-bigint",
  "num-traits",
  "rand 0.8.6",
+ "rayon",
  "sha2 0.10.9",
  "sha3-circuit",
 ]
@@ -3371,7 +3442,7 @@ dependencies = [
  "actix-rt",
  "anyhow",
  "clap",
- "console",
+ "console 0.16.3",
  "const-hex",
  "env_logger",
  "futures-executor",
@@ -3408,7 +3479,7 @@ dependencies = [
  "actix-rt",
  "anyhow",
  "clap",
- "console",
+ "console 0.16.3",
  "const-hex",
  "env_logger",
  "futures-executor",
@@ -3773,6 +3844,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4032,6 +4114,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4471,6 +4562,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4950,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-circuit"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be83e5373c70fbe71d6aa678da6d139029a497faccd1c693f393526fe0195101"
+checksum = "4237ceb913f4dcf6219c5303d37122c8cd3734cbe1314274158a8eb609dedac8"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -5015,6 +5115,26 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+dependencies = [
+ "console 0.15.11",
+ "similar",
+]
 
 [[package]]
 name = "siphasher"
@@ -5198,17 +5318,6 @@ dependencies = [
  "quote 0.3.15",
  "synom",
  "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote 1.0.45",
- "unicode-ident",
 ]
 
 [[package]]
@@ -6162,6 +6271,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -6487,6 +6605,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/transient-crypto/Cargo.toml
+++ b/transient-crypto/Cargo.toml
@@ -27,10 +27,10 @@ storage-core = { version = "1.0.0", path = "../storage-core", package = "midnigh
 
 ff = "^0.13.1"
 group = "^0.13.0"
-midnight-curves = { version = "^0.2.0" }
-midnight-proofs = { version = "^0.7.0" }
-midnight-circuits = { version = "^6.0.0" }
-midnight-zk-stdlib = { version = "^1.0.0" }
+midnight-curves = { version = "^0.3.0" }
+midnight-proofs = { version = "^0.8.0" }
+midnight-circuits = { version = "^7.0.0" }
+midnight-zk-stdlib = { version = "^2.0.0" }
 anyhow = { version = "^1.0.102" }
 lru = "0.17.0"
 

--- a/transient-crypto/src/mock_verify.rs
+++ b/transient-crypto/src/mock_verify.rs
@@ -325,6 +325,7 @@ struct TestIr {
 }
 
 impl Relation for TestIr {
+    type Error = midnight_proofs::plonk::Error;
     type Instance = Vec<Fr>;
     type Witness = Self;
     fn format_instance(

--- a/transient-crypto/src/proofs.rs
+++ b/transient-crypto/src/proofs.rs
@@ -24,7 +24,7 @@ use midnight_proofs::{
     poly::kzg::params::{ParamsKZG, ParamsVerifierKZG},
     utils::SerdeFormat,
 };
-use midnight_zk_stdlib::{MidnightCircuit, MidnightPK, MidnightVK, Relation};
+use midnight_zk_stdlib::{MidnightPK, MidnightVK, Relation, optimal_k};
 #[cfg(feature = "proptest")]
 use proptest::arbitrary::Arbitrary;
 #[cfg(feature = "proptest")]
@@ -180,7 +180,7 @@ pub trait Zkir: Relation + Any + Send + Sync + Debug {
 
     /// Returns the k value for this circuit
     fn k(&self) -> u8 {
-        MidnightCircuit::from_relation(self).min_k() as u8
+        optimal_k(self) as u8
     }
 
     /// Performs key generation on this circuit, outputting the verifier key
@@ -449,6 +449,7 @@ struct DummyRelation;
 // in the verifier key, and use that for deserializing, but those API endpoints
 // do not currently exist in midnight-circuits.
 impl Relation for DummyRelation {
+    type Error = midnight_proofs::plonk::Error;
     type Instance = Vec<outer::Scalar>;
     type Witness = ();
     fn format_instance(

--- a/zkir-v3/Cargo.toml
+++ b/zkir-v3/Cargo.toml
@@ -27,10 +27,10 @@ base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-
 serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
 transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto", features = ["cli"] }
 
-midnight-curves = { version = "0.2.0" }
-midnight-proofs = { version = "^0.7.0" }
-midnight-circuits = { version = "^6.0.0" }
-midnight-zk-stdlib = { version = "^1.0.0" }
+midnight-curves = { version = "0.3.0" }
+midnight-proofs = { version = "^0.8.0" }
+midnight-circuits = { version = "^7.0.0" }
+midnight-zk-stdlib = { version = "^2.0.0" }
 
 group = "^0.13.0"
 const-hex = "^1.14.0"

--- a/zkir-v3/src/ir.rs
+++ b/zkir-v3/src/ir.rs
@@ -664,7 +664,7 @@ impl IrSource {
     /// Retrieves a model representation of this circuit.
     pub fn model(&self) -> Model {
         Model {
-            model: midnight_zk_stdlib::cost_model(self),
+            model: midnight_zk_stdlib::cost_model(self, None),
         }
     }
 

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -630,6 +630,7 @@ impl IrSource {
 }
 
 impl Relation for IrSource {
+    type Error = midnight_proofs::plonk::Error;
     type Instance = Vec<outer::Scalar>;
 
     type Witness = Preprocessed;
@@ -1136,6 +1137,8 @@ impl Relation for IrSource {
             nr_pow2range_cols: 4,
             secp256k1: false,
             bls12_381: false,
+            curve25519: false, 
+            p256: false,
             base64: false,
             automaton: false,
         }

--- a/zkir/Cargo.toml
+++ b/zkir/Cargo.toml
@@ -27,9 +27,9 @@ base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-
 serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
 transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto", features = ["cli"] }
 
-midnight-proofs = { version = "^0.7.0" }
-midnight-circuits = { version = "^6.0.0" }
-midnight-zk-stdlib = { version = "^1.0.0" }
+midnight-proofs = { version = "^0.8.0" }
+midnight-circuits = { version = "^7.0.0" }
+midnight-zk-stdlib = { version = "^2.0.0" }
 
 group = "^0.13.0"
 const-hex = "^1.14.0"

--- a/zkir/src/ir.rs
+++ b/zkir/src/ir.rs
@@ -472,7 +472,7 @@ impl IrSource {
     /// Retrieves a model representation of this circuit.
     pub fn model(&self) -> Model {
         Model {
-            model: midnight_zk_stdlib::cost_model(self),
+            model: midnight_zk_stdlib::cost_model(self, None),
         }
     }
 

--- a/zkir/src/ir_vm.rs
+++ b/zkir/src/ir_vm.rs
@@ -514,6 +514,7 @@ impl IrSource {
 }
 
 impl Relation for IrSource {
+    type Error = Error;
     type Instance = Vec<outer::Scalar>;
 
     type Witness = Preprocessed;
@@ -876,6 +877,8 @@ impl Relation for IrSource {
             nr_pow2range_cols,
             secp256k1: false,
             bls12_381: false,
+            curve25519: false, 
+            p256: false,
             base64: false,
             automaton: false,
         }


### PR DESCRIPTION
## Description

Version bump to [zk-stdlib-v2](https://crates.io/crates/midnight-zk-stdlib/2.0.0). CHANGELOG available [here](https://github.com/midnightntwrk/midnight-zk/blob/main/zk_stdlib/CHANGELOG.md#200).

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [x] contains data format changes [^1]
- [x] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [x] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
