### PR TITLE
Allow setting dust sync time

### DIFF
--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -522,7 +522,7 @@ export class DustLocalState {
   toString(compact?: boolean): string;
   readonly utxos: QualifiedDustOutput[];
   readonly params: DustParameters;
-  readonly syncTime: Date;
+  syncTime: Date;
   readonly generatingTreeFirstFree: bigint;
   readonly commitmentTreeFirstFree: bigint;
 }

--- a/ledger-wasm/src/dust.rs
+++ b/ledger-wasm/src/dust.rs
@@ -1586,6 +1586,13 @@ impl DustLocalState {
     pub fn sync_time(&self) -> Date {
         seconds_to_js_date(self.0.sync_time.to_secs())
     }
+
+    #[wasm_bindgen(setter, js_name = "syncTime")]
+    pub fn set_sync_time(&mut self, sync_time: &Date) -> Result<(), JsError> {
+        let sync_time = Timestamp::from_secs(js_date_to_seconds(sync_time));
+        self.0.sync_time = sync_time;
+        Ok(())
+    }
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
## Description

Currently, the dust sync time could only be set via the processed events.
This PR allows setting it manually, which is required by the event-less sync model.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
