### PR TITLE
Improve `ClaimRewardTransaction` envelope

### DIFF
--- a/.tag-decompositions/claim-rewards-transaction[v2](())
+++ b/.tag-decompositions/claim-rewards-transaction[v2](())
@@ -1,0 +1,1 @@
+((string,u128,signature-verifying-key[v1],zswap-nonce[v1],(),claim-kind[v1],timestamp))

--- a/.tag-decompositions/transaction[v10]((),(),pedersen[v1])
+++ b/.tag-decompositions/transaction[v10]((),(),pedersen[v1])
@@ -1,0 +1,1 @@
+[(standard-transaction[v9]((),(),pedersen[v1])),(claim-rewards-transaction[v2](()))]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 - feat: add `UnlockToTreasury` system transaction, moving funds from the locked
   pool to the treasury.
 - fix: correctly exclude the identity point during coin ciphertext decryption
+- fix: correct signing envelope for `ClaimRewardsTransaction`, and add TTL to it.
 
 ## Unreleased (8.2)
 

--- a/ledger-wasm/ledger-v9.template.d.ts
+++ b/ledger-wasm/ledger-v9.template.d.ts
@@ -2029,9 +2029,9 @@ export type ClaimKind = "Reward" | "CardanoBridge";
  * A request to allocate rewards, authorized by the reward's recipient
  */
 export class ClaimRewardsTransaction<S extends Signaturish> {
-  constructor(markerS: S['instance'], network_id: string, value: bigint, owner: SignatureVerifyingKey, nonce: Nonce, signature: S, kind?: ClaimKind);
+  constructor(markerS: S['instance'], network_id: string, value: bigint, owner: SignatureVerifyingKey, nonce: Nonce, signature: S, kind: ClaimKind, ttl: Date);
 
-  static new(network_id: string, value: bigint, owner: SignatureVerifyingKey, nonce: Nonce, kind: ClaimKind): ClaimRewardsTransaction<SignatureErased>;
+  static new(network_id: string, value: bigint, owner: SignatureVerifyingKey, nonce: Nonce, kind: ClaimKind, ttl: Date): ClaimRewardsTransaction<SignatureErased>;
 
   addSignature(signature: Signature): ClaimRewardsTransaction<SignatureEnabled>;
 
@@ -2074,6 +2074,12 @@ export class ClaimRewardsTransaction<S extends Signaturish> {
    * The kind of claim being made, either a `Reward` or a `CardanoBridge` claim.
    */
   readonly kind: ClaimKind
+
+  /**
+   * The time this claim expires. Bounds the replay-protection window for the
+   * signed claim; after this time the transaction is no longer accepted.
+   */
+  readonly ttl: Date;
 }
 
 /**

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -1479,16 +1479,14 @@ impl ClaimRewardsTransaction {
         owner: &str,
         nonce: &str,
         signature: JsValue,
-        kind: JsValue,
+        kind: &str,
+        ttl: &Date,
     ) -> Result<ClaimRewardsTransaction, JsError> {
         let owner: schnorr::VerifyingKey = from_value_hex_ser(owner)?;
         let value = u128::try_from(value).map_err(|_| JsError::new("value is out of range"))?;
         let nonce = Nonce(from_hex_ser(nonce)?);
-        let kind = if kind.is_null() || kind.is_undefined() {
-            ledger::structure::ClaimKind::Reward
-        } else {
-            text_to_claim_kind(&String::from(JsString::from(kind)))?
-        };
+        let kind = text_to_claim_kind(kind)?;
+        let ttl = Timestamp::from_secs(js_date_to_seconds(ttl));
 
         use ClaimRewardsTransactionTypes::*;
         use Signaturish::*;
@@ -1506,6 +1504,7 @@ impl ClaimRewardsTransaction {
                     nonce,
                     signature: signature.deref().0.clone(),
                     kind,
+                    ttl,
                 })
             }
             SignatureErased => {
@@ -1519,6 +1518,7 @@ impl ClaimRewardsTransaction {
                     nonce,
                     signature: (),
                     kind,
+                    ttl,
                 })
             }
         }))
@@ -1530,11 +1530,13 @@ impl ClaimRewardsTransaction {
         owner: &str,
         nonce: &str,
         kind: &str,
+        ttl: &Date,
     ) -> Result<ClaimRewardsTransaction, JsError> {
         let owner: schnorr::VerifyingKey = from_value_hex_ser(owner)?;
         let value = u128::try_from(value).map_err(|_| JsError::new("value is out of range"))?;
         let nonce = Nonce(from_hex_ser(nonce)?);
         let kind = text_to_claim_kind(kind)?;
+        let ttl = Timestamp::from_secs(js_date_to_seconds(ttl));
         use ClaimRewardsTransactionTypes::*;
         Ok(ClaimRewardsTransaction(SignatureErasedClaimRewards(
             ledger::structure::ClaimRewardsTransaction {
@@ -1544,6 +1546,7 @@ impl ClaimRewardsTransaction {
                 nonce,
                 signature: (),
                 kind,
+                ttl,
             },
         )))
     }
@@ -1675,6 +1678,15 @@ impl ClaimRewardsTransaction {
             SignatureClaimRewards(val) => JsValue::from(SignatureEnabled(val.signature.clone())),
             SignatureErasedClaimRewards(_) => JsValue::from(SignatureErased()),
         })
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn ttl(&self) -> Date {
+        use ClaimRewardsTransactionTypes::*;
+        match &self.0 {
+            SignatureClaimRewards(val) => seconds_to_js_date(val.ttl.to_secs()),
+            SignatureErasedClaimRewards(val) => seconds_to_js_date(val.ttl.to_secs()),
+        }
     }
 }
 

--- a/ledger/src/semantics.rs
+++ b/ledger/src/semantics.rs
@@ -1731,7 +1731,7 @@ fn claim_unshielded<D: DB>(
     .mk_intent_hash(NIGHT);
     let replay_protection = match state.replay_protection.clone().apply_member(
         hash,
-        context.tblock + state.parameters.global_ttl,
+        tx.ttl,
         context.tblock,
         state.parameters.global_ttl,
     ) {
@@ -2037,6 +2037,7 @@ mod tests {
             nonce: rng.r#gen(),
             signature: (),
             kind: ClaimKind::CardanoBridge,
+            ttl: Timestamp::default(),
         };
         let context = BlockContext::default();
         match claim_unshielded(
@@ -2091,6 +2092,7 @@ mod tests {
             nonce: rng.r#gen(),
             signature: (),
             kind: ClaimKind::CardanoBridge,
+            ttl: Timestamp::default(),
         };
         let context = BlockContext::default();
         match claim_unshielded(
@@ -2147,6 +2149,7 @@ mod tests {
             nonce: rng.r#gen(),
             signature: (),
             kind: ClaimKind::Reward,
+            ttl: Timestamp::default(),
         };
         let context = BlockContext::default();
         match claim_unshielded(
@@ -2202,6 +2205,7 @@ mod tests {
             nonce: rng.r#gen(),
             signature: (),
             kind: ClaimKind::Reward,
+            ttl: Timestamp::default(),
         };
         let context = BlockContext::default();
         match claim_unshielded(

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -1254,6 +1254,7 @@ impl LedgerParameters {
                     nonce: Default::default(),
                     signature: Default::default(),
                     kind: ClaimKind::Reward,
+                    ttl: Timestamp::default(),
                 },
             )
             .cost(self, true)
@@ -1296,7 +1297,7 @@ pub const INITIAL_PARAMETERS: LedgerParameters = LedgerParameters {
 #[derive(Storable)]
 #[storable(db = D)]
 #[derive_where(Clone; S, B, P)]
-#[tag = "transaction[v9]"]
+#[tag = "transaction[v10]"]
 // TODO: Getting `Box` to serialize is a pain right now. Revisit later.
 #[allow(clippy::large_enum_variant)]
 pub enum Transaction<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> {
@@ -1757,7 +1758,7 @@ type ErasedClaimRewardsTransaction<D> = ClaimRewardsTransaction<(), D>;
 #[derive(Storable)]
 #[derive_where(Clone, PartialEq, Eq; S)]
 #[storable(db = D)]
-#[tag = "claim-rewards-transaction[v1]"]
+#[tag = "claim-rewards-transaction[v2]"]
 pub struct ClaimRewardsTransaction<S: SignatureKind<D>, D: DB> {
     pub network_id: String,
     pub value: u128,
@@ -1765,6 +1766,7 @@ pub struct ClaimRewardsTransaction<S: SignatureKind<D>, D: DB> {
     pub nonce: Nonce,
     pub signature: S::Signature<ErasedClaimRewardsTransaction<D>>,
     pub kind: ClaimKind,
+    pub ttl: Timestamp,
 }
 tag_enforcement_test!(ClaimRewardsTransaction<(), InMemoryDB>);
 
@@ -1777,6 +1779,7 @@ impl<S: SignatureKind<D>, D: DB> ClaimRewardsTransaction<S, D> {
             nonce: self.nonce,
             signature,
             kind: self.kind,
+            ttl: self.ttl,
         }
     }
 
@@ -1788,6 +1791,7 @@ impl<S: SignatureKind<D>, D: DB> ClaimRewardsTransaction<S, D> {
             nonce: self.nonce,
             signature: (),
             kind: self.kind,
+            ttl: self.ttl,
         }
     }
 }
@@ -1807,6 +1811,8 @@ impl<D: DB> ClaimRewardsTransaction<(), D> {
         Serializable::serialize(&rewards.nonce, &mut data)
             .expect("In-memory serialization should succeed");
         Serializable::serialize(&rewards.kind, &mut data)
+            .expect("In-memory serialization should succeed");
+        Serializable::serialize(&rewards.ttl, &mut data)
             .expect("In-memory serialization should succeed");
         data
     }

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -1806,6 +1806,8 @@ impl<D: DB> ClaimRewardsTransaction<(), D> {
             .expect("In-memory serialization should succeed");
         Serializable::serialize(&rewards.nonce, &mut data)
             .expect("In-memory serialization should succeed");
+        Serializable::serialize(&rewards.kind, &mut data)
+            .expect("In-memory serialization should succeed");
         data
     }
 }

--- a/ledger/src/test_utilities.rs
+++ b/ledger/src/test_utilities.rs
@@ -230,6 +230,7 @@ impl<D: DB> TestState<D> {
                 nonce,
                 signature: (),
                 kind: ClaimKind::Reward,
+                ttl: self.time,
             }),
             &test_resolver(""),
         )

--- a/ledger/src/verify.rs
+++ b/ledger/src/verify.rs
@@ -540,6 +540,25 @@ impl<S: SignatureKind<D>, D: DB> ClaimRewardsTransaction<S, D> {
         .then_some(())
         .ok_or(IntentSignatureVerificationFailure)
     }
+
+    fn ttl_check_weak(
+        &self,
+        tblock: Timestamp,
+        global_ttl: Duration,
+    ) -> Result<(), TransactionApplicationError> {
+        if self.ttl < tblock {
+            Err(TransactionApplicationError::IntentTtlExpired(
+                self.ttl, tblock,
+            ))?;
+        }
+        if self.ttl > tblock + global_ttl {
+            Err(TransactionApplicationError::IntentTtlTooFarInFuture(
+                self.ttl,
+                tblock + global_ttl,
+            ))?;
+        }
+        Ok(())
+    }
 }
 
 impl<
@@ -644,6 +663,10 @@ where
             }
             Transaction::ClaimRewards(mtx) => {
                 ref_state.network_check(&mtx.network_id)?;
+                ref_state.param_check(true, |params| {
+                    mtx.ttl_check_weak(tblock, params.global_ttl)
+                        .map_err(MalformedTransaction::TransactionApplicationError)
+                })?;
                 ref_state.stateless_check(|| {
                     B::when_sealed(Ok(
                         // There's no point in checking this unless we actually care about signature verification

--- a/ledger/tests/system_tx.rs
+++ b/ledger/tests/system_tx.rs
@@ -77,6 +77,7 @@ async fn system_tx_pay_from_unshielded() {
             nonce,
             signature: (),
             kind: ClaimKind::Reward,
+            ttl: state.time,
         }),
         &RESOLVER,
     )


### PR DESCRIPTION
## Description

Oversight in the previous iteration was to miss `kind` from the signing envelope. Additionally, this transaction kind did not do a TTL check, which enabled potential replays. Note that this is *not* a live issue, as this transaction kind is currently unused.

## Sanity Checklist

This PR:
- [X] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [X] contains breaking API changes [^1][^2]
- [X] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
