### PR TITLE
ci: publish ledger-9 packages to public npm (@midnightntwrk)

### DIFF
--- a/.github/scripts/npm-publish-idempotent.sh
+++ b/.github/scripts/npm-publish-idempotent.sh
@@ -74,4 +74,10 @@ if is_published; then
   exit 0
 fi
 
-npm publish "$TGZ" --registry="$REG" --tag "$TAG"
+publish_args=(--registry="$REG" --tag "$TAG")
+# Scoped packages publish as 'restricted' by default on public npm; make the
+# first publish public. (GH Packages visibility is governed by the repo/org.)
+if [ "$REG_HOST" = "registry.npmjs.org" ]; then
+  publish_args+=(--access public)
+fi
+npm publish "$TGZ" "${publish_args[@]}"

--- a/.github/scripts/npm-publish-idempotent.sh
+++ b/.github/scripts/npm-publish-idempotent.sh
@@ -35,8 +35,15 @@ fi
 
 REG_HOST="${REG#https://}"; REG_HOST="${REG_HOST%%/*}"
 
+# Scope of the package, e.g. "@midnightntwrk". setup-node writes a
+# `<scope>:registry=...` line into .npmrc, and for scoped packages npm resolves
+# the registry from that mapping and IGNORES --registry. Override the scope
+# registry explicitly so view/publish actually target $REG.
+SCOPE="${PKG%%/*}"
+SCOPE_REG_ARG="--${SCOPE}:registry=$REG"
+
 is_published() {
-  npm view "$PKG@$VER" version --registry="$REG" >/dev/null 2>&1
+  npm view "$PKG@$VER" version --registry="$REG" "$SCOPE_REG_ARG" >/dev/null 2>&1
 }
 
 if [ "${FORCE:-false}" = "true" ]; then
@@ -74,7 +81,7 @@ if is_published; then
   exit 0
 fi
 
-publish_args=(--registry="$REG" --tag "$TAG")
+publish_args=(--registry="$REG" "$SCOPE_REG_ARG" --tag "$TAG")
 # Scoped packages publish as 'restricted' by default on public npm; make the
 # first publish public. (GH Packages visibility is governed by the repo/org.)
 if [ "$REG_HOST" = "registry.npmjs.org" ]; then

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -87,10 +87,13 @@ jobs:
           fi
           # Write the resolved token into the file npm actually reads: setup-node
           # points npm at $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc is
-          # ignored. Write the value directly (double quotes) rather than relying
-          # on npm's in-file ${VAR} expansion, which did not resolve here and left
-          # the auth token empty (ENEEDAUTH).
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          # ignored. The value is written directly (not npm's ${VAR} expansion,
+          # which left the token empty -> ENEEDAUTH). The leading newline guards
+          # against setup-node's npmrc lacking a trailing newline, which would
+          # otherwise concatenate this onto its last line and corrupt both.
+          printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "npmrc (tokens redacted):"
+          sed -E 's/(_authToken=).*/\1[REDACTED]/' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" || true
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for
@@ -161,10 +164,13 @@ jobs:
           fi
           # Write the resolved token into the file npm actually reads: setup-node
           # points npm at $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc is
-          # ignored. Write the value directly (double quotes) rather than relying
-          # on npm's in-file ${VAR} expansion, which did not resolve here and left
-          # the auth token empty (ENEEDAUTH).
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          # ignored. The value is written directly (not npm's ${VAR} expansion,
+          # which left the token empty -> ENEEDAUTH). The leading newline guards
+          # against setup-node's npmrc lacking a trailing newline, which would
+          # otherwise concatenate this onto its last line and corrupt both.
+          printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "npmrc (tokens redacted):"
+          sed -E 's/(_authToken=).*/\1[REDACTED]/' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" || true
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for
@@ -237,10 +243,13 @@ jobs:
           fi
           # Write the resolved token into the file npm actually reads: setup-node
           # points npm at $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc is
-          # ignored. Write the value directly (double quotes) rather than relying
-          # on npm's in-file ${VAR} expansion, which did not resolve here and left
-          # the auth token empty (ENEEDAUTH).
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          # ignored. The value is written directly (not npm's ${VAR} expansion,
+          # which left the token empty -> ENEEDAUTH). The leading newline guards
+          # against setup-node's npmrc lacking a trailing newline, which would
+          # otherwise concatenate this onto its last line and corrupt both.
+          printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "npmrc (tokens redacted):"
+          sed -E 's/(_authToken=).*/\1[REDACTED]/' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" || true
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -85,11 +85,12 @@ jobs:
           if [ -z "${NPM_TOKEN:-}" ]; then
             echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set — cannot authenticate to npmjs"; exit 1
           fi
