### PR TITLE
fix: changed force_as_arc lock hold logic

### DIFF
--- a/CHANGELOG_storage_core.md
+++ b/CHANGELOG_storage_core.md
@@ -11,6 +11,7 @@
 - fix: remove pending Update from memory before cache_insert_new_key in get()
 - fix: Respect lock ordering in `force_as_arc`
 - fix: hold metadata lock across `track_lazy` and `Sp::lazy` in `BackendLoader::get` lazy path to prevent a panic when a concurrent drop removes the ref-counted entry between the two calls
+- fix: avoid holding arena metadata and `Sp` cache locks while `force_as_arc` loads from the backend
 
 ## Version `1.1.0`
 

--- a/storage-core/src/arena.rs
+++ b/storage-core/src/arena.rs
@@ -976,14 +976,9 @@ impl<D: DB> Loader<D> for BackendLoader<'_, D> {
             let sp = {
                 let metadata_lock = self.arena.lock_metadata();
                 if let ArenaKey::Ref(key) = child {
-                    self.arena
-                        .track_lazy(&metadata_lock, key.clone(), child);
+                    self.arena.track_lazy(&metadata_lock, key.clone(), child);
                 }
-                Sp::lazy(
-                    self.arena.clone(),
-                    child.hash().clone(),
-                    child.clone(),
-                )
+                Sp::lazy(self.arena.clone(), child.hash().clone(), child.clone())
             };
             return Ok(sp);
         }
@@ -1637,18 +1632,12 @@ impl<T: Storable<D>, D: DB> Sp<T, D> {
     fn force_as_arc(&self) -> &Arc<T> {
         // Initialize `OnceLock` if necessary.
         if self.data.get().is_none() {
-            // Acquire metadata before sp_cache to respect the documented lock
-            // ordering (metadata → sp_cache → backend; see Arena struct).
-            // from_arena and its callees (track_lazy, increment_ref) also
-            // acquire metadata, but that is safe because the locks are
-            // reentrant. Acquiring sp_cache first would invert the ordering
-            // and deadlock against new_sp_locked (which holds metadata, then
-            // acquires sp_cache).
-            let _metadata_lock = self.arena.lock_metadata();
-            let cache_lock = self.arena.lock_sp_cache();
-            let maybe_arc = self
-                .arena
-                .read_sp_cache_locked::<T>(&cache_lock, &self.root);
+            let maybe_arc = {
+                let _metadata_lock = self.arena.lock_metadata();
+                let cache_lock = self.arena.lock_sp_cache();
+                self.arena
+                    .read_sp_cache_locked::<T>(&cache_lock, &self.root)
+            };
             let arc: Arc<T> = match maybe_arc {
                 Some(arc) => arc,
                 None => {
@@ -1665,23 +1654,20 @@ impl<T: Storable<D>, D: DB> Sp<T, D> {
                                 std::any::type_name::<T>()
                             ),
                         };
-                    let arc = sp
-                        .data
+                    sp.data
                         .take()
-                        .expect("result of Sp::from_arena should be initialized");
-                    if let ArenaKey::Ref(_) = &self.child_repr {
-                        self.arena.write_sp_cache_locked(
-                            &cache_lock,
-                            self.root.clone(),
-                            arc.clone(),
-                        );
-                    }
-                    arc
+                        .expect("result of Sp::from_arena should be initialized")
                 }
             };
             // We don't care if this succeeds: failure just means
             // someone else set the same value in another thread.
             let _ = self.data.set(arc);
+            if let (ArenaKey::Ref(_), Some(arc)) = (&self.child_repr, self.data.get()) {
+                let _metadata_lock = self.arena.lock_metadata();
+                let cache_lock = self.arena.lock_sp_cache();
+                self.arena
+                    .write_sp_cache_locked(&cache_lock, self.root.clone(), arc.clone());
+            }
         }
         self.data.get().unwrap()
     }


### PR DESCRIPTION
## Description

https://github.com/midnightntwrk/midnight-ledger/pull/262 & https://github.com/midnightntwrk/midnight-ledger/pull/499 fixed the ABBA lock-ordering issue by acquiring locks in `metadata -> sp_cache` order, but it held those locks for too long.

On a cache miss, `force_as_arc` called `Sp::from_arena(...)` while still holding both `metadata` and `sp_cache`. That path goes through `BackendLoader::get`, backend access, deserialization, and child `Sp` loading.

Under concurrent collapsed Merkle update walks, one Tokio worker could sit inside that slow or recursive load while holding arena locks, causing other workers to pile up behind those locks. That matches the observed “no panic, no logs, runtime appears parked” symptom.
## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [X] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
