### PR TITLE
Refactor dust successor's calculation

### DIFF
--- a/integration-tests/src/test/no-proving/DustLocalState.test.ts
+++ b/integration-tests/src/test/no-proving/DustLocalState.test.ts
@@ -1421,6 +1421,7 @@ describe('Ledger API - DustLocalState', () => {
     const localState = state.dust;
     const { secretKey } = state.dustKey;
     const qdo = localState.utxos[0];
+    const genInfo = localState.generationInfo(qdo)!;
 
     // we can't calculate the nonce for seq=0
     expect(qdo.seq).toEqual(0);
@@ -1431,7 +1432,7 @@ describe('Ledger API - DustLocalState', () => {
     const newCommitmentIndex = qdo.mtIndex + 1n;
     const fee = 1000n;
 
-    const newUtxo = localState.successorUtxo(qdo, state.time, fee, newCommitmentIndex, secretKey);
+    const newUtxo = localState.successorUtxo(qdo, state.time, fee, newCommitmentIndex, genInfo, secretKey);
     const calculatedNonce = dustNonce(qdo.backingNight, BigInt(newUtxo.seq), secretKey);
 
     expect(calculatedNonce).toEqual(newUtxo.nonce);

--- a/integration-tests/src/test/no-proving/DustLocalState.test.ts
+++ b/integration-tests/src/test/no-proving/DustLocalState.test.ts
@@ -1394,7 +1394,7 @@ describe('Ledger API - DustLocalState', () => {
     const now = state.time;
     const fee = 1000n;
     const expectedValue = updatedValue(qdo.ctime, qdo.initialValue, genInfo, state.time, initialParameters) - fee;
-    const newUtxo = localState.successorUtxo(qdo, state.time, fee, newCommitmentIndex, secretKey);
+    const newUtxo = localState.successorUtxo(qdo, state.time, fee, newCommitmentIndex, genInfo, secretKey);
 
     expect(newUtxo.seq).toEqual(qdo.seq + 1);
     expect(newUtxo.ctime).toEqual(now);

--- a/integration-tests/src/test/no-proving/DustLocalState.test.ts
+++ b/integration-tests/src/test/no-proving/DustLocalState.test.ts
@@ -40,7 +40,8 @@ import {
   dustInitialNonce,
   dustNonce,
   dustFirstNonce,
-  dustNullifier
+  dustNullifier,
+  successorDustUtxo
 } from '@midnight-ntwrk/ledger';
 import { expect } from 'vitest';
 import { ProofMarker, SignatureMarker } from '@/test/utils/Markers';
@@ -1377,7 +1378,7 @@ describe('Ledger API - DustLocalState', () => {
   });
 
   /**
-   * Test utility methods - successorUtxo
+   * Test utility methods - successorDustUtxo
    *
    * @given A DustLocalState with a UTXO
    * @when Calling successorUtxo to get the next UTXO with a reduced value
@@ -1394,7 +1395,7 @@ describe('Ledger API - DustLocalState', () => {
     const now = state.time;
     const fee = 1000n;
     const expectedValue = updatedValue(qdo.ctime, qdo.initialValue, genInfo, state.time, initialParameters) - fee;
-    const newUtxo = localState.successorUtxo(qdo, state.time, fee, newCommitmentIndex, genInfo, secretKey);
+    const newUtxo = successorDustUtxo(qdo, state.time, fee, newCommitmentIndex, genInfo, secretKey, initialParameters);
 
     expect(newUtxo.seq).toEqual(qdo.seq + 1);
     expect(newUtxo.ctime).toEqual(now);
@@ -1432,7 +1433,7 @@ describe('Ledger API - DustLocalState', () => {
     const newCommitmentIndex = qdo.mtIndex + 1n;
     const fee = 1000n;
 
-    const newUtxo = localState.successorUtxo(qdo, state.time, fee, newCommitmentIndex, genInfo, secretKey);
+    const newUtxo = successorDustUtxo(qdo, state.time, fee, newCommitmentIndex, genInfo, secretKey, initialParameters);
     const calculatedNonce = dustNonce(qdo.backingNight, BigInt(newUtxo.seq), secretKey);
 
     expect(calculatedNonce).toEqual(newUtxo.nonce);

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -516,7 +516,7 @@ export class DustLocalState {
   /**
    * Returns a new UTXO with a reduced value and the sequential nonce
    */
-  successorUtxo(qdo: QualifiedDustOutput, now: Date, subtract_fee: bigint, new_commitment_index: bigint, sk: DustSecretKey): QualifiedDustOutput;
+  successorUtxo(qdo: QualifiedDustOutput, now: Date, subtractFee: bigint, newCommitmentIndex: bigint, genInfo: DustGenerationInfo, sk: DustSecretKey): QualifiedDustOutput;
   serialize(): Uint8Array;
   static deserialize(raw: Uint8Array): DustLocalState;
   toString(compact?: boolean): string;

--- a/ledger-wasm/ledger-v8.template.d.ts
+++ b/ledger-wasm/ledger-v8.template.d.ts
@@ -513,10 +513,6 @@ export class DustLocalState {
   addUtxo(nullifier: DustNullifier, utxo: QualifiedDustOutput, pendingUntil?: Date): DustLocalState;
   findUtxoByNullifier(nullifier: DustNullifier): QualifiedDustOutput | undefined;
   removeUtxo(nullifier: DustNullifier): DustLocalState;
-  /**
-   * Returns a new UTXO with a reduced value and the sequential nonce
-   */
-  successorUtxo(qdo: QualifiedDustOutput, now: Date, subtractFee: bigint, newCommitmentIndex: bigint, genInfo: DustGenerationInfo, sk: DustSecretKey): QualifiedDustOutput;
   serialize(): Uint8Array;
   static deserialize(raw: Uint8Array): DustLocalState;
   toString(compact?: boolean): string;
@@ -1525,6 +1521,11 @@ export function dustFirstNonce(backingNight: DustInitialNonce, dustAddress: Dust
  * Calculate Dust initial nonce (a backing night hash)
  */
 export function dustInitialNonce(outputNo: bigint, intentHash: IntentHash): DustInitialNonce;
+
+/**
+ * Returns a new Dust UTXO with a reduced value and the sequential nonce
+ */
+export function successorDustUtxo(qdo: QualifiedDustOutput, now: Date, subtractFee: bigint, newCommitmentIndex: bigint, genInfo: DustGenerationInfo, sk: DustSecretKey, dustParams: DustParameters): QualifiedDustOutput;
 
 /**
  * Parameters used by the Midnight ledger, including transaction fees and

--- a/ledger-wasm/src/dust.rs
+++ b/ledger-wasm/src/dust.rs
@@ -1525,6 +1525,7 @@ impl DustLocalState {
         now: &Date,
         subtract_fee: BigInt,
         new_commitment_index: BigInt,
+        gen_info: JsValue,
         sk: &DustSecretKey,
     ) -> Result<JsValue, JsError> {
         let qdo = value_to_qdo(utxo)?;
@@ -1533,10 +1534,16 @@ impl DustLocalState {
             .map_err(|_| JsError::new("subtract_fee is out of range"))?;
         let new_commitment_index = u64::try_from(new_commitment_index)
             .map_err(|_| JsError::new("new_commitment_index is out of range"))?;
+        let gen_info = value_to_dust_gen_info(gen_info)?;
         let sk = sk.try_unwrap()?;
-        let new_utxo =
-            self.0
-                .successor_utxo(&qdo, &now, subtract_fee, new_commitment_index, &sk)?;
+        let new_utxo = self.0.successor_utxo(
+            &qdo,
+            &now,
+            subtract_fee,
+            new_commitment_index,
+            &gen_info,
+            &sk,
+        );
         qdo_to_value(&new_utxo)
     }
 

--- a/ledger-wasm/src/dust.rs
+++ b/ledger-wasm/src/dust.rs
@@ -26,7 +26,7 @@ use ledger::dust::{
     DustRegistration as LedgerDustRegistration, DustSecretKey as LedgerDustSecretKey,
     DustSpend as LedgerDustSpend, DustState as LedgerDustState,
     DustUtxoState as LedgerDustUtxoState, InitialNonce,
-    WithDustStateChanges as LedgerWithDustStateChanges,
+    WithDustStateChanges as LedgerWithDustStateChanges, successor_utxo,
 };
 use ledger::structure::{ProofMarker, ProofPreimageMarker, UtxoMeta as LedgerUtxoMeta};
 use onchain_runtime_wasm::{from_value_hex_ser, from_value_ser, to_value_hex_ser};
@@ -1518,35 +1518,6 @@ impl DustLocalState {
         Ok(DustLocalState(new_state))
     }
 
-    #[wasm_bindgen(js_name = "successorUtxo")]
-    pub fn successor_utxo(
-        &self,
-        utxo: JsValue,
-        now: &Date,
-        subtract_fee: BigInt,
-        new_commitment_index: BigInt,
-        gen_info: JsValue,
-        sk: &DustSecretKey,
-    ) -> Result<JsValue, JsError> {
-        let qdo = value_to_qdo(utxo)?;
-        let now = Timestamp::from_secs(js_date_to_seconds(now));
-        let subtract_fee = u128::try_from(subtract_fee)
-            .map_err(|_| JsError::new("subtract_fee is out of range"))?;
-        let new_commitment_index = u64::try_from(new_commitment_index)
-            .map_err(|_| JsError::new("new_commitment_index is out of range"))?;
-        let gen_info = value_to_dust_gen_info(gen_info)?;
-        let sk = sk.try_unwrap()?;
-        let new_utxo = self.0.successor_utxo(
-            &qdo,
-            &now,
-            subtract_fee,
-            new_commitment_index,
-            &gen_info,
-            &sk,
-        );
-        qdo_to_value(&new_utxo)
-    }
-
     pub fn serialize(&self) -> Result<Uint8Array, JsError> {
         let mut res = Vec::new();
         tagged_serialize(&self.0, &mut res)?;
@@ -1624,6 +1595,36 @@ impl UtxoMeta {
         self.0.ctime = ctime;
         Ok(())
     }
+}
+
+#[wasm_bindgen(js_name = "successorDustUtxo")]
+pub fn successor_dust_utxo(
+    utxo: JsValue,
+    now: &Date,
+    subtract_fee: BigInt,
+    new_commitment_index: BigInt,
+    gen_info: JsValue,
+    sk: &DustSecretKey,
+    dust_parameters: &DustParameters,
+) -> Result<JsValue, JsError> {
+    let qdo = value_to_qdo(utxo)?;
+    let now = Timestamp::from_secs(js_date_to_seconds(now));
+    let subtract_fee =
+        u128::try_from(subtract_fee).map_err(|_| JsError::new("subtract_fee is out of range"))?;
+    let new_commitment_index = u64::try_from(new_commitment_index)
+        .map_err(|_| JsError::new("new_commitment_index is out of range"))?;
+    let gen_info = value_to_dust_gen_info(gen_info)?;
+    let sk = sk.try_unwrap()?;
+    let new_utxo = successor_utxo(
+        &qdo,
+        &now,
+        subtract_fee,
+        new_commitment_index,
+        &gen_info,
+        &sk,
+        &dust_parameters.0,
+    );
+    qdo_to_value(&new_utxo)
 }
 
 #[wasm_bindgen(js_name = "updatedValue")]

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -1506,18 +1506,12 @@ impl<D: DB> DustLocalState<D> {
         now: &Timestamp,
         subtract_fee: u128,
         new_commitment_index: u64,
+        gen_info: &DustGenerationInfo,
         sk: &DustSecretKey,
-    ) -> Result<QualifiedDustOutput, DustLocalStateError> {
-        let gen_idx = self.night_indices.get(&utxo.backing_night).ok_or(
-            DustLocalStateError::BackingNightNotFound {
-                backing_night: utxo.backing_night,
-            },
-        )?;
-
-        let gen_info = self.generating_tree.index(*gen_idx).unwrap().1;
+    ) -> QualifiedDustOutput {
         let v_pre_spend = DustOutput::from(*utxo).updated_value(gen_info, *now, &self.params);
         let v_now = v_pre_spend.saturating_sub(subtract_fee);
-        let qdo_new = QualifiedDustOutput {
+        QualifiedDustOutput {
             backing_night: utxo.backing_night,
             ctime: *now,
             initial_value: v_now,
@@ -1525,8 +1519,7 @@ impl<D: DB> DustLocalState<D> {
             nonce: dust_nonce(&utxo.backing_night, utxo.seq + 1, sk),
             owner: utxo.owner,
             mt_index: new_commitment_index,
-        };
-        Ok(qdo_new)
+        }
     }
 
     pub fn generation_info(&self, qdo: &QualifiedDustOutput) -> Option<DustGenerationInfo> {

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -1500,28 +1500,6 @@ impl<D: DB> DustLocalState<D> {
         Ok(state)
     }
 
-    pub fn successor_utxo(
-        &self,
-        utxo: &QualifiedDustOutput,
-        now: &Timestamp,
-        subtract_fee: u128,
-        new_commitment_index: u64,
-        gen_info: &DustGenerationInfo,
-        sk: &DustSecretKey,
-    ) -> QualifiedDustOutput {
-        let v_pre_spend = DustOutput::from(*utxo).updated_value(gen_info, *now, &self.params);
-        let v_now = v_pre_spend.saturating_sub(subtract_fee);
-        QualifiedDustOutput {
-            backing_night: utxo.backing_night,
-            ctime: *now,
-            initial_value: v_now,
-            seq: utxo.seq + 1,
-            nonce: dust_nonce(&utxo.backing_night, utxo.seq + 1, sk),
-            owner: utxo.owner,
-            mt_index: new_commitment_index,
-        }
-    }
-
     pub fn generation_info(&self, qdo: &QualifiedDustOutput) -> Option<DustGenerationInfo> {
         Some(
             *self
@@ -2061,6 +2039,29 @@ impl<D: DB> DustLocalState<D> {
         res.result.commitment_tree = res.result.commitment_tree.rehash();
         res.result.generating_tree = res.result.generating_tree.rehash();
         Ok(res)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn successor_utxo(
+    utxo: &QualifiedDustOutput,
+    now: &Timestamp,
+    subtract_fee: u128,
+    new_commitment_index: u64,
+    gen_info: &DustGenerationInfo,
+    sk: &DustSecretKey,
+    params: &DustParameters,
+) -> QualifiedDustOutput {
+    let v_pre_spend = DustOutput::from(*utxo).updated_value(gen_info, *now, params);
+    let v_now = v_pre_spend.saturating_sub(subtract_fee);
+    QualifiedDustOutput {
+        backing_night: utxo.backing_night,
+        ctime: *now,
+        initial_value: v_now,
+        seq: utxo.seq + 1,
+        nonce: dust_nonce(&utxo.backing_night, utxo.seq + 1, sk),
+        owner: utxo.owner,
+        mt_index: new_commitment_index,
     }
 }
 

--- a/ledger/src/error.rs
+++ b/ledger/src/error.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::dust::{DustGenerationInfo, DustNullifier, DustRegistration, DustSpend, InitialNonce};
+use crate::dust::{DustGenerationInfo, DustNullifier, DustRegistration, DustSpend};
 use crate::error::coin::UserAddress;
 use crate::structure::MAX_SUPPLY;
 use crate::structure::{ClaimKind, ContractOperationVersion, Utxo, UtxoOutput, UtxoSpend};
@@ -1392,9 +1392,6 @@ pub enum DustLocalStateError {
     CommitmentIndexNotFound {
         commitment_index: u64,
     },
-    BackingNightNotFound {
-        backing_night: InitialNonce,
-    },
     MerkleTreeError(InvalidUpdate),
 }
 
@@ -1421,11 +1418,6 @@ impl Display for DustLocalStateError {
             CommitmentIndexNotFound { commitment_index } => write!(
                 f,
                 "failed to find commitment for commitment index {commitment_index}"
-            ),
-            BackingNightNotFound { backing_night } => write!(
-                f,
-                "failed to find generation info for backing night {:?}",
-                backing_night.0
             ),
             MerkleTreeError(err) => err.fmt(f),
         }


### PR DESCRIPTION
## Description

Remove the dependency on the dust generation state in `successor_utxo()` method

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