-          # Append to the file npm actually reads: setup-node points npm at
-          # $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc would be ignored.
-          # npm expands ${NPM_TOKEN} from the env when it reads the file.
-          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at read time
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          # Write the resolved token into the file npm actually reads: setup-node
+          # points npm at $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc is
+          # ignored. Write the value directly (double quotes) rather than relying
+          # on npm's in-file ${VAR} expansion, which did not resolve here and left
+          # the auth token empty (ENEEDAUTH).
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for
@@ -158,11 +159,12 @@ jobs:
           if [ -z "${NPM_TOKEN:-}" ]; then
             echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set — cannot authenticate to npmjs"; exit 1
           fi
-          # Append to the file npm actually reads: setup-node points npm at
-          # $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc would be ignored.
-          # npm expands ${NPM_TOKEN} from the env when it reads the file.
-          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at read time
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          # Write the resolved token into the file npm actually reads: setup-node
+          # points npm at $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc is
+          # ignored. Write the value directly (double quotes) rather than relying
+          # on npm's in-file ${VAR} expansion, which did not resolve here and left
+          # the auth token empty (ENEEDAUTH).
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for
@@ -233,11 +235,12 @@ jobs:
           if [ -z "${NPM_TOKEN:-}" ]; then
             echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set — cannot authenticate to npmjs"; exit 1
           fi
-          # Append to the file npm actually reads: setup-node points npm at
-          # $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc would be ignored.
-          # npm expands ${NPM_TOKEN} from the env when it reads the file.
-          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at read time
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          # Write the resolved token into the file npm actually reads: setup-node
+          # points npm at $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc is
+          # ignored. Write the value directly (double quotes) rather than relying
+          # on npm's in-file ${VAR} expansion, which did not resolve here and left
+          # the auth token empty (ENEEDAUTH).
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -92,8 +92,6 @@ jobs:
           # against setup-node's npmrc lacking a trailing newline, which would
           # otherwise concatenate this onto its last line and corrupt both.
           printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
-          echo "npmrc (tokens redacted):"
-          sed -E 's/(_authToken=).*/\1[REDACTED]/' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" || true
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for
@@ -169,8 +167,6 @@ jobs:
           # against setup-node's npmrc lacking a trailing newline, which would
           # otherwise concatenate this onto its last line and corrupt both.
           printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
-          echo "npmrc (tokens redacted):"
-          sed -E 's/(_authToken=).*/\1[REDACTED]/' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" || true
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for
@@ -248,8 +244,6 @@ jobs:
           # against setup-node's npmrc lacking a trailing newline, which would
           # otherwise concatenate this onto its last line and corrupt both.
           printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
-          echo "npmrc (tokens redacted):"
-          sed -E 's/(_authToken=).*/\1[REDACTED]/' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}" || true
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -77,6 +77,7 @@ jobs:
           if [ -z "$SHORT_VERSION" ]; then echo "::error::could not derive ledger package epoch from flake.nix"; exit 1; fi
           TAG_NAME="ledger-${SHORT_VERSION}.${VERSION}"
           PKG="@midnightntwrk/ledger-v${SHORT_VERSION}"
+          SCOPE="${PKG%%/*}"
           GH_REG="https://npm.pkg.github.com/midnightntwrk"
           NPMJS_REG="https://registry.npmjs.org/"
 
@@ -85,12 +86,12 @@ jobs:
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
 
           # Build only if the version is missing from at least one target registry
-          # (or FORCE is set). Checking each registry directly means a newly added
-          # registry (npmjs) still gets published even when GH Packages — and the
-          # git tag — already exist from an earlier run.
+          # (or FORCE is set). The "--<scope>:registry" override is required: for
+          # scoped packages npm uses the scope->registry mapping in .npmrc and
+          # ignores --registry, so without it both checks hit GH Packages.
           if [ "${FORCE:-false}" != "true" ] \
