### PR TITLE
fix: ensure metadata_lock for track_lazy and sp lazy calls

### DIFF
--- a/CHANGELOG_storage_core.md
+++ b/CHANGELOG_storage_core.md
@@ -10,6 +10,7 @@
 - feat: allow shared parity_db backend through generic Dere
 - fix: remove pending Update from memory before cache_insert_new_key in get()
 - fix: Respect lock ordering in `force_as_arc`
+- fix: hold metadata lock across `track_lazy` and `Sp::lazy` in `BackendLoader::get` lazy path to prevent a panic when a concurrent drop removes the ref-counted entry between the two calls
 
 ## Version `1.1.0`
 

--- a/storage-core/src/arena.rs
+++ b/storage-core/src/arena.rs
@@ -973,15 +973,19 @@ impl<D: DB> Loader<D> for BackendLoader<'_, D> {
         child: &ArenaKey<<D as DB>::Hasher>,
     ) -> Result<Sp<T, D>, std::io::Error> {
         if self.max_depth == Some(0) {
-            if let ArenaKey::Ref(key) = child {
-                self.arena
-                    .track_lazy(&self.arena.lock_metadata(), key.clone(), child);
-            }
-            return Ok(Sp::lazy(
-                self.arena.clone(),
-                child.hash().clone(),
-                child.clone(),
-            ));
+            let sp = {
+                let metadata_lock = self.arena.lock_metadata();
+                if let ArenaKey::Ref(key) = child {
+                    self.arena
+                        .track_lazy(&metadata_lock, key.clone(), child);
+                }
+                Sp::lazy(
+                    self.arena.clone(),
+                    child.hash().clone(),
+                    child.clone(),
+                )
+            };
+            return Ok(sp);
         }
         #[cfg(feature = "test-utilities")]
         let _tracker = ConstructTracker(std::any::type_name::<T>(), std::time::Instant::now());


### PR DESCRIPTION
## Description

Hold the metadata lock across `track_lazy` and `Sp::lazy` on the shallow lazy-load path so a concurrent drop cannot remove the entry between the two calls and trigger a panic.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [X] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
