### PR TITLE
Unified signing envelopes

### DIFF
--- a/.tag-decompositions/contract-maintenance-update-signing-envelope[v2]
+++ b/.tag-decompositions/contract-maintenance-update-signing-envelope[v2]
@@ -1,0 +1,1 @@
+((contract-address[v2],mpt-array[v1](maintenance-update-single-update[v2]),u32,()))

--- a/.tag-decompositions/dust-actions-signing-envelope[v2]((),())
+++ b/.tag-decompositions/dust-actions-signing-envelope[v2]((),())
@@ -1,0 +1,1 @@
+((mpt-array[v1](dust-spend[v1](())),vec-envelope(dust-registration-signing-envelope[v8](())),timestamp))

--- a/.tag-decompositions/dust-registration-signing-envelope[v8](())
+++ b/.tag-decompositions/dust-registration-signing-envelope[v8](())
@@ -1,0 +1,1 @@
+((signature-verifying-key[v2],option(dust-public-key[v1]),u128,()))

--- a/.tag-decompositions/inner-intent-pedersen-challenge-envelope[v8]((),(),pedersen[v1])
+++ b/.tag-decompositions/inner-intent-pedersen-challenge-envelope[v8]((),(),pedersen[v1])
@@ -1,1 +1,1 @@
-((option-envelope(unshielded-offer-signing-envelope[v2](())),option-envelope(unshielded-offer-signing-envelope[v2](())),mpt-array[v1](contract-action[v8](())),option(dust-actions[v2]((),())),timestamp,()))
+((option-envelope(unshielded-offer-signing-envelope[v2](())),option-envelope(unshielded-offer-signing-envelope[v2](())),mpt-array[v1](contract-action[v8](())),option-envelope(dust-actions[v2]((),())),timestamp,()))

--- a/.tag-decompositions/inner-intent-pedersen-challenge-envelope[v8]((),(),pedersen[v1])
+++ b/.tag-decompositions/inner-intent-pedersen-challenge-envelope[v8]((),(),pedersen[v1])
@@ -1,0 +1,1 @@
+((option-envelope(unshielded-offer-signing-envelope[v2](())),option-envelope(unshielded-offer-signing-envelope[v2](())),mpt-array[v1](contract-action[v8](())),option(dust-actions[v2]((),())),timestamp,()))

--- a/.tag-decompositions/inner-intent-signing-envelope[v8]((),(),pedersen[v1])
+++ b/.tag-decompositions/inner-intent-signing-envelope[v8]((),(),pedersen[v1])
@@ -1,1 +1,1 @@
-((option-envelope(unshielded-offer-signing-envelope[v2](())),option-envelope(unshielded-offer-signing-envelope[v2](())),mpt-array[v1](contract-action[v8](())),option(dust-actions[v2]((),())),timestamp,pedersen[v1]))
+((option-envelope(unshielded-offer-signing-envelope[v2](())),option-envelope(unshielded-offer-signing-envelope[v2](())),mpt-array[v1](contract-action[v8](())),option-envelope(dust-actions-signing-envelope[v2]((),())),timestamp,pedersen[v1]))

--- a/.tag-decompositions/inner-intent-signing-envelope[v8]((),(),pedersen[v1])
+++ b/.tag-decompositions/inner-intent-signing-envelope[v8]((),(),pedersen[v1])
@@ -1,0 +1,1 @@
+((option-envelope(unshielded-offer-signing-envelope[v2](())),option-envelope(unshielded-offer-signing-envelope[v2](())),mpt-array[v1](contract-action[v8](())),option(dust-actions[v2]((),())),timestamp,pedersen[v1]))

--- a/.tag-decompositions/intent-pedersen-challenge-envelope[v8]
+++ b/.tag-decompositions/intent-pedersen-challenge-envelope[v8]
@@ -1,0 +1,1 @@
+((u16,inner-intent-pedersen-challenge-envelope[v8]((),(),pedersen[v1])))

--- a/.tag-decompositions/intent-signing-envelope[v8]
+++ b/.tag-decompositions/intent-signing-envelope[v8]
@@ -1,0 +1,1 @@
+((u16,inner-intent-signing-envelope[v8]((),(),pedersen[v1])))

--- a/.tag-decompositions/unshielded-offer-signing-envelope[v2](())
+++ b/.tag-decompositions/unshielded-offer-signing-envelope[v2](())
@@ -1,0 +1,1 @@
+((mpt-array[v1](unshielded-utxo-spend[v2]),mpt-array[v1](unshielded-utxo-output[v1]),()))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 # Change Log
 
+## Unreleased
+
+- breaking: unify the construction of signing envelopes
+
 ## Ledger 9.0.1.0-rc.1
 
 - feat: add explicit price floor, denominated in full blocks, and governed by

--- a/CHANGELOG_base-crypto.md
+++ b/CHANGELOG_base-crypto.md
@@ -3,6 +3,7 @@
 ## Version `1.1.0`
 
 - feat: add `within_bounds` on `RunningCost`
+- feat: add `Envelope` trait derive macro, for building signing envelopes
 
 ## Version `1.0.0`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
  "indicatif 0.17.11",
  "k256",
  "lazy_static",
- "midnight-base-crypto-derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "midnight-base-crypto-derive 1.0.0",
  "midnight-serialize 1.0.0",
  "pastey 0.1.1",
  "rand 0.8.6",
