### PR TITLE
feat(transient-crypto): make proving-chain trait futures Send off wasm32

### DIFF
--- a/CHANGELOG_transient-crypto.md
+++ b/CHANGELOG_transient-crypto.md
@@ -1,5 +1,19 @@
 # `transient-crypto` Changelog
 
+## Unreleased
+
+- feat: the proving-chain traits (`Resolver`, `ParamsProverProvider`,
+  `ProvingProvider`) now return `Send` futures off `wasm32`, so a whole
+  `Transaction::prove` future is `Send` and can be driven on multi-threaded
+  executors (e.g. `tokio::spawn`ed proving). This is expressed via the new
+  `MaybeSend`/`MaybeSync` marker bounds, which alias `Send`/`Sync` everywhere
+  except `wasm32` (where they are vacuous, preserving the `!Send`
+  `JsValue`-backed WASM bindings). `async fn` implementations are unaffected as
+  long as their futures are `Send` off `wasm32`.
+- breaking (non-`wasm32`): out-of-tree `Resolver`/`ProvingProvider`/
+  `ParamsProverProvider` implementations whose futures are not `Send` will no
+  longer compile off `wasm32`.
+
 ## Version `3.0.0`
 
 - breaking: upgrade to `midnight-zk-stdlib` v2 / `midnight-circuits` v7

--- a/ledger-wasm/src/lib.rs
+++ b/ledger-wasm/src/lib.rs
@@ -11,6 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// WASM bindings: this crate is `!Send` by nature (its `Resolver`/`ProvingProvider`
+// impls capture `JsValue`/`JsFuture`). Off `wasm32` the proving-chain trait futures in
+// `transient-crypto` require `Send` (so the node's `Transaction::prove` future is `Send`),
+// which these bindings cannot satisfy. This crate only ever runs on `wasm32`, so gate it
+// to that target: keeps `cargo {check,clippy,build} --workspace` green on the host while
+// the real artifacts are still built for `wasm32` via the `*-wasm` nix targets.
+// NOTE: rust-analyzer (host target) treats this crate as inactive; set
+// `rust-analyzer.cargo.target = "wasm32-unknown-unknown"` locally when editing it.
+#![cfg(target_arch = "wasm32")]
 #![deny(warnings)]
 pub mod contract;
 pub mod conversions;

--- a/ledger/src/test_utilities.rs
+++ b/ledger/src/test_utilities.rs
@@ -187,7 +187,7 @@ impl<D: DB> TestState<D> {
         }
     }
 
