### PR TITLE
Fix `communication_commitment` to hash value-only representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 - fix: fix potential panic in bridge fee processing
 - fix: address non-associativity of Dust event processing.
 - fix: tighten cost heuristic, no longer being overly conservative, moving less transactions to the fallible section.
+- fix: `communication_commitment` now hashes the value-only representation of its inputs.
 
 ## 8.1.0
 

--- a/CHANGELOG_onchain-runtime.md
+++ b/CHANGELOG_onchain-runtime.md
@@ -1,5 +1,9 @@
 # `midnight-onchain-runtime` Changelog
 
+## Unreleased
+
+- fix: `communication_commitment` now hashes the value-only representation of its inputs.
+
 ## Version `3.1.0`
 
 - feat: add more flexibility to `findPathForLeaf`, allowing it to scan index


### PR DESCRIPTION
There are two `communication_commitment` functions which compute `transient_commit` over the input/output pair as a bare `AlignedValue`. `<AlignedValue as FieldRepr>::field_repr` writes the alignment encoding before the value, so the result was a hash of `[alignment.., values..]` rather than of the values alone.

Everything else commits over the value-only representation. `Intent::add_call` builds the commitment that's stored on a ContractCall from `value_only_field_repr` while `StandardTransaction.add_calls` builds the commitment from the alignment encoding. I'm not _certain_ this is a bug but it looks like one.