-             && npm view "$PKG@$VERSION" version --registry="$GH_REG"    >/dev/null 2>&1 \
-             && npm view "$PKG@$VERSION" version --registry="$NPMJS_REG" >/dev/null 2>&1; then
+             && npm view "$PKG@$VERSION" version --registry="$GH_REG"    "--${SCOPE}:registry=$GH_REG"    >/dev/null 2>&1 \
+             && npm view "$PKG@$VERSION" version --registry="$NPMJS_REG" "--${SCOPE}:registry=$NPMJS_REG" >/dev/null 2>&1; then
             echo "$PKG@$VERSION already published to GH Packages and npmjs — skipping build/publish."
           else
             cd ledger-wasm
@@ -143,6 +144,7 @@ jobs:
           SHORT_VERSION=$(echo "$VERSION" | awk -F. '{print $1}')
           TAG_NAME="onchain-runtime-${VERSION}"
           PKG="@midnightntwrk/onchain-runtime-v${SHORT_VERSION}"
+          SCOPE="${PKG%%/*}"
           GH_REG="https://npm.pkg.github.com/midnightntwrk"
           NPMJS_REG="https://registry.npmjs.org/"
 
@@ -151,12 +153,12 @@ jobs:
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
 
           # Build only if the version is missing from at least one target registry
-          # (or FORCE is set). Checking each registry directly means a newly added
-          # registry (npmjs) still gets published even when GH Packages — and the
-          # git tag — already exist from an earlier run.
+          # (or FORCE is set). The "--<scope>:registry" override is required: for
+          # scoped packages npm uses the scope->registry mapping in .npmrc and
+          # ignores --registry, so without it both checks hit GH Packages.
           if [ "${FORCE:-false}" != "true" ] \
-             && npm view "$PKG@$VERSION" version --registry="$GH_REG"    >/dev/null 2>&1 \
-             && npm view "$PKG@$VERSION" version --registry="$NPMJS_REG" >/dev/null 2>&1; then
+             && npm view "$PKG@$VERSION" version --registry="$GH_REG"    "--${SCOPE}:registry=$GH_REG"    >/dev/null 2>&1 \
+             && npm view "$PKG@$VERSION" version --registry="$NPMJS_REG" "--${SCOPE}:registry=$NPMJS_REG" >/dev/null 2>&1; then
             echo "$PKG@$VERSION already published to GH Packages and npmjs — skipping build/publish."
           else
             cd onchain-runtime-wasm
@@ -211,6 +213,7 @@ jobs:
           WASM_VERSION="${ZKIR_WASM_VERSION}"
           SHORT_VERSION=$(echo "$WASM_VERSION" | awk -F. '{print $1}')
           PKG="@midnightntwrk/zkir-v${SHORT_VERSION}"
+          SCOPE="${PKG%%/*}"
           GH_REG="https://npm.pkg.github.com/midnightntwrk"
           NPMJS_REG="https://registry.npmjs.org/"
 
@@ -219,12 +222,12 @@ jobs:
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
 
           # Build only if the version is missing from at least one target registry
-          # (or FORCE is set). Checking each registry directly means a newly added
-          # registry (npmjs) still gets published even when GH Packages — and the
-          # git tag — already exist from an earlier run.
+          # (or FORCE is set). The "--<scope>:registry" override is required: for
+          # scoped packages npm uses the scope->registry mapping in .npmrc and
+          # ignores --registry, so without it both checks hit GH Packages.
           if [ "${FORCE:-false}" != "true" ] \
-             && npm view "$PKG@$WASM_VERSION" version --registry="$GH_REG"    >/dev/null 2>&1 \
-             && npm view "$PKG@$WASM_VERSION" version --registry="$NPMJS_REG" >/dev/null 2>&1; then
+             && npm view "$PKG@$WASM_VERSION" version --registry="$GH_REG"    "--${SCOPE}:registry=$GH_REG"    >/dev/null 2>&1 \
+             && npm view "$PKG@$WASM_VERSION" version --registry="$NPMJS_REG" "--${SCOPE}:registry=$NPMJS_REG" >/dev/null 2>&1; then
             echo "$PKG@$WASM_VERSION already published to GH Packages and npmjs — skipping build/publish."
           else
             cd zkir-wasm

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -76,9 +76,22 @@ jobs:
           SHORT_VERSION=$(awk -F'"' '/packages\.ledger-wasm =/{for(i=1;i<=NF;i++) if($i ~ /^ledger-v[0-9]+$/){sub(/^ledger-v/,"",$i); print $i; exit}}' flake.nix)
           if [ -z "$SHORT_VERSION" ]; then echo "::error::could not derive ledger package epoch from flake.nix"; exit 1; fi
           TAG_NAME="ledger-${SHORT_VERSION}.${VERSION}"
