### PR TITLE
Backport: cargo audit vulnerabilities (crossbeam-epoch + quick-xml)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,9 @@
+# quick-xml 0.26 is pulled in via pprof -> inferno 0.11 (dev/bench dependency only).
+# inferno 0.12 dropped quick-xml, but pprof 0.15 (latest) pins inferno 0.11 and
+# cargo [patch] can't cross semver boundaries for pre-1.0 crates.
+# These are not exploitable in our context as they only affect benchmark flamegraph generation.
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0194", # quick-xml: quadratic duplicate attribute check
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
Backport of ledger-9 commit \`2e63c998\` (Alex Dalton, 2026-07-07) onto ledger-8. Fixes three RUSTSEC advisories that dropped after ledger-8's last successful CI run (2026-07-01), which are currently red-lining every PR against ledger-8 including #635.

- RUSTSEC-2026-0204: bump \`crossbeam-epoch\` 0.9.18 → 0.9.20 (Cargo.lock)
- RUSTSEC-2026-0194 / RUSTSEC-2026-0195: ignore \`quick-xml 0.26\` advisories via \`.cargo/audit.toml\` (pulled in via dev-only \`pprof → inferno 0.11\`; no upstream fix available since pprof pins inferno and cargo can't [patch] across pre-1.0 semver)

## Test plan
- [ ] CI \`check\` job passes on this PR
- [ ] After merge, rebase #635 on ledger-8 and confirm the same check passes there

## Provenance
- Original commit on ledger-9: 2e63c998 (\`fix: cargo audit vulnerabilities\`)
- Reasoning verbatim from Alex's commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)