### PR TITLE
Enforce AlignedValue alignment in Key and StateValue deserialization

### DIFF
--- a/base-crypto/src/fab/encoding.rs
+++ b/base-crypto/src/fab/encoding.rs
@@ -535,6 +535,26 @@ impl AlignedValue {
         }
     }
 
+    /// Checks that the value matches its alignment and is in normal form. This is the same
+    /// invariant enforced by `serde` deserialization, but `Deserializable::deserialize` does not
+    /// enforce it for backwards-compatibility reasons; callers that want to reject malformed
+    /// values from untrusted input should invoke this explicitly.
+    pub fn check_well_formed(&self) -> std::io::Result<()> {
+        if !self.alignment.fits(&self.value) {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "value deserialized as aligned failed alignment check",
+            ))
+        } else if !self.value.0.iter().all(ValueAtom::is_in_normal_form) {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "aligned value is not in normal form (has trailing zero bytes)",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Concatenates two aligned values.
     pub fn concat<'a, I: IntoIterator<Item = &'a AlignedValue>>(iter: I) -> AlignedValue {
         let mut val = Vec::new();

--- a/onchain-state/src/state.rs
+++ b/onchain-state/src/state.rs
@@ -405,8 +405,14 @@ impl<D: DB> Debug for StateValue<D> {
 impl<D: DB> StateValue<D> {
     fn invariant(&self) -> std::io::Result<()> {
         match self {
-            StateValue::Null | StateValue::Map(_) => {}
+            StateValue::Null => {}
+            StateValue::Map(m) => {
+                for kv in m.iter() {
+                    kv.0.check_well_formed()?;
+                }
+            }
             StateValue::Cell(v) => {
+                v.check_well_formed()?;
                 if (**v).serialized_size() > CELL_BOUND {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
@@ -1069,5 +1075,58 @@ mod tests {
         for h in 0..16 {
             assert_eq!(s!({MT(h) {}}).log_size(), h as usize);
         }
+    }
+
+    fn misaligned_value() -> AlignedValue {
+        // 10-byte value with alignment that only permits up to 4 bytes — does not fit.
+        AlignedValue {
+            value: base_crypto::fab::Value(vec![base_crypto::fab::ValueAtom(vec![0xff; 10])]),
+            alignment: Alignment(vec![base_crypto::fab::AlignmentSegment::Atom(
+                AlignmentAtom::Bytes { length: 4 },
+            )]),
+        }
+    }
+
+    #[test]
+    fn test_statevalue_cell_wire_deser_rejects_misaligned() {
+        let bad = StateValue::<InMemoryDB>::Cell(Sp::new(misaligned_value()));
+        let mut bytes = Vec::new();
+        <StateValue<InMemoryDB> as Serializable>::serialize(&bad, &mut bytes).unwrap();
+        let err = <StateValue<InMemoryDB> as Deserializable>::deserialize(&mut bytes.as_slice(), 0)
+            .expect_err("Cell wire deserialization should reject misaligned AlignedValue");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_statevalue_map_key_wire_deser_rejects_misaligned() {
+        let bad = StateValue::<InMemoryDB>::Map(
+            HashMap::new().insert(misaligned_value(), StateValue::Null),
+        );
+        let mut bytes = Vec::new();
+        <StateValue<InMemoryDB> as Serializable>::serialize(&bad, &mut bytes).unwrap();
+        let err = <StateValue<InMemoryDB> as Deserializable>::deserialize(&mut bytes.as_slice(), 0)
+            .expect_err("Map wire deserialization should reject misaligned key");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_statevalue_cell_backend_load_accepts_misaligned() {
+        // Confirms the backwards-compat carve-out: the storage loader (CHECK_INVARIANTS=false)
+        // must still be able to materialize misaligned cells that pre-date the invariant.
+        use storage::arena::BackendLoader;
+        use storage::storage::default_storage;
+
+        let arena = default_storage::<InMemoryDB>().arena.clone();
+        let bad = StateValue::<InMemoryDB>::Cell(Sp::new(misaligned_value()));
+        let sp = arena.alloc(bad.clone());
+        let mut data = Vec::new();
+        <StateValue<InMemoryDB> as Storable<InMemoryDB>>::to_binary_repr(&bad, &mut data).unwrap();
+        let loader = BackendLoader::new(&arena, None);
+        <StateValue<InMemoryDB> as Storable<InMemoryDB>>::from_binary_repr(
+            &mut data.as_slice(),
+            &mut sp.children().into_iter(),
+            &loader,
+        )
+        .expect("BackendLoader should not enforce the alignment invariant");
     }
 }

--- a/onchain-vm/src/ops.rs
+++ b/onchain-vm/src/ops.rs
@@ -34,14 +34,67 @@ use storage::{DefaultDB, Storable, arena::ArenaKey};
 use transient_crypto::curve::Fr;
 use transient_crypto::repr::FieldRepr;
 
-#[derive(Clone, Hash, PartialEq, Eq, Serialize, Deserialize, Serializable, Storable)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Deserialize, Storable)]
 #[storable(base)]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[serde(tag = "tag", content = "value", rename_all = "camelCase")]
-#[tag = "impact-idx-key"]
 pub enum Key {
     Value(AlignedValue),
     Stack,
+}
+
+// Manual `Serializable`/`Deserializable` so that deserialization can reject misaligned
+// `AlignedValue`s (which `AlignedValue`'s own `Deserializable` does not check).
+impl Serializable for Key {
+    fn serialize(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
+        match self {
+            Key::Value(v) => {
+                <u8 as Serializable>::serialize(&0u8, writer)?;
+                <AlignedValue as Serializable>::serialize(v, writer)?;
+            }
+            Key::Stack => {
+                <u8 as Serializable>::serialize(&1u8, writer)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn serialized_size(&self) -> usize {
+        match self {
+            Key::Value(v) => 1 + <AlignedValue as Serializable>::serialized_size(v),
+            Key::Stack => 1,
+        }
+    }
+}
+
+impl Deserializable for Key {
+    fn deserialize(
+        reader: &mut impl std::io::Read,
+        recursion_depth: u32,
+    ) -> std::io::Result<Self> {
+        let discriminant = <u8 as Deserializable>::deserialize(reader, recursion_depth)?;
+        match discriminant {
+            0 => {
+                let v = <AlignedValue as Deserializable>::deserialize(reader, recursion_depth)?;
+                v.check_well_formed()?;
+                Ok(Key::Value(v))
+            }
+            1 => Ok(Key::Stack),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "unrecognised discriminant",
+            )),
+        }
+    }
+}
+
+impl Tagged for Key {
+    fn tag() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("impact-idx-key")
+    }
+    fn tag_unique_factor() -> String {
+        format!("[({}),()]", <AlignedValue as Tagged>::tag())
+    }
 }
 tag_enforcement_test!(Key);
 
@@ -578,5 +631,27 @@ mod tests {
         let op2: Op<ResultModeGather, DefaultDB> =
             serialize::Deserializable::deserialize(&mut &ser[..], 0).unwrap();
         assert_eq!(op, op2);
+    }
+
+    #[test]
+    fn test_key_wire_deser_rejects_misaligned() {
+        use crate::ops::Key;
+        use base_crypto::fab::{
+            AlignedValue, Alignment, AlignmentAtom, AlignmentSegment, Value, ValueAtom,
+        };
+
+        // 10-byte value with alignment that only permits up to 4 bytes.
+        let bad = AlignedValue {
+            value: Value(vec![ValueAtom(vec![0xff; 10])]),
+            alignment: Alignment(vec![AlignmentSegment::Atom(AlignmentAtom::Bytes {
+                length: 4,
+            })]),
+        };
+        let key = Key::Value(bad);
+        let mut bytes = Vec::new();
+        <Key as serialize::Serializable>::serialize(&key, &mut bytes).unwrap();
+        let err = <Key as serialize::Deserializable>::deserialize(&mut bytes.as_slice(), 0)
+            .expect_err("Key wire deserialization should reject misaligned AlignedValue");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 }


### PR DESCRIPTION
## Description

`AlignedValue` didn't check alignment on deserialization. That's *mostly* harmless, but we should fix anyway. To make this backwards compatible, we're checking at the point of use – in the onchain runtime. There's two of these: `Key` and `StateValue`. The former is ephemeral, and just in transcripts, so checking there is fine. The latter, we check in the state invariant, so that existing state is still accepted.

Note that formally this is *not* a data-format change, as old *state* will still be accepted.
<!-- describe what this PR does, and why it is needed -->

## Sanity Checklist

This PR:
- [X] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
