### PR TITLE
Wasm constructors for DustStateChanges and ZswapStateChanges

### DIFF
--- a/integration-tests/src/test/no-proving/DustStateChanges.test.ts
+++ b/integration-tests/src/test/no-proving/DustStateChanges.test.ts
@@ -1,0 +1,257 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  DustActions,
+  DustLocalState,
+  DustRegistration,
+  DustStateChanges,
+  Intent,
+  type IntentHash,
+  type PreProof,
+  SignatureEnabled,
+  signData,
+  Transaction,
+  TransactionContext,
+  UnshieldedOffer,
+  type UtxoOutput,
+  type UtxoSpend,
+  WellFormedStrictness
+} from '@midnight-ntwrk/ledger';
+import { expect } from 'vitest';
+import { ProofMarker, SignatureMarker } from '@/test/utils/Markers';
+import {
+  BALANCING_OVERHEAD,
+  DEFAULT_TOKEN_TYPE,
+  HEX_64_REGEX,
+  INITIAL_NIGHT_AMOUNT,
+  initialParameters,
+  LOCAL_TEST_NETWORK_ID,
+  Static
+} from '@/test-objects';
+import { TestState } from '@/test/utils/TestState';
+
+const buildRegistrationEvents = () => {
+  const state = TestState.new();
+  const localState = new DustLocalState(initialParameters);
+  const { secretKey } = state.dustKey;
+
+  state.rewardNight(INITIAL_NIGHT_AMOUNT);
+  state.fastForward(initialParameters.timeToCapSeconds);
+
+  const utxoIh: IntentHash = state.ledger.utxo.utxos.values().next().value!.intentHash;
+  const intent = Intent.new(state.time);
+  const inputs: UtxoSpend[] = [
+    {
+      value: INITIAL_NIGHT_AMOUNT,
+      owner: state.nightKey.verifyingKey(),
+      type: DEFAULT_TOKEN_TYPE,
+      intentHash: utxoIh,
+      outputNo: 0
+    }
+  ];
+  const outputs: UtxoOutput[] = [
+    { owner: state.initialNightAddress, type: DEFAULT_TOKEN_TYPE, value: INITIAL_NIGHT_AMOUNT }
+  ];
+
+  intent.guaranteedUnshieldedOffer = UnshieldedOffer.new(inputs, outputs, []);
+
+  const baseRegistrations: DustRegistration<SignatureEnabled>[] = [
+    new DustRegistration(
+      SignatureMarker.signature,
+      state.nightKey.verifyingKey(),
+      state.dustKey.publicKey(),
+      BALANCING_OVERHEAD
+    )
+  ];
+
+  intent.dustActions = new DustActions<SignatureEnabled, PreProof>(
+    SignatureMarker.signature,
+    ProofMarker.preProof,
+    state.time,
+    [],
+    baseRegistrations
+  );
+
+  const intentSignatureData = intent.signatureData(1);
+  const signatureEnabled = new SignatureEnabled(signData(state.nightKey.signingKey, intentSignatureData));
+
+  intent.dustActions = new DustActions(
+    SignatureMarker.signature,
+    ProofMarker.preProof,
+    state.time,
+    [],
+    baseRegistrations.map(
+      (reg) =>
+        new DustRegistration(
+          SignatureMarker.signature,
+          reg.nightKey,
+          reg.dustAddress,
+          reg.allowFeePayment,
+          signatureEnabled
+        )
+    )
+  );
+
+  const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, undefined, undefined, intent);
+  const txCtx = new TransactionContext(state.ledger, Static.blockContext(state.time));
+  const strictness = new WellFormedStrictness();
+  strictness.enforceBalancing = false;
+  const verifiedTx = tx.wellFormed(state.ledger, strictness, state.time);
+  const { events } = state.ledger.apply(verifiedTx, txCtx)[1];
+
+  return { localState, secretKey, events };
+};
+
+describe('Ledger API - DustStateChanges', () => {
+  /**
+   * Test construction with empty UTXO arrays.
+   *
+   * @given A valid source hex string and empty UTXO arrays
+   * @when Constructing a DustStateChanges instance
+   * @then Should return an instance with matching source and UTXO arrays
+   */
+  test('should construct with empty received and spent UTXO arrays', () => {
+    const { localState, secretKey, events } = buildRegistrationEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKey, events);
+    const [{ source, receivedUtxos, spentUtxos }] = withChanges.changes;
+
+    const changes = new DustStateChanges(source, receivedUtxos, spentUtxos);
+
+    expect(changes.source).toEqual(source);
+    expect(changes.receivedUtxos).toEqual(receivedUtxos);
+    expect(changes.spentUtxos).toEqual(spentUtxos);
+  });
+
+  /**
+   * Test construction with received UTXOs.
+   *
+   * @given A valid source hex string and a QualifiedDustOutput received in a real transaction
+   * @when Constructing a DustStateChanges instance
+   * @then Should return an instance whose receivedUtxos getter returns the provided UTXOs
+   */
+  test('should construct with received UTXOs and expose them via getter', () => {
+    const { localState, secretKey, events } = buildRegistrationEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKey, events);
+    const [{ source }] = withChanges.changes;
+    const receivedUtxo = withChanges.state.utxos[0];
+
+    const changes = new DustStateChanges(source, [receivedUtxo], []);
+
+    expect(changes.receivedUtxos).toHaveLength(1);
+    expect(changes.receivedUtxos[0]).toEqual(receivedUtxo);
+    expect(changes.spentUtxos).toEqual([]);
+  });
+
+  /**
+   * Test construction with spent UTXOs.
+   *
+   * @given A valid source hex string and a QualifiedDustOutput as a spent UTXO
+   * @when Constructing a DustStateChanges instance
+   * @then Should return an instance whose spentUtxos getter returns the provided UTXOs
+   */
+  test('should construct with spent UTXOs and expose them via getter', () => {
+    const { localState, secretKey, events } = buildRegistrationEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKey, events);
+    const [{ source }] = withChanges.changes;
+    const utxo = withChanges.state.utxos[0];
+
+    const changes = new DustStateChanges(source, [], [utxo]);
+
+    expect(changes.spentUtxos).toHaveLength(1);
+    expect(changes.spentUtxos[0]).toEqual(utxo);
+    expect(changes.receivedUtxos).toEqual([]);
+  });
+
+  /**
+   * Test construction with multiple received and spent UTXOs.
+   *
+   * @given A valid source and multiple UTXOs in both received and spent arrays
+   * @when Constructing a DustStateChanges instance
+   * @then Should preserve all UTXOs in both arrays
+   */
+  test('should construct with multiple received and spent UTXOs', () => {
+    const { localState, secretKey, events } = buildRegistrationEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKey, events);
+    const [{ source }] = withChanges.changes;
+    const utxo = withChanges.state.utxos[0];
+
+    const changes = new DustStateChanges(source, [utxo, utxo], [utxo]);
+
+    expect(changes.receivedUtxos).toHaveLength(2);
+    expect(changes.spentUtxos).toHaveLength(1);
+  });
+
+  /**
+   * Test that source getter returns a valid hex string.
+   *
+   * @given A DustStateChanges obtained by replaying real transaction events
+   * @when Reading the source after reconstructing it via the public constructor
+   * @then Should return a hex-encoded string matching the expected pattern
+   */
+  test('should expose source as a hex-encoded string', () => {
+    const { localState, secretKey, events } = buildRegistrationEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKey, events);
+    const [{ source }] = withChanges.changes;
+
+    const changes = new DustStateChanges(source, [], []);
+
+    expect(changes.source).toMatch(HEX_64_REGEX);
+  });
+
+  /**
+   * Test error thrown on invalid source hex string.
+   *
+   * @given A non-hex source string
+   * @when Constructing a DustStateChanges instance
+   * @then Should throw an error indicating the source is invalid
+   */
+  test('should throw on invalid source hex string', () => {
+    expect(() => new DustStateChanges('not-a-hex-string', [], [])).toThrow();
+  });
+
+  /**
+   * Test error thrown on a hex source with the wrong length.
+   *
+   * @given A hex source string too short to represent a TransactionHash
+   * @when Constructing a DustStateChanges instance
+   * @then Should throw an error
+   */
+  test('should throw on source hex string with wrong length', () => {
+    expect(() => new DustStateChanges('deadbeef', [], [])).toThrow();
+  });
+
+  /**
+   * Test error thrown on a malformed UTXO object.
+   *
+   * @given A valid source but a UTXO object with invalid field values
+   * @when Constructing a DustStateChanges instance
+   * @then Should throw an error indicating the UTXO is invalid
+   */
+  test('should throw on malformed UTXO object in receivedUtxos', () => {
+    const { localState, secretKey, events } = buildRegistrationEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKey, events);
+    const [{ source }] = withChanges.changes;
+    const invalidUtxo = {
+      initialValue: 100n,
+      owner: 999999999999999999999999999999999999999999999999999999999999n,
+      nonce: -1n,
+      seq: 0,
+      ctime: new Date(),
+      backingNight: 'not-a-hex',
+      mtIndex: 0n
+    };
+
+    expect(() => new DustStateChanges(source, [invalidUtxo as never], [])).toThrow();
+  });
+});