@@ -3056,7 +3056,7 @@ dependencies = [
  "k256",
  "lazy_static",
  "midnight-base-crypto 1.1.0",
- "midnight-base-crypto-derive 1.0.0",
+ "midnight-base-crypto-derive 1.1.0",
  "midnight-serialize 1.2.0",
  "pastey 0.2.2",
  "proptest",
@@ -3077,21 +3077,21 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto-derive"
 version = "1.0.0"
-dependencies = [
- "proc-macro2",
- "quote 1.0.45",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "midnight-base-crypto-derive"
-version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62d0904a6357c953a55316b0ea7fac93d971f2d00c94d51e082817ae24872126"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "midnight-base-crypto-derive"
+version = "1.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3667,7 +3667,7 @@ dependencies = [
  "lazy_static",
  "lru 0.16.4",
  "midnight-base-crypto 1.0.0",
- "midnight-base-crypto-derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "midnight-base-crypto-derive 1.0.0",
  "midnight-circuits 6.2.0",
  "midnight-curves 0.2.0",
  "midnight-proofs 0.7.1",
@@ -3703,7 +3703,7 @@ dependencies = [
  "lazy_static",
  "lru 0.18.0",
  "midnight-base-crypto 1.1.0",
- "midnight-base-crypto-derive 1.0.0",
+ "midnight-base-crypto-derive 1.1.0",
  "midnight-circuits 7.2.0",
  "midnight-curves 0.3.0",
  "midnight-proofs 0.8.0",

--- a/base-crypto-derive/Cargo.toml
+++ b/base-crypto-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-base-crypto-derive"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/base-crypto-derive/src/lib.rs
+++ b/base-crypto-derive/src/lib.rs
@@ -20,8 +20,7 @@ use quote::{format_ident, quote};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{
-    ConstParam, Data, DataStruct, DeriveInput, Fields, GenericParam, Generics, Ident, Index,
-    TypeParam, parse_macro_input,
+    ConstParam, Data, DataStruct, DeriveInput, Fields, GenericParam, Generics, Ident, Index, PathArguments, Type, TypeParam, parse_macro_input
 };
 
 fn generic_variants(
@@ -45,7 +44,7 @@ fn generic_variants(
             }) => GenericParam::Type(TypeParam {
                 attrs: Vec::new(),
                 ident,
-                colon_token,
+colon_token,
                 bounds,
                 eq_token: None,
                 default: None,
@@ -146,6 +145,66 @@ pub fn field_repr(tokens: TokenStream) -> TokenStream {
             }
         }
     })
+}
+
+#[proc_macro_derive(Envelope, attributes(envelope))]
+pub fn envelope(tokens: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(tokens as DeriveInput);
+    let name = input.ident;
+    let (generic_bounded, generic_idents, _type_params) = generic_variants(input.generics.clone());
+    let generic_where = input.generics.where_clause;
+    let where_predicates = generic_where.as_ref().map(|wh| wh.predicates.clone());
+    let fields = match input.data {
+        Data::Struct(DataStruct { fields: Fields::Named(fields), .. }) => fields.named.into_iter().map(|field| {
+                let ident = field.ident.expect("named field must have a name!");
+                quote!(#ident)
+        }).collect::<Vec<_>>(),
+
+        _ => panic!("Only named structs can currently derive Envelope"),
+    };
+    let targets: Vec<Type> = input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("envelope"))
+        .map(|attr| attr.parse_args::<Type>())
+        .collect::<syn::Result<_>>()
+        .unwrap_or_else(|e| panic!("{}", e));
+    if targets.is_empty() {
+        panic!("`Envelope` derivation requires at least one `#[envelope(Type)]` attribute.");
+    }
+    let constructors: Vec<proc_macro2::TokenStream> = targets.iter().map(|target| {
+        let Type::Path(tp) = target else {
+            panic!("Expected 'path' type as `Envelope` target");
+        };
+        let mut path = tp.path.clone();
+        if let Some(last) = path.segments.last_mut() {
+            // turn `Foo<T>` args into `Foo::<T>`
+            match &mut last.arguments {
+                PathArguments::AngleBracketed(args) => {
+                    args.colon2_token = Some(Default::default());
+                }
+                _ => {}
+            }
+        }
+        quote!(#path)
+    }).collect();
+
+    let impls = targets.iter().zip(constructors.iter()).map(|(target, constructor)| {
+        quote! {
+            impl<#generic_bounded> Envelope<#target> for #name<#(#generic_idents),*>
+                where
+                   #where_predicates
+                #generic_where
+            {
+                fn into_envelope(&self) -> #target {
+                    #constructor {
+                        #(#fields: self.#fields.into_envelope(),)*
+                    }
+                }
+            }
+        }
+    });
+    TokenStream::from(quote! { #(#impls)* })
 }
 
 #[proc_macro_derive(BinaryHashRepr)]

--- a/base-crypto-derive/src/lib.rs
+++ b/base-crypto-derive/src/lib.rs
@@ -188,11 +188,8 @@ pub fn envelope(tokens: TokenStream) -> TokenStream {
             let mut path = tp.path.clone();
             if let Some(last) = path.segments.last_mut() {
                 // turn `Foo<T>` args into `Foo::<T>`
-                match &mut last.arguments {
-                    PathArguments::AngleBracketed(args) => {
-                        args.colon2_token = Some(Default::default());
-                    }
-                    _ => {}
+                if let PathArguments::AngleBracketed(args) = &mut last.arguments {
+                    args.colon2_token = Some(Default::default());
                 }
             }
             quote!(#path)

--- a/base-crypto-derive/src/lib.rs
+++ b/base-crypto-derive/src/lib.rs
@@ -20,7 +20,8 @@ use quote::{format_ident, quote};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{
-    ConstParam, Data, DataStruct, DeriveInput, Fields, GenericParam, Generics, Ident, Index, PathArguments, Type, TypeParam, parse_macro_input
+    ConstParam, Data, DataStruct, DeriveInput, Fields, GenericParam, Generics, Ident, Index,
+    PathArguments, Type, TypeParam, parse_macro_input,
 };
 
 fn generic_variants(
@@ -44,7 +45,7 @@ fn generic_variants(
             }) => GenericParam::Type(TypeParam {
                 attrs: Vec::new(),
                 ident,
-colon_token,
+                colon_token,
                 bounds,
                 eq_token: None,
                 default: None,
@@ -153,12 +154,18 @@ pub fn envelope(tokens: TokenStream) -> TokenStream {
     let name = input.ident;
     let (generic_bounded, generic_idents, _type_params) = generic_variants(input.generics.clone());
     let generic_where = input.generics.where_clause;
-    let where_predicates = generic_where.as_ref().map(|wh| wh.predicates.clone());
     let fields = match input.data {
-        Data::Struct(DataStruct { fields: Fields::Named(fields), .. }) => fields.named.into_iter().map(|field| {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(fields),
+            ..
+        }) => fields
+            .named
+            .into_iter()
+            .map(|field| {
                 let ident = field.ident.expect("named field must have a name!");
                 quote!(#ident)
-        }).collect::<Vec<_>>(),
+            })
+            .collect::<Vec<_>>(),
 
         _ => panic!("Only named structs can currently derive Envelope"),
     };
@@ -172,38 +179,42 @@ pub fn envelope(tokens: TokenStream) -> TokenStream {
     if targets.is_empty() {
         panic!("`Envelope` derivation requires at least one `#[envelope(Type)]` attribute.");
     }
-    let constructors: Vec<proc_macro2::TokenStream> = targets.iter().map(|target| {
-        let Type::Path(tp) = target else {
-            panic!("Expected 'path' type as `Envelope` target");
-        };
-        let mut path = tp.path.clone();
-        if let Some(last) = path.segments.last_mut() {
-            // turn `Foo<T>` args into `Foo::<T>`
-            match &mut last.arguments {
-                PathArguments::AngleBracketed(args) => {
-                    args.colon2_token = Some(Default::default());
+    let constructors: Vec<proc_macro2::TokenStream> = targets
+        .iter()
+        .map(|target| {
+            let Type::Path(tp) = target else {
+                panic!("Expected 'path' type as `Envelope` target");
+            };
+            let mut path = tp.path.clone();
+            if let Some(last) = path.segments.last_mut() {
+                // turn `Foo<T>` args into `Foo::<T>`
+                match &mut last.arguments {
+                    PathArguments::AngleBracketed(args) => {
+                        args.colon2_token = Some(Default::default());
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
-        }
-        quote!(#path)
-    }).collect();
+            quote!(#path)
+        })
+        .collect();
 
-    let impls = targets.iter().zip(constructors.iter()).map(|(target, constructor)| {
-        quote! {
-            impl<#generic_bounded> Envelope<#target> for #name<#(#generic_idents),*>
-                where
-                   #where_predicates
-                #generic_where
-            {
-                fn into_envelope(&self) -> #target {
-                    #constructor {
-                        #(#fields: self.#fields.into_envelope(),)*
+    let impls = targets
+        .iter()
+        .zip(constructors.iter())
+        .map(|(target, constructor)| {
+            quote! {
+                impl<#generic_bounded> Envelope<#target> for #name<#(#generic_idents),*>
+                    #generic_where
+                {
+                    fn into_envelope(&self) -> #target {
+                        #constructor {
+                            #(#fields: self.#fields.into_envelope(),)*
+                        }
                     }
                 }
             }
-        }
-    });
+        });
     TokenStream::from(quote! { #(#impls)* })
 }
 

--- a/base-crypto/src/envelope.rs
+++ b/base-crypto/src/envelope.rs
@@ -13,8 +13,11 @@
 
 //! This module deals with cryptographic envelopes, specifically through the `[Envelope]` trait.
 
-use std::{io::{self, Write}, marker::PhantomData};
 use serialize::{Serializable, Tagged, tagged_serialize};
+use std::{
+    io::{self, Write},
+    marker::PhantomData,
+};
 
 pub use derive::Envelope;
 
@@ -29,20 +32,25 @@ pub use derive::Envelope;
 /// The primary benefit of the `Envelope` trait is it's support for `#[derive(Envelope)]`, which
 /// ensures that the cryptographic envelope does not become detached from the source type by making
 /// any misalignment a compilation error.
-///
-/// An example of how an `Envelope` 
 pub trait Envelope<T> {
     /// Converts this value into its envelope.
     fn into_envelope(&self) -> T;
 
     /// Writes the serialization of the envelope into a bytestring.
-    fn envelope_data(&self) -> Vec<u8> where T: Serializable + Tagged {
+    fn envelope_data(&self) -> Vec<u8>
+    where
+        T: Serializable + Tagged,
+    {
         let mut output = Vec::new();
-        self.envelope_write(&mut output).expect("in-memory serialization should succeed");
+        self.envelope_write(&mut output)
+            .expect("in-memory serialization should succeed");
         output
     }
     /// Writes the serialization of the envelope into a [Write]r.
-    fn envelope_write(&self, writer: impl Write) -> io::Result<()> where T: Serializable + Tagged{
+    fn envelope_write(&self, writer: impl Write) -> io::Result<()>
+    where
+        T: Serializable + Tagged,
+    {
         tagged_serialize(&self.into_envelope(), writer)
     }
 }
@@ -61,8 +69,8 @@ impl<T> Envelope<PhantomData<T>> for T {
 
 #[cfg(test)]
 mod tests {
+    use serialize::{Deserializable, Serializable, Tagged};
     use std::marker::PhantomData;
-    use serialize::{Serializable, Deserializable, Tagged};
 
     use super::Envelope;
 
@@ -97,8 +105,23 @@ mod tests {
 
     #[test]
     fn test_envelope() {
-        let foo = Foo { bar: Bar(42), baz: Baz(64) };
-        assert_eq!(BarEnvelope { bar: Bar(42), baz: PhantomData }, foo.into_envelope());
-        assert_eq!(BazEnvelope { bar: PhantomData, baz: Baz(64) }, foo.into_envelope());
+        let foo = Foo {
+            bar: Bar(42),
+            baz: Baz(64),
+        };
+        assert_eq!(
+            BarEnvelope {
+                bar: Bar(42),
+                baz: PhantomData
+            },
+            foo.into_envelope()
+        );
+        assert_eq!(
+            BazEnvelope {
+                bar: PhantomData,
+                baz: Baz(64)
+            },
+            foo.into_envelope()
+        );
     }
 }

--- a/base-crypto/src/envelope.rs
+++ b/base-crypto/src/envelope.rs
@@ -1,0 +1,104 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module deals with cryptographic envelopes, specifically through the `[Envelope]` trait.
+
+use std::{io::{self, Write}, marker::PhantomData};
+use serialize::{Serializable, Tagged, tagged_serialize};
+
+pub use derive::Envelope;
+
+/// The envelope trait defines a conversion between a 'base' type into a cryptographic envelope
+/// type. This is typically a 1:1 copy of the base, but often with translation or erasure of certain
+/// fields, specifically to avoid self-reference in cryptographic envelopes (e.g. signing the
+/// signature itself).
+///
+/// Note that `T` is the target (envelope) type, and `Self` is the source type (the data *including*
+/// cryptographic values).
+///
+/// The primary benefit of the `Envelope` trait is it's support for `#[derive(Envelope)]`, which
+/// ensures that the cryptographic envelope does not become detached from the source type by making
+/// any misalignment a compilation error.
+///
+/// An example of how an `Envelope` 
+pub trait Envelope<T> {
+    /// Converts this value into its envelope.
+    fn into_envelope(&self) -> T;
+
+    /// Writes the serialization of the envelope into a bytestring.
+    fn envelope_data(&self) -> Vec<u8> where T: Serializable + Tagged {
+        let mut output = Vec::new();
+        self.envelope_write(&mut output).expect("in-memory serialization should succeed");
+        output
+    }
+    /// Writes the serialization of the envelope into a [Write]r.
+    fn envelope_write(&self, writer: impl Write) -> io::Result<()> where T: Serializable + Tagged{
+        tagged_serialize(&self.into_envelope(), writer)
+    }
+}
+
+impl<T: Clone> Envelope<T> for T {
+    fn into_envelope(&self) -> T {
+        self.clone()
+    }
+}
+
+impl<T> Envelope<PhantomData<T>> for T {
+    fn into_envelope(&self) -> PhantomData<T> {
+        PhantomData
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+    use serialize::{Serializable, Deserializable, Tagged};
+
+    use super::Envelope;
+
+    #[derive(Serializable, Clone, PartialEq, Eq, Debug)]
+    #[tag = "bar"]
+    struct Bar(u64);
+    #[derive(Serializable, Clone, PartialEq, Eq, Debug)]
+    #[tag = "baz"]
+    struct Baz(u64);
+
+    #[derive(Envelope)]
+    #[envelope(BazEnvelope)]
+    #[envelope(BarEnvelope)]
+    struct Foo {
+        bar: Bar,
+        baz: Baz,
+    }
+
+    #[derive(Serializable, Clone, PartialEq, Eq, Debug)]
+    #[tag = "bar-envelope"]
+    struct BarEnvelope {
+        bar: Bar,
+        baz: PhantomData<Baz>,
+    }
+
+    #[derive(Serializable, Clone, PartialEq, Eq, Debug)]
+    #[tag = "bar-envelope"]
+    struct BazEnvelope {
+        bar: PhantomData<Bar>,
+        baz: Baz,
+    }
+
+    #[test]
+    fn test_envelope() {
+        let foo = Foo { bar: Bar(42), baz: Baz(64) };
+        assert_eq!(BarEnvelope { bar: Bar(42), baz: PhantomData }, foo.into_envelope());
+        assert_eq!(BazEnvelope { bar: PhantomData, baz: Baz(64) }, foo.into_envelope());
+    }
+}

--- a/base-crypto/src/envelope.rs
+++ b/base-crypto/src/envelope.rs
@@ -34,6 +34,7 @@ pub use derive::Envelope;
 /// any misalignment a compilation error.
 pub trait Envelope<T> {
     /// Converts this value into its envelope.
+    #[allow(clippy::wrong_self_convention)]
     fn into_envelope(&self) -> T;
 
     /// Writes the serialization of the envelope into a bytestring.

--- a/base-crypto/src/lib.rs
+++ b/base-crypto/src/lib.rs
@@ -31,6 +31,7 @@ pub mod repr;
 pub mod rng;
 pub mod schnorr;
 pub mod time;
+pub mod envelope;
 
 #[deprecated = "`signatures` has been renamed to `schnorr` due to the addition of new signature schemes. Please prefer `schnorr`."]
 pub use schnorr as signatures;

--- a/base-crypto/src/lib.rs
+++ b/base-crypto/src/lib.rs
@@ -25,13 +25,13 @@
 pub mod cost_model;
 pub mod data_provider;
 pub mod ecdsa;
+pub mod envelope;
 pub mod fab;
 pub mod hash;
 pub mod repr;
 pub mod rng;
 pub mod schnorr;
 pub mod time;
-pub mod envelope;
 
 #[deprecated = "`signatures` has been renamed to `schnorr` due to the addition of new signature schemes. Please prefer `schnorr`."]
 pub use schnorr as signatures;

--- a/ledger/src/construct.rs
+++ b/ledger/src/construct.rs
@@ -14,7 +14,11 @@
 use crate::dust::{DUST_GENERATION_INFO_SIZE, DustActions};
 use crate::error::{MalformedTransaction, PartitionFailure};
 use crate::structure::{
-    ContractAction, ContractCall, ContractDeploy, GUARANTEED_SEGMENT, Intent, IntentSigningEnvelope, LedgerParameters, MIN_PROOF_SIZE, MaintenanceUpdate, ProofPreimageMarker, ProofPreimageVersioned, Signature, SignatureKind, SignaturesValue, SigningKey, SingleUpdate, StandardTransaction, Transaction, TransactionCostModel, UnshieldedOffer
+    ContractAction, ContractCall, ContractDeploy, GUARANTEED_SEGMENT, Intent,
+    IntentSigningEnvelope, LedgerParameters, MIN_PROOF_SIZE, MaintenanceUpdate,
+    ProofPreimageMarker, ProofPreimageVersioned, Signature, SignatureKind, SignaturesValue,
+    SigningKey, SingleUpdate, StandardTransaction, Transaction, TransactionCostModel,
+    UnshieldedOffer,
 };
 use crate::structure::{
     EXPECTED_CONTRACT_DEPTH, EXPECTED_OPERATIONS_DEPTH, EXPECTED_UTXO_DEPTH,
@@ -380,12 +384,14 @@ impl<
             .erase_signatures()
             .data_to_sign(segment_id);
 
-        let mut sign_unshielded_offers =
-            |unshielded_offer: &mut Option<Sp<UnshieldedOffer<S, D>, D>>,
-             signing_keys: &[SigningKey]|
-             -> Result<(), MalformedTransaction<D>> {
-                if let Some(offer) = unshielded_offer {
-                    let signatures: Vec<<S as SignatureKind<D>>::Signature<IntentSigningEnvelope<D>>> = offer
+        let mut sign_unshielded_offers = |unshielded_offer: &mut Option<
+            Sp<UnshieldedOffer<S, D>, D>,
+        >,
+                                          signing_keys: &[SigningKey]|
+         -> Result<(), MalformedTransaction<D>> {
+            if let Some(offer) = unshielded_offer {
+                let signatures: Vec<<S as SignatureKind<D>>::Signature<IntentSigningEnvelope<D>>> =
+                    offer
                         .inputs
                         .iter()
                         .zip(signing_keys)
@@ -397,12 +403,12 @@ impl<
                         })
                         .collect::<Result<Vec<_>, _>>()?;
 
-                    let mut new = (*offer).deref().clone();
-                    new.add_signatures(signatures);
-                    *unshielded_offer = Some(Sp::new(new.clone()));
-                }
-                Ok(())
-            };
+                let mut new = (*offer).deref().clone();
+                new.add_signatures(signatures);
+                *unshielded_offer = Some(Sp::new(new.clone()));
+            }
+            Ok(())
+        };
 
         sign_unshielded_offers(
             &mut self.guaranteed_unshielded_offer,

--- a/ledger/src/construct.rs
+++ b/ledger/src/construct.rs
@@ -14,14 +14,11 @@
 use crate::dust::{DUST_GENERATION_INFO_SIZE, DustActions};
 use crate::error::{MalformedTransaction, PartitionFailure};
 use crate::structure::{
-    ContractAction, ContractCall, ContractDeploy, GUARANTEED_SEGMENT, Intent, LedgerParameters,
-    MIN_PROOF_SIZE, MaintenanceUpdate, ProofPreimageMarker, ProofPreimageVersioned, Signature,
-    SignatureKind, SignaturesValue, SigningKey, SingleUpdate, StandardTransaction, Transaction,
-    TransactionCostModel, UnshieldedOffer,
+    ContractAction, ContractCall, ContractDeploy, GUARANTEED_SEGMENT, Intent, IntentSigningEnvelope, LedgerParameters, MIN_PROOF_SIZE, MaintenanceUpdate, ProofPreimageMarker, ProofPreimageVersioned, Signature, SignatureKind, SignaturesValue, SigningKey, SingleUpdate, StandardTransaction, Transaction, TransactionCostModel, UnshieldedOffer
 };
 use crate::structure::{
     EXPECTED_CONTRACT_DEPTH, EXPECTED_OPERATIONS_DEPTH, EXPECTED_UTXO_DEPTH,
-    FRESH_DUST_COMMITMENT_HASHES, SegIntent, UTXO_SIZE, VERIFIER_KEY_SIZE,
+    FRESH_DUST_COMMITMENT_HASHES, UTXO_SIZE, VERIFIER_KEY_SIZE,
 };
 use crate::structure::{PedersenDowngradeable, ProofKind};
 use base_crypto::cost_model::CostDuration;
@@ -388,7 +385,7 @@ impl<
              signing_keys: &[SigningKey]|
              -> Result<(), MalformedTransaction<D>> {
                 if let Some(offer) = unshielded_offer {
-                    let signatures: Vec<<S as SignatureKind<D>>::Signature<SegIntent<D>>> = offer
+                    let signatures: Vec<<S as SignatureKind<D>>::Signature<IntentSigningEnvelope<D>>> = offer
                         .inputs
                         .iter()
                         .zip(signing_keys)

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -17,7 +17,9 @@ use crate::error::{
 use crate::events::{Event, EventDetails};
 use crate::semantics::TransactionContext;
 use crate::structure::{
-    ErasedIntent, IntentHash, IntentSigningEnvelope, ProofKind, ProofMarker, ProofPreimageMarker, SPECKS_PER_DUST, STARS_PER_NIGHT, SignatureKind, SignatureVerifyingKey, Symbol, TransactionHash, UnshieldedOffer, Utxo, UtxoSpend, UtxoState
+    ErasedIntent, IntentHash, IntentSigningEnvelope, ProofKind, ProofMarker, ProofPreimageMarker,
+    SPECKS_PER_DUST, STARS_PER_NIGHT, SignatureKind, SignatureVerifyingKey, Symbol,
+    TransactionHash, UnshieldedOffer, Utxo, UtxoSpend, UtxoState,
 };
 use crate::verify::{StateReference, WellFormedStrictness};
 use base_crypto::{
@@ -634,7 +636,8 @@ impl<P: ProofKind<D>, D: DB> DustSpend<P, D> {
                     op.field_repr(&mut pis);
                 }
                 debug_assert_eq!(pis.len(), DUST_SPEND_PIS);
-                let dust_op = onchain_runtime::state::ContractOperation::new(Some(SPEND_VK.clone()), None);
+                let dust_op =
+                    onchain_runtime::state::ContractOperation::new(Some(SPEND_VK.clone()), None);
                 let dust_call = crate::structure::ContractCall {
                     address: coin_structure::contract::ContractAddress::default(),
                     entry_point: onchain_runtime::state::EntryPointBuf(vec![]),

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -21,7 +21,9 @@ use crate::structure::{
     SPECKS_PER_DUST, STARS_PER_NIGHT, SignatureKind, SignatureVerifyingKey, Symbol,
     TransactionHash, UnshieldedOffer, Utxo, UtxoSpend, UtxoState,
 };
+use crate::utils::VecEnvelope;
 use crate::verify::{StateReference, WellFormedStrictness};
+use base_crypto::envelope::Envelope;
 use base_crypto::{
     MemWrite,
     hash::{HashOutput, PERSISTENT_HASH_BYTES, PersistentHashWriter, persistent_commit},
@@ -49,6 +51,7 @@ use serialize::tagged_deserialize;
 use serialize::{Deserializable, Serializable, Tagged, tag_enforcement_test};
 use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter};
+use std::marker::PhantomData;
 #[cfg(test)]
 use storage::db::InMemoryDB;
 use storage::{
@@ -664,9 +667,10 @@ impl<P: ProofKind<D>, D: DB> DustSpend<P, D> {
     }
 }
 
-#[derive(Storable)]
+#[derive(Storable, Envelope)]
 #[derive_where(Clone, PartialEq, Eq, Debug; S)]
 #[storable(db = D)]
+#[envelope(DustRegistrationSigningEnvelope<S, D>)]
 #[tag = "dust-registration[v2]"]
 pub struct DustRegistration<S: SignatureKind<D>, D: DB> {
     pub night_key: SignatureVerifyingKey,
@@ -676,6 +680,18 @@ pub struct DustRegistration<S: SignatureKind<D>, D: DB> {
     pub signature: Option<Sp<S::Signature<IntentSigningEnvelope<D>>, D>>,
 }
 tag_enforcement_test!(DustRegistration<(), InMemoryDB>);
+
+#[derive(Serializable)]
+#[tag = "dust-registration-signing-envelope[v8]"]
+#[phantom(D)]
+pub struct DustRegistrationSigningEnvelope<S: SignatureKind<D>, D: DB> {
+    pub night_key: SignatureVerifyingKey,
+    pub dust_address: Option<Sp<DustPublicKey, D>>,
+    pub allow_fee_payment: u128,
+    #[allow(clippy::type_complexity)]
+    pub signature: PhantomData<Option<Sp<S::Signature<IntentSigningEnvelope<D>>, D>>>,
+}
+tag_enforcement_test!(DustRegistrationSigningEnvelope<(), InMemoryDB>);
 
 impl<S: SignatureKind<D>, D: DB> DustRegistration<S, D> {
     pub(crate) fn erase_signatures(&self) -> DustRegistration<(), D> {
@@ -712,10 +728,11 @@ impl<S: SignatureKind<D>, D: DB> DustRegistration<S, D> {
     }
 }
 
-#[derive(Storable)]
+#[derive(Storable, Envelope)]
 #[derive_where(Debug)]
 #[derive_where(Clone, PartialEq, Eq; S, P)]
 #[storable(db = D)]
+#[envelope(DustActionsSigningEnvelope<S, P, D>)]
 #[tag = "dust-actions[v2]"]
 pub struct DustActions<S: SignatureKind<D>, P: ProofKind<D>, D: DB> {
     pub spends: storage::storage::Array<DustSpend<P, D>, D>,
@@ -723,6 +740,16 @@ pub struct DustActions<S: SignatureKind<D>, P: ProofKind<D>, D: DB> {
     pub ctime: Timestamp,
 }
 tag_enforcement_test!(DustActions<(), (), InMemoryDB>);
+
+#[derive(Serializable)]
+#[tag = "dust-actions-signing-envelope[v2]"]
+#[phantom(D)]
+pub struct DustActionsSigningEnvelope<S: SignatureKind<D>, P: ProofKind<D>, D: DB> {
+    pub spends: storage::storage::Array<DustSpend<P, D>, D>,
+    pub registrations: VecEnvelope<DustRegistrationSigningEnvelope<S, D>>,
+    pub ctime: Timestamp,
+}
+tag_enforcement_test!(DustActionsSigningEnvelope<(), (), InMemoryDB>);
 
 impl<S: SignatureKind<D>, D: DB> DustActions<S, ProofPreimageMarker, D> {
     pub(crate) async fn prove(

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -17,9 +17,7 @@ use crate::error::{
 use crate::events::{Event, EventDetails};
 use crate::semantics::TransactionContext;
 use crate::structure::{
-    ErasedIntent, IntentHash, ProofKind, ProofMarker, ProofPreimageMarker, SPECKS_PER_DUST,
-    STARS_PER_NIGHT, SignatureKind, SignatureVerifyingKey, Symbol, TransactionHash,
-    UnshieldedOffer, Utxo, UtxoSpend, UtxoState,
+    ErasedIntent, IntentHash, IntentSigningEnvelope, ProofKind, ProofMarker, ProofPreimageMarker, SPECKS_PER_DUST, STARS_PER_NIGHT, SignatureKind, SignatureVerifyingKey, Symbol, TransactionHash, UnshieldedOffer, Utxo, UtxoSpend, UtxoState
 };
 use crate::verify::{StateReference, WellFormedStrictness};
 use base_crypto::{
@@ -672,7 +670,7 @@ pub struct DustRegistration<S: SignatureKind<D>, D: DB> {
     pub dust_address: Option<Sp<DustPublicKey, D>>,
     pub allow_fee_payment: u128,
     #[allow(clippy::type_complexity)]
-    pub signature: Option<Sp<S::Signature<(u16, ErasedIntent<D>)>, D>>,
+    pub signature: Option<Sp<S::Signature<IntentSigningEnvelope<D>>, D>>,
 }
 tag_enforcement_test!(DustRegistration<(), InMemoryDB>);
 

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -19,11 +19,13 @@ use crate::dust::{DustActions, DustParameters, DustState, INITIAL_DUST_PARAMETER
 use crate::error::FeeCalculationError;
 use crate::error::InvariantViolation;
 use crate::error::MalformedTransaction;
+use crate::utils::OptionEnvelope;
 use crate::verify::ProofVerificationMode;
 use base_crypto::BinaryHashRepr;
 use base_crypto::cost_model::RunningCost;
 use base_crypto::cost_model::price_adjustment_function;
 use base_crypto::cost_model::{CostDuration, FeePrices, FixedPoint, SyntheticCost};
+use base_crypto::envelope::Envelope;
 use base_crypto::hash::HashOutput;
 use base_crypto::hash::PERSISTENT_HASH_BYTES;
 use base_crypto::hash::persistent_hash;
@@ -646,16 +648,20 @@ pub struct OutputInstructionUnshielded {
 }
 tag_enforcement_test!(OutputInstructionUnshielded);
 
+#[derive(Serializable)]
+#[tag = "output-instruction-unshielded-with-token-type[v1]"]
+struct OutputInstructionUnshieldedWithTokenType {
+    token_type: UnshieldedTokenType,
+    instruction: OutputInstructionUnshielded,
+}
+
 impl OutputInstructionUnshielded {
     pub fn to_hash_data(self, tt: UnshieldedTokenType) -> Vec<u8> {
         let mut data = Vec::new();
-        data.extend(b"midnight:hash-output-instruction-unshielded:");
-        Serializable::serialize(&tt, &mut data).expect("In-memory serialization should succeed");
-        Serializable::serialize(&self.amount, &mut data)
-            .expect("In-memory serialization should succeed");
-        Serializable::serialize(&self.target_address, &mut data)
-            .expect("In-memory serialization should succeed");
-        Serializable::serialize(&self.nonce, &mut data)
+        tagged_serialize(&OutputInstructionUnshieldedWithTokenType {
+            token_type: tt,
+            instruction: self,
+        }, &mut data)
             .expect("In-memory serialization should succeed");
         data
     }
@@ -730,18 +736,8 @@ pub enum SystemTransaction {
 }
 tag_enforcement_test!(SystemTransaction);
 
-#[derive(Storable)]
-#[derive_where(Clone, PartialEq, Eq)]
-#[storable(db = D)]
-pub struct SegIntent<D: DB>(u16, ErasedIntent<D>);
-
-impl<D: DB> SegIntent<D> {
-    pub fn into_inner(&self) -> (u16, ErasedIntent<D>) {
-        (self.0, self.1.clone())
-    }
-}
-
-#[derive(Storable)]
+#[derive(Storable, Envelope)]
+#[envelope(UnshieldedOfferSigningEnvelope<S, D>)]
 #[tag = "unshielded-offer[v2]"]
 #[derive_where(Clone, PartialEq, Eq, PartialOrd, Ord; S)]
 #[storable(db = D)]
@@ -753,9 +749,20 @@ pub struct UnshieldedOffer<S: SignatureKind<D>, D: DB> {
     pub outputs: storage::storage::Array<UtxoOutput, D>,
     // Note that for S = (), this has a fixed point of ().
     // This signs the intent, and the segment ID
-    pub signatures: storage::storage::Array<S::Signature<SegIntent<D>>, D>,
+    pub signatures: storage::storage::Array<S::Signature<IntentSigningEnvelope<D>>, D>,
 }
 tag_enforcement_test!(UnshieldedOffer<(), InMemoryDB>);
+
+#[derive(Storable)]
+#[tag = "unshielded-offer-signing-envelope[v2]"]
+#[derive_where(Clone, PartialEq, Eq, PartialOrd, Ord; S)]
+#[storable(db = D)]
+pub struct UnshieldedOfferSigningEnvelope<S: SignatureKind<D>, D: DB> {
+    pub inputs: storage::storage::Array<UtxoSpend, D>,
+    pub outputs: storage::storage::Array<UtxoOutput, D>,
+    pub signatures: PhantomData<storage::storage::Array<S::Signature<IntentSigningEnvelope<D>>, D>>,
+}
+tag_enforcement_test!(UnshieldedOfferSigningEnvelope<(), InMemoryDB>);
 
 impl<S: SignatureKind<D>, D: DB> fmt::Debug for UnshieldedOffer<S, D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -773,7 +780,7 @@ impl<S: SignatureKind<D>, D: DB> fmt::Debug for UnshieldedOffer<S, D> {
 impl<S: SignatureKind<D>, D: DB> UnshieldedOffer<S, D> {
     pub fn add_signatures(
         &mut self,
-        signatures: Vec<<S as SignatureKind<D>>::Signature<SegIntent<D>>>,
+        signatures: Vec<<S as SignatureKind<D>>::Signature<IntentSigningEnvelope<D>>>,
     ) {
         for signature in signatures {
             self.signatures = self.signatures.push(signature);
@@ -828,11 +835,13 @@ impl rand::distributions::Distribution<IntentHash> for rand::distributions::Stan
 
 pub type ErasedIntent<D> = Intent<(), (), Pedersen, D>;
 
-#[derive(Storable)]
+#[derive(Storable, Envelope)]
+#[envelope(InnerIntentSigningEnvelope<S, P, B, D>)]
+#[envelope(InnerIntentPedersenEnvelope<S, P, B, D>)]
 #[tag = "intent[v8]"]
 #[derive_where(Clone, PartialEq, Eq; S, B, P)]
 #[storable(db = D)]
-pub struct Intent<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> {
+pub struct Intent<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D> + Clone, D: DB> {
     pub guaranteed_unshielded_offer: Option<Sp<UnshieldedOffer<S, D>, D>>,
     pub fallible_unshielded_offer: Option<Sp<UnshieldedOffer<S, D>, D>>,
     pub actions: storage::storage::Array<ContractAction<P, D>, D>,
@@ -842,11 +851,66 @@ pub struct Intent<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> {
 }
 tag_enforcement_test!(Intent<(), (), Pedersen, InMemoryDB>);
 
-impl<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> Intent<S, P, B, D> {
-    pub fn challenge_pre_for(&self, segment_id: u16) -> Vec<u8> {
-        let mut data = ContractAction::challenge_pre_for(Vec::from(&self.actions).as_slice());
-        let _ = Serializable::serialize(&segment_id, &mut data);
+#[derive(Serializable)]
+#[tag = "inner-intent-signing-envelope[v8]"]
+#[phantom(D)]
+// Note: This signing envelope is *not* just the erased intent in order to not count the number of
+// signatures in unshielded offers. For this same reason, no wrapper is required for dust/contract
+// actions; these *already* have erased the signatures/proofs from them.
+pub struct InnerIntentSigningEnvelope<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> {
+    pub guaranteed_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
+    pub fallible_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
+    pub actions: storage::storage::Array<ContractAction<P, D>, D>,
+    pub dust_actions: Option<Sp<DustActions<S, P, D>, D>>,
+    pub ttl: Timestamp,
+    pub binding_commitment: B,
+}
+tag_enforcement_test!(InnerIntentSigningEnvelope<(), (), Pedersen, InMemoryDB>);
 
+#[derive(Serializable)]
+#[tag = "inner-intent-signing-envelope[v8]"]
+#[phantom(D)]
+pub struct IntentSigningEnvelope<D: DB> {
+    pub segment: u16,
+    pub intent: InnerIntentSigningEnvelope<(), (), Pedersen, D>,
+}
+tag_enforcement_test!(IntentSigningEnvelope<InMemoryDB>);
+
+#[derive(Serializable)]
+#[tag = "inner-intent-pedersen-challenge-envelope[v8]"]
+#[phantom(D)]
+// Note: The pedersen envelope differs from the signing envelope in that it *fully* erases the
+// binding commitment. Otherwise, it follows the same rules as the signing envelope, and should only
+// be used on the erased intent. This is not enforced at a type level due to the limitations of the
+// `Envelope` derive macro, which is considered required as the automated nature of this will flag
+// envelope mismatches.
+struct InnerIntentPedersenEnvelope<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D> + Clone, D: DB> {
+    guaranteed_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
+    fallible_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
+    actions: storage::storage::Array<ContractAction<P, D>, D>,
+    dust_actions: Option<Sp<DustActions<S, P, D>, D>>,
+    ttl: Timestamp,
+    binding_commitment: PhantomData<B>,
+}
+tag_enforcement_test!(InnerIntentPedersenEnvelope<(), (), Pedersen, InMemoryDB>);
+
+#[derive(Serializable)]
+#[tag = "inner-intent-pedersen-challenge-envelope[v8]"]
+#[phantom(D)]
+struct IntentPedersenEnvelope<D: DB> {
+    segment: u16,
+    intent: InnerIntentPedersenEnvelope<(), (), Pedersen, D>,
+}
+tag_enforcement_test!(IntentSigningEnvelope<InMemoryDB>);
+
+impl<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D> + Serializable + PedersenDowngradeable<D>, D: DB> Intent<S, P, B, D> {
+    pub fn challenge_pre_for(&self, segment_id: u16) -> Vec<u8> {
+        let mut data = Vec::new();
+        let envelope = IntentPedersenEnvelope {
+            segment: segment_id,
+            intent: self.erase_proofs().erase_signatures().into_envelope(),
+        };
+        tagged_serialize(&envelope, &mut data).expect("in-memory serialization must succeed");
         data
     }
 }
@@ -869,20 +933,6 @@ impl<S: SignatureKind<D> + Debug, P: ProofKind<D>, B: Storable<D>, D: DB> fmt::D
             .field("binding_commitment", &Symbol("<binding commitment>"))
             .finish()
     }
-}
-
-fn to_hash_data<D: DB>(intent: Intent<(), (), Pedersen, D>, mut data: Vec<u8>) -> Vec<u8> {
-    Serializable::serialize(&intent.guaranteed_unshielded_offer, &mut data)
-        .expect("In-memory serialization should succeed");
-    Serializable::serialize(&intent.fallible_unshielded_offer, &mut data)
-        .expect("In-memory serialization should succeed");
-    Serializable::serialize(&intent.actions, &mut data)
-        .expect("In-memory serialization should succeed");
-    Serializable::serialize(&intent.ttl, &mut data)
-        .expect("In-memory serialization should succeed");
-    Serializable::serialize(&intent.binding_commitment, &mut data)
-        .expect("In-memory serialization should succeed");
-    data
 }
 
 impl<
@@ -973,10 +1023,12 @@ impl<
 impl<D: DB> Intent<(), (), Pedersen, D> {
     pub fn data_to_sign(&self, segment_id: u16) -> Vec<u8> {
         let mut data = Vec::new();
-        data.extend(b"midnight:hash-intent:");
-        Serializable::serialize(&segment_id, &mut data)
-            .expect("In-memory serialization should succeed");
-        to_hash_data::<D>(self.clone(), data)
+        let envelope = IntentSigningEnvelope {
+            segment: segment_id,
+            intent: self.into_envelope(),
+        };
+        tagged_serialize(&envelope, &mut data).expect("in-memory serialization must succeed");
+        data
     }
 }
 
@@ -1740,9 +1792,10 @@ impl<S: SignatureKind<D>, P: ProofKind<D> + Serializable + Deserializable, B: St
 
 type ErasedClaimRewardsTransaction<D> = ClaimRewardsTransaction<(), D>;
 
-#[derive(Storable)]
+#[derive(Storable, Envelope)]
 #[derive_where(Clone, PartialEq, Eq; S)]
 #[storable(db = D)]
+#[envelope(ClaimRewardsTransactionSigningEnvelope<S, D>)]
 #[tag = "claim-rewards-transaction[v2]"]
 pub struct ClaimRewardsTransaction<S: SignatureKind<D>, D: DB> {
     pub network_id: String,
@@ -1753,6 +1806,18 @@ pub struct ClaimRewardsTransaction<S: SignatureKind<D>, D: DB> {
     pub kind: ClaimKind,
 }
 tag_enforcement_test!(ClaimRewardsTransaction<(), InMemoryDB>);
+
+#[derive(Serializable)]
+#[phantom(S, D)]
+#[tag = "claim-rewards-transaction-signing-envelope[v2]"]
+struct ClaimRewardsTransactionSigningEnvelope<S: SignatureKind<D>, D: DB> {
+    network_id: String,
+    value: u128,
+    owner: SignatureVerifyingKey,
+    nonce: Nonce,
+    signature: PhantomData<S::Signature<ErasedClaimRewardsTransaction<D>>>,
+    kind: ClaimKind,
+}
 
 impl<S: SignatureKind<D>, D: DB> ClaimRewardsTransaction<S, D> {
     pub fn add_signature(&self, signature: Signature) -> ClaimRewardsTransaction<Signature, D> {
@@ -1780,19 +1845,7 @@ impl<S: SignatureKind<D>, D: DB> ClaimRewardsTransaction<S, D> {
 
 impl<D: DB> ClaimRewardsTransaction<(), D> {
     pub fn data_to_sign(&self) -> Vec<u8> {
-        let mut data = Vec::new();
-        data.extend(b"midnight:sig-claim_rewards_transaction:");
-        Self::to_hash_data(self.clone(), data)
-    }
-
-    pub fn to_hash_data(rewards: ClaimRewardsTransaction<(), D>, mut data: Vec<u8>) -> Vec<u8> {
-        Serializable::serialize(&rewards.value, &mut data)
-            .expect("In-memory serialization should succeed");
-        Serializable::serialize(&rewards.owner, &mut data)
-            .expect("In-memory serialization should succeed");
-        Serializable::serialize(&rewards.nonce, &mut data)
-            .expect("In-memory serialization should succeed");
-        data
+        <Self as Envelope<ClaimRewardsTransactionSigningEnvelope<_, _>>>::envelope_data(self)
     }
 }
 
@@ -2828,7 +2881,8 @@ impl SignaturesValue {
     }
 }
 
-#[derive(Storable)]
+#[derive(Storable, Envelope)]
+#[envelope(MaintenanceUpdateSigningEnvelope<D>)]
 #[derive_where(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[tag = "contract-maintenance-update[v2]"]
 #[storable(db = D)]
@@ -2839,6 +2893,17 @@ pub struct MaintenanceUpdate<D: DB> {
     pub signatures: storage::storage::Array<SignaturesValue, D>,
 }
 tag_enforcement_test!(MaintenanceUpdate<InMemoryDB>);
+
+#[derive(Serializable)]
+#[phantom(D)]
+#[tag = "contract-maintenance-update[v2]"]
+struct MaintenanceUpdateSigningEnvelope<D: DB> {
+    address: ContractAddress,
+    updates: storage::storage::Array<SingleUpdate, D>,
+    counter: u32,
+    signatures: PhantomData<storage::storage::Array<SignaturesValue, D>>,
+}
+tag_enforcement_test!(MaintenanceUpdateSigningEnvelope<InMemoryDB>);
 
 impl<D: DB> Debug for MaintenanceUpdate<D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -2853,15 +2918,7 @@ impl<D: DB> Debug for MaintenanceUpdate<D> {
 
 impl<D: DB> MaintenanceUpdate<D> {
     pub fn data_to_sign(&self) -> Vec<u8> {
-        let mut data = Vec::new();
-        data.extend(b"midnight:contract-update:");
-        Serializable::serialize(&self.address, &mut data)
-            .expect("In-memory serialization should succeed");
-        Serializable::serialize(&self.updates, &mut data)
-            .expect("In-memory serialization should succeed");
-        Serializable::serialize(&self.counter, &mut data)
-            .expect("In-memory serialization should succeed");
-        data
+        <Self as Envelope<MaintenanceUpdateSigningEnvelope<D>>>::envelope_data(self)
     }
 }
 
@@ -2918,32 +2975,6 @@ impl<P: ProofKind<D>, D: DB> ContractAction<P, D> {
             .into_iter()
             .map(ContractAction::erase_proof)
             .collect()
-    }
-
-    pub fn challenge_pre_for(calls: &[ContractAction<P, D>]) -> Vec<u8> {
-        let mut data = Vec::new();
-        for cd in calls.iter() {
-            match cd {
-                ContractAction::Call(call) => {
-                    data.push(0u8);
-                    let _ = Serializable::serialize(&call.address, &mut data);
-                    let _ = Serializable::serialize(&call.entry_point, &mut data);
-
-                    let _ = Serializable::serialize(&call.guaranteed_transcript, &mut data);
-
-                    let _ = Serializable::serialize(&call.fallible_transcript, &mut data);
-                }
-                ContractAction::Deploy(deploy) => {
-                    data.push(1u8);
-                    let _ = Serializable::serialize(&deploy, &mut data);
-                }
-                ContractAction::Maintain(upd) => {
-                    data.push(2u8);
-                    let _ = Serializable::serialize(&upd, &mut data);
-                }
-            }
-        }
-        data
     }
 }
 

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -311,9 +311,7 @@ impl Serializable for ProofVersioned {
     }
     fn serialized_size(&self) -> usize {
         match self {
-            ProofVersioned::V2(proof) | ProofVersioned::V3(proof) => {
-                proof.serialized_size() + 1
-            }
+            ProofVersioned::V2(proof) | ProofVersioned::V3(proof) => proof.serialized_size() + 1,
         }
     }
 }
@@ -473,11 +471,10 @@ impl<D: DB> ProofKind<D> for ProofMarker {
         match proof {
             ProofVersioned::V2(_) => match mode {
                 #[cfg(feature = "mock-verify")]
-                ProofVerificationMode::CalibratedMock => zkir_v2::ir_v1::v1_mock_verify(
-                    vk,
-                    pis.into_iter(),
-                )
-                .map_err(MalformedTransaction::<D>::InvalidProof),
+                ProofVerificationMode::CalibratedMock => {
+                    zkir_v2::ir_v1::v1_mock_verify(vk, pis.into_iter())
+                        .map_err(MalformedTransaction::<D>::InvalidProof)
+                }
                 _ => zkir_v2::ir_v1::v1_verify(vk, inner_proof, pis.into_iter())
                     .map_err(MalformedTransaction::<D>::InvalidProof),
             },
@@ -658,11 +655,14 @@ struct OutputInstructionUnshieldedWithTokenType {
 impl OutputInstructionUnshielded {
     pub fn to_hash_data(self, tt: UnshieldedTokenType) -> Vec<u8> {
         let mut data = Vec::new();
-        tagged_serialize(&OutputInstructionUnshieldedWithTokenType {
-            token_type: tt,
-            instruction: self,
-        }, &mut data)
-            .expect("In-memory serialization should succeed");
+        tagged_serialize(
+            &OutputInstructionUnshieldedWithTokenType {
+                token_type: tt,
+                instruction: self,
+            },
+            &mut data,
+        )
+        .expect("In-memory serialization should succeed");
         data
     }
 
@@ -868,7 +868,7 @@ pub struct InnerIntentSigningEnvelope<S: SignatureKind<D>, P: ProofKind<D>, B: S
 tag_enforcement_test!(InnerIntentSigningEnvelope<(), (), Pedersen, InMemoryDB>);
 
 #[derive(Serializable)]
-#[tag = "inner-intent-signing-envelope[v8]"]
+#[tag = "intent-signing-envelope[v8]"]
 #[phantom(D)]
 pub struct IntentSigningEnvelope<D: DB> {
     pub segment: u16,
@@ -884,7 +884,12 @@ tag_enforcement_test!(IntentSigningEnvelope<InMemoryDB>);
 // be used on the erased intent. This is not enforced at a type level due to the limitations of the
 // `Envelope` derive macro, which is considered required as the automated nature of this will flag
 // envelope mismatches.
-struct InnerIntentPedersenEnvelope<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D> + Clone, D: DB> {
+struct InnerIntentPedersenEnvelope<
+    S: SignatureKind<D>,
+    P: ProofKind<D>,
+    B: Storable<D> + Clone,
+    D: DB,
+> {
     guaranteed_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
     fallible_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
     actions: storage::storage::Array<ContractAction<P, D>, D>,
@@ -895,15 +900,21 @@ struct InnerIntentPedersenEnvelope<S: SignatureKind<D>, P: ProofKind<D>, B: Stor
 tag_enforcement_test!(InnerIntentPedersenEnvelope<(), (), Pedersen, InMemoryDB>);
 
 #[derive(Serializable)]
-#[tag = "inner-intent-pedersen-challenge-envelope[v8]"]
+#[tag = "intent-pedersen-challenge-envelope[v8]"]
 #[phantom(D)]
 struct IntentPedersenEnvelope<D: DB> {
     segment: u16,
     intent: InnerIntentPedersenEnvelope<(), (), Pedersen, D>,
 }
-tag_enforcement_test!(IntentSigningEnvelope<InMemoryDB>);
+tag_enforcement_test!(IntentPedersenEnvelope<InMemoryDB>);
 
-impl<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D> + Serializable + PedersenDowngradeable<D>, D: DB> Intent<S, P, B, D> {
+impl<
+    S: SignatureKind<D>,
+    P: ProofKind<D>,
+    B: Storable<D> + Serializable + PedersenDowngradeable<D>,
+    D: DB,
+> Intent<S, P, B, D>
+{
     pub fn challenge_pre_for(&self, segment_id: u16) -> Vec<u8> {
         let mut data = Vec::new();
         let envelope = IntentPedersenEnvelope {
@@ -2896,7 +2907,7 @@ tag_enforcement_test!(MaintenanceUpdate<InMemoryDB>);
 
 #[derive(Serializable)]
 #[phantom(D)]
-#[tag = "contract-maintenance-update[v2]"]
+#[tag = "contract-maintenance-update-signing-envelope[v2]"]
 struct MaintenanceUpdateSigningEnvelope<D: DB> {
     address: ContractAddress,
     updates: storage::storage::Array<SingleUpdate, D>,

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -15,6 +15,7 @@ use crate::annotation::NightAnn;
 use crate::dust::DUST_GENERATION_INFO_SIZE;
 use crate::dust::DUST_SPEND_PIS;
 use crate::dust::DUST_SPEND_PROOF_SIZE;
+use crate::dust::DustActionsSigningEnvelope;
 use crate::dust::{DustActions, DustParameters, DustState, INITIAL_DUST_PARAMETERS};
 use crate::error::FeeCalculationError;
 use crate::error::InvariantViolation;
@@ -855,13 +856,13 @@ tag_enforcement_test!(Intent<(), (), Pedersen, InMemoryDB>);
 #[tag = "inner-intent-signing-envelope[v8]"]
 #[phantom(D)]
 // Note: This signing envelope is *not* just the erased intent in order to not count the number of
-// signatures in unshielded offers. For this same reason, no wrapper is required for dust/contract
+// signatures in unshielded offers. For this same reason, no wrapper is required for contract
 // actions; these *already* have erased the signatures/proofs from them.
 pub struct InnerIntentSigningEnvelope<S: SignatureKind<D>, P: ProofKind<D>, B: Storable<D>, D: DB> {
     pub guaranteed_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
     pub fallible_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
     pub actions: storage::storage::Array<ContractAction<P, D>, D>,
-    pub dust_actions: Option<Sp<DustActions<S, P, D>, D>>,
+    pub dust_actions: OptionEnvelope<DustActionsSigningEnvelope<S, P, D>>,
     pub ttl: Timestamp,
     pub binding_commitment: B,
 }
@@ -893,7 +894,7 @@ struct InnerIntentPedersenEnvelope<
     guaranteed_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
     fallible_unshielded_offer: OptionEnvelope<UnshieldedOfferSigningEnvelope<S, D>>,
     actions: storage::storage::Array<ContractAction<P, D>, D>,
-    dust_actions: Option<Sp<DustActions<S, P, D>, D>>,
+    dust_actions: OptionEnvelope<DustActions<S, P, D>>,
     ttl: Timestamp,
     binding_commitment: PhantomData<B>,
 }

--- a/ledger/src/utils.rs
+++ b/ledger/src/utils.rs
@@ -98,3 +98,14 @@ impl<A: Envelope<B> + Storable<D>, B, D: DB> Envelope<OptionEnvelope<B>> for Opt
         }
     }
 }
+
+// Technical means to get around not being able to blanket-impl `Envelope` for `Option`
+#[derive(Serializable, Clone)]
+#[tag = "vec-envelope"]
+pub struct VecEnvelope<T>(pub Vec<T>);
+
+impl<A: Envelope<B> + Storable<D>, B, D: DB> Envelope<VecEnvelope<B>> for storage::storage::Array<A, D> {
+    fn into_envelope(&self) -> VecEnvelope<B> {
+        VecEnvelope(self.iter_deref().map(A::into_envelope).collect())
+    }
+}

--- a/ledger/src/utils.rs
+++ b/ledger/src/utils.rs
@@ -13,7 +13,8 @@
 
 use std::io::Read;
 
-use serialize::Serializable;
+use base_crypto::envelope::Envelope;
+use serialize::{Serializable, Tagged, Deserializable};
 use storage::{Storable, arena::Sp, db::DB, storage::HashMap};
 
 #[allow(unused)]
@@ -78,5 +79,22 @@ impl<K: Ord + Serializable + Storable<D>, V: Storable<D>, D: DB> KeySortedIter
         let mut items = self.iter().map(|sp| (*sp).clone()).collect::<Vec<_>>();
         items.sort_by_key(|a| a.0.clone());
         items.into_iter().map(|(_, v)| v)
+    }
+}
+
+// Technical means to get around not being able to blanket-impl `Envelope` for `Option`
+#[derive(Serializable, Clone)]
+#[tag = "option-envelope"]
+pub enum OptionEnvelope<T> {
+    Some(T),
+    None
+}
+
+impl<A: Envelope<B> + Storable<D>, B, D: DB> Envelope<OptionEnvelope<B>> for Option<Sp<A, D>> {
+    fn into_envelope(&self) -> OptionEnvelope<B> {
+        match self {
+            Some(t) => OptionEnvelope::Some((**t).into_envelope()),
+            None => OptionEnvelope::None,
+        }
     }
 }

--- a/ledger/src/utils.rs
+++ b/ledger/src/utils.rs
@@ -14,7 +14,7 @@
 use std::io::Read;
 
 use base_crypto::envelope::Envelope;
-use serialize::{Serializable, Tagged, Deserializable};
+use serialize::{Deserializable, Serializable, Tagged};
 use storage::{Storable, arena::Sp, db::DB, storage::HashMap};
 
 #[allow(unused)]
@@ -87,7 +87,7 @@ impl<K: Ord + Serializable + Storable<D>, V: Storable<D>, D: DB> KeySortedIter
 #[tag = "option-envelope"]
 pub enum OptionEnvelope<T> {
     Some(T),
-    None
+    None,
 }
 
 impl<A: Envelope<B> + Storable<D>, B, D: DB> Envelope<OptionEnvelope<B>> for Option<Sp<A, D>> {

--- a/ledger/tests/intent.rs
+++ b/ledger/tests/intent.rs
@@ -22,7 +22,6 @@ use midnight_ledger::construct::{ContractCallPrototype, PreTranscript, partition
 use midnight_ledger::error::MalformedTransaction;
 use midnight_ledger::error::TransactionApplicationError;
 use midnight_ledger::prove::Resolver;
-use midnight_ledger::structure::ContractAction;
 use midnight_ledger::structure::ReplayProtectionState;
 use midnight_ledger::structure::{
     ContractDeploy, INITIAL_PARAMETERS, Intent, LedgerState, Signature, SigningKey, Transaction,
@@ -254,7 +253,7 @@ async fn well_formed_signature_verification_failure_all() {
     intent_bc.binding_commitment = PureGeneratorPedersen::new_from(
         &mut rng.clone(),
         &rng.r#gen(),
-        &ContractAction::challenge_pre_for(&Vec::from(&intent_bc.actions)),
+        &intent_bc.challenge_pre_for(segment_id),
     );
 
     let strictness = WellFormedStrictness::default();


### PR DESCRIPTION
## Description

Unify signing/commitment envelopes, and ensure they remain synced to their source structs.

Technically a format change, as the signing envelopes have changed.

## Sanity Checklist

This PR:
- [X] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [X] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
