### PR TITLE
Add a helper for constructing the first dust nonce

### DIFF
--- a/integration-tests/src/test/no-proving/DustLocalState.test.ts
+++ b/integration-tests/src/test/no-proving/DustLocalState.test.ts
@@ -39,6 +39,7 @@ import {
   dustCommitment,
   dustInitialNonce,
   dustNonce,
+  dustFirstNonce,
   dustNullifier
 } from '@midnight-ntwrk/ledger';
 import { expect } from 'vitest';
@@ -1424,6 +1425,8 @@ describe('Ledger API - DustLocalState', () => {
     // we can't calculate the nonce for seq=0
     expect(qdo.seq).toEqual(0);
     expect(() => dustNonce(qdo.backingNight, BigInt(qdo.seq), secretKey)).toThrow();
+    const firstNonce = dustFirstNonce(qdo.backingNight, qdo.owner);
+    expect(firstNonce).toEqual(qdo.nonce);
 
     const newCommitmentIndex = qdo.mtIndex + 1n;
     const fee = 1000n;

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -1517,6 +1517,11 @@ export function dustNullifier(qdo: QualifiedDustOutput, sk: DustSecretKey): Dust
 export function dustNonce(initialNonce: DustInitialNonce, seq: bigint, sk: DustSecretKey): DustNonce;
 
 /**
+ * Calculate Dust first nonce (when seq=0)
+ */
+export function dustFirstNonce(backingNight: DustInitialNonce, dustAddress: DustPublicKey): DustNonce;
+
+/**
  * Calculate Dust initial nonce (a backing night hash)
  */
 export function dustInitialNonce(outputNo: bigint, intentHash: IntentHash): DustInitialNonce;

--- a/ledger-wasm/src/lib.rs
+++ b/ledger-wasm/src/lib.rs
@@ -44,7 +44,7 @@ use conversions::{
 use js_sys::{Array, BigInt, Map, Reflect, Uint8Array};
 use ledger::{
     self,
-    dust::InitialNonce,
+    dust::{InitialNonce, DustPublicKey},
     structure::{FEE_TOKEN, IntentHash, ProofPreimageVersioned},
 };
 use rand::Rng;
@@ -159,13 +159,19 @@ pub fn dust_nonce(initial_nonce: String, seq: u64, sk: &DustSecretKey) -> Result
         return Err(JsError::new("seq exceeded u32 max"));
     }
     if seq == 0 {
-        return Err(JsError::new(
-            "for seq=0 we use DustPublicKey instead of DustSecretKey",
-        ));
+        return Err(JsError::new("for seq=0 use dustFirstNonce()"));
     }
     let initial_nonce = InitialNonce(from_hex_ser(&initial_nonce)?);
     let sk = sk.try_unwrap()?;
     let nonce = ledger::dust::dust_nonce(&initial_nonce, seq as u32, &sk);
+    Ok(fr_to_bigint(nonce))
+}
+
+#[wasm_bindgen(js_name = "dustFirstNonce")]
+pub fn dust_first_nonce(backing_night: String, dust_address: BigInt) -> Result<BigInt, JsError> {
+    let initial_nonce = InitialNonce(from_hex_ser(&backing_night)?);
+    let dust_address = DustPublicKey(bigint_to_fr(dust_address)?);
+    let nonce = ledger::dust::dust_first_nonce(&initial_nonce, &dust_address);
     Ok(fr_to_bigint(nonce))
 }
 

--- a/ledger-wasm/src/lib.rs
+++ b/ledger-wasm/src/lib.rs
@@ -44,7 +44,7 @@ use conversions::{
 use js_sys::{Array, BigInt, Map, Reflect, Uint8Array};
 use ledger::{
     self,
-    dust::{InitialNonce, DustPublicKey},
+    dust::{DustPublicKey, InitialNonce},
     structure::{FEE_TOKEN, IntentHash, ProofPreimageVersioned},
 };
 use rand::Rng;

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -261,6 +261,10 @@ pub fn dust_nonce(initial_nonce: &InitialNonce, seq: u32, sk: &DustSecretKey) ->
     transient_hash((*initial_nonce, seq, sk.0).field_vec().as_ref())
 }
 
+pub fn dust_first_nonce(initial_nonce: &InitialNonce, dust_addr: &DustPublicKey) -> Fr {
+    transient_hash((*initial_nonce, 0u32, *dust_addr).field_vec().as_ref())
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serializable, Storable, FieldRepr)]
 #[storable(base)]
 #[tag = "dust-output[v1]"]
@@ -1091,11 +1095,10 @@ impl<D: DB> DustState<D> {
         mut event_push: impl FnMut(Box<dyn FnOnce() -> EventDetails<D>>),
     ) -> Result<Self, DustStateError> {
         let mut state = self.clone();
-        let seq = 0u32;
         let dust_pre_projection = DustPreProjection {
             initial_value,
             owner: dust_addr,
-            nonce: transient_hash((initial_nonce, seq, dust_addr).field_vec().as_ref()),
+            nonce: dust_first_nonce(&initial_nonce, &dust_addr),
             ctime: tnow,
         };
         let dust_commitment = dust_pre_projection.commitment();


### PR DESCRIPTION
## Description

This PR adds a new Wasm API method to construct the first Dust nonce

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