+          PKG="@midnightntwrk/ledger-v${SHORT_VERSION}"
+          GH_REG="https://npm.pkg.github.com/midnightntwrk"
+          NPMJS_REG="https://registry.npmjs.org/"
 
-          if git ls-remote --tags origin | grep -qE "refs/tags/${TAG_NAME}(\^\{\})?$"; then
-            echo "Tag ${TAG_NAME} already exists on remote. Skipping tagging for ledger."
+          # Authenticate npmjs (GH Packages auth is configured by setup-node).
+          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+
+          # Build only if the version is missing from at least one target registry
+          # (or FORCE is set). Checking each registry directly means a newly added
+          # registry (npmjs) still gets published even when GH Packages — and the
+          # git tag — already exist from an earlier run.
+          if [ "${FORCE:-false}" != "true" ] \
+             && npm view "$PKG@$VERSION" version --registry="$GH_REG"    >/dev/null 2>&1 \
+             && npm view "$PKG@$VERSION" version --registry="$NPMJS_REG" >/dev/null 2>&1; then
+            echo "$PKG@$VERSION already published to GH Packages and npmjs — skipping build/publish."
           else
             cd ledger-wasm
             cargo check
@@ -99,16 +112,18 @@ jobs:
             echo "Contents of result/lib:"
             ls -lah
             TGZ="midnight-ledger-v${SHORT_VERSION}-${{ env.LEDGER_WASM_VERSION }}.tgz"
-            PKG="@midnightntwrk/ledger-v${SHORT_VERSION}"
+            # Publish is idempotent per-registry: skips where the version already exists.
             "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" https://npm.pkg.github.com/midnightntwrk "$PKG" "${{ env.LEDGER_WASM_VERSION }}"
-            # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
-            echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+              "$TGZ" "$GH_REG" "$PKG" "${{ env.LEDGER_WASM_VERSION }}"
             "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" https://registry.npmjs.org/ "$PKG" "${{ env.LEDGER_WASM_VERSION }}"
+              "$TGZ" "$NPMJS_REG" "$PKG" "${{ env.LEDGER_WASM_VERSION }}"
             cd ../..
+          fi
 
-            # Create and push the new tag
+          # Create and push the new tag only if it does not already exist.
+          if git ls-remote --tags origin | grep -qE "refs/tags/${TAG_NAME}(\^\{\})?$"; then
+            echo "Tag ${TAG_NAME} already exists on remote. Skipping tagging for ledger."
+          else
             git tag "${TAG_NAME}"
             git push origin "${TAG_NAME}"
           fi
@@ -127,9 +142,22 @@ jobs:
           VERSION="${ONCHAIN_RUNTIME_WASM_VERSION}"
           SHORT_VERSION=$(echo "$VERSION" | awk -F. '{print $1}')
           TAG_NAME="onchain-runtime-${VERSION}"
+          PKG="@midnightntwrk/onchain-runtime-v${SHORT_VERSION}"
+          GH_REG="https://npm.pkg.github.com/midnightntwrk"
+          NPMJS_REG="https://registry.npmjs.org/"
 
-          if git ls-remote --tags origin | grep -qE "refs/tags/${TAG_NAME}(\^\{\})?$"; then
-            echo "Tag ${TAG_NAME} already exists on remote. Skipping tagging for onchain runtime."
+          # Authenticate npmjs (GH Packages auth is configured by setup-node).
+          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+
+          # Build only if the version is missing from at least one target registry
+          # (or FORCE is set). Checking each registry directly means a newly added
+          # registry (npmjs) still gets published even when GH Packages — and the
+          # git tag — already exist from an earlier run.
+          if [ "${FORCE:-false}" != "true" ] \
+             && npm view "$PKG@$VERSION" version --registry="$GH_REG"    >/dev/null 2>&1 \
+             && npm view "$PKG@$VERSION" version --registry="$NPMJS_REG" >/dev/null 2>&1; then
+            echo "$PKG@$VERSION already published to GH Packages and npmjs — skipping build/publish."
           else
             cd onchain-runtime-wasm
             cargo check