-    pub async fn reward_night(&mut self, rng: &mut (impl CryptoRng + SplittableRng), amount: u128) {
+    pub async fn reward_night(&mut self, rng: &mut (impl CryptoRng + SplittableRng + transient_crypto::proofs::MaybeSend + transient_crypto::proofs::MaybeSync), amount: u128) {
         let amount = u128::max(amount, self.ledger.parameters.min_claimable_rewards());
         let address = UserAddress::from(self.night_key.verifying_key());
 
@@ -240,7 +240,7 @@ impl<D: DB> TestState<D> {
 
     pub async fn rewards_unshielded(
         &mut self,
-        rng: &mut (impl CryptoRng + SplittableRng),
+        rng: &mut (impl CryptoRng + SplittableRng + transient_crypto::proofs::MaybeSend + transient_crypto::proofs::MaybeSync),
         token: UnshieldedTokenType,
         amount: u128,
     ) {
@@ -355,7 +355,7 @@ impl<D: DB> TestState<D> {
 
     pub async fn give_fee_token(
         &mut self,
-        rng: &mut (impl CryptoRng + SplittableRng),
+        rng: &mut (impl CryptoRng + SplittableRng + transient_crypto::proofs::MaybeSend + transient_crypto::proofs::MaybeSync),
         utxos: usize,
     ) {
         use crate::structure::STARS_PER_NIGHT;
@@ -482,7 +482,7 @@ impl<D: DB> TestState<D> {
         B: Serializable + Clone + PedersenDowngradeable<D> + Storable<D>,
     >(
         &mut self,
-        mut rng: impl CryptoRng + SplittableRng,
+        mut rng: impl CryptoRng + SplittableRng + transient_crypto::proofs::MaybeSend + transient_crypto::proofs::MaybeSync,
         mut tx: Transaction<S, P, B, D>,
         resolver: &Resolver,
     ) -> Result<Transaction<S, P, B, D>, MalformedTransaction<D>> {
@@ -721,7 +721,11 @@ pub enum ClientProvingError<D: DB> {
 
 pub async fn tx_prove_bind<
     S: SignatureKind<D> + Tagged,
-    R: Rng + CryptoRng + SplittableRng,
+    R: Rng
+        + CryptoRng
+        + SplittableRng
+        + transient_crypto::proofs::MaybeSend
+        + transient_crypto::proofs::MaybeSync,
     D: DB,
 >(
     #[allow(unused_mut)] mut rng: R,
@@ -738,7 +742,15 @@ pub async fn tx_prove_bind<
     }
 }
 
-pub async fn tx_prove<S: SignatureKind<D> + Tagged, R: Rng + CryptoRng + SplittableRng, D: DB>(
+pub async fn tx_prove<
+    S: SignatureKind<D> + Tagged,
+    R: Rng
+        + CryptoRng
+        + SplittableRng
+        + transient_crypto::proofs::MaybeSend
+        + transient_crypto::proofs::MaybeSync,
+    D: DB,
+>(
     #[cfg_attr(feature = "proving", allow(unused_mut))] mut _rng: R,
     tx: &Transaction<S, ProofPreimageMarker, PedersenRandomness, D>,
     #[cfg_attr(not(feature = "proving"), allow(unused_variables))] resolver: &Resolver,
@@ -955,7 +967,7 @@ pub trait ProofKindExt<B: Storable<D>, D: DB>: ProofKind<D> {
     // Allowed as this is testing-only API
     #[allow(async_fn_in_trait)]
     async fn from_unproven<S: SignatureKind<D> + Tagged>(
-        rng: impl CryptoRng + SplittableRng,
+        rng: impl CryptoRng + SplittableRng + transient_crypto::proofs::MaybeSend + transient_crypto::proofs::MaybeSync,
         resolver: &Resolver,
         tx: Transaction<S, ProofPreimageMarker, PedersenRandomness, D>,
     ) -> Transaction<S, Self, B, D>;
@@ -966,7 +978,7 @@ pub trait ProofKindExt<B: Storable<D>, D: DB>: ProofKind<D> {
 
 impl<D: DB> ProofKindExt<PedersenRandomness, D> for ProofPreimageMarker {
     async fn from_unproven<S: SignatureKind<D> + Tagged>(
-        _rng: impl CryptoRng + SplittableRng,
+        _rng: impl CryptoRng + SplittableRng + transient_crypto::proofs::MaybeSend + transient_crypto::proofs::MaybeSync,
         _resolver: &Resolver,
         tx: Transaction<S, ProofPreimageMarker, PedersenRandomness, D>,
     ) -> Transaction<S, Self, PedersenRandomness, D> {
@@ -981,7 +993,7 @@ impl<D: DB> ProofKindExt<PedersenRandomness, D> for ProofPreimageMarker {
 
 impl<D: DB> ProofKindExt<Pedersen, D> for () {
     async fn from_unproven<S: SignatureKind<D> + Tagged>(
-        mut _rng: impl CryptoRng + SplittableRng,
+        mut _rng: impl CryptoRng + SplittableRng + transient_crypto::proofs::MaybeSend + transient_crypto::proofs::MaybeSync,
         _resolver: &Resolver,
         tx: Transaction<S, ProofPreimageMarker, PedersenRandomness, D>,
     ) -> Transaction<S, Self, Pedersen, D> {
@@ -997,7 +1009,7 @@ impl<D: DB> ProofKindExt<Pedersen, D> for () {
 #[cfg(feature = "proving")]
 impl<D: DB> ProofKindExt<PureGeneratorPedersen, D> for ProofMarker {
     async fn from_unproven<S: SignatureKind<D> + Tagged>(
-        mut rng: impl CryptoRng + SplittableRng,
+        mut rng: impl CryptoRng + SplittableRng + transient_crypto::proofs::MaybeSend + transient_crypto::proofs::MaybeSync,
         resolver: &Resolver,
         tx: Transaction<S, ProofPreimageMarker, PedersenRandomness, D>,
     ) -> Transaction<S, Self, PureGeneratorPedersen, D> {
@@ -1016,7 +1028,11 @@ impl<D: DB> ProofKindExt<PureGeneratorPedersen, D> for ProofMarker {
 #[cfg(feature = "proving")]
 #[allow(clippy::type_complexity, clippy::result_large_err)]
 pub fn well_formed_tx_builder<
-    R: Rng + CryptoRng + SplittableRng,
+    R: Rng
+        + CryptoRng
+        + SplittableRng
+        + transient_crypto::proofs::MaybeSend
+        + transient_crypto::proofs::MaybeSync,
     S: SignatureKind<D> + Tagged,
     D: DB,
 >(

--- a/transient-crypto/src/proofs.rs
+++ b/transient-crypto/src/proofs.rs
@@ -52,13 +52,48 @@ use storage_core::db::DB;
 use storage_core::storable::Loader;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 use derive_where::derive_where;
+use std::future::Future;
+
+/// Marker bound applied to the futures returned by the proving-chain traits
+/// ([`ParamsProverProvider`], [`Resolver`], [`ProvingProvider`]).
+///
+/// Off `wasm32` it is an alias for [`Send`], so those futures can be driven on
+/// multi-threaded executors (e.g. `tokio::spawn`ed proving) and a whole
+/// `Transaction::prove` future stays `Send`. On `wasm32` it is a vacuous bound:
+/// the WASM bindings (`ledger-wasm`, `zkir-wasm`) implement these traits with
+/// `!Send` `JsValue`/`js_sys::Function`-backed futures, and WASM is single-threaded
+/// so `Send` is neither available nor needed there.
+///
+/// Implementors never name this bound — an `async fn` implementation satisfies it
+/// automatically as long as its future is `Send` (off `wasm32`).
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSend: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send> MaybeSend for T {}
+/// See the non-`wasm32` definition above; on `wasm32` this bound is vacuous.
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSend {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSend for T {}
+
+/// Companion to [`MaybeSend`] for [`Sync`]: an alias for [`Sync`] off `wasm32`,
+/// vacuous on `wasm32`. Used to bound the generic provider/resolver types whose
+/// `&T` is captured across awaits, so a `MaybeSend` future built from them is
+/// actually `Send` off `wasm32`.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSync: Sync {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Sync> MaybeSync for T {}
+/// See the non-`wasm32` definition above; on `wasm32` this bound is vacuous.
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSync {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSync for T {}
 
 /// A provider of prover parameters.
 pub trait ParamsProverProvider {
-    // Allowed because we don't care about auto traits here.
-    #[allow(async_fn_in_trait)]
     /// Retrieve the parameters for a given `k` value
-    async fn get_params(&self, k: u8) -> io::Result<ParamsProver>;
+    fn get_params(&self, k: u8) -> impl Future<Output = io::Result<ParamsProver>> + MaybeSend;
 }
 
 /// The hash used during proof transcript processing
@@ -674,24 +709,27 @@ tag_enforcement_test!(ProvingKeyMaterial);
 /// A mechanism to retrieve / resolve zero-knowledge key material from a short location string.
 pub trait Resolver {
     /// Resolves the given key to the key material it represents, if available.
-    // Allowed as we do not need auto traits here
-    #[allow(async_fn_in_trait)]
-    async fn resolve_key(&self, key: KeyLocation) -> io::Result<Option<ProvingKeyMaterial>>;
+    fn resolve_key(
+        &self,
+        key: KeyLocation,
+    ) -> impl Future<Output = io::Result<Option<ProvingKeyMaterial>>> + MaybeSend;
 }
 
 /// A tool that provides proving against opaque/serialized proof preimages
 /// It is assumed (though not strictly required) that this also implements
 /// `Resolver` to resolve keys.
-#[allow(async_fn_in_trait)]
 pub trait ProvingProvider {
     /// Check the proof preimage is valid, and if so returns the pi skip sequence
-    async fn check(&self, preimage: &ProofPreimage) -> Result<Vec<Option<usize>>, anyhow::Error>;
+    fn check(
+        &self,
+        preimage: &ProofPreimage,
+    ) -> impl Future<Output = Result<Vec<Option<usize>>, anyhow::Error>> + MaybeSend;
     /// Produces the proof, optionally modifying the binding input in the proof preimage first.
-    async fn prove(
+    fn prove(
         self,
         preimage: &ProofPreimage,
         overwrite_binding_input: Option<Fr>,
-    ) -> Result<Proof, anyhow::Error>;
+    ) -> impl Future<Output = Result<Proof, anyhow::Error>> + MaybeSend;
     /// Creates a copy of this provider. As providers often include an RNG, this
     /// may mutate the provider itself.
     fn split(&mut self) -> Self;

--- a/wasm-proving-demos/zkir-mt/src/lib.rs
+++ b/wasm-proving-demos/zkir-mt/src/lib.rs
@@ -11,5 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// WASM-only demo: re-exports the `wasm32`-gated `midnight-zkir-wasm` bindings and uses
+// `wasm-bindgen-rayon`, so it likewise only compiles for `wasm32`. Gating keeps
+// `cargo --workspace` green on the host. See `zkir-wasm/src/lib.rs` for the full why.
+#![cfg(target_arch = "wasm32")]
 pub use wasm_bindgen_rayon::init_thread_pool;
 pub use zkir::*;

--- a/zkir-v3-wasm/src/lib.rs
+++ b/zkir-v3-wasm/src/lib.rs
@@ -11,6 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// WASM bindings: this crate is `!Send` by nature (its `Resolver`/`ProvingProvider`
+// impls capture `JsValue`/`JsFuture`). Off `wasm32` the proving-chain trait futures in
+// `transient-crypto` require `Send` (so the node's `Transaction::prove` future is `Send`),
+// which these bindings cannot satisfy. This crate only ever runs on `wasm32`, so gate it
+// to that target: keeps `cargo {check,clippy,build} --workspace` green on the host while
+// the real artifacts are still built for `wasm32` via the `*-wasm` nix targets.
+// NOTE: rust-analyzer (host target) treats this crate as inactive; set
+// `rust-analyzer.cargo.target = "wasm32-unknown-unknown"` locally when editing it.
+#![cfg(target_arch = "wasm32")]
 #![allow(dead_code)]
 use hex::FromHex;
 use js_sys::{BigInt, Function, JsString, Promise, Uint8Array};

--- a/zkir-wasm/src/lib.rs
+++ b/zkir-wasm/src/lib.rs
@@ -11,6 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// WASM bindings: this crate is `!Send` by nature (its `Resolver`/`ProvingProvider`
+// impls capture `JsValue`/`JsFuture`). Off `wasm32` the proving-chain trait futures in
+// `transient-crypto` require `Send` (so the node's `Transaction::prove` future is `Send`),
+// which these bindings cannot satisfy. This crate only ever runs on `wasm32`, so gate it
+// to that target: keeps `cargo {check,clippy,build} --workspace` green on the host while
+// the real artifacts are still built for `wasm32` via the `*-wasm` nix targets.
+// NOTE: rust-analyzer (host target) treats this crate as inactive; set
+// `rust-analyzer.cargo.target = "wasm32-unknown-unknown"` locally when editing it.
+#![cfg(target_arch = "wasm32")]
 #![allow(dead_code)]
 use hex::FromHex;
 use js_sys::{BigInt, Function, JsString, Promise, Uint8Array};

--- a/zkir/src/lib.rs
+++ b/zkir/src/lib.rs
@@ -38,9 +38,13 @@ pub struct LocalProvingProvider<'a, R: Rng + CryptoRng + SplittableRng, S, P> {
 
 impl<
     'a,
-    R: Rng + CryptoRng + SplittableRng,
-    S: transient_crypto::proofs::Resolver,
-    P: transient_crypto::proofs::ParamsProverProvider,
+    R: Rng
+        + CryptoRng
+        + SplittableRng
+        + transient_crypto::proofs::MaybeSend
+        + transient_crypto::proofs::MaybeSync,
+    S: transient_crypto::proofs::Resolver + transient_crypto::proofs::MaybeSync,
+    P: transient_crypto::proofs::ParamsProverProvider + transient_crypto::proofs::MaybeSync,
 > transient_crypto::proofs::ProvingProvider for LocalProvingProvider<'a, R, S, P>
 {
     async fn check(

--- a/zswap/benches/benchmarking.rs
+++ b/zswap/benches/benchmarking.rs
@@ -16,15 +16,15 @@ use rand::rngs::StdRng;
 use rand::{CryptoRng, Rng};
 use storage::db::InMemoryDB;
 use transient_crypto::proofs::{
-    ParamsProverProvider, Proof, ProofPreimage, ProvingError, Resolver,
+    MaybeSend, MaybeSync, ParamsProverProvider, Proof, ProofPreimage, ProvingError, Resolver,
 };
 use zkir_v2::LocalProvingProvider;
 
 fn sync_prove(
     offer: &Offer<ProofPreimage, InMemoryDB>,
-    rng: impl CryptoRng + SplittableRng,
-    pp: &impl ParamsProverProvider,
-    resolver: &impl Resolver,
+    rng: impl CryptoRng + SplittableRng + MaybeSend + MaybeSync,
+    pp: &(impl ParamsProverProvider + MaybeSync),
+    resolver: &(impl Resolver + MaybeSync),
 ) -> Result<Offer<Proof, InMemoryDB>, ProvingError> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()


### PR DESCRIPTION
## Description

The `Resolver` / `ParamsProverProvider` / `ProvingProvider` traits use
async-fn-in-trait (RPITIT), whose futures don't carry `Send`. [`Transaction::prove`]
takes the provider generically (`prove(&self, prover: impl ProvingProvider, …)`) and
fans its futures through `join_all`/`futures::join!`, so in that generic body the
compiler cannot assume the provider's futures are `Send` — making the whole
`Transaction::prove` future `!Send` and unusable on a multi-threaded executor (e.g.
`tokio::spawn`ed proving in downstream tooling).

This adds `MaybeSend`/`MaybeSync` marker bounds (aliases for `Send`/`Sync` off
`wasm32`, vacuous on `wasm32` to preserve the `!Send` `JsValue`-backed WASM bindings)
to the proving-chain trait futures. `async fn` impls are unchanged where their futures
are already `Send`. Closes the need for the node-side `run_local_proving` thread-bridge.

## Root cause & why it only surfaced in ledger-9 rc.3

This was a **latent `!Send`** that ledger-9 rc.3's dual-stack consolidation surfaced —
not a regression in any trait header (the proving-chain traits have always been bare
`async fn` in trait, `#[allow(async_fn_in_trait)]`, across the 2.x and 3.x stacks).

The concrete trigger is how `zkir`'s `LocalProvingProvider::prove` bottoms out. Between
[`zkir-2.2.0-rc.2`] (ledger-9 rc.2) and [`zkir-2.2.0-rc.3`] (rc.3) it changed from a
tail-await of an **inherent `async fn`** to an `.await` on a **trait method**:

```rust
// rc.2 — proved via an inherent `async fn` (ir_v1::v1_prove)
ir_v1::v1_prove(&preimage, self.rng, self.params, self.resolver).await

// rc.3 — V0/V1 now awaits a bare async-fn-in-trait on the 2.x crate
let (proof, _, _) =
    transient_crypto_old::proofs::Zkir::prove(&ir, self.rng, &v1_params, pk, &old_preimage).await?;
```

- An **inherent `async fn`** ([`ir_v1::v1_prove`]) leaks its future's auto-traits from
  its concrete argument types, so `v1_prove(self.rng: StdRng, …)` is `Send`. rc.2's
  concrete proving future was therefore `Send`, and the node's
  `#[async_trait] ProofProvider: Send` proof server compiled with a **direct
  `tx.prove(..).await`** — no bridge.
- A **bare async-fn-in-trait** ([`transient_crypto_old::Zkir::prove`] —
  `#[allow(async_fn_in_trait)]`, no `Send` bound) is RPITIT: its future is treated as
  `!Send`. Awaiting it in the proving body, then routing the result up through the
  generic [`Transaction::prove<impl ProvingProvider>`] (whose `ProvingProvider` /
  `Resolver` methods are *also* bound-less RPITIT), makes the whole `Transaction::prove`
  future `!Send` with no way to recover it by monomorphization. That is what forced the
  node's `run_local_proving` scoped-thread bridge.

So the answer to *"where did the `Send` go?"* is: rc.2 got it for free from an inherent
`async fn`; rc.3 started `.await`ing a bound-less async-fn-in-trait, which is `!Send`.

(The same rc.3 consolidation — node commit `feat: ledger 9-rc.3` — also dropped the
separate 2.x `zkir-2-1` crate and added the `transient-crypto-old` 2.2.0 dependency, so a
single `midnight-zkir 2.2.0` proves L7/L8/L9 alike. The node's own bridge comment names
this PR as the fix: *"REMOVE once `transient-crypto`'s `Resolver::resolve_key` gains a
`Send` bound upstream and the new ledger release is adopted."*)

## Why this scope is sufficient

- The bound is applied to the provider-trait futures (the generic boundary that needs
  the guarantee) **and** to `zkir`'s `LocalProvingProvider` `R`/`S`/`P` generics, so the
  rng/resolver/params captured across the awaits are `Send`/`Sync`. Together these
  re-supply the `Send` guarantee that rc.2's inherent-fn path gave implicitly.
- `transient-crypto-old` and the `Zkir` trait are intentionally left untouched:
  `Zkir::prove` is only ever awaited on the **concrete** `IrSource`, so its future's
  `Send`-ness leaks from the impl once the captured generics are bounded `Send`.
- Verified: `cargo check` over the default members (which include `zkir`) compiles
  `LocalProvingProvider` against the now-`Send`-bounded `ProvingProvider` — i.e. the
  concrete proving future (both the V2+ `ProofPreimage::prove` and the V0/V1
  `transient_crypto_old::Zkir::prove` paths) genuinely is `Send`.

[`Transaction::prove`]: https://github.com/midnightntwrk/midnight-ledger/blob/crate-ledger-9.1.0.0-rc.3/ledger/src/prove.rs#L151-L156
[`Transaction::prove<impl ProvingProvider>`]: https://github.com/midnightntwrk/midnight-ledger/blob/crate-ledger-9.1.0.0-rc.3/ledger/src/prove.rs#L151-L156
[`zkir-2.2.0-rc.2`]: https://github.com/midnightntwrk/midnight-ledger/blob/zkir-2.2.0-rc.2/zkir/src/lib.rs#L63-L74
[`zkir-2.2.0-rc.3`]: https://github.com/midnightntwrk/midnight-ledger/blob/zkir-2.2.0-rc.3/zkir/src/lib.rs#L89-L114
[`ir_v1::v1_prove`]: https://github.com/midnightntwrk/midnight-ledger/blob/zkir-2.2.0-rc.2/zkir/src/ir_v1.rs#L150-L155
[`transient_crypto_old::Zkir::prove`]: https://github.com/midnightntwrk/midnight-ledger/blob/transient-crypto-2.2.0-rc.1/transient-crypto/src/proofs.rs#L152-L173

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [x] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [x] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [x] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.

> [!NOTE]
> Breaking only for **out-of-tree** `Resolver`/`ProvingProvider`/`ParamsProverProvider`
> implementations whose futures are not `Send` (off `wasm32`); all in-tree impls and the
> `wasm32` bindings are unaffected. Targeted at `ledger-9` accordingly.
