### PR TITLE
ci: gate ZKIR publish on wasm version to skip already-published releases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -186,7 +186,8 @@ jobs:
         run: |
           git config --global user.name 'MidnightCI'
           git config --global user.email 'midnight-automation+midnightci@iohk.io'
-          VAR_NAME=$(echo "ZKIR_VERSION")
+          # Use wasm version, as this will include pre-release tags
+          VAR_NAME=$(echo "ZKIR_WASM_VERSION")
           VERSION=${!VAR_NAME}
           TAG_NAME="zkir-${VERSION}"
           SHORT_VERSION=$(echo "$VERSION" | awk -F. '{print $1}')


### PR DESCRIPTION
## Problem

The `Publish Ledger Release` workflow failed on `ledger-9` at the **Build and Publish ZKIR** step:

```
npm error 409 Conflict - Cannot publish over existing version
@midnight-ntwrk/zkir-v2@2.1.0
```

[Failing run](https://github.com/midnightntwrk/midnight-ledger/actions/runs/27157162108/job/80162882557)

## Root cause

Each publish step has a git-tag gate that should silently skip a release that already shipped. ZKIR's gate was keyed off the **wrong version**:

| Step | Gate/tag version | npm publish version | In sync? |
|---|---|---|---|
| Ledger | `LEDGER_WASM_VERSION` | `LEDGER_WASM_VERSION` | ✅ |
| Onchain Runtime | `ONCHAIN_RUNTIME_WASM_VERSION` | `ONCHAIN_RUNTIME_WASM_VERSION` | ✅ |
| **ZKIR (before)** | `ZKIR_VERSION` (zkir crate = `2.2.0`) | `ZKIR_WASM_VERSION` (zkir-wasm = `2.1.0`) | ❌ |

On `ledger-9` the `zkir` crate was bumped `2.1.0 → 2.2.0` but `zkir-wasm` (the package actually published to npm) stayed at `2.1.0`. The gate looked for tag `zkir-2.2.0` (doesn't exist) → treated it as a fresh release → tried to republish `zkir-v2@2.1.0`, which already exists → 409.

The `zkir-2.1.0` tag already exists on the remote, so keying the gate on the wasm version makes the step **silently skip** instead of failing — the desired behavior.

## Fix

Switch the ZKIR gate to `ZKIR_WASM_VERSION`, mirroring the fix already applied to the Ledger and Onchain Runtime steps. One-line change; the publish path is unaffected (`SHORT_VERSION` resolves to `2` either way).

Refs shieldedtech/shielded-sre#293

🤖 Generated with [Claude Code](https://claude.com/claude-code)