@@ -150,16 +178,18 @@ jobs:
             echo "Contents of result/lib:"
             ls -lah
             TGZ="midnight-onchain-runtime-v${SHORT_VERSION}-${{ env.ONCHAIN_RUNTIME_WASM_VERSION }}.tgz"
-            PKG="@midnightntwrk/onchain-runtime-v${SHORT_VERSION}"
+            # Publish is idempotent per-registry: skips where the version already exists.
             "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" https://npm.pkg.github.com/midnightntwrk "$PKG" "${{ env.ONCHAIN_RUNTIME_WASM_VERSION }}"
-            # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
-            echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+              "$TGZ" "$GH_REG" "$PKG" "${{ env.ONCHAIN_RUNTIME_WASM_VERSION }}"
             "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" https://registry.npmjs.org/ "$PKG" "${{ env.ONCHAIN_RUNTIME_WASM_VERSION }}"
+              "$TGZ" "$NPMJS_REG" "$PKG" "${{ env.ONCHAIN_RUNTIME_WASM_VERSION }}"
             cd ../..
+          fi
 
-            # Create and push the new tag
+          # Create and push the new tag only if it does not already exist.
+          if git ls-remote --tags origin | grep -qE "refs/tags/${TAG_NAME}(\^\{\})?$"; then
+            echo "Tag ${TAG_NAME} already exists on remote. Skipping tagging for onchain runtime."
+          else
             git tag "${TAG_NAME}"
             git push origin "${TAG_NAME}"
           fi
@@ -174,12 +204,28 @@ jobs:
         run: |
           git config --global user.name 'MidnightCI'
           git config --global user.email 'midnight-automation+midnightci@iohk.io'
+          # ZKIR's git tag tracks the zkir crate version, but the published npm
+          # package uses the zkir-wasm version — check existence against the wasm version.
           VERSION="${ZKIR_VERSION}"
           TAG_NAME="zkir-${VERSION}"
-          SHORT_VERSION=$(echo "$VERSION" | awk -F. '{print $1}')
+          WASM_VERSION="${ZKIR_WASM_VERSION}"
+          SHORT_VERSION=$(echo "$WASM_VERSION" | awk -F. '{print $1}')
+          PKG="@midnightntwrk/zkir-v${SHORT_VERSION}"
+          GH_REG="https://npm.pkg.github.com/midnightntwrk"
+          NPMJS_REG="https://registry.npmjs.org/"
 
-          if git ls-remote --tags origin | grep -qE "refs/tags/${TAG_NAME}(\^\{\})?$"; then
-            echo "Tag ${TAG_NAME} already exists on remote. Skipping tagging for zkir."
+          # Authenticate npmjs (GH Packages auth is configured by setup-node).
+          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+
+          # Build only if the version is missing from at least one target registry
+          # (or FORCE is set). Checking each registry directly means a newly added
+          # registry (npmjs) still gets published even when GH Packages — and the
+          # git tag — already exist from an earlier run.
+          if [ "${FORCE:-false}" != "true" ] \
+             && npm view "$PKG@$WASM_VERSION" version --registry="$GH_REG"    >/dev/null 2>&1 \
+             && npm view "$PKG@$WASM_VERSION" version --registry="$NPMJS_REG" >/dev/null 2>&1; then
+            echo "$PKG@$WASM_VERSION already published to GH Packages and npmjs — skipping build/publish."
           else
             cd zkir-wasm
             cargo check
@@ -200,16 +246,18 @@ jobs:
             echo "Contents of result/lib:"
             ls -lah
             TGZ="midnight-zkir-v${SHORT_VERSION}-${{ env.ZKIR_WASM_VERSION }}.tgz"
-            PKG="@midnightntwrk/zkir-v${SHORT_VERSION}"
+            # Publish is idempotent per-registry: skips where the version already exists.
             "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" https://npm.pkg.github.com/midnightntwrk "$PKG" "${{ env.ZKIR_WASM_VERSION }}"
-            # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
-            echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+              "$TGZ" "$GH_REG" "$PKG" "${{ env.ZKIR_WASM_VERSION }}"
             "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" https://registry.npmjs.org/ "$PKG" "${{ env.ZKIR_WASM_VERSION }}"
