### PR TITLE
zkir-v3: fix inputs advancement in fab_decode_to_bytes_atom

### DIFF
--- a/proof-server/src/worker_pool.rs
+++ b/proof-server/src/worker_pool.rs
@@ -36,9 +36,9 @@ pub enum WorkerPoolError {
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum WorkError {
-    #[error("bad input")]
+    #[error("bad input {0}")]
     BadInput(String),
-    #[error("internal error")]
+    #[error("internal error {0}")]
     InternalError(String),
     #[error("work cancelled unexpectedly")]
     CancelledUnexpectedly,

--- a/proof-server/src/worker_pool.rs
+++ b/proof-server/src/worker_pool.rs
@@ -36,9 +36,9 @@ pub enum WorkerPoolError {
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum WorkError {
-    #[error("bad input {0}")]
+    #[error("bad input")]
     BadInput(String),
-    #[error("internal error {0}")]
+    #[error("internal error")]
     InternalError(String),
     #[error("work cancelled unexpectedly")]
     CancelledUnexpectedly,

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -165,8 +165,8 @@ fn fab_decode_to_bytes_atom(
             }
             for i in 0..chunks {
                 bytes_from(res, FR_BYTES_STORED, inputs[chunks - 1 - i].clone())?;
-                *inputs = &inputs[1..];
             }
+            *inputs = &inputs[chunks..];
             res.extend(res_vec);
             Ok(())
         }

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -165,6 +165,7 @@ fn fab_decode_to_bytes_atom(
             }
             for i in 0..chunks {
                 bytes_from(res, FR_BYTES_STORED, inputs[chunks - 1 - i].clone())?;
+                *inputs = &inputs[1..];
             }
             *inputs = &inputs[chunks..];
             res.extend(res_vec);

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -167,7 +167,6 @@ fn fab_decode_to_bytes_atom(
                 bytes_from(res, FR_BYTES_STORED, inputs[chunks - 1 - i].clone())?;
                 *inputs = &inputs[1..];
             }
-            *inputs = &inputs[chunks..];
             res.extend(res_vec);
             Ok(())
         }


### PR DESCRIPTION
Advancing inputs by one inside the loop while indexing inputs[chunks - 1 - i] re-read the same element each iteration. Index stably and advance by chunks once after the loop.

## Description
zkir v2: https://github.com/midnightntwrk/midnight-ledger/blob/cb6690234c44507c59b028897ef0ee38896c3a49/zkir/src/ir_vm.rs#L159
zkir v3: https://github.com/midnightntwrk/midnight-ledger/blob/cb6690234c44507c59b028897ef0ee38896c3a49/zkir-v3/src/ir_vm.rs#L168

zkir v3 is doing fab decode differently compared to zkir v2.
And this caused keccak256 fail for Bytes<62+>, while sha256 still works (since sha256 is zkir v2)

<!-- describe what this PR does, and why it is needed -->

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [X] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
