### PR TITLE
fix(ci): fully-qualify Secret Manager ref for proof-server signing key

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -215,7 +215,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@2b5f97c5a4b9c105e64646762ad4fc3f5128e6f5 # v2.2.5
         with:
           secrets: |-
-            SIGNING_KEY:midnight-proof-server-signing-key/latest
+            SIGNING_KEY:projects/mnf-federated-node-operator/secrets/midnight-proof-server-signing-key/versions/latest
 
       - name: Sign proof-server build manifest
         env:

--- a/base-crypto/src/fab/encoding.rs
+++ b/base-crypto/src/fab/encoding.rs
@@ -462,7 +462,7 @@ impl TryFrom<AlignedValueUnchecked> for AlignedValue {
         if !unchecked.alignment.fits(&unchecked.value) {
             Err(format!(
                 "value deserialized as aligned failed alignment check (value: {:?}; alignment: {:?})",
-                &unchecked.value, &unchecked.alignment
+                unchecked.value, unchecked.alignment
             ))
         } else if !unchecked.value.0.iter().all(ValueAtom::is_in_normal_form) {
             Err("aligned value is not in normal form (has trailing zero bytes)".into())

--- a/ledger-wasm/src/contract.rs
+++ b/ledger-wasm/src/contract.rs
@@ -56,9 +56,9 @@ impl ContractDeploy {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -104,9 +104,9 @@ impl ContractCallPrototype {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -222,23 +222,23 @@ impl ContractCall {
         match &self.0 {
             ProvenContractCall(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenContractCall(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedContractCall(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -276,9 +276,9 @@ impl ReplaceAuthority {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -320,9 +320,9 @@ impl ContractOperationVersion {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -381,9 +381,9 @@ impl ContractOperationVersionedVerifierKey {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -417,9 +417,9 @@ impl VerifierKeyRemove {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -453,9 +453,9 @@ impl VerifierKeyInsert {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -515,9 +515,9 @@ impl MaintenanceUpdate {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 

--- a/ledger-wasm/src/crypto.rs
+++ b/ledger-wasm/src/crypto.rs
@@ -48,9 +48,9 @@ impl SignatureEnabled {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -109,9 +109,9 @@ impl PreBinding {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -147,9 +147,9 @@ impl Binding {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -185,9 +185,9 @@ impl NoBinding {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -223,9 +223,9 @@ impl PreProof {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -261,9 +261,9 @@ impl Proof {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 

--- a/ledger-wasm/src/dust.rs
+++ b/ledger-wasm/src/dust.rs
@@ -144,23 +144,23 @@ impl DustSpend {
         match &self.0 {
             ProvenDustSpend(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenDustSpend(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedDustSpend(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -308,16 +308,16 @@ impl DustRegistration {
         match &self.0 {
             Signature(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             SignatureErased(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -700,44 +700,44 @@ impl DustActions {
         match &self.0 {
             UnprovenWithSignature(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenWithSignatureErased(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProvenWithSignature(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProvenWithSignatureErased(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedWithSignature(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedWithSignatureErased(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -997,9 +997,9 @@ impl DustParameters {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -1077,9 +1077,9 @@ impl DustUtxoState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -1111,9 +1111,9 @@ impl DustGenerationState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -1142,9 +1142,9 @@ impl DustState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -1531,9 +1531,9 @@ impl DustLocalState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -1704,9 +1704,9 @@ impl DustGenerationTreeInsertionPath {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -1767,9 +1767,9 @@ impl DustStateMerkleTreeCollapsedUpdate {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }

--- a/ledger-wasm/src/events.rs
+++ b/ledger-wasm/src/events.rs
@@ -40,9 +40,9 @@ impl Event {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 

--- a/ledger-wasm/src/intent.rs
+++ b/ledger-wasm/src/intent.rs
@@ -317,72 +317,72 @@ impl Intent {
         match &self.0 {
             UnprovenWithSignaturePreBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenWithSignatureBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenWithSignatureErasedPreBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenWithSignatureErasedBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProvenWithSignaturePreBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProvenWithSignatureBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProvenWithSignatureErasedPreBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProvenWithSignatureErasedBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedWithSignatureNoBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedWithSignatureErasedNoBinding(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }

--- a/ledger-wasm/src/state.rs
+++ b/ledger-wasm/src/state.rs
@@ -216,9 +216,9 @@ impl LedgerState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 

--- a/ledger-wasm/src/state_changes.rs
+++ b/ledger-wasm/src/state_changes.rs
@@ -80,9 +80,9 @@ impl ZswapStateChanges {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.inner)
+            format!("{:?}", self.inner)
         } else {
-            format!("{:#?}", &self.inner)
+            format!("{:#?}", self.inner)
         }
     }
 }
@@ -152,9 +152,9 @@ impl DustStateChanges {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.inner)
+            format!("{:?}", self.inner)
         } else {
-            format!("{:#?}", &self.inner)
+            format!("{:#?}", self.inner)
         }
     }
 }

--- a/ledger-wasm/src/transcript.rs
+++ b/ledger-wasm/src/transcript.rs
@@ -50,9 +50,9 @@ impl PreTranscript {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self)
+            format!("{:?}", self)
         } else {
-            format!("{:#?}", &self)
+            format!("{:#?}", self)
         }
     }
 }

--- a/ledger-wasm/src/tx.rs
+++ b/ledger-wasm/src/tx.rs
@@ -135,9 +135,9 @@ impl PrePartitionContractCall {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -1272,9 +1272,9 @@ where
 
     fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self)
+            format!("{:?}", self)
         } else {
-            format!("{:#?}", &self)
+            format!("{:#?}", self)
         }
     }
 
@@ -1607,16 +1607,16 @@ impl ClaimRewardsTransaction {
         match &self.0 {
             SignatureClaimRewards(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             SignatureErasedClaimRewards(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -1715,9 +1715,9 @@ impl SystemTransaction {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -1745,9 +1745,9 @@ impl TransactionContext {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -1800,9 +1800,9 @@ impl TransactionResult {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 

--- a/ledger-wasm/src/unshielded.rs
+++ b/ledger-wasm/src/unshielded.rs
@@ -146,16 +146,16 @@ impl UnshieldedOffer {
         match &self.0 {
             Signature(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             SignatureErased(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }

--- a/ledger-wasm/src/zswap_state.rs
+++ b/ledger-wasm/src/zswap_state.rs
@@ -85,9 +85,9 @@ impl MerkleTreeCollapsedUpdate {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -433,9 +433,9 @@ impl ZswapLocalState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -520,9 +520,9 @@ impl ZswapChainState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }

--- a/ledger-wasm/src/zswap_wasm.rs
+++ b/ledger-wasm/src/zswap_wasm.rs
@@ -123,23 +123,23 @@ impl ZswapTransient {
         match &self.0 {
             ProvenTransient(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenTransient(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedTransient(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -311,23 +311,23 @@ impl ZswapOutput {
         match &self.0 {
             ProvenOutput(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenOutput(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedOutput(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -445,23 +445,23 @@ impl ZswapInput {
         match &self.0 {
             ProvenInput(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenInput(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedInput(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -779,23 +779,23 @@ impl ZswapOffer {
         match &self.0 {
             ProvenOffer(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenOffer(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedOffer(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }
@@ -876,9 +876,9 @@ impl LedgerParameters {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -921,9 +921,9 @@ impl TransactionCostModel {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 
@@ -1050,23 +1050,23 @@ impl AuthorizedClaim {
         match &self.0 {
             ProvenAuthorizedClaim(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             UnprovenAuthorizedClaim(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
             ProofErasedAuthorizedClaim(val) => {
                 if compact.unwrap_or(false) {
-                    format!("{:?}", &val)
+                    format!("{:?}", val)
                 } else {
-                    format!("{:#?}", &val)
+                    format!("{:#?}", val)
                 }
             }
         }

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -2229,7 +2229,7 @@ mod tests {
             println!("  seed:                  {:?}", entry.seed.0);
             println!(
                 "  intermediate bytes:    {:?}",
-                &entry.dust.secretKeyIntermediateBytes.0
+                entry.dust.secretKeyIntermediateBytes.0
             );
             println!(
                 "  intermediate computed: {:?}",

--- a/ledger/src/test_utilities.rs
+++ b/ledger/src/test_utilities.rs
@@ -806,7 +806,7 @@ impl ProofServerProvider<'_> {
                 .resolve_key(preimage.key_location().clone())
                 .await?
                 .ok_or_else(|| {
-                    anyhow::anyhow!("failed to find key '{}'", &preimage.key_location().0)
+                    anyhow::anyhow!("failed to find key '{}'", preimage.key_location().0)
                 })?;
             Some(WrappedIr(data.ir_source))
         };
@@ -846,7 +846,7 @@ impl ProvingProvider for ProofServerProvider<'_> {
             .await?;
         println!("    Check request: {} bytes", ser.len());
         let resp = Client::new()
-            .post(format!("{}/check", &self.base_url))
+            .post(format!("{}/check", self.base_url))
             .body(ser)
             .send()
             .await?;
@@ -875,7 +875,7 @@ impl ProvingProvider for ProofServerProvider<'_> {
             .await?;
         println!("    Proving request: {} bytes", ser.len());
         let resp = Client::new()
-            .post(format!("{}/prove", &self.base_url))
+            .post(format!("{}/prove", self.base_url))
             .body(ser)
             .send()
             .await?;

--- a/onchain-runtime-wasm/src/context.rs
+++ b/onchain-runtime-wasm/src/context.rs
@@ -54,9 +54,9 @@ impl QueryResults {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -110,9 +110,9 @@ impl CostModel {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -235,9 +235,9 @@ impl QueryContext {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }

--- a/onchain-runtime-wasm/src/state.rs
+++ b/onchain-runtime-wasm/src/state.rs
@@ -73,9 +73,9 @@ impl StateMap {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -165,9 +165,9 @@ impl StateBoundedMerkleTree {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -197,9 +197,9 @@ impl ChargedState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -339,9 +339,9 @@ impl StateValue {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -467,9 +467,9 @@ impl ContractState {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -522,9 +522,9 @@ impl ContractOperation {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -612,9 +612,9 @@ impl ContractMaintenanceAuthority {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }

--- a/onchain-runtime-wasm/src/vm.rs
+++ b/onchain-runtime-wasm/src/vm.rs
@@ -52,9 +52,9 @@ impl VmResults {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }
@@ -102,9 +102,9 @@ impl VmStack {
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string(&self, compact: Option<bool>) -> String {
         if compact.unwrap_or(false) {
-            format!("{:?}", &self.0)
+            format!("{:?}", self.0)
         } else {
-            format!("{:#?}", &self.0)
+            format!("{:#?}", self.0)
         }
     }
 }

--- a/onchain-runtime/src/main.rs
+++ b/onchain-runtime/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
                 0,
             )
             .unwrap();
-        println!("Input state: {:#?}", &state_in);
+        println!("Input state: {:#?}", state_in);
         let prog_in: Vec<Op<ResultModeGather, DefaultDB>> = {
             let mut prog = Vec::new();
             let mut file = BufReader::new(File::open(&args[2]).unwrap());
@@ -46,7 +46,7 @@ fn main() {
             }
             prog
         };
-        println!("Input program: {:#?}", &prog_in);
+        println!("Input program: {:#?}", prog_in);
 
         match run_program(
             &[VmValue::new(ValueStrength::Strong, state_in)],
@@ -55,9 +55,9 @@ fn main() {
             &INITIAL_COST_MODEL,
         ) {
             Ok(res) => {
-                println!("Result stack: {:#?}", &res.stack);
-                println!("Events output: {:#?}", &res.events);
-                println!("Gas cost: {:#?}", &res.gas_cost);
+                println!("Result stack: {:#?}", res.stack);
+                println!("Events output: {:#?}", res.events);
+                println!("Gas cost: {:#?}", res.gas_cost);
 
                 if args.len() == 4 {
                     Serializable::serialize(

--- a/proof-server/src/endpoints.rs
+++ b/proof-server/src/endpoints.rs
@@ -212,7 +212,7 @@ pub(crate) async fn check(
                             .ok_or_else(|| {
                                 WorkError::BadInput(format!(
                                     "couldn't find built-in key {}",
-                                    &ppi.key_location().0
+                                    ppi.key_location().0
                                 ))
                             })?
                             .ir_source
@@ -297,7 +297,7 @@ pub(crate) async fn prove(
                                 .ok_or_else(|| {
                                     WorkError::BadInput(format!(
                                         "couldn't find key {}",
-                                        &ppi.key_location.0
+                                        ppi.key_location.0
                                     ))
                                 })?,
                         };

--- a/storage-core/src/db/sql.rs
+++ b/storage-core/src/db/sql.rs
@@ -167,7 +167,7 @@ impl<H: WellBehavedHasher> SqlDB<H> {
             .create(true)
             .truncate(true)
             .open(&mutex_file_path)
-            .unwrap_or_else(|e| panic!("can't open .mutex file {:?}: {e}", &mutex_file_path));
+            .unwrap_or_else(|e| panic!("can't open .mutex file {:?}: {e}", mutex_file_path));
         if exclusive {
             fs2::FileExt::try_lock_exclusive(&lock_file)
                 .expect("can't get exclusive lock with existing locks active");

--- a/storage/src/state_translation.rs
+++ b/storage/src/state_translation.rs
@@ -324,7 +324,7 @@ pub struct TranslationId(pub Cow<'static, str>, pub Cow<'static, str>);
 
 impl Debug for TranslationId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} => {}", &self.0, &self.1)
+        write!(f, "{} => {}", self.0, self.1)
     }
 }
 

--- a/transient-crypto/src/merkle_tree.rs
+++ b/transient-crypto/src/merkle_tree.rs
@@ -543,7 +543,7 @@ struct DebugEntry<'a, A>(HashOutput, &'a A);
 
 impl<A: Debug> Debug for DebugEntry<'_, A> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "({:?}, {:?})", &self.0, &self.1)
+        write!(f, "({:?}, {:?})", self.0, self.1)
     }
 }
 

--- a/transient-crypto/src/proofs.rs
+++ b/transient-crypto/src/proofs.rs
@@ -750,7 +750,7 @@ impl ProofPreimage {
             .await?
             .ok_or(anyhow::Error::msg(format!(
                 "failed to find proving key for '{}'",
-                &self.key_location.0
+                self.key_location.0
             )))?;
         let ir = Z::load_ir_from_tagged(io::Cursor::new(&proof_data.ir_source[..]))?;
         let verifier_key = tagged_deserialize::<VerifierKey>(&mut &proof_data.verifier_key[..])?;

--- a/zkir-v3-wasm/src/lib.rs
+++ b/zkir-v3-wasm/src/lib.rs
@@ -165,7 +165,7 @@ pub async fn check(ser_preimage: Uint8Array, provider: JsValue) -> Result<Vec<Js
     let Some(data) = provider.resolve_key(preimage.key_location.clone()).await? else {
         return Err(JsError::new(&format!(
             "failed to resolve key at '{}'",
-            &preimage.key_location.0
+            preimage.key_location.0
         )));
     };
 

--- a/zkir-v3/tests/proofs.rs
+++ b/zkir-v3/tests/proofs.rs
@@ -100,14 +100,14 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
-        let vk_fmt = format!("{:#?}", &vk);
+        let pk_fmt = format!("{:#?}", pk);
+        let vk_fmt = format!("{:#?}", vk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         let vk: VerifierKey = Deserializable::deserialize(&mut &vk_data[..], 0).unwrap();
         pk.init().unwrap();
         vk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
-        dbg!(vk_fmt == format!("{:#?}", &vk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
+        dbg!(vk_fmt == format!("{:#?}", vk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,
@@ -159,10 +159,10 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,
@@ -216,10 +216,10 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,
@@ -266,10 +266,10 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,
@@ -323,18 +323,18 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let mut pk_data = Vec::new();
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let p = EmbeddedGroupAffine::generator();
         let q: EmbeddedGroupAffine = JubjubSubgroup::random(OsRng).into();
         let preimage = ProofPreimage {
@@ -388,14 +388,14 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
-        let vk_fmt = format!("{:#?}", &vk);
+        let pk_fmt = format!("{:#?}", pk);
+        let vk_fmt = format!("{:#?}", vk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         let vk: VerifierKey = Deserializable::deserialize(&mut &vk_data[..], 0).unwrap();
         pk.init().unwrap();
         vk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
-        dbg!(vk_fmt == format!("{:#?}", &vk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
+        dbg!(vk_fmt == format!("{:#?}", vk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,

--- a/zkir-wasm/src/lib.rs
+++ b/zkir-wasm/src/lib.rs
@@ -164,7 +164,7 @@ pub async fn check(ser_preimage: Uint8Array, provider: JsValue) -> Result<Vec<Js
     let Some(data) = provider.resolve_key(preimage.key_location.clone()).await? else {
         return Err(JsError::new(&format!(
             "failed to resolve key at '{}'",
-            &preimage.key_location.0
+            preimage.key_location.0
         )));
     };
     let ir = IrSource::load_from_tagged(std::io::Cursor::new(&data.ir_source[..]))?;

--- a/zkir/tests/proofs.rs
+++ b/zkir/tests/proofs.rs
@@ -121,14 +121,14 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
-        let vk_fmt = format!("{:#?}", &vk);
+        let pk_fmt = format!("{:#?}", pk);
+        let vk_fmt = format!("{:#?}", vk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         let vk: VerifierKey = Deserializable::deserialize(&mut &vk_data[..], 0).unwrap();
         pk.init().unwrap();
         vk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
-        dbg!(vk_fmt == format!("{:#?}", &vk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
+        dbg!(vk_fmt == format!("{:#?}", vk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,
@@ -175,10 +175,10 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,
@@ -224,10 +224,10 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,
@@ -319,10 +319,10 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,
@@ -367,18 +367,18 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let mut pk_data = Vec::new();
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
+        let pk_fmt = format!("{:#?}", pk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         pk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
         let p = EmbeddedGroupAffine::generator();
         let preimage = ProofPreimage {
             binding_input: 42.into(),
@@ -428,14 +428,14 @@ mod proof_tests {
         let mut vk_data = Vec::new();
         Serializable::serialize(&pk, &mut pk_data).unwrap();
         Serializable::serialize(&vk, &mut vk_data).unwrap();
-        let pk_fmt = format!("{:#?}", &pk);
-        let vk_fmt = format!("{:#?}", &vk);
+        let pk_fmt = format!("{:#?}", pk);
+        let vk_fmt = format!("{:#?}", vk);
         let pk: ProverKey = Deserializable::deserialize(&mut &pk_data[..], 0).unwrap();
         let vk: VerifierKey = Deserializable::deserialize(&mut &vk_data[..], 0).unwrap();
         pk.init().unwrap();
         vk.init().unwrap();
-        dbg!(pk_fmt == format!("{:#?}", &pk));
-        dbg!(vk_fmt == format!("{:#?}", &vk));
+        dbg!(pk_fmt == format!("{:#?}", pk));
+        dbg!(vk_fmt == format!("{:#?}", vk));
         let preimage = ProofPreimage {
             binding_input: 42.into(),
             communications_commitment: None,

--- a/zswap/src/keys.rs
+++ b/zswap/src/keys.rs
@@ -245,7 +245,7 @@ mod tests {
             println!("  seed:                  {:?}", entry.seed.0);
             println!(
                 "  intermediate bytes:    {:?}",
-                &entry.encryption.secretKeyIntermediateBytes.0
+                entry.encryption.secretKeyIntermediateBytes.0
             );
             println!(
                 "  intermediate computed: {:?}",


### PR DESCRIPTION
## Summary
Follow-up to #635. The `docker-manifest` job's **Fetch signing key from Secret Manager** step failed with a 403 on the first real run.

`google-github-actions/get-secretmanager-secrets` parses the short reference `midnight-proof-server-signing-key/latest` as **`<project>/<secret>`**, so it tried to read the secret from a GCP *project* literally named `midnight-proof-server-signing-key`:

```
403 Permission denied on resource project midnight-proof-server-signing-key
accessed: projects/midnight-proof-server-signing-key/secrets/latest/versions/latest
```

`GCLOUD_PROJECT` is not consulted by this action for the ref — the project must be encoded in the reference itself. This changes it to the fully-qualified form:

```
SIGNING_KEY:projects/mnf-federated-node-operator/secrets/midnight-proof-server-signing-key/versions/latest
```

(Project confirmed via `midnight-iac` `gcp/shared/_global`: secret `midnight-proof-server-signing-key` in project `mnf-federated-node-operator`.)

## Evidence
- Failed run: https://github.com/midnightntwrk/midnight-ledger/actions/runs/29587324737 — WIF auth (step 9) succeeded; Secret Manager fetch (step 10) 403'd; sign + upload skipped.

## Test plan
- [ ] Re-dispatch **Docker Build multiplatform image and push to registry** on this branch
- [ ] `docker-manifest` completes green through Fetch key → Sign → Upload artifact

## Depends on
- The signing key **version** must be present in Secret Manager (added manually per key-management runbook Step 6 — `midnight-iac` `proof-server-signing.tf` creates only the empty secret shell). If no version exists yet, this fix corrects the reference but the fetch will still fail until the key material is uploaded.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>