+              "$TGZ" "$NPMJS_REG" "$PKG" "${{ env.ZKIR_WASM_VERSION }}"
             cd ../..
+          fi
 
-            # Create and push the new tag
+          # Create and push the new tag only if it does not already exist.
+          if git ls-remote --tags origin | grep -qE "refs/tags/${TAG_NAME}(\^\{\})?$"; then
+            echo "Tag ${TAG_NAME} already exists on remote. Skipping tagging for zkir."
+          else
             git tag "${TAG_NAME}"
             git push origin "${TAG_NAME}"
           fi

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build and Publish Ledger
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
           GH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           FORCE: ${{ github.event.inputs.force }}
         run: |
@@ -117,7 +117,7 @@ jobs:
       - name: Build and Publish Onchain Runtime
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
           GH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           FORCE: ${{ github.event.inputs.force }}
         run: |
@@ -168,7 +168,7 @@ jobs:
       - name: Build and Publish ZKIR
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
           GH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           FORCE: ${{ github.event.inputs.force }}
         run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -82,8 +82,14 @@ jobs:
           NPMJS_REG="https://registry.npmjs.org/"
 
           # Authenticate npmjs (GH Packages auth is configured by setup-node).
-          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set — cannot authenticate to npmjs"; exit 1
+          fi
+          # Append to the file npm actually reads: setup-node points npm at
+          # $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc would be ignored.
+          # npm expands ${NPM_TOKEN} from the env when it reads the file.
+          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at read time
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for
@@ -149,8 +155,14 @@ jobs:
           NPMJS_REG="https://registry.npmjs.org/"
 
           # Authenticate npmjs (GH Packages auth is configured by setup-node).
-          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set — cannot authenticate to npmjs"; exit 1
+          fi
+          # Append to the file npm actually reads: setup-node points npm at
+          # $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc would be ignored.
+          # npm expands ${NPM_TOKEN} from the env when it reads the file.
+          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at read time
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for
@@ -218,8 +230,14 @@ jobs:
           NPMJS_REG="https://registry.npmjs.org/"
 
           # Authenticate npmjs (GH Packages auth is configured by setup-node).
-          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at .npmrc read time
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set — cannot authenticate to npmjs"; exit 1
+          fi
+          # Append to the file npm actually reads: setup-node points npm at
+          # $NPM_CONFIG_USERCONFIG (in RUNNER_TEMP), so ~/.npmrc would be ignored.
+          # npm expands ${NPM_TOKEN} from the env when it reads the file.
+          # shellcheck disable=SC2016  # ${NPM_TOKEN} expanded by npm at read time
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build only if the version is missing from at least one target registry
           # (or FORCE is set). The "--<scope>:registry" override is required: for

--- a/integration-tests/yarn.lock
+++ b/integration-tests/yarn.lock
@@ -536,15 +536,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/ledger@link:../result/lib/node_modules/@midnight-ntwrk/ledger-v9::locator=%40midnight%2Fledger-api-tests%40workspace%3A.":
+"@midnight-ntwrk/ledger@link:../result/lib/node_modules/@midnightntwrk/ledger-v9::locator=%40midnight%2Fledger-api-tests%40workspace%3A.":
   version: 0.0.0-use.local
-  resolution: "@midnight-ntwrk/ledger@link:../result/lib/node_modules/@midnight-ntwrk/ledger-v9::locator=%40midnight%2Fledger-api-tests%40workspace%3A."
+  resolution: "@midnight-ntwrk/ledger@link:../result/lib/node_modules/@midnightntwrk/ledger-v9::locator=%40midnight%2Fledger-api-tests%40workspace%3A."
   languageName: node
   linkType: soft
 
-"@midnight-ntwrk/zkir-v2@link:../result/lib/node_modules/@midnight-ntwrk/zkir-v2::locator=%40midnight%2Fledger-api-tests%40workspace%3A.":
+"@midnight-ntwrk/zkir-v2@link:../result/lib/node_modules/@midnightntwrk/zkir-v2::locator=%40midnight%2Fledger-api-tests%40workspace%3A.":
   version: 0.0.0-use.local
