### PR TITLE
Add locked => treasury/reserve gestures.

### DIFF
--- a/.tag-decompositions/system-transaction[v8]
+++ b/.tag-decompositions/system-transaction[v8]
@@ -1,0 +1,1 @@
+[(ledger-parameters[v6]),(claim-kind[v1],vec(output-instruction-unshielded[v1])),(u128),(vec(output-instruction-shielded[v2]),array(u8,32),shielded-token-type[v1]),(vec(output-instruction-unshielded[v1]),unshielded-token-type[v1]),(u128),(vec(cnight-generates-dust-event[v1])),(u128),(u128)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 - feat: add explicit price floor, denominated in full blocks, and governed by
   ledger parameters.
+- feat: add `UnlockToTreasury` system transaction, moving funds from the locked
+  pool to the treasury.
 - fix: correctly exclude the identity point during coin ciphertext decryption
 
 ## Unreleased (8.2)

--- a/ledger-wasm/src/state.rs
+++ b/ledger-wasm/src/state.rs
@@ -231,7 +231,7 @@ impl LedgerState {
     ) -> Result<LedgerState, JsError> {
         let address: UserAddress = from_hex_ser(user_address)?;
         let amount = u128::try_from(amount).map_err(|_| JsError::new("amount is out of range"))?;
-        let sys_tx_distribute = ledger::structure::SystemTransaction::DistributeReserve(amount);
+        let sys_tx_distribute = ledger::structure::SystemTransaction::DistributeReserve { amount };
         let time = Timestamp::from_secs(js_date_to_seconds(tblock));
         let (ledger, _) = self.0.apply_system_tx(&sys_tx_distribute, time)?;
 

--- a/ledger/benches/benchmarking.rs
+++ b/ledger/benches/benchmarking.rs
@@ -133,7 +133,9 @@ pub fn rewards(c: &mut Criterion) {
     let mut ledger_state: LedgerState<InMemoryDB> = LedgerState::new("local-test");
     ledger_state = ledger_state
         .apply_system_tx(
-            &SystemTransaction::DistributeReserve(ledger_state.reserve_pool),
+            &SystemTransaction::DistributeReserve {
+                amount: ledger_state.reserve_pool,
+            },
             Timestamp::from_secs(0),
         )
         .unwrap()

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -721,6 +721,32 @@ impl<D: DB> LedgerState<D> {
                 let res = (state, vec![]);
                 Ok(res)
             }
+            SystemTransaction::UnlockToTreasury { amount } => {
+                if *amount > self.locked_pool {
+                    error!(?amount, supply = ?self.block_reward_pool, "[privileged] unlock to treasury rejected due to insufficient locked pool");
+                    return Err(SystemTransactionError::IllegalPayout {
+                        claimed_amount: None,
+                        supply: self.block_reward_pool,
+                        bridged_amount: Some(*amount),
+                        locked: self.locked_pool,
+                    });
+                }
+                info!(?amount, supply_before = ?self.block_reward_pool, "[privileged] unlock to treasury");
+                let mut treasury = self.treasury.clone();
+                let native_token = treasury
+                    .get(&TokenType::Unshielded(NIGHT))
+                    .copied()
+                    .unwrap_or(0)
+                    .saturating_add(*amount);
+                treasury = treasury.insert(TokenType::Unshielded(NIGHT), native_token);
+                let state = LedgerState {
+                    locked_pool: self.locked_pool - *amount,
+                    treasury,
+                    ..self.clone()
+                };
+                let res = (state, vec![]);
+                Ok(res)
+            }
             // NOTE: Treasury payments have been completely disabled until governance for the
             // treasury has been agreed. All code has been commented out to maximize clarity.
             SystemTransaction::PayFromTreasuryShielded { .. }
@@ -1316,7 +1342,8 @@ impl<D: DB> LedgerState<D> {
     ) -> Result<GuaranteedApplyResult<D>, TransactionInvalid<D>> {
         match &tx.inner {
             Transaction::Standard(stx) => {
-                let (state, deferred_events) = self.apply_section(stx, tx.hash, tx.fees, 0, context)?;
+                let (state, deferred_events) =
+                    self.apply_section(stx, tx.hash, tx.fees, 0, context)?;
                 debug!(
                     "state transition: {:?} => {:?} [transaction {:?}; guaranteed]",
                     self.state_hash(),
@@ -2290,7 +2317,8 @@ mod tests {
         let expected_fee = basis_points_of(
             INITIAL_PARAMETERS.cardano_to_midnight_bridge_fee_basis_points,
             amount,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             new_state
                 .bridge_receiving

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -718,6 +718,7 @@ impl<D: DB> LedgerState<D> {
                     treasury,
                     ..self.clone()
                 };
+                state.check_night_balance_invariant()?;
                 let res = (state, vec![]);
                 Ok(res)
             }
@@ -744,6 +745,7 @@ impl<D: DB> LedgerState<D> {
                     treasury,
                     ..self.clone()
                 };
+                state.check_night_balance_invariant()?;
                 let res = (state, vec![]);
                 Ok(res)
             }
@@ -976,7 +978,7 @@ impl<D: DB> LedgerState<D> {
                 state.dust = Sp::new(dust_state);
                 Ok((state, events))
             }
-            SystemTransaction::DistributeReserve(amount) => {
+            SystemTransaction::DistributeReserve { amount } => {
                 if *amount > self.reserve_pool {
                     error!(?amount, reserve_supply = ?self.reserve_pool, "[privileged] reserve distribution rejected due to insufficient reserve supply");
                     return Err(SystemTransactionError::IllegalReserveDistribution {
@@ -991,6 +993,31 @@ impl<D: DB> LedgerState<D> {
                 let new_st = LedgerState {
                     reserve_pool,
                     block_reward_pool,
+                    ..self.clone()
+                };
+
+                new_st.check_night_balance_invariant()?;
+
+                Ok((new_st, vec![]))
+            }
+            SystemTransaction::UnlockToReserve { amount } => {
+                if *amount > self.locked_pool {
+                    error!(?amount, supply = ?self.block_reward_pool, "[privileged] unlock to reserve rejected due to insufficient locked pool");
+                    return Err(SystemTransactionError::IllegalPayout {
+                        claimed_amount: None,
+                        supply: self.block_reward_pool,
+                        bridged_amount: Some(*amount),
+                        locked: self.locked_pool,
+                    });
+                }
+                info!(?amount, supply_before = ?self.block_reward_pool, "[privileged] unlock to reserve");
+
+                let locked_pool = self.locked_pool - *amount;
+                let reserve_pool = self.reserve_pool + *amount;
+
+                let new_st = LedgerState {
+                    reserve_pool,
+                    locked_pool,
                     ..self.clone()
                 };
 

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -732,11 +732,16 @@ pub enum SystemTransaction {
         outputs: Vec<OutputInstructionUnshielded>,
         token_type: UnshieldedTokenType,
     },
-    DistributeReserve(u128),
+    DistributeReserve {
+        amount: u128,
+    },
     CNightGeneratesDustUpdate {
         events: Vec<CNightGeneratesDustEvent>,
     },
     UnlockToTreasury {
+        amount: u128,
+    },
+    UnlockToReserve {
         amount: u128,
     },
 }
@@ -2315,7 +2320,7 @@ impl SystemTransaction {
                 );
                 cost
             }
-            DistributeReserve(..) => {
+            DistributeReserve { .. } | UnlockToReserve { .. } => {
                 // changing two pool balances
                 let cost = model.cell_read(16) + model.cell_write(16, true);
                 cost * 2u64

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -712,7 +712,7 @@ pub struct CardanoBridge {
 tag_enforcement_test!(CardanoBridge);
 
 #[derive(Clone, Debug, PartialEq, Serializable, Storable)]
-#[tag = "system-transaction[v7]"]
+#[tag = "system-transaction[v8]"]
 #[storable(base)]
 #[non_exhaustive]
 // TODO: Getting `Box` to serialize is a pain right now. Revisit later.
@@ -735,6 +735,9 @@ pub enum SystemTransaction {
     DistributeReserve(u128),
     CNightGeneratesDustUpdate {
         events: Vec<CNightGeneratesDustEvent>,
+    },
+    UnlockToTreasury {
+        amount: u128,
     },
 }
 tag_enforcement_test!(SystemTransaction);
@@ -2263,7 +2266,7 @@ impl SystemTransaction {
                 // n offers
                 cost * outputs.len()
             }
-            PayBlockRewardsToTreasury { .. } => {
+            PayBlockRewardsToTreasury { .. } | UnlockToTreasury { .. } => {
                 let mut cost = RunningCost::ZERO;
                 cost += model.cell_read(16) + model.cell_write(16, true);
                 cost += model.map_index(EXPECTED_TOKEN_TYPE_DEPTH);

--- a/ledger/src/test_utilities.rs
+++ b/ledger/src/test_utilities.rs
@@ -193,7 +193,7 @@ impl<D: DB> TestState<D> {
         let address = UserAddress::from(self.night_key.verifying_key());
 
         // Distribute reserve
-        let sys_tx_distribute = SystemTransaction::DistributeReserve(amount);
+        let sys_tx_distribute = SystemTransaction::DistributeReserve { amount };
 
         let (ledger, _) = self
             .ledger

--- a/ledger/tests/system_tx.rs
+++ b/ledger/tests/system_tx.rs
@@ -42,7 +42,7 @@ async fn system_tx_pay_from_unshielded() {
     let address = UserAddress::from(verifying_key.clone());
 
     // Distribute reserve
-    let sys_tx_distribute = SystemTransaction::DistributeReserve(500_000);
+    let sys_tx_distribute = SystemTransaction::DistributeReserve { amount: 500_000 };
 
     let (ledger, _) = state
         .ledger
@@ -175,6 +175,40 @@ async fn system_tx_unlock_to_treasury_insufficient_locked_pool() {
             .expect("genesis settings should be valid");
 
     let sys_tx = SystemTransaction::UnlockToTreasury { amount: locked + 1 };
+    let result = ledger_state.apply_system_tx(&sys_tx, Timestamp::from_secs(0));
+    assert!(
+        result.is_err(),
+        "should reject unlock exceeding locked pool"
+    );
+}
+
+#[tokio::test]
+async fn system_tx_unlock_to_reserve() {
+    let locked = 500_000;
+    let reserve = MAX_SUPPLY - locked;
+    let ledger_state: LedgerState<InMemoryDB> =
+        LedgerState::with_genesis_settings("local-test", INITIAL_PARAMETERS, locked, reserve, 0)
+            .expect("genesis settings should be valid");
+
+    let amount = 200_000;
+    let sys_tx = SystemTransaction::UnlockToReserve { amount };
+    let (ledger_state, _) = ledger_state
+        .apply_system_tx(&sys_tx, Timestamp::from_secs(0))
+        .expect("unlock to reserve should succeed");
+
+    assert_eq!(ledger_state.locked_pool, locked - amount);
+    assert_eq!(ledger_state.reserve_pool, reserve + amount);
+}
+
+#[tokio::test]
+async fn system_tx_unlock_to_reserve_insufficient_locked_pool() {
+    let locked = 100_000;
+    let reserve = MAX_SUPPLY - locked;
+    let ledger_state: LedgerState<InMemoryDB> =
+        LedgerState::with_genesis_settings("local-test", INITIAL_PARAMETERS, locked, reserve, 0)
+            .expect("genesis settings should be valid");
+
+    let sys_tx = SystemTransaction::UnlockToReserve { amount: locked + 1 };
     let result = ledger_state.apply_system_tx(&sys_tx, Timestamp::from_secs(0));
     assert!(
         result.is_err(),

--- a/ledger/tests/system_tx.rs
+++ b/ledger/tests/system_tx.rs
@@ -13,11 +13,12 @@
 
 use base_crypto::rng::SplittableRng;
 use base_crypto::time::Timestamp;
+use coin_structure::coin::NIGHT;
 use coin_structure::coin::{SecretKey, TokenType, UserAddress};
 use lazy_static::lazy_static;
 use midnight_ledger::structure::{
-    ClaimKind, ClaimRewardsTransaction, LedgerState, MAX_SUPPLY, OutputInstructionShielded,
-    OutputInstructionUnshielded, SystemTransaction, Transaction,
+    ClaimKind, ClaimRewardsTransaction, INITIAL_PARAMETERS, LedgerState, MAX_SUPPLY,
+    OutputInstructionShielded, OutputInstructionUnshielded, SystemTransaction, Transaction,
 };
 use midnight_ledger::test_utilities::tx_prove;
 use midnight_ledger::test_utilities::{Resolver, TestState, test_resolver};
@@ -138,4 +139,45 @@ async fn system_tx_pay_from_shielded() {
         0
     );
     // Would be nice to add an assert to confirm the tokens went to the right place
+}
+
+#[tokio::test]
+async fn system_tx_unlock_to_treasury() {
+    let locked = 500_000;
+    let reserve = MAX_SUPPLY - locked;
+    let ledger_state: LedgerState<InMemoryDB> =
+        LedgerState::with_genesis_settings("local-test", INITIAL_PARAMETERS, locked, reserve, 0)
+            .expect("genesis settings should be valid");
+
+    let amount = 200_000;
+    let sys_tx = SystemTransaction::UnlockToTreasury { amount };
+    let (ledger_state, _) = ledger_state
+        .apply_system_tx(&sys_tx, Timestamp::from_secs(0))
+        .expect("unlock to treasury should succeed");
+
+    assert_eq!(ledger_state.locked_pool, locked - amount);
+    assert_eq!(
+        ledger_state
+            .treasury
+            .get(&coin_structure::coin::TokenType::Unshielded(NIGHT))
+            .copied()
+            .unwrap_or(0),
+        amount
+    );
+}
+
+#[tokio::test]
+async fn system_tx_unlock_to_treasury_insufficient_locked_pool() {
+    let locked = 100_000;
+    let reserve = MAX_SUPPLY - locked;
+    let ledger_state: LedgerState<InMemoryDB> =
+        LedgerState::with_genesis_settings("local-test", INITIAL_PARAMETERS, locked, reserve, 0)
+            .expect("genesis settings should be valid");
+
+    let sys_tx = SystemTransaction::UnlockToTreasury { amount: locked + 1 };
+    let result = ledger_state.apply_system_tx(&sys_tx, Timestamp::from_secs(0));
+    assert!(
+        result.is_err(),
+        "should reject unlock exceeding locked pool"
+    );
 }


### PR DESCRIPTION
## Description

System transaction to move funds from the locked pool into the treasury. This mirrors the block rewards => treasury flow, and will be used the the protocol bridge.
Similarly, adds a new locked pool => reserve gesture.

## Sanity Checklist

This PR:
- [X] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [X] contains breaking API changes [^1][^2]
- [X] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