--- a/integration-tests/src/test/no-proving/ZswapStateChanges.test.ts
+++ b/integration-tests/src/test/no-proving/ZswapStateChanges.test.ts
@@ -1,0 +1,206 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  LedgerState,
+  Transaction,
+  TransactionContext,
+  WellFormedStrictness,
+  ZswapChainState,
+  ZswapLocalState,
+  ZswapOffer,
+  ZswapOutput,
+  ZswapSecretKeys,
+  ZswapStateChanges
+} from '@midnight-ntwrk/ledger';
+import { getQualifiedShieldedCoinInfo, HEX_64_REGEX, LOCAL_TEST_NETWORK_ID, Static } from '@/test-objects';
+
+describe('Ledger API - ZswapStateChanges', () => {
+  const buildLedgerAndEvents = () => {
+    const localState = new ZswapLocalState();
+    const ledgerState = new LedgerState(LOCAL_TEST_NETWORK_ID, new ZswapChainState());
+    const secretKeys = ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(1));
+    const coinInfo = Static.shieldedCoinInfo(10n);
+    const unprovenOffer = ZswapOffer.fromOutput(
+      ZswapOutput.new(coinInfo, 0, secretKeys.coinPublicKey, secretKeys.encryptionPublicKey),
+      coinInfo.type,
+      coinInfo.value
+    );
+    const tx = Transaction.fromParts(LOCAL_TEST_NETWORK_ID, unprovenOffer);
+    const txCtx = new TransactionContext(ledgerState, Static.blockContext(new Date(0)));
+    const strictness = new WellFormedStrictness();
+    strictness.enforceBalancing = false;
+    const verifiedTx = tx.wellFormed(ledgerState, strictness, new Date(0));
+    const { events } = ledgerState.apply(verifiedTx, txCtx)[1];
+    return { localState, secretKeys, coinInfo, events };
+  };
+
+  /**
+   * Test construction with empty coin arrays.
+   *
+   * @given A valid source hex string and empty coin arrays
+   * @when Constructing a ZswapStateChanges instance
+   * @then Should return an instance with matching source and empty coin arrays
+   */
+  test('should construct with empty received and spent coin arrays', () => {
+    const { localState, secretKeys, events } = buildLedgerAndEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKeys, events);
+    const [firstChange] = withChanges.changes;
+    const { source } = firstChange;
+
+    const changes = new ZswapStateChanges(source, [], []);
+
+    expect(changes.source).toEqual(source);
+    expect(changes.receivedCoins).toEqual([]);
+    expect(changes.spentCoins).toEqual([]);
+  });
+
+  /**
+   * Test construction with received coins.
+   *
+   * @given A valid source hex string and a list of received QualifiedShieldedCoinInfo
+   * @when Constructing a ZswapStateChanges instance
+   * @then Should return an instance whose receivedCoins getter returns the provided coins
+   */
+  test('should construct with received coins and expose them via getter', () => {
+    const { localState, secretKeys, events, coinInfo } = buildLedgerAndEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKeys, events);
+    const [{ source }] = withChanges.changes;
+    const coin = getQualifiedShieldedCoinInfo(coinInfo, 0n);
+
+    const changes = new ZswapStateChanges(source, [coin], []);
+
+    expect(changes.receivedCoins).toHaveLength(1);
+    expect(changes.receivedCoins[0]).toEqual(coin);
+    expect(changes.spentCoins).toEqual([]);
+  });
+
+  /**
+   * Test construction with spent coins.
+   *
+   * @given A valid source hex string and a list of spent QualifiedShieldedCoinInfo
+   * @when Constructing a ZswapStateChanges instance
+   * @then Should return an instance whose spentCoins getter returns the provided coins
+   */
+  test('should construct with spent coins and expose them via getter', () => {
+    const { localState, secretKeys, events, coinInfo } = buildLedgerAndEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKeys, events);
+    const [{ source }] = withChanges.changes;
+    const coin = getQualifiedShieldedCoinInfo(coinInfo, 1n);
+
+    const changes = new ZswapStateChanges(source, [], [coin]);
+
+    expect(changes.spentCoins).toHaveLength(1);
+    expect(changes.spentCoins[0]).toEqual(coin);
+    expect(changes.receivedCoins).toEqual([]);
+  });
+
+  /**
+   * Test construction with multiple received and spent coins.
+   *
+   * @given A valid source hex string and multiple coins in each category
+   * @when Constructing a ZswapStateChanges instance
+   * @then Should preserve all coins in both received and spent arrays
+   */
+  test('should construct with multiple received and spent coins', () => {
+    const { localState, secretKeys, events } = buildLedgerAndEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKeys, events);
+    const [{ source }] = withChanges.changes;
+    const receivedCoins = [
+      getQualifiedShieldedCoinInfo(Static.shieldedCoinInfo(5n), 0n),
+      getQualifiedShieldedCoinInfo(Static.shieldedCoinInfo(10n), 1n)
+    ];
+    const spentCoins = [getQualifiedShieldedCoinInfo(Static.shieldedCoinInfo(3n), 2n)];
+
+    const changes = new ZswapStateChanges(source, receivedCoins, spentCoins);
+
+    expect(changes.receivedCoins).toHaveLength(2);
+    expect(changes.spentCoins).toHaveLength(1);
+    expect(changes.receivedCoins).toEqual(receivedCoins);
+    expect(changes.spentCoins).toEqual(spentCoins);
+  });
+
+  /**
+   * Test round-trip: reconstruct ZswapStateChanges from values obtained via replayEventsWithChanges.
+   *
+   * @given A ZswapStateChanges obtained by replaying real transaction events
+   * @when Reconstructing it using the public constructor with the same source and coins
+   * @then The reconstructed instance should have an identical source, receivedCoins, and spentCoins
+   */
+  test('should round-trip: reconstruct from replayEventsWithChanges values', () => {
+    const { localState, secretKeys, events } = buildLedgerAndEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKeys, events);
+    const [original] = withChanges.changes;
+
+    const reconstructed = new ZswapStateChanges(original.source, [...original.receivedCoins], [...original.spentCoins]);
+
+    expect(reconstructed.source).toEqual(original.source);
+    expect(reconstructed.receivedCoins).toEqual(original.receivedCoins);
+    expect(reconstructed.spentCoins).toEqual(original.spentCoins);
+  });
+
+  /**
+   * Test that the source getter returns a valid hex string.
+   *
+   * @given A ZswapStateChanges obtained by replaying real transaction events
+   * @when Reading the source after reconstructing it via the public constructor
+   * @then Should return a hex-encoded string matching the expected pattern
+   */
+  test('should expose source as a hex-encoded string', () => {
+    const { localState, secretKeys, events } = buildLedgerAndEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKeys, events);
+    const [{ source }] = withChanges.changes;
+
+    const changes = new ZswapStateChanges(source, [], []);
+
+    expect(changes.source).toMatch(HEX_64_REGEX);
+  });
+
+  /**
+   * Test error thrown on invalid source hex string.
+   *
+   * @given A non-hex source string
+   * @when Constructing a ZswapStateChanges instance
+   * @then Should throw an error indicating the source is invalid
+   */
+  test('should throw on invalid source hex string', () => {
+    expect(() => new ZswapStateChanges('not-a-hex-string', [], [])).toThrow();
+  });
+
+  /**
+   * Test error thrown on hex string with the wrong length.
+   *
+   * @given A hex source string that is too short to represent a TransactionHash
+   * @when Constructing a ZswapStateChanges instance
+   * @then Should throw an error
+   */
+  test('should throw on source hex string with wrong length', () => {
+    expect(() => new ZswapStateChanges('deadbeef', [], [])).toThrow();
+  });
+
+  /**
+   * Test error thrown on a malformed coin object.
+   *
+   * @given A valid source but a coin object with missing required fields
+   * @when Constructing a ZswapStateChanges instance
+   * @then Should throw an error indicating the coin is invalid
+   */
+  test('should throw on malformed coin object in receivedCoins', () => {
+    const { localState, secretKeys, events } = buildLedgerAndEvents();
+    const withChanges = localState.replayEventsWithChanges(secretKeys, events);
+    const [{ source }] = withChanges.changes;
+    const invalidCoin = { type: 'not-valid-hex', nonce: 'also-invalid', value: 10n, mt_index: 0n };
+
+    expect(() => new ZswapStateChanges(source, [invalidCoin as never], [])).toThrow();
+  });
+});

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -459,7 +459,7 @@ export class DustState {
 }
 
 export class DustStateChanges {
-  private constructor();
+  constructor(source: string, receivedUtxos: QualifiedDustOutput[], spentUtxos: QualifiedDustOutput[]);
   /**
    * The source of the state change, as a hex-encoded string
    */
@@ -1727,7 +1727,7 @@ export class ZswapChainState {
 }
 
 export class ZswapStateChanges {
-  private constructor();
+  constructor(source: string, receivedCoins: QualifiedShieldedCoinInfo[], spentCoins: QualifiedShieldedCoinInfo[]);
   /**
    * The source of the state change, as a hex-encoded string
    */

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -459,12 +459,12 @@ export class DustState {
 }
 
 export class DustStateChanges {
-  constructor(source: string, receivedUtxos: QualifiedDustOutput[], spentUtxos: QualifiedDustOutput[]);
+  constructor(source: TransactionHash, receivedUtxos: QualifiedDustOutput[], spentUtxos: QualifiedDustOutput[]);
   toString(compact?: boolean): string;
   /**
    * The source of the state change, as a hex-encoded string
    */
-  readonly source: string;
+  readonly source: TransactionHash;
   /**
    * The UTXOs that were received in this state change
    */
@@ -1728,12 +1728,12 @@ export class ZswapChainState {
 }
 
 export class ZswapStateChanges {
-  constructor(source: string, receivedCoins: QualifiedShieldedCoinInfo[], spentCoins: QualifiedShieldedCoinInfo[]);
+  constructor(source: TransactionHash, receivedCoins: QualifiedShieldedCoinInfo[], spentCoins: QualifiedShieldedCoinInfo[]);
   toString(compact?: boolean): string;
   /**
    * The source of the state change, as a hex-encoded string
    */
-  readonly source: string;
+  readonly source: TransactionHash;
   /**
    * The coins that were received in this state change
    */

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -460,6 +460,7 @@ export class DustState {
 
 export class DustStateChanges {
   constructor(source: string, receivedUtxos: QualifiedDustOutput[], spentUtxos: QualifiedDustOutput[]);
+  toString(compact?: boolean): string;
   /**
    * The source of the state change, as a hex-encoded string
    */
@@ -1728,6 +1729,7 @@ export class ZswapChainState {
 
 export class ZswapStateChanges {
   constructor(source: string, receivedCoins: QualifiedShieldedCoinInfo[], spentCoins: QualifiedShieldedCoinInfo[]);
+  toString(compact?: boolean): string;
   /**
    * The source of the state change, as a hex-encoded string
    */

--- a/ledger-wasm/src/state_changes.rs
+++ b/ledger-wasm/src/state_changes.rs
@@ -76,6 +76,15 @@ impl ZswapStateChanges {
         }
         Ok(coins)
     }
+
+    #[wasm_bindgen(js_name = "toString")]
+    pub fn to_string(&self, compact: Option<bool>) -> String {
+        if compact.unwrap_or(false) {
+            format!("{:?}", &self.inner)
+        } else {
+            format!("{:#?}", &self.inner)
+        }
+    }
 }
 
 impl From<LedgerZswapStateChanges> for ZswapStateChanges {
@@ -138,6 +147,15 @@ impl DustStateChanges {
             utxos.push(&qdo_to_value(utxo)?);
         }
         Ok(utxos)
+    }
+
+    #[wasm_bindgen(js_name = "toString")]
+    pub fn to_string(&self, compact: Option<bool>) -> String {
+        if compact.unwrap_or(false) {
+            format!("{:?}", &self.inner)
+        } else {
+            format!("{:#?}", &self.inner)
+        }
     }
 }
 

--- a/ledger-wasm/src/state_changes.rs
+++ b/ledger-wasm/src/state_changes.rs
@@ -30,6 +30,30 @@ pub struct ZswapStateChanges {
 
 #[wasm_bindgen]
 impl ZswapStateChanges {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        source: &str,
+        received_coins: Vec<JsValue>,
+        spent_coins: Vec<JsValue>,
+    ) -> Result<ZswapStateChanges, JsError> {
+        let source = from_hex_ser(source)?;
+        let received_coins = received_coins
+            .into_iter()
+            .map(value_to_qualified_shielded_coininfo)
+            .collect::<Result<Vec<_>, _>>()?;
+        let spent_coins = spent_coins
+            .into_iter()
+            .map(value_to_qualified_shielded_coininfo)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ZswapStateChanges {
+            inner: LedgerZswapStateChanges {
+                source,
+                received_coins,
+                spent_coins,
+            },
+        })
+    }
+
     #[wasm_bindgen(getter)]
     pub fn source(&self) -> Result<String, JsError> {
         to_hex_ser(&self.inner.source)
@@ -69,6 +93,30 @@ pub struct DustStateChanges {
 
 #[wasm_bindgen]
 impl DustStateChanges {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        source: &str,
+        received_utxos: Vec<JsValue>,
+        spent_utxos: Vec<JsValue>,
+    ) -> Result<DustStateChanges, JsError> {
+        let source = from_hex_ser(source)?;
+        let received_utxos = received_utxos
+            .into_iter()
+            .map(value_to_qdo)
+            .collect::<Result<Vec<_>, _>>()?;
+        let spent_utxos = spent_utxos
+            .into_iter()
+            .map(value_to_qdo)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(DustStateChanges {
+            inner: LedgerDustStateChanges {
+                source,
+                received_utxos,
+                spent_utxos,
+            },
+        })
+    }
+
     #[wasm_bindgen(getter)]
     pub fn source(&self) -> Result<String, JsError> {
         to_hex_ser(&self.inner.source)

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -1365,7 +1365,7 @@ pub struct DustLocalState<D: DB> {
 }
 tag_enforcement_test!(DustLocalState<InMemoryDB>);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DustStateChanges {
     pub received_utxos: Vec<QualifiedDustOutput>,
     pub spent_utxos: Vec<QualifiedDustOutput>,

--- a/ledger/src/zswap.rs
+++ b/ledger/src/zswap.rs
@@ -14,7 +14,7 @@
 use crate::structure::TransactionHash;
 use coin_structure::coin::QualifiedInfo;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ZswapStateChanges {
     pub received_coins: Vec<QualifiedInfo>,
     pub spent_coins: Vec<QualifiedInfo>,


### PR DESCRIPTION
## Description

This PR adds Wasm constructors for DustStateChanges and ZswapStateChanges classes

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