-  resolution: "@midnight-ntwrk/zkir-v2@link:../result/lib/node_modules/@midnight-ntwrk/zkir-v2::locator=%40midnight%2Fledger-api-tests%40workspace%3A."
+  resolution: "@midnight-ntwrk/zkir-v2@link:../result/lib/node_modules/@midnightntwrk/zkir-v2::locator=%40midnight%2Fledger-api-tests%40workspace%3A."
   languageName: node
   linkType: soft
 
@@ -555,8 +555,8 @@ __metadata:
     "@d2t/vitest-ctrf-json-reporter": "npm:1.2.0"
     "@dao-xyz/borsh": "npm:5.2.3"
     "@eslint/compat": "npm:1.3.2"
-    "@midnight-ntwrk/ledger": "link:../result/lib/node_modules/@midnight-ntwrk/ledger-v9"
-    "@midnight-ntwrk/zkir-v2": "link:../result/lib/node_modules/@midnight-ntwrk/zkir-v2"
+    "@midnight-ntwrk/ledger": "link:../result/lib/node_modules/@midnightntwrk/ledger-v9"
+    "@midnight-ntwrk/zkir-v2": "link:../result/lib/node_modules/@midnightntwrk/zkir-v2"
     "@tsconfig/node24": "npm:24.0.4"
     "@types/eslint": "npm:9.6.1"
     "@types/eslint-config-prettier": "npm:6.11.3"


### PR DESCRIPTION
Targets `alexshielded/prep-ledger-9.0.1.0-rc.1` so it folds into #569.

Gets the ledger-9 release publishing to **public npm** (`registry.npmjs.org`, scope `@midnightntwrk`) in addition to GitHub Packages, and fixes that branch's integration-test CI. Verified end-to-end: `@midnightntwrk/{ledger-v9@0.1.0-rc.1, onchain-runtime-v4@4.0.0-rc.1, zkir-v2@2.1.0}` are all live on npmjs (HTTP 200), published by `ntwrk-bot`.

## Changes

**`integration-tests/yarn.lock`** — the scope rename `@midnight-ntwrk` → `@midnightntwrk` had updated the `link:` targets in `package.json` but not the lockfile, so the hardened/immutable install on PRs failed (`YN0028: The lockfile would have been modified`). Updated the six link-target paths to `@midnightntwrk`; dependency names stay `@midnight-ntwrk/*`.

**`.github/workflows/prerelease.yml`** — reworked all three publish steps (Ledger / Onchain Runtime / ZKIR):
- **Correct secret name** — use `MIDNIGHTCI_NPMJS_TOKEN` (provisioned per shieldedtech/shielded-sre#293), not the non-existent `MIDNIGHTCI_NPM_TOKEN`.
- **Gate on per-registry existence, not the git tag** — the old git-tag gate wrapped the whole build+publish block, so once the tags existed from an earlier GitHub-Packages-only run, the newly added npmjs publish was skipped entirely. Now each step builds only when the version is missing from at least one target registry (or `FORCE`), publishes idempotently to both, and creates the git tag separately only if absent.
- **Override the scope registry for npmjs** — `setup-node` writes `@midnightntwrk:registry=…github…` into `.npmrc`; for scoped packages npm ignores `--registry`, so existence checks and the publish were silently hitting GH Packages. Pass `--<scope>:registry=<reg>` so npmjs operations actually target npmjs.
- **npmjs auth** — write the resolved `MIDNIGHTCI_NPMJS_TOKEN` to the file npm actually reads (`$NPM_CONFIG_USERCONFIG`, not `~/.npmrc`), on its own line (leading newline), and fail fast if the token is empty.

**`.github/scripts/npm-publish-idempotent.sh`**:
- Add `--access public` for `registry.npmjs.org` (scoped packages default to `restricted` and would fail the first public publish).
- Apply the same `--<scope>:registry` override in `is_published()` and `npm publish`.

## Notes
- ZKIR checks existence against the **zkir-wasm** version (what it publishes), while its git tag still tracks the zkir crate version.
- Publishing requires `MIDNIGHTCI_NPMJS_TOKEN` to be an npmjs **automation / 2FA-bypass** token with read-write on `@midnightntwrk` — otherwise the publish fails with `EOTP`. (Account-side setup, part of #293.)

Refs shieldedtech/shielded-sre#293

🤖 Generated with [Claude Code](https://claude.com/claude-code)