### PR TITLE
fix(ci): sign proof-server manifest non-interactively with key passphrase

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -14,6 +14,8 @@ on:
         required: true
       GCP_SIGNING_SERVICE_ACCOUNT:
         required: true
+      PROOF_SERVER_SIGNING_KEY_PASSPHRASE:
+        required: true
 
 jobs:
   docker-amd64:
@@ -220,11 +222,20 @@ jobs:
       - name: Sign proof-server build manifest
         env:
           SIGNING_KEY: ${{ steps.fetch-key.outputs.SIGNING_KEY }}
+          SIGNING_KEY_PASSPHRASE: ${{ secrets.PROOF_SERVER_SIGNING_KEY_PASSPHRASE }}
         run: |
           set -euo pipefail
           umask 077
 
           export GNUPGHOME=$(mktemp -d)
+
+          # CI runners have no TTY, so gpg-agent can't launch an interactive
+          # pinentry to collect the key passphrase (it would fail with
+          # "Inappropriate ioctl for device"). Configure loopback pinentry so
+          # the passphrase is fed directly on stdin instead. Written before the
+          # first gpg call so the agent picks it up on launch.
+          printf 'pinentry-mode loopback\n' > "$GNUPGHOME/gpg.conf"
+          printf 'allow-loopback-pinentry\n' > "$GNUPGHOME/gpg-agent.conf"
 
           # Runs on every exit path (success or failure) so the imported
           # signing key never outlives this step. Batch-mode secret-key
@@ -255,8 +266,13 @@ jobs:
           }
           EOF
 
-          gpg --batch --yes --armor --local-user "$KEY_ID" \
-            --detach-sign --output build-manifest.json.asc build-manifest.json
+          # --passphrase-fd 0 reads the passphrase from stdin (not argv, which
+          # would leak it via the process list); loopback keeps gpg from
+          # prompting.
+          printf '%s' "$SIGNING_KEY_PASSPHRASE" \
+            | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 \
+                --armor --local-user "$KEY_ID" \
+                --detach-sign --output build-manifest.json.asc build-manifest.json
 
           gpg --verify build-manifest.json.asc build-manifest.json
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -313,6 +313,7 @@ jobs:
       GH_PASSWORD: ${{ secrets.GH_PASSWORD }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_SIGNING_SERVICE_ACCOUNT: ${{ secrets.GCP_SIGNING_SERVICE_ACCOUNT }}
+      PROOF_SERVER_SIGNING_KEY_PASSPHRASE: ${{ secrets.PROOF_SERVER_SIGNING_KEY_PASSPHRASE }}
 
   # No `secrets:` - neither reusable workflow consumes any (GITHUB_TOKEN is
   # always provided), so passing them would violate least privilege.


### PR DESCRIPTION
## Context
The full end-to-end run of the proof-server docker signing job ([run 29734400194](https://github.com/midnightntwrk/midnight-ledger/actions/runs/29734400194)) — the first time the signing step actually executed after #651 fixed the Secret Manager reference — failed at **Sign proof-server build manifest** with:

```
gpg: key 452391B057ADD8C7: secret key imported   # fetch + import OK (thanks to #651)
gpg: signing failed: Inappropriate ioctl for device
```

The signing key is passphrase-protected. On a TTY-less CI runner, gpg-agent can't launch an interactive pinentry to collect the passphrase, so signing aborts.

## Change
- Configure **loopback pinentry** in the fresh `$GNUPGHOME` (`gpg.conf` + `gpg-agent.conf`), written before the first gpg call.
- Feed the passphrase to `--detach-sign` via `--passphrase-fd 0` (stdin), keeping it out of argv/the process list.
- Source the passphrase from a new `PROOF_SERVER_SIGNING_KEY_PASSPHRASE` secret, threaded through the `prerelease.yml` → `docker-push.yml` call.

## Required before this works
The **`PROOF_SERVER_SIGNING_KEY_PASSPHRASE`** GitHub Actions secret must be set (repo or org level) to the signing key's passphrase.

## Verification
After the secret is set, dispatch `docker-push.yml` on this branch and confirm the **Sign proof-server build manifest** and **Upload signed build manifest** steps pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)