### PR TITLE
feat(formal): Agda mechanisation of ZKIR v2

### DIFF
--- a/.github/workflows/agda.yml
+++ b/.github/workflows/agda.yml
@@ -1,0 +1,36 @@
+name: Check Agda
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'formal/**'
+      - '.github/workflows/agda.yml'
+  push:
+    branches:
+      - 'ledger-*'
+    paths:
+      - 'formal/**'
+      - '.github/workflows/agda.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Typecheck Agda
+        run: |
+          cd formal/src
+          nix run .#agda -- zkir-v2/Main.agda

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ logs
 **/.yarn/install-state.gz
 **/.yarn/cache
 .midnight-pp
+
+# Agda
+formal/src/_build/
+*.agdai

--- a/formal/src/README.md
+++ b/formal/src/README.md
@@ -1,0 +1,25 @@
+# Agda development — toolchain and type-checking
+
+This directory holds the Agda code ([zkir-v2/](zkir-v2/)) and the Nix flake
+providing the toolchain (the same one CI uses, via
+[.github/workflows/agda.yml](../../.github/workflows/agda.yml)).
+
+Everything runs from this directory via the flake:
+
+```sh
+cd formal/src
+nix run .#agda -- zkir-v2/Main.agda    # type-checks the entire zkir-v2 development
+```
+
+Inside a nix shell (or with a suitable Agda + standard-library setup) the
+bare invocation works from the repository root:
+
+```sh
+agda --safe -i formal/src formal/src/zkir-v2/Main.agda
+```
+
+`zkir-v2/Main.agda` imports every module, so checking it verifies the whole
+development. `CircuitProof.agda` is large — a cold check can take several
+minutes. Dependencies are declared in
+[zkir-formal-spec.agda-lib](zkir-formal-spec.agda-lib)
+(`standard-library`, `standard-library-classes`, `standard-library-meta`).

--- a/formal/src/flake.lock
+++ b/formal/src/flake.lock
@@ -1,0 +1,200 @@
+{
+  "nodes": {
+    "abstract-set-theory": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771423838,
+        "narHash": "sha256-IFTHS6C44PHdwYQVWNW/0WZf+3fWtzSfR21c3UmihLU=",
+        "owner": "input-output-hk",
+        "repo": "agda-sets",
+        "rev": "2253231ad856b9b95f32d6b06709748e59bdbb3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "agda-sets",
+        "type": "github"
+      }
+    },
+    "agda-nix": {
+      "inputs": {
+        "abstract-set-theory": "abstract-set-theory",
+        "categorical-crypto": "categorical-crypto",
+        "flake-utils": "flake-utils",
+        "iog-prelude": "iog-prelude",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "standard-library-classes": "standard-library-classes",
+        "standard-library-meta": "standard-library-meta"
+      },
+      "locked": {
+        "lastModified": 1774867665,
+        "narHash": "sha256-gyw9Eu1alpRcG6cMnsZBVKVRjYWQWeILH9S7Qgx5akM=",
+        "owner": "input-output-hk",
+        "repo": "agda.nix",
+        "rev": "2fc7a81e385d01b30a5df57902f93c46d7d21bff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "agda.nix",
+        "type": "github"
+      }
+    },
+    "categorical-crypto": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774441400,
+        "narHash": "sha256-t0HXmhW3C4VPkl1IMiwa16lgZVomxuu74O30qwoEeNU=",
+        "owner": "input-output-hk",
+        "repo": "categorical-crypto",
+        "rev": "6cdf63785fb39f5e340240667e7a0c5aed473d90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "categorical-crypto",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "iog-prelude": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765201741,
+        "narHash": "sha256-xTivBEzcpJBqzdjj+gJqJ7wrEMmh/ZwXRi8h575XPFs=",
+        "owner": "input-output-hk",
+        "repo": "iog-agda-prelude",
+        "rev": "e12e69e8cc76cd41d19d0e38a44afa4358969a47",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iog-agda-prelude",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777983031,
+        "narHash": "sha256-vmhC9xelEeYwg2IQJ3DzBv6u7NKuSZgBXpKqInP528U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cadd3b008c77da2d2e4d1c40c4e49dccc8706318",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agda-nix": "agda-nix",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "standard-library-classes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754406591,
+        "narHash": "sha256-tuXuZcwu6XNFP979oSZg0yfFY9eMyqpkUNddk+QchVc=",
+        "owner": "agda",
+        "repo": "agda-stdlib-classes",
+        "rev": "e732956fb01eb616bb3429f290d9434f4ab59b6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "repo": "agda-stdlib-classes",
+        "type": "github"
+      }
+    },
+    "standard-library-meta": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754406588,
+        "narHash": "sha256-YH8OqGsQ2DKhKqhSUWBDTimQSZsNCnqwZqNqQwnnVS0=",
+        "owner": "agda",
+        "repo": "agda-stdlib-meta",
+        "rev": "ba0159a198c99185bda86541362f8e0a4a82538a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "repo": "agda-stdlib-meta",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/formal/src/flake.nix
+++ b/formal/src/flake.nix
@@ -1,0 +1,57 @@
+# Warning: only edit this file if you know what you're doing!
+# In this case, consider using `agda.nix` directly.
+{
+  description = "Pagda nix template";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    agda-nix = {
+      url = "github:input-output-hk/agda.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+  };
+
+  outputs =
+    inputs@{
+      self,
+        nixpkgs,
+        flake-utils,
+        ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+    in
+      flake-utils.lib.eachDefaultSystem (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              inputs.agda-nix.overlays.default
+            ];
+          };
+
+          pagda = import ./pagda.nix { agdaPackages = pkgs.agdaPackages; };
+
+          agda = pkgs.agdaPackages.agda.withPackages
+            (builtins.filter (p: p ? isAgdaDerivation) pagda.default.buildInputs);
+        in
+          {
+            packages = pagda // {
+              inherit agda;
+            };
+
+            # The Darwin stdenv used to build the Agda packages exports
+            # DEVELOPER_DIR/SDKROOT pointing at the Nix apple-sdk, which
+            # redirects the /usr/bin/git stub at an SDK that ships no git.
+            # Ship a real git in the shell so it works regardless.
+            devShells.default = pkgs.mkShell {
+              packages = [ agda pkgs.git ];
+            };
+          }
+      );
+}

--- a/formal/src/pagda.nix
+++ b/formal/src/pagda.nix
@@ -1,0 +1,17 @@
+{ agdaPackages }: with agdaPackages; rec {
+
+  zkir-formal-spec = mkDerivation {
+    pname = "zkir-formal-spec";
+    version = "0.1";
+    src = ./.;
+    meta = { };
+    libraryFile = "zkir-formal-spec.agda-lib";
+    buildInputs = [
+      standard-library
+      standard-library-classes
+      standard-library-meta
+    ];
+  };
+
+  default = zkir-formal-spec;
+}

--- a/formal/src/zkir-formal-spec.agda-lib
+++ b/formal/src/zkir-formal-spec.agda-lib
@@ -1,0 +1,5 @@
+name: zkir-formal-spec
+depend: standard-library
+--        standard-library-classes
+--        standard-library-meta
+include: .

--- a/formal/src/zkir-v2/Assumptions.agda
+++ b/formal/src/zkir-v2/Assumptions.agda
@@ -1,0 +1,167 @@
+{-# OPTIONS --safe #-}
+
+------------------------------------------------------------------------
+-- Assumptions of the zkir-v2 formalization
+--
+-- The entire trust base of the development, collected into a single flat
+-- record `Assumptions`.  Downstream modules take an `Assumptions` value
+-- as a module parameter (`module M (⋯ : _) (open Assumptions ⋯) where`),
+-- so the whole development typechecks under `--safe` with no
+-- `postulate`s.  No concrete BLS12-381 instantiation is provided;
+-- the development is intentionally abstract over this interface.
+--
+-- The record bundles:
+--   * the primitive carrier types and field/curve/hash/commitment
+--     operations, together with the field laws;
+--   * the encoding / valuation axioms.
+------------------------------------------------------------------------
+
+module zkir-v2.Assumptions where
+
+open import Data.Bool  using (Bool; if_then_else_)
+open import Data.List  using (List; []; _∷_; length)
+open import Data.Maybe using (Maybe)
+open import Data.Nat   using (ℕ; _+_; _∸_; _%_; _≤_; _<_; _<?_; _*_; _^_; NonZero)
+open import Data.Product using (_×_)
+open import Relation.Binary.Definitions using (DecidableEquality)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+open import Relation.Nullary using (¬_; Dec)
+
+-- Integer value of a little-endian bit list.
+bits-to-ℕ : List Bool → ℕ
+bits-to-ℕ []       = 0
+bits-to-ℕ (b ∷ bs) = (if b then 1 else 0) + 2 * bits-to-ℕ bs
+
+record Assumptions : Set₁ where
+
+  ----------------------------------------------------------------------
+  -- Primitive carrier types and operations.
+  ----------------------------------------------------------------------
+
+  field
+    -- Carrier types.
+    Fr        : Set
+    -- ^ BLS12-381 scalar field element (transient_crypto::curve::Fr).
+    Alignment : Set
+    -- ^ Byte-alignment descriptor (base_crypto::fab::Alignment).
+
+    -- Field constants
+    0ᶠ 1ᶠ : Fr
+
+    -- Field arithmetic
+    _+ᶠ_ _*ᶠ_ : Fr → Fr → Fr
+    -ᶠ_       : Fr → Fr
+
+    -- Decidable propositional equality on field elements.
+    _≟ᶠ_ : DecidableEquality Fr
+
+    -- Field laws.  The fragment of the BLS12-381 scalar-field axioms the
+    -- development actually uses; together with `1ᶠ≢0ᶠ` they say `Fr` with
+    -- the operations above is a non-trivial field.
+    *-zero-l : ∀ x → 0ᶠ *ᶠ x ≡ 0ᶠ
+    *-one-l  : ∀ x → 1ᶠ *ᶠ x ≡ x
+    +-zero-l : ∀ x → 0ᶠ +ᶠ x ≡ x
+    +-inv-r  : ∀ x → x +ᶠ (-ᶠ x) ≡ 0ᶠ
+    +ᶠ-assoc : ∀ x y z → (x +ᶠ y) +ᶠ z ≡ x +ᶠ (y +ᶠ z)
+    +ᶠ-comm  : ∀ x y → x +ᶠ y ≡ y +ᶠ x
+    -- (The mirrored identities — `+-zero-r`, `+ᶠ-inv-l` — are derived
+    -- from these in `FieldProperties`, not assumed.)
+
+    -- 1 ≠ 0 — non-triviality.  Used by `not-fwd` for the `bv = 1ᶠ` case,
+    -- and to characterize `to-bool 1ᶠ`.
+    1ᶠ≢0ᶠ : ¬ (1ᶠ ≡ 0ᶠ)
+
+  field
+    -- Number of bits in a field element (255 for BLS12-381 scalar field)
+    FR-BITS : ℕ
+
+    -- Order of the scalar field (the prime |Fr|, ≈ 2^255 for BLS12-381).
+    -- `from-le-bits` reduces modulo this value.
+    FR-ORDER : ℕ
+
+    -- Little-endian bit decomposition: to-le-bits x has exactly FR-BITS entries
+    to-le-bits   : Fr → List Bool
+    from-le-bits : List Bool → Fr
+
+    -- Jubjub EC operations; nothing = invalid input point(s)
+    ec-add-pts       : Fr → Fr → Fr → Fr → Maybe (Fr × Fr)
+    ec-mul-pt        : Fr → Fr → Fr → Maybe (Fr × Fr)
+    ec-mul-gen       : Fr → Fr × Fr
+    hash-to-curve-fn : List Fr → Fr × Fr
+
+    -- Hash functions
+    transient-hash-fn  : List Fr → Fr
+    persistent-hash-fn : Alignment → List Fr → Fr × Fr
+
+    -- Communications commitment: transient_commit(inputs ++ outputs, randomness)
+    transient-commit : List Fr → Fr → Fr
+
+  ----------------------------------------------------------------------
+  -- Axioms: the bit-decomposition / encoding / valuation laws relating
+  -- `Fr` to its little-endian bit representation.
+  ----------------------------------------------------------------------
+
+  field
+    ------------------------------------------------------------------
+    -- Encoding correctness laws.
+    --
+    -- The defining properties of the BLS12-381 little-endian scalar
+    -- encoding, stated via the pure `bits-to-ℕ`.  Together they say:
+    -- `to-le-bits` returns the canonical FR_BITS-wide LE representation,
+    -- and `from-le-bits` reads a bit list as an integer and reduces it
+    -- modulo the field order.  Every correct implementation satisfies
+    -- them.
+    ------------------------------------------------------------------
+
+    -- `to-le-bits` produces exactly FR_BITS bits.
+    to-le-bits-length : ∀ x → length (to-le-bits x) ≡ FR-BITS
+
+    -- The field order is non-zero (any non-trivial field).  An instance
+    -- field, so `_%_ FR-ORDER` resolves in the laws below.
+    ⦃ FR-ORDER-nonZero ⦄ : NonZero FR-ORDER
+
+    -- Round trip: `from-le-bits` interprets the bits as an integer and
+    -- reduces mod the field order; `to-le-bits` recovers the canonical
+    -- representative's bit value.
+    from-le-bits-roundtrip : ∀ bs
+      → bits-to-ℕ (to-le-bits (from-le-bits bs)) ≡ bits-to-ℕ bs % FR-ORDER
+
+  ------------------------------------------------------------------
+  -- Valuation laws: `Fr` is the prime field ℤ/FR-ORDER via the
+  -- canonical valuation `valFr = bits-to-ℕ ∘ to-le-bits`.
+  ------------------------------------------------------------------
+
+  -- Canonical integer value of a field element (in [0, FR-ORDER) by
+  -- `valFr-bound`).
+  valFr : Fr → ℕ
+  valFr x = bits-to-ℕ (to-le-bits x)
+
+  -- In-range predicate: a LE bit pattern denotes a valid field element
+  -- iff its integer value is below the field order.
+  BitsInField : List Bool → Set
+  BitsInField bs = bits-to-ℕ bs < FR-ORDER
+
+  bitsInField? : ∀ bs → Dec (BitsInField bs)
+  bitsInField? bs = bits-to-ℕ bs <? FR-ORDER
+
+  field
+    -- The canonical value is in range, and distinct field elements have
+    -- distinct canonical values.
+    valFr-bound : ∀ x → valFr x < FR-ORDER
+    valFr-inj   : ∀ {x y} → valFr x ≡ valFr y → x ≡ y
+
+    -- The valuation is a (multiplicative-unit-preserving) semiring
+    -- homomorphism into ℤ/FR-ORDER.
+    valFr-1 : valFr 1ᶠ ≡ 1 % FR-ORDER
+    valFr-+ : ∀ x y → valFr (x +ᶠ y) ≡ (valFr x + valFr y) % FR-ORDER
+    valFr-* : ∀ x y → valFr (x *ᶠ y) ≡ (valFr x * valFr y) % FR-ORDER
+
+    -- BLS12-381: the field order exceeds the top representable bit,
+    -- 2^(FR_BITS−1) ≤ |Fr|.  (Numeric fact: |Fr| ≈ 2^254.86.)
+    order-lb : 2 ^ (FR-BITS ∸ 1) ≤ FR-ORDER
+
+    -- CAUTION: do NOT add a `div-mod-unique`-style uniqueness axiom here.
+    -- With only the bounds `fits-in q (FR-BITS∸bits)`, the value
+    -- `q·2^bits + r` can reach 2^FR_BITS − 1 > |Fr|, so two distinct pairs
+    -- can be congruent mod |Fr| (e.g. (0,0) and the decomposition of |Fr|
+    -- itself) — such an axiom is FALSE for BLS12-381.

--- a/formal/src/zkir-v2/Circuit.agda
+++ b/formal/src/zkir-v2/Circuit.agda
@@ -1,0 +1,1076 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.Circuit (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v2.FieldProperties ⋯
+
+------------------------------------------------------------------------
+-- Circuit (Halo2 PLONKish) semantics for ZKIR v2 (V1 lowerings).
+--
+-- This module defines (spec §6.5):
+--
+--   • Section A defines a closed vocabulary of arithmetization
+--     primitives (`Expr`, `Constraint`) and the structural synthesis
+--     function (`circuit-instr`, `circuit`) that lowers each source
+--     instruction to a *list of constraints*, mirroring §5.2's emission
+--     contracts.  Synthesis is a deterministic function of the source
+--     alone — independent of the prover's preimage (§5.4).
+--
+--   • Section B defines a wire-assignment model (`Witness`) and the
+--     satisfaction relation (`holds`, `satisfies`).  `holds` is a single
+--     interpreter over the closed `Constraint` vocabulary: every
+--     constraint is either a polynomial gate (`gate`, a field
+--     expression that evaluates to 0) or one of a fixed set of gadget
+--     atoms (range, boolean, Poseidon, Jubjub, SHA-256, …).  Because
+--     the only way to describe a constraint is through this
+--     vocabulary, "the circuit emits valid constraints" is witnessed
+--     by the synthesis *data*
+--     (`circuit-instr`), not by reading a bespoke proposition per
+--     instruction.
+--
+--     The gadget atoms interpret chip behaviour (Poseidon, Jubjub,
+--     SHA-256, range checks) via the same canonical functions defined in
+--     `zkir-v2.Assumptions`; this makes the chip "perfectly sound" by
+--     construction and is the axiomatic interface to Halo2's chip layer.
+--
+--   • The closing section proves satisfaction decidable (`is-bit?`,
+--     `holds?`) — an executable witness checker.  It is a deliverable
+--     of this module; no proof in the development consumes it.
+------------------------------------------------------------------------
+
+-- Field/curve operations and the `Fits-in`/`bits-lt`/`to-bool`/`pow2-fr`/
+-- `lt-bits` helpers come from the `Assumptions` parameter (opened by the
+-- module telescope) and `FieldProperties`.  Only the genuinely
+-- Semantics-level definitions are imported here.
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+  using ( mem-lookup; mem-lookups; from-bool
+        ; Preprocessed; ProofPreimage )
+
+open import Data.Bool    using (Bool; true; false; if_then_else_)
+open import Data.List    using (List; []; _∷_; _++_; _∷ʳ_; length; take)
+open import Data.Maybe   using (Maybe; nothing; just; _>>=_; map)
+open import Data.Nat     using (ℕ; suc; zero; _∸_; _+_)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.List.Relation.Unary.All using (All)
+open import Data.Unit    using (⊤; tt)
+open import Data.Empty   using (⊥)
+open import Data.Sum     using (_⊎_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; subst)
+open import Relation.Nullary using (¬_; Dec; yes; no)
+open import Relation.Nullary.Decidable using (map′; _×-dec_; _⊎-dec_; ¬?)
+open import Function using (case_of_)
+open import Data.Maybe.Properties using (just-injective)
+  renaming (≡-dec to maybe-≡-dec)
+open import Data.Product.Properties renaming (≡-dec to ×-≡-dec)
+
+------------------------------------------------------------------------
+-- Local helpers
+--
+-- These helpers are exported because `holds` (Section B) refers to them
+-- in its result types, and downstream proofs need to construct/destruct
+-- those types.
+------------------------------------------------------------------------
+
+-- "Wire bound to memory cell i has value v" — phrased as a
+-- propositional equality, for readability in constraint definitions.
+_at_↦_ : List Fr → Index → Fr → Set
+mem at i ↦ v = mem-lookup mem i ≡ just v
+
+infix 1 _at_↦_
+
+-- A bit predicate: v ∈ {0, 1}.  Encoded as a sum.
+is-bit : Fr → Set
+is-bit v = (v ≡ 0ᶠ) ⊎ (v ≡ 1ᶠ)
+
+------------------------------------------------------------------------
+-- Section A.  Circuit syntax
+------------------------------------------------------------------------
+
+-- Field expressions over the wires.
+--
+-- A `wire` is a wire reference (by `Index`); `con` is an inline constant;
+-- `_⊕_`, `_⊗_`, `⊝_` are the field operations.  Expressions are the
+-- left-/right-hand sides of polynomial gates; they evaluate to a
+-- field value via `eval` once a wire assignment is fixed (Section B).
+
+data Expr : Set where
+  wire : (i : Index) → Expr
+  con : (k : Fr) → Expr
+  _⊕_ : (l r : Expr) → Expr
+  _⊗_ : (l r : Expr) → Expr
+  ⊝_  : (e : Expr) → Expr
+
+infixl 6 _⊕_
+infixl 7 _⊗_
+infix  8 ⊝_
+
+-- Subtraction, the difference used by every polynomial gate `l − r = 0`.
+_⊖_ : Expr → Expr → Expr
+l ⊖ r = l ⊕ ⊝ r
+
+infixl 6 _⊖_
+
+-- Constraints
+--
+-- The closed vocabulary of arithmetization primitives.  `gate` is a
+-- polynomial custom gate (a field expression constrained to 0).  Every
+-- other constructor is a gadget atom whose meaning (Section B) is fixed
+-- by the corresponding canonical chip function.  Wire references are by
+-- `Index`; PI-vector positions (`entry`) count from zero across the
+-- entire PI vector, including the structural preamble (binding-input,
+-- optional comm.0).
+
+data Constraint : Set where
+
+  -- Polynomial custom gate: the field expression ⟦e⟧ evaluates to 0.
+  -- Via the `_≑_` sugar (⟦l⟧ = ⟦r⟧ ≔ gate (l ⊖ r)) this covers add,
+  -- mul, neg, copy, constrain_eq, and load_imm.
+  gate
+    : (e : Expr) → Constraint
+
+  -- constrain_to_boolean(v): ⟦v⟧ ∈ {0, 1}
+  boolean
+    : (v : Index) → Constraint
+
+  -- assert(c): ⟦c⟧ ≠ 0
+  non-zero
+    : (c : Index) → Constraint
+
+  -- constrain_bits(v, n) / range chip: ⟦v⟧ < 2^n
+  in-range
+    : (v : Index) → (bits : ℕ) → Constraint
+
+  -- cond_select(b, a, c): ⟦b⟧ ∈ {0,1} ∧ out = ⟦b⟧·⟦a⟧ + (1−⟦b⟧)·⟦c⟧
+  select
+    : (out b a c : Index) → Constraint
+
+  -- div_mod_power_of_two(v, n):
+  --   ⟦v⟧ = ⟦q⟧·2^n + ⟦r⟧  ∧  ⟦r⟧ < 2^n  ∧  ⟦q⟧ < 2^(FR_BITS − n)
+  --   ∧  ⟦q⟧·2^n + ⟦r⟧ < |Fr|  (non-wrapping: pins the canonical split)
+  div-mod
+    : (q r v : Index) → (bits : ℕ) → Constraint
+
+  -- reconstitute_field(d, m, n):
+  --   ⟦d⟧ < 2^(FR_BITS − n)  ∧  ⟦m⟧ < 2^n  ∧  out = ⟦d⟧·2^n + ⟦m⟧
+  -- (No overflow check — see §6.3 and obligation O3.)
+  reconstitute
+    : (out d m : Index) → (bits : ℕ) → Constraint
+
+  -- not(a): out = is_zero(⟦a⟧)
+  is-zero
+    : (out a : Index) → Constraint
+
+  -- test_eq(a, b): out = 1 iff ⟦a⟧ = ⟦b⟧
+  test-eq
+    : (out a b : Index) → Constraint
+
+  -- less_than(a, b, n): out = 1 iff ⟦a⟧ < ⟦b⟧, using a range-check chip
+  -- with padded bit-bound `lt-bits n`.
+  less-than
+    : (out a b : Index) → (bits : ℕ) → Constraint
+
+  -- transient_hash(I): out = Poseidon(⟦I⟧)
+  poseidon
+    : (out : Index) → (inputs : List Index) → Constraint
+
+  -- persistent_hash(α, I): (h₁, h₂) is the SHA-256 decomposition (high
+  -- byte / low 31 bytes) of the FAB byte encoding of ⟦I⟧ under α.
+  sha256
+    : (h₁ h₂ : Index) → (alignment : Alignment)
+    → (inputs : List Index) → Constraint
+
+  -- ec_add: (⟦aₓ⟧,⟦aᵧ⟧) ∈ J ∧ (⟦bₓ⟧,⟦bᵧ⟧) ∈ J ∧ (cₓ,cᵧ) = sum
+  ec-add
+    : (c-x c-y a-x a-y b-x b-y : Index) → Constraint
+
+  -- ec_mul: (⟦aₓ⟧,⟦aᵧ⟧) ∈ J ∧ (cₓ,cᵧ) = ⟦s⟧ · (⟦aₓ⟧,⟦aᵧ⟧)
+  ec-mul
+    : (c-x c-y a-x a-y scalar : Index) → Constraint
+
+  -- ec_mul_generator: (cₓ,cᵧ) = ⟦s⟧ · G
+  ec-gen
+    : (c-x c-y scalar : Index) → Constraint
+
+  -- hash_to_curve: (cₓ,cᵧ) = H2C(⟦I⟧)
+  h2c
+    : (c-x c-y : Index) → (inputs : List Index) → Constraint
+
+  -- Declared PI binding: pis[entry] = ⟦wire⟧
+  bind
+    : (entry : ℕ) → (widx : Index) → Constraint
+
+  -- Guarded input cell: ⟦i⟧ ∈ {0, 1} ∧ ((out = 0) ∨ (⟦i⟧ = 1)).
+  -- Emitted when public/private_input has a guard; the guard wire is
+  -- range-restricted to a boolean by a checked native→bit conversion.
+  guard-disj
+    : (out i : Index) → Constraint
+
+  -- Communications-commitment constraint (§5.3):
+  --   pis[1] = Poseidon(comm-rand ‖ inputs ‖ outputs)
+  -- where `inputs = [0 .. num_inputs)` and `outputs` are the args of
+  -- `output(v)` instructions in source order.
+  comm
+    : (inputs outputs : List Index) → Constraint
+
+-- The constraint system: structurally a list of constraints, plus the
+-- structural shape (number of wires, PI-vector length, comm-commitment
+-- flag).  Determined by the source alone.
+record Circuit : Set where
+  constructor mk-circuit
+  field
+    nr-wires    : ℕ
+    constraints : List Constraint
+    pi-len      : ℕ          -- expected length of the verifier's PI vector
+    has-comm    : Bool
+
+------------------------------------------------------------------------
+-- Synthesis
+--
+-- `circuit-instr` processes one instruction, growing the wire count and
+-- appending constraints.  It mirrors the shape of `preprocess-instr` but
+-- is total (synthesis cannot fail; §5.4).
+--
+-- The synthesis state additionally tracks the count of `DeclarePubInput`
+-- emitted (for PI-entry indexing) and the indices of `output(v)`
+-- arguments (in source order; consumed by the comm-commitment constraint).
+------------------------------------------------------------------------
+
+record SynthState : Set where
+  constructor mk-synth
+  field
+    nr-wires       : ℕ                  -- next wire to be allocated
+    constraints    : List Constraint    -- in emission order
+    nr-declared-pi : ℕ                  -- # DeclarePubInput processed
+    output-wires   : List Index         -- args of `output(v)` in order
+
+-- Number of "preamble" PI entries (binding-input + optional comm.0).
+preamble-pi-count : Bool → ℕ
+preamble-pi-count true  = 2
+preamble-pi-count false = 1
+
+-- Update helpers.
+
+private
+  push : SynthState → Constraint → SynthState
+  push st c = record st { constraints = SynthState.constraints st ∷ʳ c }
+
+  bump-wires : SynthState → ℕ → SynthState
+  bump-wires st n = record st { nr-wires = SynthState.nr-wires st + n }
+
+-- Equality gate: ⟦l⟧ = ⟦r⟧, lowered to the polynomial gate l − r = 0.
+_≑_ : Expr → Expr → Constraint
+l ≑ r = gate (l ⊖ r)
+
+infix 4 _≑_
+
+-- One instruction's worth of synthesis.  `has-comm` is the source-level
+-- flag, threaded in because `declare-pub-input` needs the PI-entry
+-- offset.
+circuit-instr : Bool → Instruction → SynthState → SynthState
+
+circuit-instr _ (assert c) st =
+  push st (non-zero c)
+
+circuit-instr _ (cond-select b a c) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (select out b a c)
+
+circuit-instr _ (constrain-bits v bits) st =
+  -- WF2 forbids bits ≥ FR_BITS; for bits ≥ FR_BITS the lowering would
+  -- emit no constraint.  We unconditionally emit the range atom and let
+  -- WF2 guarantee its existence in the model.
+  push st (in-range v bits)
+
+circuit-instr _ (constrain-eq a b) st =
+  push st (wire a ≑ wire b)
+
+circuit-instr _ (constrain-to-boolean v) st =
+  push st (boolean v)
+
+circuit-instr _ (copy v) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (wire out ≑ wire v)
+
+circuit-instr has-comm (declare-pub-input v) st =
+  let entry = preamble-pi-count has-comm + SynthState.nr-declared-pi st
+      st'   = record st { nr-declared-pi = suc (SynthState.nr-declared-pi st) }
+  in push st' (bind entry v)
+
+circuit-instr _ (pi-skip _ _) st =
+  st  -- no in-circuit constraints
+
+circuit-instr _ (ec-add a-x a-y b-x b-y) st =
+  let cx = SynthState.nr-wires st
+      cy = suc cx
+  in push (bump-wires st 2) (ec-add cx cy a-x a-y b-x b-y)
+
+circuit-instr _ (ec-mul a-x a-y scalar) st =
+  let cx = SynthState.nr-wires st
+      cy = suc cx
+  in push (bump-wires st 2) (ec-mul cx cy a-x a-y scalar)
+
+circuit-instr _ (ec-mul-generator scalar) st =
+  let cx = SynthState.nr-wires st
+      cy = suc cx
+  in push (bump-wires st 2) (ec-gen cx cy scalar)
+
+circuit-instr _ (hash-to-curve inputs) st =
+  let cx = SynthState.nr-wires st
+      cy = suc cx
+  in push (bump-wires st 2) (h2c cx cy inputs)
+
+circuit-instr _ (load-imm imm) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (wire out ≑ con imm)
+
+circuit-instr _ (div-mod-power-of-two v bits) st =
+  let q = SynthState.nr-wires st
+      r = suc q
+  in push (bump-wires st 2) (div-mod q r v bits)
+
+circuit-instr _ (reconstitute-field d m bits) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (reconstitute out d m bits)
+
+circuit-instr _ (output v) st =
+  -- No constraints; the wire index is recorded for the comm-commitment
+  -- constraint emitted at the end of synthesis (if has-comm).
+  record st { output-wires = SynthState.output-wires st ∷ʳ v }
+
+circuit-instr _ (transient-hash inputs) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (poseidon out inputs)
+
+circuit-instr _ (persistent-hash alignment inputs) st =
+  let h₁ = SynthState.nr-wires st
+      h₂ = suc h₁
+  in push (bump-wires st 2) (sha256 h₁ h₂ alignment inputs)
+
+circuit-instr _ (test-eq a b) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (test-eq out a b)
+
+circuit-instr _ (add a b) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (wire out ≑ wire a ⊕ wire b)
+
+circuit-instr _ (mul a b) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (wire out ≑ wire a ⊗ wire b)
+
+circuit-instr _ (neg a) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (wire out ≑ ⊝ wire a)
+
+circuit-instr _ (not a) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (is-zero out a)
+
+circuit-instr _ (less-than a b bits) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (less-than out a b bits)
+
+circuit-instr _ (public-input nothing) st =
+  bump-wires st 1                      -- a free witness wire, no constraint
+circuit-instr _ (public-input (just g)) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (guard-disj out g)
+
+circuit-instr _ (private-input nothing) st =
+  bump-wires st 1
+circuit-instr _ (private-input (just g)) st =
+  let out = SynthState.nr-wires st in
+  push (bump-wires st 1) (guard-disj out g)
+
+-- Fold over an instruction list.
+
+circuit-instrs : Bool → List Instruction → SynthState → SynthState
+circuit-instrs _        []       st = st
+circuit-instrs has-comm (i ∷ is) st =
+  circuit-instrs has-comm is (circuit-instr has-comm i st)
+
+-- Top-level synthesis.  Wires `[0 .. num_inputs)` are the
+-- circuit-input wires (no constraints bind them; their values are part
+-- of the witness).  After processing the instruction list, if has-comm,
+-- append the comm-commitment constraint.
+
+-- Natural-number range [0, 1, …, n-1].  Used as `cm-inputs` inside
+-- `circuit`'s comm constraint, and by `CircuitProof.inputs-lookup-init`.
+nat-range : ℕ → List Index
+nat-range zero    = []
+nat-range (suc k) = nat-range k ∷ʳ k
+
+circuit : IrSource → Circuit
+circuit src =
+  let n   = IrSource.num-inputs src
+      hc  = IrSource.do-communications-commitment src
+      st₀ = mk-synth n [] 0 []
+      st  = circuit-instrs hc (IrSource.instructions src) st₀
+      cs  = SynthState.constraints st
+      -- Built-in inputs to the comm-commitment: [0 .. n).
+      cm-inputs = nat-range n
+      cs' = if hc
+        then cs ∷ʳ comm cm-inputs (SynthState.output-wires st)
+        else cs
+      pi-len = preamble-pi-count hc + SynthState.nr-declared-pi st
+  in mk-circuit (SynthState.nr-wires st) cs' pi-len hc
+
+------------------------------------------------------------------------
+-- Section B.  Wire assignments and satisfaction
+------------------------------------------------------------------------
+
+-- Witness for a circuit
+--
+-- The Halo2 prover commits to:
+--   • `mem` — values of the witness wires (one per allocated cell).
+--   • `pis` — values of the public-input wires (verifier-supplied).
+--   • `comm-rand` — the randomness `comm_commitment.1`, allocated as
+--     an additional witness wire iff the circuit has-comm.
+--
+-- `CircuitProof.witness-of` builds a `Witness` from the operational
+-- state and the preimage.
+
+record Witness : Set where
+  constructor mk-witness
+  field
+    mem       : List Fr
+    pis       : List Fr
+    comm-rand : Maybe Fr
+
+-- The randomness component of a preimage's optional commitment.
+comm-rand-of : ProofPreimage → Maybe Fr
+comm-rand-of pre = map (λ (_ , r) → r) (ProofPreimage.comm-commitment pre)
+
+-- The witness assignment produced by an operational execution: the
+-- allocated wire values, the verifier-supplied PI entries, and the
+-- commitment randomness.  Independent of the `IrSource`.
+witness-of : Preprocessed → ProofPreimage → Witness
+witness-of s pre = mk-witness
+  (Preprocessed.memory s)
+  (Preprocessed.pis    s)
+  (comm-rand-of pre)
+
+-- The i-th PI entry is looked up exactly like a memory cell: the pis
+-- vector is a `List Fr` and out-of-range yields `nothing`.
+pi-lookup : List Fr → ℕ → Maybe Fr
+pi-lookup = mem-lookup
+
+-- Evaluation of a field expression against a memory assignment.
+-- `nothing` if any referenced wire is out of range.
+eval : List Fr → Expr → Maybe Fr
+eval mem (wire i)  = mem-lookup mem i
+eval mem (con k)  = just k
+eval mem (l ⊕ r)  = eval mem l >>= λ x → eval mem r >>= λ y → just (x +ᶠ y)
+eval mem (l ⊗ r)  = eval mem l >>= λ x → eval mem r >>= λ y → just (x *ᶠ y)
+eval mem (⊝ e)    = eval mem e >>= λ x → just (-ᶠ x)
+
+------------------------------------------------------------------------
+-- Constraint satisfaction
+--
+-- `holds w c` is the proposition "wire assignment `w` satisfies
+-- constraint `c`".  It is the single interpreter over the closed
+-- `Constraint` vocabulary: a polynomial gate (`gate e`) requires the
+-- field expression to evaluate to 0, and each gadget atom requires the
+-- looked-up wire values to stand in the relation given by the
+-- corresponding canonical chip primitive (a field of the `Assumptions`
+-- record — the module parameter; nothing is postulated).
+--
+-- Treating chip primitives as canonical functions (rather than as
+-- separate axiomatic relations) implicitly bakes in the chips'
+-- soundness.
+------------------------------------------------------------------------
+
+holds : Witness → Constraint → Set
+
+holds w (gate e) = eval (Witness.mem w) e ≡ just 0ᶠ
+
+holds w (boolean v) =
+  ∃-syntax (λ vv →
+    (Witness.mem w at v ↦ vv) × is-bit vv)
+
+holds w (non-zero c) =
+  ∃-syntax (λ v →
+    (Witness.mem w at c ↦ v) × (¬ (v ≡ 0ᶠ)))
+
+holds w (in-range v bits) =
+  ∃-syntax (λ vv →
+      (Witness.mem w at v ↦ vv)
+    × (Fits-in vv bits))
+
+holds w (select out b a c) =
+  ∃-syntax (λ bv → ∃-syntax (λ av → ∃-syntax (λ cv → ∃-syntax (λ ov →
+      (Witness.mem w at b ↦ bv)
+    × (Witness.mem w at a ↦ av)
+    × (Witness.mem w at c ↦ cv)
+    × (Witness.mem w at out ↦ ov)
+    × is-bit bv
+    × (ov ≡ (bv *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ bv)) *ᶠ cv))))))
+
+holds w (div-mod q r v bits) =
+  ∃-syntax (λ qv → ∃-syntax (λ rv → ∃-syntax (λ vv →
+      (Witness.mem w at q ↦ qv)
+    × (Witness.mem w at r ↦ rv)
+    × (Witness.mem w at v ↦ vv)
+    × (Fits-in rv bits)
+    × (Fits-in qv (FR-BITS ∸ bits))
+    × (NoWrap qv rv bits)
+    × (vv ≡ (qv *ᶠ pow2-fr bits) +ᶠ rv))))
+  -- The `NoWrap` conjunct forces the canonical (non-wrapping)
+  -- decomposition, so (q, r) is the unique Euclidean split of `valFr v`
+  -- (see `Encoding.div-mod-constraint-unique`).  Without it the bounds alone
+  -- admit a second pair congruent mod |Fr|.
+
+holds w (reconstitute out d m bits) =
+  ∃-syntax (λ dv → ∃-syntax (λ mv → ∃-syntax (λ ov →
+      (Witness.mem w at d ↦ dv)
+    × (Witness.mem w at m ↦ mv)
+    × (Witness.mem w at out ↦ ov)
+    × (Fits-in dv (FR-BITS ∸ bits))
+    × (Fits-in mv bits)
+    × (ov ≡ (dv *ᶠ pow2-fr bits) +ᶠ mv))))
+  -- N.B.: no overflow check.  A witness with dv·2^bits + mv ≥ |Fr| and
+  -- ov the field-reduced value satisfies this but not the operational
+  -- rule; producer obligation O3 closes the gap (§6.3).
+
+holds w (is-zero out a) =
+  -- is_zero(a): returns 1 iff a = 0, else 0.
+  ∃-syntax (λ av → ∃-syntax (λ ov →
+      (Witness.mem w at a ↦ av)
+    × (Witness.mem w at out ↦ ov)
+    × (ov ≡ from-bool (av ≡ᶠ? 0ᶠ))))
+
+holds w (test-eq out a b) =
+  ∃-syntax (λ av → ∃-syntax (λ bv → ∃-syntax (λ ov →
+      (Witness.mem w at a ↦ av)
+    × (Witness.mem w at b ↦ bv)
+    × (Witness.mem w at out ↦ ov)
+    × (ov ≡ from-bool (av ≡ᶠ? bv)))))
+
+holds w (less-than out a b bits) =
+  -- Range checks use the *padded* bit count (cf. §5.2 footnote).
+  ∃-syntax (λ av → ∃-syntax (λ bv → ∃-syntax (λ ov →
+      (Witness.mem w at a ↦ av)
+    × (Witness.mem w at b ↦ bv)
+    × (Witness.mem w at out ↦ ov)
+    × (Fits-in av (lt-bits bits))
+    × (Fits-in bv (lt-bits bits))
+    × (ov ≡ from-bool (bits-lt (take (lt-bits bits) (to-le-bits av))
+                               (take (lt-bits bits) (to-le-bits bv)))))))
+
+holds w (poseidon out inputs) =
+  ∃-syntax (λ vs → ∃-syntax (λ ov →
+      (mem-lookups (Witness.mem w) inputs ≡ just vs)
+    × (Witness.mem w at out ↦ ov)
+    × (ov ≡ transient-hash-fn vs)))
+
+holds w (sha256 h₁ h₂ alignment inputs) =
+  ∃-syntax (λ vs → ∃-syntax (λ v1 → ∃-syntax (λ v2 →
+      (mem-lookups (Witness.mem w) inputs ≡ just vs)
+    × (Witness.mem w at h₁ ↦ v1)
+    × (Witness.mem w at h₂ ↦ v2)
+    × (persistent-hash-fn alignment vs ≡ (v1 , v2)))))
+
+holds w (ec-add c-x c-y a-x a-y b-x b-y) =
+  ∃-syntax (λ ax → ∃-syntax (λ ay → ∃-syntax (λ bx → ∃-syntax (λ by →
+   ∃-syntax (λ cx → ∃-syntax (λ cy →
+        (Witness.mem w at a-x ↦ ax)
+      × (Witness.mem w at a-y ↦ ay)
+      × (Witness.mem w at b-x ↦ bx)
+      × (Witness.mem w at b-y ↦ by)
+      × (Witness.mem w at c-x ↦ cx)
+      × (Witness.mem w at c-y ↦ cy)
+      × (ec-add-pts ax ay bx by ≡ just (cx , cy))))))))
+
+holds w (ec-mul c-x c-y a-x a-y scalar) =
+  ∃-syntax (λ ax → ∃-syntax (λ ay → ∃-syntax (λ sc →
+   ∃-syntax (λ cx → ∃-syntax (λ cy →
+        (Witness.mem w at a-x ↦ ax)
+      × (Witness.mem w at a-y ↦ ay)
+      × (Witness.mem w at scalar ↦ sc)
+      × (Witness.mem w at c-x ↦ cx)
+      × (Witness.mem w at c-y ↦ cy)
+      × (ec-mul-pt ax ay sc ≡ just (cx , cy)))))))
+
+holds w (ec-gen c-x c-y scalar) =
+  ∃-syntax (λ sc → ∃-syntax (λ cx → ∃-syntax (λ cy →
+      (Witness.mem w at scalar ↦ sc)
+    × (Witness.mem w at c-x ↦ cx)
+    × (Witness.mem w at c-y ↦ cy)
+    × (ec-mul-gen sc ≡ (cx , cy)))))
+
+holds w (h2c c-x c-y inputs) =
+  ∃-syntax (λ vs → ∃-syntax (λ cx → ∃-syntax (λ cy →
+      (mem-lookups (Witness.mem w) inputs ≡ just vs)
+    × (Witness.mem w at c-x ↦ cx)
+    × (Witness.mem w at c-y ↦ cy)
+    × (hash-to-curve-fn vs ≡ (cx , cy)))))
+
+holds w (bind entry widx) =
+  ∃-syntax (λ wv → ∃-syntax (λ pv →
+      (Witness.mem w at widx ↦ wv)
+    × (pi-lookup (Witness.pis w) entry ≡ just pv)
+    × (pv ≡ wv)))
+
+holds w (guard-disj out i) =
+  ∃-syntax (λ ov → ∃-syntax (λ iv →
+      (Witness.mem w at out ↦ ov)
+    × (Witness.mem w at i ↦ iv)
+    × is-bit iv
+    × ((ov ≡ 0ᶠ) ⊎ (iv ≡ 1ᶠ))))
+  -- The guard wire is lowered through a checked native→bit conversion,
+  -- so `⟦i⟧ ∈ {0, 1}` in addition to the disjunction.
+
+holds w (comm inputs outputs) =
+  ∃-syntax (λ ivs → ∃-syntax (λ ovs → ∃-syntax (λ rv → ∃-syntax (λ pv →
+      (mem-lookups (Witness.mem w) inputs ≡ just ivs)
+    × (mem-lookups (Witness.mem w) outputs ≡ just ovs)
+    × (Witness.comm-rand w ≡ just rv)
+    × (pi-lookup (Witness.pis w) 1 ≡ just pv)
+    × (pv ≡ transient-commit (ivs ++ ovs) rv)))))
+
+------------------------------------------------------------------------
+-- Decidability of constraint satisfaction
+--
+-- This section is a *deliverable* of the module in its own right: it
+-- makes `satisfies` executable as a concrete witness checker (given an
+-- instantiation of `Assumptions` with decidable primitives).  No proof
+-- elsewhere in the development consumes it — do not mistake it for
+-- dead code.
+--
+-- `holds w c` is decidable.  Each constraint is an existential block whose
+-- bound values are pinned by a *functional* lookup
+-- (`mem-lookup`/`mem-lookups`/`pi-lookup`/`comm-rand`): once the lookup
+-- resolves, the value is unique (`just`-injectivity), so the existential
+-- collapses to deciding the residual predicate, which is built from the
+-- decidable atoms `_≟ᶠ_`, `fits-in?`, `noWrap?` and `is-bit?`.
+--
+-- The proofs decide the *chained* form (each lookup immediately followed
+-- by the rest, as an existential) and `map′` it onto the `holds` shape
+-- (all lookups grouped before the residual predicate); the two are
+-- logically equivalent and the transport functions just reassociate the
+-- tuple.
+------------------------------------------------------------------------
+
+-- A field value is a bit exactly when it equals `0ᶠ` or `1ᶠ`.
+is-bit? : ∀ v → Dec (is-bit v)
+is-bit? v = (v ≟ᶠ 0ᶠ) ⊎-dec (v ≟ᶠ 1ᶠ)
+
+private
+  -- `∃ x. (m ≡ just x) × P x` is decidable when `P` is: `nothing` has no
+  -- witness, and `just y` forces `x ≡ y` by injectivity.
+  dec-just : ∀ {a p} {A : Set a} (m : Maybe A) (P : A → Set p)
+    → (∀ x → Dec (P x))
+    → Dec (∃-syntax (λ x → (m ≡ just x) × P x))
+  dec-just nothing  P P? = no λ { (_ , () , _) }
+  dec-just (just y) P P? =
+    map′ (λ p → y , refl , p)
+         (λ (_ , eq , p) → subst P (just-injective (sym eq)) p)
+         (P? y)
+
+  -- The same, specialized to a wire lookup `mem at i ↦ v`.
+  dec-↦ : ∀ {p} mem i (P : Fr → Set p) → (∀ v → Dec (P v))
+    → Dec (∃-syntax (λ v → (mem at i ↦ v) × P v))
+  dec-↦ mem i = dec-just (mem-lookup mem i)
+
+holds? : ∀ w c → Dec (holds w c)
+
+holds? w (gate e) = maybe-≡-dec _≟ᶠ_ (eval (Witness.mem w) e) (just 0ᶠ)
+
+holds? w (boolean v) = dec-↦ (Witness.mem w) v is-bit is-bit?
+
+holds? w (non-zero c) =
+  dec-↦ (Witness.mem w) c (λ v → ¬ (v ≡ 0ᶠ)) (λ v → ¬? (v ≟ᶠ 0ᶠ))
+
+holds? w (in-range v bits) =
+  dec-↦ (Witness.mem w) v (λ vv → Fits-in vv bits) (λ vv → fits-in? vv bits)
+
+holds? w (select out b a c) = map′ to from
+  (dec-↦ mem b _
+    (λ bv → dec-↦ mem a _
+      (λ av → dec-↦ mem c _
+        (λ cv → dec-↦ mem out _
+          (λ ov → is-bit? bv ×-dec
+                  (ov ≟ᶠ ((bv *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ bv)) *ᶠ cv))))))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (select out b a c)
+    to (bv , lb , av , la , cv , lc , ov , lo , ib , eq) =
+      bv , av , cv , ov , lb , la , lc , lo , ib , eq
+    from : holds w (select out b a c) → _
+    from (bv , av , cv , ov , lb , la , lc , lo , ib , eq) =
+      bv , lb , av , la , cv , lc , ov , lo , ib , eq
+
+holds? w (div-mod q r v bits) = map′ to from
+  (dec-↦ mem q _
+    (λ qv → dec-↦ mem r _
+      (λ rv → dec-↦ mem v _
+        (λ vv → fits-in? rv bits
+                ×-dec fits-in? qv (FR-BITS ∸ bits)
+                ×-dec noWrap? qv rv bits
+                ×-dec (vv ≟ᶠ ((qv *ᶠ pow2-fr bits) +ᶠ rv))))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (div-mod q r v bits)
+    to (qv , lq , rv , lr , vv , lv , fr , fq , nw , eq) =
+      qv , rv , vv , lq , lr , lv , fr , fq , nw , eq
+    from : holds w (div-mod q r v bits) → _
+    from (qv , rv , vv , lq , lr , lv , fr , fq , nw , eq) =
+      qv , lq , rv , lr , vv , lv , fr , fq , nw , eq
+
+holds? w (reconstitute out d m bits) = map′ to from
+  (dec-↦ mem d _
+    (λ dv → dec-↦ mem m _
+      (λ mv → dec-↦ mem out _
+        (λ ov → fits-in? dv (FR-BITS ∸ bits)
+                ×-dec fits-in? mv bits
+                ×-dec (ov ≟ᶠ ((dv *ᶠ pow2-fr bits) +ᶠ mv))))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (reconstitute out d m bits)
+    to (dv , ld , mv , lm , ov , lo , fd , fm , eq) =
+      dv , mv , ov , ld , lm , lo , fd , fm , eq
+    from : holds w (reconstitute out d m bits) → _
+    from (dv , mv , ov , ld , lm , lo , fd , fm , eq) =
+      dv , ld , mv , lm , ov , lo , fd , fm , eq
+
+holds? w (is-zero out a) = map′ to from
+  (dec-↦ mem a _
+    (λ av → dec-↦ mem out _
+      (λ ov → ov ≟ᶠ from-bool (av ≡ᶠ? 0ᶠ))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (is-zero out a)
+    to (av , la , ov , lo , eq) = av , ov , la , lo , eq
+    from : holds w (is-zero out a) → _
+    from (av , ov , la , lo , eq) = av , la , ov , lo , eq
+
+holds? w (test-eq out a b) = map′ to from
+  (dec-↦ mem a _
+    (λ av → dec-↦ mem b _
+      (λ bv → dec-↦ mem out _
+        (λ ov → ov ≟ᶠ from-bool (av ≡ᶠ? bv)))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (test-eq out a b)
+    to (av , la , bv , lb , ov , lo , eq) = av , bv , ov , la , lb , lo , eq
+    from : holds w (test-eq out a b) → _
+    from (av , bv , ov , la , lb , lo , eq) = av , la , bv , lb , ov , lo , eq
+
+holds? w (less-than out a b bits) = map′ to from
+  (dec-↦ mem a _
+    (λ av → dec-↦ mem b _
+      (λ bv → dec-↦ mem out _
+        (λ ov → fits-in? av (lt-bits bits)
+                ×-dec fits-in? bv (lt-bits bits)
+                ×-dec (ov ≟ᶠ from-bool
+                  (bits-lt (take (lt-bits bits) (to-le-bits av))
+                           (take (lt-bits bits) (to-le-bits bv))))))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (less-than out a b bits)
+    to (av , la , bv , lb , ov , lo , fa , fb , eq) =
+      av , bv , ov , la , lb , lo , fa , fb , eq
+    from : holds w (less-than out a b bits) → _
+    from (av , bv , ov , la , lb , lo , fa , fb , eq) =
+      av , la , bv , lb , ov , lo , fa , fb , eq
+
+holds? w (poseidon out inputs) = map′ to from
+  (dec-just (mem-lookups mem inputs) _
+    (λ vs → dec-↦ mem out _
+      (λ ov → ov ≟ᶠ transient-hash-fn vs)))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (poseidon out inputs)
+    to (vs , lvs , ov , lo , eq) = vs , ov , lvs , lo , eq
+    from : holds w (poseidon out inputs) → _
+    from (vs , ov , lvs , lo , eq) = vs , lvs , ov , lo , eq
+
+holds? w (sha256 h₁ h₂ alignment inputs) = map′ to from
+  (dec-just (mem-lookups mem inputs) _
+    (λ vs → dec-↦ mem h₁ _
+      (λ v1 → dec-↦ mem h₂ _
+        (λ v2 → ×-≡-dec _≟ᶠ_ _≟ᶠ_
+                  (persistent-hash-fn alignment vs) (v1 , v2)))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (sha256 h₁ h₂ alignment inputs)
+    to (vs , lvs , v1 , l1 , v2 , l2 , eq) = vs , v1 , v2 , lvs , l1 , l2 , eq
+    from : holds w (sha256 h₁ h₂ alignment inputs) → _
+    from (vs , v1 , v2 , lvs , l1 , l2 , eq) = vs , lvs , v1 , l1 , v2 , l2 , eq
+
+holds? w (ec-add c-x c-y a-x a-y b-x b-y) = map′ to from
+  (dec-↦ mem a-x _
+    (λ ax → dec-↦ mem a-y _
+      (λ ay → dec-↦ mem b-x _
+        (λ bx → dec-↦ mem b-y _
+          (λ by → dec-↦ mem c-x _
+            (λ cx → dec-↦ mem c-y _
+              (λ cy → maybe-≡-dec (×-≡-dec _≟ᶠ_ _≟ᶠ_)
+                        (ec-add-pts ax ay bx by) (just (cx , cy)))))))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (ec-add c-x c-y a-x a-y b-x b-y)
+    to (ax , lax , ay , lay , bx , lbx , by , lby , cx , lcx , cy , lcy , eq) =
+      ax , ay , bx , by , cx , cy , lax , lay , lbx , lby , lcx , lcy , eq
+    from : holds w (ec-add c-x c-y a-x a-y b-x b-y) → _
+    from (ax , ay , bx , by , cx , cy , lax , lay , lbx , lby , lcx , lcy , eq) =
+      ax , lax , ay , lay , bx , lbx , by , lby , cx , lcx , cy , lcy , eq
+
+holds? w (ec-mul c-x c-y a-x a-y scalar) = map′ to from
+  (dec-↦ mem a-x _
+    (λ ax → dec-↦ mem a-y _
+      (λ ay → dec-↦ mem scalar _
+        (λ sc → dec-↦ mem c-x _
+          (λ cx → dec-↦ mem c-y _
+            (λ cy → maybe-≡-dec (×-≡-dec _≟ᶠ_ _≟ᶠ_)
+                      (ec-mul-pt ax ay sc) (just (cx , cy))))))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (ec-mul c-x c-y a-x a-y scalar)
+    to (ax , lax , ay , lay , sc , ls , cx , lcx , cy , lcy , eq) =
+      ax , ay , sc , cx , cy , lax , lay , ls , lcx , lcy , eq
+    from : holds w (ec-mul c-x c-y a-x a-y scalar) → _
+    from (ax , ay , sc , cx , cy , lax , lay , ls , lcx , lcy , eq) =
+      ax , lax , ay , lay , sc , ls , cx , lcx , cy , lcy , eq
+
+holds? w (ec-gen c-x c-y scalar) = map′ to from
+  (dec-↦ mem scalar _
+    (λ sc → dec-↦ mem c-x _
+      (λ cx → dec-↦ mem c-y _
+        (λ cy → ×-≡-dec _≟ᶠ_ _≟ᶠ_ (ec-mul-gen sc) (cx , cy)))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (ec-gen c-x c-y scalar)
+    to (sc , ls , cx , lcx , cy , lcy , eq) = sc , cx , cy , ls , lcx , lcy , eq
+    from : holds w (ec-gen c-x c-y scalar) → _
+    from (sc , cx , cy , ls , lcx , lcy , eq) = sc , ls , cx , lcx , cy , lcy , eq
+
+holds? w (h2c c-x c-y inputs) = map′ to from
+  (dec-just (mem-lookups mem inputs) _
+    (λ vs → dec-↦ mem c-x _
+      (λ cx → dec-↦ mem c-y _
+        (λ cy → ×-≡-dec _≟ᶠ_ _≟ᶠ_ (hash-to-curve-fn vs) (cx , cy)))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (h2c c-x c-y inputs)
+    to (vs , lvs , cx , lcx , cy , lcy , eq) = vs , cx , cy , lvs , lcx , lcy , eq
+    from : holds w (h2c c-x c-y inputs) → _
+    from (vs , cx , cy , lvs , lcx , lcy , eq) = vs , lvs , cx , lcx , cy , lcy , eq
+
+holds? w (bind entry widx) = map′ to from
+  (dec-↦ (Witness.mem w) widx _
+    (λ wv → dec-just (pi-lookup (Witness.pis w) entry) _
+      (λ pv → pv ≟ᶠ wv)))
+  where
+    to : _ → holds w (bind entry widx)
+    to (wv , lw , pv , lp , eq) = wv , pv , lw , lp , eq
+    from : holds w (bind entry widx) → _
+    from (wv , pv , lw , lp , eq) = wv , lw , pv , lp , eq
+
+holds? w (guard-disj out i) = map′ to from
+  (dec-↦ mem out _
+    (λ ov → dec-↦ mem i _
+      (λ iv → is-bit? iv ×-dec ((ov ≟ᶠ 0ᶠ) ⊎-dec (iv ≟ᶠ 1ᶠ)))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (guard-disj out i)
+    to (ov , lo , iv , li , ib , d) = ov , iv , lo , li , ib , d
+    from : holds w (guard-disj out i) → _
+    from (ov , iv , lo , li , ib , d) = ov , lo , iv , li , ib , d
+
+holds? w (comm inputs outputs) = map′ to from
+  (dec-just (mem-lookups mem inputs) _
+    (λ ivs → dec-just (mem-lookups mem outputs) _
+      (λ ovs → dec-just (Witness.comm-rand w) _
+        (λ rv → dec-just (pi-lookup (Witness.pis w) 1) _
+          (λ pv → pv ≟ᶠ transient-commit (ivs ++ ovs) rv)))))
+  where
+    mem = Witness.mem w
+    to : _ → holds w (comm inputs outputs)
+    to (ivs , li , ovs , lo , rv , lr , pv , lp , eq) =
+      ivs , ovs , rv , pv , li , lo , lr , lp , eq
+    from : holds w (comm inputs outputs) → _
+    from (ivs , ovs , rv , pv , li , lo , lr , lp , eq) =
+      ivs , li , ovs , lo , rv , lr , pv , lp , eq
+
+------------------------------------------------------------------------
+-- Polynomial-gate bridges
+--
+-- The arithmetic instructions (add, mul, neg, copy, constrain_eq,
+-- load_imm) lower to equality gates `l ≑ r`.  These lemmas relate
+-- `holds w (l ≑ r)` to the field-equation shape on the looked-up wire
+-- values that the per-instruction faithfulness proofs reason with.
+------------------------------------------------------------------------
+
+-- Inversion for a binary-operator expression: if `l ⊕ r` evaluates,
+-- both operands evaluate and the result is their sum.
+eval-⊕ : ∀ mem l r {v} → eval mem (l ⊕ r) ≡ just v
+  → ∃-syntax (λ x → ∃-syntax (λ y →
+      (eval mem l ≡ just x) × (eval mem r ≡ just y) × (v ≡ x +ᶠ y)))
+eval-⊕ mem l r ev with eval mem l
+... | nothing = case ev of λ ()
+... | just x with eval mem r
+...   | nothing = case ev of λ ()
+...   | just y = x , y , refl , refl , sym (just-injective ev)
+
+-- Likewise for products and negations.
+eval-⊗ : ∀ mem l r {v} → eval mem (l ⊗ r) ≡ just v
+  → ∃-syntax (λ x → ∃-syntax (λ y →
+      (eval mem l ≡ just x) × (eval mem r ≡ just y) × (v ≡ x *ᶠ y)))
+eval-⊗ mem l r ev with eval mem l
+... | nothing = case ev of λ ()
+... | just x with eval mem r
+...   | nothing = case ev of λ ()
+...   | just y = x , y , refl , refl , sym (just-injective ev)
+
+eval-⊝ : ∀ mem e {v} → eval mem (⊝ e) ≡ just v
+  → ∃-syntax (λ x → (eval mem e ≡ just x) × (v ≡ -ᶠ x))
+eval-⊝ mem e ev with eval mem e
+... | nothing = case ev of λ ()
+... | just x = x , refl , sym (just-injective ev)
+
+-- An equality gate holds exactly when both sides evaluate to a common
+-- value.  Forward: from a shared value; inverse: to the shared value.
+-- The memory list is an *explicit* argument: every occurrence of it sits
+-- under `mem-lookup` (not injective) or `eval`/`holds` (which reduce it
+-- away), so it cannot be recovered by unification and must be supplied.
+-- `eval mem (l ⊖ r) ≡ just 0ᶠ` is precisely `holds w (l ≑ r)` for a
+-- witness `w` with `Witness.mem w = mem`.
+≑-fwd : ∀ mem (l r : Expr) {x}
+  → eval mem l ≡ just x → eval mem r ≡ just x → eval mem (l ⊖ r) ≡ just 0ᶠ
+≑-fwd _ l r {x} el er rewrite el | er = cong just (+-inv-r x)
+
+≑-inv : ∀ mem (l r : Expr) → eval mem (l ⊖ r) ≡ just 0ᶠ
+  → ∃-syntax (λ x → ∃-syntax (λ y →
+      (eval mem l ≡ just x) × (eval mem r ≡ just y) × (x ≡ y)))
+≑-inv mem l r h
+  with x , z , el , e⊝ , 0≡x+z ← eval-⊕ mem l (⊝ r) h
+  with y , er , z≡-y          ← eval-⊝ mem r e⊝
+  = x , y , el , er
+  , +ᶠ-cancel (trans (cong (x +ᶠ_) (sym z≡-y)) (sym 0≡x+z))
+
+-- Output-gate bridges.  An instruction whose result wire `out` is
+-- constrained to a small expression over input wires lowers to a single
+-- equality gate.  Each lemma exposes the wire-lookups and the field
+-- equation the per-instruction faithfulness proofs build and destruct.
+-- The memory list is explicit for the reason given above.
+
+-- out = ⟦a⟧ + ⟦b⟧
+≑⊕-fwd : ∀ mem {out a b av bv}
+  → (mem at a ↦ av) → (mem at b ↦ bv) → (mem at out ↦ (av +ᶠ bv))
+  → eval mem (wire out ⊖ (wire a ⊕ wire b)) ≡ just 0ᶠ
+≑⊕-fwd mem {out} {a} {b} {av} {bv} la lb lo =
+  ≑-fwd mem (wire out) (wire a ⊕ wire b) lo e
+  where e : eval mem (wire a ⊕ wire b) ≡ just (av +ᶠ bv)
+        e rewrite la | lb = refl
+
+≑⊕-inv : ∀ mem {out a b} → eval mem (wire out ⊖ (wire a ⊕ wire b)) ≡ just 0ᶠ
+  → ∃-syntax (λ av → ∃-syntax (λ bv → ∃-syntax (λ ov →
+      (mem at a ↦ av) × (mem at b ↦ bv)
+    × (mem at out ↦ ov) × (ov ≡ av +ᶠ bv))))
+≑⊕-inv mem {out} {a} {b} h
+  with ov , _ , lo , er , ov≡y ← ≑-inv mem (wire out) (wire a ⊕ wire b) h
+  with av , bv , la , lb , y≡sum ← eval-⊕ mem (wire a) (wire b) er
+  = av , bv , ov , la , lb , lo , trans ov≡y y≡sum
+
+-- out = ⟦a⟧ · ⟦b⟧
+≑⊗-fwd : ∀ mem {out a b av bv}
+  → (mem at a ↦ av) → (mem at b ↦ bv) → (mem at out ↦ (av *ᶠ bv))
+  → eval mem (wire out ⊖ (wire a ⊗ wire b)) ≡ just 0ᶠ
+≑⊗-fwd mem {out} {a} {b} {av} {bv} la lb lo =
+  ≑-fwd mem (wire out) (wire a ⊗ wire b) lo e
+  where e : eval mem (wire a ⊗ wire b) ≡ just (av *ᶠ bv)
+        e rewrite la | lb = refl
+
+≑⊗-inv : ∀ mem {out a b} → eval mem (wire out ⊖ (wire a ⊗ wire b)) ≡ just 0ᶠ
+  → ∃-syntax (λ av → ∃-syntax (λ bv → ∃-syntax (λ ov →
+      (mem at a ↦ av) × (mem at b ↦ bv)
+    × (mem at out ↦ ov) × (ov ≡ av *ᶠ bv))))
+≑⊗-inv mem {out} {a} {b} h
+  with ov , _ , lo , er , ov≡y ← ≑-inv mem (wire out) (wire a ⊗ wire b) h
+  with av , bv , la , lb , y≡prod ← eval-⊗ mem (wire a) (wire b) er
+  = av , bv , ov , la , lb , lo , trans ov≡y y≡prod
+
+-- out = − ⟦a⟧
+≑⊝-fwd : ∀ mem {out a av}
+  → (mem at a ↦ av) → (mem at out ↦ (-ᶠ av))
+  → eval mem (wire out ⊖ ⊝ wire a) ≡ just 0ᶠ
+≑⊝-fwd mem {out} {a} {av} la lo =
+  ≑-fwd mem (wire out) (⊝ wire a) lo e
+  where e : eval mem (⊝ wire a) ≡ just (-ᶠ av)
+        e rewrite la = refl
+
+≑⊝-inv : ∀ mem {out a} → eval mem (wire out ⊖ ⊝ wire a) ≡ just 0ᶠ
+  → ∃-syntax (λ av → ∃-syntax (λ ov →
+      (mem at a ↦ av) × (mem at out ↦ ov) × (ov ≡ -ᶠ av)))
+≑⊝-inv mem {out} {a} h
+  with ov , _ , lo , er , ov≡y ← ≑-inv mem (wire out) (⊝ wire a) h
+  with av , la , y≡neg ← eval-⊝ mem (wire a) er
+  = av , ov , la , lo , trans ov≡y y≡neg
+
+-- out = ⟦v⟧  (copy)
+≑wire-fwd : ∀ mem {out v vv}
+  → (mem at v ↦ vv) → (mem at out ↦ vv)
+  → eval mem (wire out ⊖ wire v) ≡ just 0ᶠ
+≑wire-fwd mem {out} {v} lv lo = ≑-fwd mem (wire out) (wire v) lo lv
+
+≑wire-inv : ∀ mem {out v} → eval mem (wire out ⊖ wire v) ≡ just 0ᶠ
+  → ∃-syntax (λ vv → ∃-syntax (λ ov →
+      (mem at v ↦ vv) × (mem at out ↦ ov) × (ov ≡ vv)))
+≑wire-inv mem {out} {v} h
+  with ov , vv , lo , lv , ov≡vv ← ≑-inv mem (wire out) (wire v) h
+  = vv , ov , lv , lo , ov≡vv
+
+-- out = k  (load_imm)
+≑con-fwd : ∀ mem {out k}
+  → (mem at out ↦ k) → eval mem (wire out ⊖ con k) ≡ just 0ᶠ
+≑con-fwd mem {out} {k} lo = ≑-fwd mem (wire out) (con k) lo refl
+
+≑con-inv : ∀ mem {out k} → eval mem (wire out ⊖ con k) ≡ just 0ᶠ
+  → ∃-syntax (λ ov → (mem at out ↦ ov) × (ov ≡ k))
+≑con-inv mem {out} {k} h
+  with ov , _ , lo , ek , ov≡k ← ≑-inv mem (wire out) (con k) h
+  = ov , lo , trans ov≡k (sym (just-injective ek))
+
+-- ⟦a⟧ = ⟦b⟧  (constrain_eq)
+≑vars-fwd : ∀ mem {a b va}
+  → (mem at a ↦ va) → (mem at b ↦ va)
+  → eval mem (wire a ⊖ wire b) ≡ just 0ᶠ
+≑vars-fwd mem {a} {b} la lb = ≑-fwd mem (wire a) (wire b) la lb
+
+≑vars-inv : ∀ mem {a b} → eval mem (wire a ⊖ wire b) ≡ just 0ᶠ
+  → ∃-syntax (λ av → ∃-syntax (λ bv →
+      (mem at a ↦ av) × (mem at b ↦ bv) × (av ≡ bv)))
+≑vars-inv mem {a} {b} h
+  with av , bv , la , lb , av≡bv ← ≑-inv mem (wire a) (wire b) h
+  = av , bv , la , lb , av≡bv
+
+-- Satisfaction of a constraint list: `holds w` for every constraint (`All`).
+satisfies-constraints : List Constraint → Witness → Set
+satisfies-constraints cs w = All (holds w) cs
+
+-- "If the circuit uses a comm-commitment, the witness must carry the
+-- randomness; otherwise the witness's comm-rand is unconstrained
+-- (the constraint that would consume it is not emitted, and the prover
+-- may carry a spurious randomness that is simply ignored)."
+Maybe-shape : Bool → Maybe Fr → Set
+Maybe-shape true  (just _) = ⊤
+Maybe-shape true  nothing  = ⊥
+Maybe-shape false _        = ⊤
+
+-- Top-level satisfaction.  An assignment satisfies a circuit when:
+--   • all constraints hold;
+--   • the witness has comm-rand iff the circuit has-comm;
+--   • the memory vector has exactly the allocated wire count;
+--   • the PI vector has the structural length recorded in the circuit
+--     (= preamble + #declared-PIs).
+record satisfies (c : Circuit) (w : Witness) : Set where
+  constructor mk-sat
+  field
+    pi-length     : length (Witness.pis w) ≡ Circuit.pi-len c
+    mem-length    : length (Witness.mem w) ≡ Circuit.nr-wires c
+    rand-shape    : Maybe-shape (Circuit.has-comm c) (Witness.comm-rand w)
+    constraint-ok : satisfies-constraints (Circuit.constraints c) w

--- a/formal/src/zkir-v2/CircuitFaithfulness.agda
+++ b/formal/src/zkir-v2/CircuitFaithfulness.agda
@@ -1,0 +1,1614 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.CircuitFaithfulness (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v2.FieldProperties ⋯
+open import zkir-v2.Encoding ⋯
+
+------------------------------------------------------------------------
+-- Per-instruction faithfulness
+--
+-- For each instruction, a forward faithfulness lemma, and — for every
+-- instruction whose emitted constraints have inversion content — a
+-- backward one:
+--
+--   fwd : R-instr pre s i s' ⇒ the constraints emitted by `circuit-instr`
+--                              for `i` are satisfied by the canonical
+--                              witness derived from s'.
+--
+--   bwd : constraints-of i satisfied by a witness whose mem has the
+--         expected post-state shape ⇒ R-instr pre s i s'.
+--
+-- Instructions with no backward lemma here (`output`, `pi-skip`,
+-- `public-input`, `private-input`, `div-mod-power-of-two`) are
+-- dispatched directly to their operational rules by `CircuitProof`;
+-- each absence is explained at the corresponding fwd lemma.
+------------------------------------------------------------------------
+
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+open import zkir-v2.Circuit ⋯
+open import zkir-v2.SemanticsLemmas ⋯
+
+open import Data.Bool      using (Bool; true; false; if_then_else_)
+import Data.Bool as Bool
+open import Data.List      using (List; []; _∷_; _++_; length; take; drop)
+open import Data.List.Relation.Unary.All using (All)
+  renaming ([] to []ᴬ; _∷_ to _∷ᴬ_)
+open import Data.Maybe     using (Maybe; nothing; just; _>>=_)
+open import Data.Maybe.Properties using (just-injective)
+open import Data.Nat       using (ℕ; suc; zero; _+_; _∸_; _≤_; _<_)
+open import Data.Product   using (_×_; _,_; ∃-syntax; proj₁; proj₂)
+open import Data.Unit      using (⊤; tt)
+open import Data.Sum       using (_⊎_; inj₁; inj₂)
+open import Data.Empty     using (⊥-elim)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; cong₂; subst)
+open import Relation.Nullary using (¬_)
+
+------------------------------------------------------------------------
+-- Axiomatic interface
+--
+-- The field-equality / `to-bool` reflection axioms, the BLS12-381
+-- scalar-field equations, and the bit-decomposition / bit-arithmetic
+-- facts that this module's per-instruction lemmas rest on are part of
+-- the trust base.  They are fields of the `Assumptions` record
+-- (`zkir-v2.Assumptions`) and come into scope via the module parameter.
+------------------------------------------------------------------------
+
+------------------------------------------------------------------------
+-- Local helpers
+--
+-- The lookup toolkit these proofs run on lives in `SemanticsLemmas`
+-- (opened above).  What remains here is specific to the backward
+-- lemmas: multi-argument `cong`, bit-lookup decomposition, and the
+-- `to-bool`/`is-bit` bridge.
+------------------------------------------------------------------------
+
+private
+
+  -- Multi-argument `cong` helpers used by the cryptographic backward
+  -- proofs (the chip primitives take 3 or 4 arguments).
+  cong₃ : ∀ {A B C D : Set} (f : A → B → C → D)
+          {a a' b b' c c'}
+        → a ≡ a' → b ≡ b' → c ≡ c'
+        → f a b c ≡ f a' b' c'
+  cong₃ f refl refl refl = refl
+
+  cong₄ : ∀ {A B C D E : Set} (f : A → B → C → D → E)
+          {a a' b b' c c' d d'}
+        → a ≡ a' → b ≡ b' → c ≡ c' → d ≡ d'
+        → f a b c d ≡ f a' b' c' d'
+  cong₄ f refl refl refl refl = refl
+
+  -- Decompose a `>>=`-style bit lookup into the underlying field value
+  -- plus the `to-bool` evidence on it.  Used wherever the operational
+  -- rule's premise is in `mem-lookup … >>= to-bool` form (assert,
+  -- cond-select's bit operand, constrain-to-boolean, not, public/
+  -- private input guards).
+  extract-bit-lookup : ∀ (mem : List Fr) b {sel}
+    → (mem-lookup mem b >>= to-bool) ≡ just sel
+    → ∃-syntax (λ bv →
+        (mem-lookup mem b ≡ just bv) × (to-bool bv ≡ just sel))
+  extract-bit-lookup mem b {sel} eq =
+    aux (mem-lookup mem b) refl eq
+    where
+      aux : ∀ (m : Maybe Fr)
+          → mem-lookup mem b ≡ m
+          → (m >>= to-bool) ≡ just sel
+          → ∃-syntax (λ bv →
+              (mem-lookup mem b ≡ just bv) × (to-bool bv ≡ just sel))
+      aux nothing   _    ()
+      aux (just bv) m-eq eq' = bv , m-eq , eq'
+
+  -- `to-bool` evidence yields the is-bit predicate required by constraints.
+  to-bool→is-bit : ∀ {v sel} → to-bool v ≡ just sel → is-bit v
+  to-bool→is-bit {sel = true}  eq = inj₂ (to-bool-true  eq)
+  to-bool→is-bit {sel = false} eq = inj₁ (to-bool-false eq)
+
+------------------------------------------------------------------------
+-- Single-instruction emission
+--
+-- For every instruction except `declare-pub-input`, only `nr-wires`
+-- matters in the synth state — `nr-declared-pi` and `output-wires` are
+-- untouched.  This abbreviation captures the emitted constraints starting
+-- from a fresh synth state with `nr-wires = n` (the `-with-decl`
+-- variant below threads `nr-declared-pi` for `declare-pub-input`).
+------------------------------------------------------------------------
+
+-- Pull a pre-state lookup back from a post-state lookup, given the
+-- index is within pre-state bounds.  Used by the backward dispatcher
+-- to bridge between satisfies-constraints witnesses (which give post-state
+-- lookups) and the per-instruction `*-bwd` lemmas (which take pre-state
+-- lookups).
+lookup-shrink : ∀ (mem suffix : List Fr) i {v}
+  → mem-lookup (mem ++ suffix) i ≡ just v
+  → suc i Data.Nat.≤ length mem
+  → mem-lookup mem i ≡ just v
+lookup-shrink []        _ _       _  ()
+lookup-shrink (x ∷ xs)  _ zero    eq _  = eq
+lookup-shrink (x ∷ xs)  s (suc i) eq (Data.Nat.s≤s lt) =
+  lookup-shrink xs s i eq lt
+
+-- Multi-index analogue of `lookup-shrink`.  Given that every index in
+-- `is` is `< length mem` (`All (_< length mem) is`), a
+-- `mem-lookups (mem ++ suffix) is ≡ just vs` collapses to
+-- `mem-lookups mem is ≡ just vs`.  Used by the backward dispatcher for
+-- the cryptographic-cluster cases.
+mem-lookups-shrink : ∀ (mem suffix : List Fr) (is : List Index) {vs}
+  → All (_< length mem) is
+  → mem-lookups (mem ++ suffix) is ≡ just vs
+  → mem-lookups mem is ≡ just vs
+mem-lookups-shrink mem suffix []       _              refl = refl
+mem-lookups-shrink mem suffix (i ∷ is) (i≤len ∷ᴬ rest) eq =
+  aux (mem-lookup (mem ++ suffix) i) refl
+      (mem-lookups (mem ++ suffix) is) refl
+      eq
+  where
+    aux : ∀ (m : Maybe Fr) → mem-lookup (mem ++ suffix) i ≡ m
+        → (ms : Maybe (List Fr)) → mem-lookups (mem ++ suffix) is ≡ ms
+        → ∀ {vs} → (m >>= λ v → ms >>= λ vs' → just (v ∷ vs')) ≡ just vs
+        → mem-lookups mem (i ∷ is) ≡ just vs
+    aux nothing   _    _          _    ()
+    aux (just _)  _    nothing    _    ()
+    aux (just v)  m-eq (just vs') ms-eq refl
+      rewrite lookup-shrink mem suffix i {v} m-eq i≤len
+            | mem-lookups-shrink mem suffix is {vs'} rest ms-eq
+      = refl
+
+single-instr-constraints : Bool → ℕ → Instruction → List Constraint
+single-instr-constraints hc n i =
+  SynthState.constraints (circuit-instr hc i (mk-synth n [] 0 []))
+
+-- Variant that exposes `nr-declared-pi`.  Used by `declare-pub-input`,
+-- whose emitted constraint's `entry` index depends on the count of
+-- previously-declared PIs.  Only `declare-pub-input` inspects
+-- `nr-declared-pi`; for every other instruction this equals
+-- `single-instr-constraints` at `d = 0`.
+single-instr-constraints-with-decl : Bool → ℕ → ℕ → Instruction → List Constraint
+single-instr-constraints-with-decl hc n d i =
+  SynthState.constraints (circuit-instr hc i (mk-synth n [] d []))
+
+------------------------------------------------------------------------
+-- add(a, b)
+--
+-- Lowering (§5.2):  out = ⟦a⟧ + ⟦b⟧
+-- Operational (§4.4): append M[a] + M[b]; Δmem = 1.
+------------------------------------------------------------------------
+
+add-fwd : ∀ {pre s s' a b hc} {rand : Maybe Fr}
+  → R-instr pre s (add a b) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (add a b))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+add-fwd {s = s} {a = a} {b = b} (r-add {av = av} {bv = bv} la lb) =
+  ≑⊕-fwd (Preprocessed.memory s ++ (av +ᶠ bv) ∷ [])
+         (lookup-extends (Preprocessed.memory s) ((av +ᶠ bv) ∷ []) a la)
+         (lookup-extends (Preprocessed.memory s) ((av +ᶠ bv) ∷ []) b lb)
+         (lookup-new     (Preprocessed.memory s) (av +ᶠ bv))
+   ∷ᴬ []ᴬ
+
+add-bwd : ∀ {pre s a b av bv v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a ≡ just av
+  → mem-lookup (Preprocessed.memory s) b ≡ just bv
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (add a b))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (v ≡ av +ᶠ bv) × R-instr pre s (add a b) (push-mem s v)
+add-bwd {pre = pre} {s = s} {a = a} {b = b} {av = av} {bv = bv} {v = v}
+        la lb (h ∷ᴬ _) =
+  let (av' , bv' , ov' , la' , lb' , lout , eq) =
+        ≑⊕-inv (Preprocessed.memory s ++ (v ∷ [])) h
+      av≡av' = extend-uniq (Preprocessed.memory s) (v ∷ []) a la la'
+      bv≡bv' = extend-uniq (Preprocessed.memory s) (v ∷ []) b lb lb'
+      v≡ov'  = new-uniq (Preprocessed.memory s) v lout
+      v≡sum  : v ≡ av +ᶠ bv
+      v≡sum  = trans v≡ov' (trans eq (cong₂ _+ᶠ_ (sym av≡av') (sym bv≡bv')))
+  in v≡sum
+   , subst (R-instr pre s (add a b)) (cong (push-mem s) (sym v≡sum))
+           (r-add la lb)
+
+------------------------------------------------------------------------
+-- copy(v)
+--
+-- Lowering: out = ⟦v⟧
+-- Operational: append M[v]; Δmem = 1.
+------------------------------------------------------------------------
+
+copy-fwd : ∀ {pre s s' v hc} {rand : Maybe Fr}
+  → R-instr pre s (copy v) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (copy v))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+copy-fwd {s = s} {v = v} (r-copy {v = v0} la) =
+  ≑wire-fwd (Preprocessed.memory s ++ v0 ∷ [])
+            (lookup-extends (Preprocessed.memory s) (v0 ∷ []) v la)
+            (lookup-new     (Preprocessed.memory s) v0)
+   ∷ᴬ []ᴬ
+
+copy-bwd : ∀ {pre s v vv w hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) v ≡ just vv
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (copy v))
+      (mk-witness (Preprocessed.memory s ++ (w ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (w ≡ vv) × R-instr pre s (copy v) (push-mem s w)
+copy-bwd {pre = pre} {s = s} {v = v} {vv = vv} {w = w}
+         la (h ∷ᴬ _) =
+  let (vv' , ov , la' , lout , eq) = ≑wire-inv (Preprocessed.memory s ++ (w ∷ [])) h
+      mem    = Preprocessed.memory s
+      vv≡vv' : vv ≡ vv'
+      vv≡vv' = extend-uniq mem (w ∷ []) v la la'
+      w≡ov   : w ≡ ov
+      w≡ov   = new-uniq mem w lout
+      w≡vv   : w ≡ vv
+      w≡vv   = trans w≡ov (trans eq (sym vv≡vv'))
+  in w≡vv
+   , subst (R-instr pre s (copy v)) (cong (push-mem s) (sym w≡vv))
+           (r-copy la)
+
+------------------------------------------------------------------------
+-- load-imm(k)
+--
+-- Lowering: out = k
+-- Operational: append k; Δmem = 1.
+------------------------------------------------------------------------
+
+load-imm-fwd : ∀ {pre s s' k hc} {rand : Maybe Fr}
+  → R-instr pre s (load-imm k) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (load-imm k))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+load-imm-fwd {s = s} {k = k} r-load-imm =
+  ≑con-fwd (Preprocessed.memory s ++ k ∷ []) (lookup-new (Preprocessed.memory s) k) ∷ᴬ []ᴬ
+
+load-imm-bwd : ∀ {pre s k w hc} {rand : Maybe Fr}
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (load-imm k))
+      (mk-witness (Preprocessed.memory s ++ (w ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (w ≡ k) × R-instr pre s (load-imm k) (push-mem s w)
+load-imm-bwd {pre = pre} {s = s} {k = k} {w = w}
+             (h ∷ᴬ _) =
+  let (ov , lout , eq) = ≑con-inv (Preprocessed.memory s ++ (w ∷ [])) h
+      w≡ov   : w ≡ ov
+      w≡ov   = new-uniq (Preprocessed.memory s) w lout
+      w≡k    : w ≡ k
+      w≡k    = trans w≡ov eq
+  in w≡k
+   , subst (R-instr pre s (load-imm k)) (cong (push-mem s) (sym w≡k))
+           r-load-imm
+
+------------------------------------------------------------------------
+-- constrain-eq(a, b)
+--
+-- Lowering: ⟦a⟧ = ⟦b⟧
+-- Operational: precondition M[a] = M[b]; Δmem = 0.
+------------------------------------------------------------------------
+
+constrain-eq-fwd : ∀ {pre s s' a b hc} {rand : Maybe Fr}
+  → R-instr pre s (constrain-eq a b) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (constrain-eq a b))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+constrain-eq-fwd {s = s} (r-constrain-eq {av = av} {bv = bv} la lb eq) =
+  ≑vars-fwd (Preprocessed.memory s) la (trans lb (cong just (sym eq))) ∷ᴬ []ᴬ
+
+constrain-eq-bwd : ∀ {pre s a b av bv hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a ≡ just av
+  → mem-lookup (Preprocessed.memory s) b ≡ just bv
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (constrain-eq a b))
+      (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) rand)
+  → R-instr pre s (constrain-eq a b) s
+constrain-eq-bwd {s = s} {a = a} {b = b} {av = av} {bv = bv}
+                 la lb (h ∷ᴬ _) =
+  let (av' , bv' , la' , lb' , av'≡bv') = ≑vars-inv (Preprocessed.memory s) h
+      mem    = Preprocessed.memory s
+      av≡av' = lookup-uniq mem a la la'
+      bv≡bv' = lookup-uniq mem b lb lb'
+      -- av ≡ av' ≡ bv' ≡ bv  (constraint uses propositional equality)
+      av≡bv  = trans av≡av' (trans av'≡bv' (sym bv≡bv'))
+  in r-constrain-eq la lb av≡bv
+
+------------------------------------------------------------------------
+-- constrain-bits(v, n)
+--
+-- Lowering: ⟦v⟧ < 2^n  (range chip; vacuous when n ≥ FR_BITS)
+-- Operational: precondition M[v] < 2^n; Δmem = 0.
+------------------------------------------------------------------------
+
+constrain-bits-fwd : ∀ {pre s s' v n hc} {rand : Maybe Fr}
+  → R-instr pre s (constrain-bits v n) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (constrain-bits v n))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+constrain-bits-fwd (r-constrain-bits {v = vv} la _ fits) =
+  (vv , la , fits) ∷ᴬ []ᴬ
+
+constrain-bits-bwd : ∀ {pre s v n vv hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) v ≡ just vv
+  → n < FR-BITS
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (constrain-bits v n))
+      (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) rand)
+  → R-instr pre s (constrain-bits v n) s
+constrain-bits-bwd {pre = pre} {s = s} {v = v} {n = n} {vv = vv}
+                   la bound ((vv' , la' , fits) ∷ᴬ _) =
+  let mem    = Preprocessed.memory s
+      vv≡vv' = lookup-uniq mem v la la'
+      fits-vv : Fits-in vv n
+      fits-vv = subst (λ z → Fits-in z n) (sym vv≡vv') fits
+  in r-constrain-bits la bound fits-vv
+
+------------------------------------------------------------------------
+-- mul(a, b), neg(a)         (identical pattern to add)
+------------------------------------------------------------------------
+
+mul-fwd : ∀ {pre s s' a b hc} {rand : Maybe Fr}
+  → R-instr pre s (mul a b) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (mul a b))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+mul-fwd {s = s} {a = a} {b = b} (r-mul {av = av} {bv = bv} la lb) =
+  ≑⊗-fwd (Preprocessed.memory s ++ (av *ᶠ bv) ∷ [])
+         (lookup-extends (Preprocessed.memory s) ((av *ᶠ bv) ∷ []) a la)
+         (lookup-extends (Preprocessed.memory s) ((av *ᶠ bv) ∷ []) b lb)
+         (lookup-new     (Preprocessed.memory s) (av *ᶠ bv))
+   ∷ᴬ []ᴬ
+
+mul-bwd : ∀ {pre s a b av bv v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a ≡ just av
+  → mem-lookup (Preprocessed.memory s) b ≡ just bv
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (mul a b))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (v ≡ av *ᶠ bv) × R-instr pre s (mul a b) (push-mem s v)
+mul-bwd {pre = pre} {s = s} {a = a} {b = b} {av = av} {bv = bv} {v = v}
+        la lb (h ∷ᴬ _) =
+  let (av' , bv' , ov' , la' , lb' , lout , eq) =
+        ≑⊗-inv (Preprocessed.memory s ++ (v ∷ [])) h
+      av≡av' = extend-uniq (Preprocessed.memory s) (v ∷ []) a la la'
+      bv≡bv' = extend-uniq (Preprocessed.memory s) (v ∷ []) b lb lb'
+      v≡ov'  = new-uniq (Preprocessed.memory s) v lout
+      v≡prod : v ≡ av *ᶠ bv
+      v≡prod = trans v≡ov' (trans eq (cong₂ _*ᶠ_ (sym av≡av') (sym bv≡bv')))
+  in v≡prod
+   , subst (R-instr pre s (mul a b)) (cong (push-mem s) (sym v≡prod))
+           (r-mul la lb)
+
+neg-fwd : ∀ {pre s s' a hc} {rand : Maybe Fr}
+  → R-instr pre s (neg a) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (neg a))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+neg-fwd {s = s} {a = a} (r-neg {av = av} la) =
+  ≑⊝-fwd (Preprocessed.memory s ++ (-ᶠ av) ∷ [])
+         (lookup-extends (Preprocessed.memory s) ((-ᶠ av) ∷ []) a la)
+         (lookup-new     (Preprocessed.memory s) (-ᶠ av))
+   ∷ᴬ []ᴬ
+
+neg-bwd : ∀ {pre s a av v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a ≡ just av
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (neg a))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (v ≡ (-ᶠ av)) × R-instr pre s (neg a) (push-mem s v)
+neg-bwd {pre = pre} {s = s} {a = a} {av = av} {v = v}
+        la (h ∷ᴬ _) =
+  let (av' , ov' , la' , lout , eq) = ≑⊝-inv (Preprocessed.memory s ++ (v ∷ [])) h
+      av≡av' : av ≡ av'
+      av≡av' = extend-uniq (Preprocessed.memory s) (v ∷ []) a la la'
+      v≡ov'  : v ≡ ov'
+      v≡ov'  = new-uniq (Preprocessed.memory s) v lout
+      v≡neg  : v ≡ (-ᶠ av)
+      v≡neg  = trans v≡ov' (trans eq (cong -ᶠ_ (sym av≡av')))
+  in v≡neg
+   , subst (R-instr pre s (neg a)) (cong (push-mem s) (sym v≡neg))
+           (r-neg la)
+
+------------------------------------------------------------------------
+-- test-eq(a, b)
+--
+-- Lowering: out = 1 iff ⟦a⟧ = ⟦b⟧, expressed as `out ≡ from-bool (a ≡ᶠ? b)`.
+-- Operational: append `from-bool (av ≡ᶠ? bv)`.
+------------------------------------------------------------------------
+
+test-eq-fwd : ∀ {pre s s' a b hc} {rand : Maybe Fr}
+  → R-instr pre s (test-eq a b) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (test-eq a b))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+test-eq-fwd {s = s} {a = a} {b = b} (r-test-eq {av = av} {bv = bv} la lb) =
+  ( av , bv , from-bool (av ≡ᶠ? bv)
+  , lookup-extends (Preprocessed.memory s) (from-bool (av ≡ᶠ? bv) ∷ []) a la
+  , lookup-extends (Preprocessed.memory s) (from-bool (av ≡ᶠ? bv) ∷ []) b lb
+  , lookup-new     (Preprocessed.memory s) (from-bool (av ≡ᶠ? bv))
+  , refl
+  ) ∷ᴬ []ᴬ
+
+test-eq-bwd : ∀ {pre s a b av bv v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a ≡ just av
+  → mem-lookup (Preprocessed.memory s) b ≡ just bv
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (test-eq a b))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (v ≡ from-bool (av ≡ᶠ? bv))
+  × R-instr pre s (test-eq a b) (push-mem s v)
+test-eq-bwd {pre = pre} {s = s} {a = a} {b = b} {av = av} {bv = bv} {v = v}
+            la lb ((av' , bv' , ov' , la' , lb' , lout , eq) ∷ᴬ _) =
+  let av≡av' : av ≡ av'
+      av≡av' = extend-uniq (Preprocessed.memory s) (v ∷ []) a la la'
+      bv≡bv' : bv ≡ bv'
+      bv≡bv' = extend-uniq (Preprocessed.memory s) (v ∷ []) b lb lb'
+      v≡ov'  : v ≡ ov'
+      v≡ov'  = new-uniq (Preprocessed.memory s) v lout
+      v≡teq  : v ≡ from-bool (av ≡ᶠ? bv)
+      v≡teq  = trans v≡ov' (trans eq (cong₂ (λ x y → from-bool (x ≡ᶠ? y))
+                                              (sym av≡av') (sym bv≡bv')))
+  in v≡teq
+   , subst (R-instr pre s (test-eq a b)) (cong (push-mem s) (sym v≡teq))
+           (r-test-eq la lb)
+
+------------------------------------------------------------------------
+-- output(v), pi-skip(g, n)     — no constraints; forward proof is trivial.
+------------------------------------------------------------------------
+
+output-fwd : ∀ {pre s s' v hc} {rand : Maybe Fr}
+  → R-instr pre s (output v) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (output v))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+output-fwd _ = []ᴬ
+
+pi-skip-fwd : ∀ {pre s s' g n hc} {rand : Maybe Fr}
+  → R-instr pre s (pi-skip g n) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (pi-skip g n))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+pi-skip-fwd _ = []ᴬ
+
+-- `output`'s backward direction is intentionally NOT exposed here: it
+-- emits no constraints, so there is nothing to invert — `CircuitProof`
+-- fires `r-output` directly from the `mem-lookup` in scope.  The same
+-- goes for pi-skip:
+-- - active branch needs the transcript-prefix-match precondition that
+--   uses the private `_≡ᶠ-list?_`;
+-- - inactive branch needs `eval-guard ≡ just false`.
+-- `CircuitProof.agda` dispatches directly to
+-- `r-pi-skip-{active,inactive}`, which has the side data in scope.
+
+------------------------------------------------------------------------
+-- constrain-to-boolean(v)
+--
+-- Lowering: ⟦v⟧ ∈ {0, 1}
+-- Operational: precondition bool(M[v]) ∈ {false, true}; Δmem = 0.
+------------------------------------------------------------------------
+
+constrain-to-boolean-fwd : ∀ {pre s s' v hc} {rand : Maybe Fr}
+  → R-instr pre s (constrain-to-boolean v) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (constrain-to-boolean v))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+constrain-to-boolean-fwd {s = s} {v = v} (r-constrain-to-boolean la-bind) =
+  let (vv , lvv , to-vv) = extract-bit-lookup (Preprocessed.memory s) v la-bind
+  in (vv , lvv , to-bool→is-bit to-vv) ∷ᴬ []ᴬ
+
+-- Backward: the constraint's `is-bit vv` gives us `vv ∈ {0, 1}`, which
+-- determines `to-bool vv`.  Combined with `mem-lookup mem v ≡ just vv`
+-- (from the constraint), we can fire `r-constrain-to-boolean`.
+constrain-to-boolean-bwd : ∀ {pre s v hc} {rand : Maybe Fr}
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (constrain-to-boolean v))
+      (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) rand)
+  → R-instr pre s (constrain-to-boolean v) s
+constrain-to-boolean-bwd {pre = pre} {s = s} {v = v}
+                         ((vv , lvv , inj₁ vv≡0) ∷ᴬ _) =
+  let mem = Preprocessed.memory s
+      to-bind : (mem-lookup mem v >>= to-bool) ≡ just false
+      to-bind = trans (cong (λ m → m >>= to-bool) lvv)
+                      (subst (λ z → to-bool z ≡ just false)
+                             (sym vv≡0) to-bool-of-0ᶠ)
+  in r-constrain-to-boolean to-bind
+constrain-to-boolean-bwd {pre = pre} {s = s} {v = v}
+                         ((vv , lvv , inj₂ vv≡1) ∷ᴬ _) =
+  let mem = Preprocessed.memory s
+      to-bind : (mem-lookup mem v >>= to-bool) ≡ just true
+      to-bind = trans (cong (λ m → m >>= to-bool) lvv)
+                      (subst (λ z → to-bool z ≡ just true)
+                             (sym vv≡1) to-bool-of-1ᶠ)
+  in r-constrain-to-boolean to-bind
+
+------------------------------------------------------------------------
+-- not(a)                   (§6.5)
+--
+-- Lowering:    out = is_zero(⟦a⟧) ≡ from-bool (⟦a⟧ ≡ᶠ? 0ᶠ)
+-- Operational: append from-bool (¬ bool(M[a]))
+--              precondition: bool(M[a]) ∈ {false, true}.
+--
+-- Forward: the operational rule provides the bit precondition.
+-- Backward: requires `is-bit av` (producer obligation O2) on the
+-- operand.
+------------------------------------------------------------------------
+
+private
+  -- For av ∈ {0ᶠ, 1ᶠ}: ¬ b = (av ≡ᶠ? 0ᶠ) in the boolean lattice.
+  not-equation : ∀ av (b : Bool)
+    → to-bool av ≡ just b
+    → from-bool (Bool.not b) ≡ from-bool (av ≡ᶠ? 0ᶠ)
+  not-equation av true to-av =
+    let av≡1 : av ≡ 1ᶠ
+        av≡1 = to-bool-true to-av
+        bool-eq : (av ≡ᶠ? 0ᶠ) ≡ false
+        bool-eq = subst (λ z → (z ≡ᶠ? 0ᶠ) ≡ false) (sym av≡1) (≡ᶠ?-false 1ᶠ≢0ᶠ)
+    in sym (cong from-bool bool-eq)
+  not-equation av false to-av =
+    let av≡0 : av ≡ 0ᶠ
+        av≡0 = to-bool-false to-av
+        bool-eq : (av ≡ᶠ? 0ᶠ) ≡ true
+        bool-eq = subst (λ z → (z ≡ᶠ? 0ᶠ) ≡ true) (sym av≡0) ≡ᶠ?-refl
+    in sym (cong from-bool bool-eq)
+
+not-fwd : ∀ {pre s s' a hc} {rand : Maybe Fr}
+  → R-instr pre s (not a) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (not a))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+not-fwd {s = s} {a = a} (r-not {b = b} la-bind) =
+  let mem    = Preprocessed.memory s
+      (av , lav , to-av) = extract-bit-lookup mem a la-bind
+      out-val = from-bool (Bool.not b)
+  in ( av , out-val
+     , lookup-extends mem (out-val ∷ []) a lav
+     , lookup-new     mem out-val
+     , not-equation av b to-av
+     ) ∷ᴬ []ᴬ
+
+-- Backward direction.
+--
+-- Requires `is-bit av` (producer obligation O2 on the operand).
+-- With av ∈ {0ᶠ, 1ᶠ} we can run `to-bool av` deterministically and the
+-- constraint's `from-bool (av ≡ᶠ? 0ᶠ)` collapses to `from-bool (Bool.not b)`.
+
+private
+  -- Operational rule firing for `not a`, split on the is-bit case.
+  -- Pre-computes the value `from-bool (av ≡ᶠ? 0ᶠ)` which is what the
+  -- constraint forces the output to be.
+  not-fire : ∀ {pre} (s : Preprocessed) (a : Index) (av : Fr)
+    → mem-lookup (Preprocessed.memory s) a ≡ just av
+    → is-bit av
+    → R-instr pre s (not a) (push-mem s (from-bool (av ≡ᶠ? 0ᶠ)))
+  not-fire {pre} s a av la (inj₁ av≡0) =
+    let to-bind : (mem-lookup (Preprocessed.memory s) a >>= to-bool) ≡ just false
+        to-bind = trans (cong (λ m → m >>= to-bool) la)
+                        (subst (λ z → to-bool z ≡ just false)
+                               (sym av≡0) to-bool-of-0ᶠ)
+        ≡ᶠ-true : (av ≡ᶠ? 0ᶠ) ≡ true
+        ≡ᶠ-true = subst (λ z → (z ≡ᶠ? 0ᶠ) ≡ true) (sym av≡0) ≡ᶠ?-refl
+        target-eq : from-bool (Bool.not false) ≡ from-bool (av ≡ᶠ? 0ᶠ)
+        target-eq = cong from-bool (sym ≡ᶠ-true)
+    in subst (R-instr pre s (not a)) (cong (push-mem s) target-eq)
+             (r-not to-bind)
+  not-fire {pre} s a av la (inj₂ av≡1) =
+    let to-bind : (mem-lookup (Preprocessed.memory s) a >>= to-bool) ≡ just true
+        to-bind = trans (cong (λ m → m >>= to-bool) la)
+                        (subst (λ z → to-bool z ≡ just true)
+                               (sym av≡1) to-bool-of-1ᶠ)
+        ≡ᶠ-false : (av ≡ᶠ? 0ᶠ) ≡ false
+        ≡ᶠ-false = subst (λ z → (z ≡ᶠ? 0ᶠ) ≡ false)
+                         (sym av≡1) (≡ᶠ?-false 1ᶠ≢0ᶠ)
+        target-eq : from-bool (Bool.not true) ≡ from-bool (av ≡ᶠ? 0ᶠ)
+        target-eq = cong from-bool (sym ≡ᶠ-false)
+    in subst (R-instr pre s (not a)) (cong (push-mem s) target-eq)
+             (r-not to-bind)
+
+not-bwd : ∀ {pre s a av v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a ≡ just av
+  → is-bit av
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (not a))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (v ≡ from-bool (av ≡ᶠ? 0ᶠ))
+  × R-instr pre s (not a) (push-mem s (from-bool (av ≡ᶠ? 0ᶠ)))
+not-bwd {pre = pre} {s = s} {a = a} {av = av} {v = v}
+        la is-bit-av ((av' , ov , la' , lout , ov-eq) ∷ᴬ _) =
+  let mem    = Preprocessed.memory s
+      av≡av' = extend-uniq mem (v ∷ []) a la la'
+      v≡ov   = new-uniq mem v lout
+      v≡target : v ≡ from-bool (av ≡ᶠ? 0ᶠ)
+      v≡target = trans v≡ov
+                  (trans ov-eq (cong (λ z → from-bool (z ≡ᶠ? 0ᶠ))
+                                     (sym av≡av')))
+  in v≡target , not-fire s a av la is-bit-av
+
+------------------------------------------------------------------------
+-- cond-select(b, a, c)              (§6.5 sketch case)
+--
+-- Lowering: ⟦b⟧ ∈ {0,1}  ∧  out = ⟦b⟧·⟦a⟧ + (1−⟦b⟧)·⟦c⟧
+-- Operational: precondition bool(M[b]) ∈ {false, true}; append M[a]
+--              when true, else M[c]; Δmem = 1.
+--
+-- §6.5 forward sketch:  case on `sel`:
+--   sel = true:  bv = 1ᶠ.  RHS = 1·av + (1+(-1))·cv = av + 0·cv = av.
+--   sel = false: bv = 0ᶠ.  RHS = 0·av + (1+(-0))·cv = 0 + 1·cv = cv.
+------------------------------------------------------------------------
+
+private
+  -- Field-arithmetic lemma for the select equation, true-branch:
+  --   1·av + (1 + (-1))·cv  ≡  av
+  select-eq-true : ∀ av cv
+    → (1ᶠ *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ 1ᶠ)) *ᶠ cv) ≡ av
+  select-eq-true av cv =
+    trans (cong₂ _+ᶠ_ (*-one-l av)
+                       (trans (cong (_*ᶠ cv) (+-inv-r 1ᶠ)) (*-zero-l cv)))
+          (+-zero-r av)
+
+  -- Field-arithmetic lemma, false-branch:
+  --   0·av + (1 + (-0))·cv  ≡  cv
+  select-eq-false : ∀ av cv
+    → (0ᶠ *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ 0ᶠ)) *ᶠ cv) ≡ cv
+  select-eq-false av cv =
+    trans (cong₂ _+ᶠ_ (*-zero-l av)
+                       (trans (cong (λ z → (1ᶠ +ᶠ z) *ᶠ cv) -ᶠ-zero)
+                              (trans (cong (_*ᶠ cv) (+-zero-r 1ᶠ))
+                                     (*-one-l cv))))
+          (+-zero-l cv)
+
+  -- The select equation holds in both branches of `sel`.
+  -- `to-bool bv ≡ just sel` already pins `bv` to 0ᶠ / 1ᶠ.
+  select-equation : ∀ (sel : Bool) bv av cv
+    → to-bool bv ≡ just sel
+    → (if sel then av else cv)
+      ≡ (bv *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ bv)) *ᶠ cv)
+  select-equation true  bv av cv to-bv =
+    subst (λ z → av ≡ (z *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ z)) *ᶠ cv))
+          (sym (to-bool-true to-bv))
+          (sym (select-eq-true av cv))
+  select-equation false bv av cv to-bv =
+    subst (λ z → cv ≡ (z *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ z)) *ᶠ cv))
+          (sym (to-bool-false to-bv))
+          (sym (select-eq-false av cv))
+
+cond-select-fwd : ∀ {pre s s' b a c hc} {rand : Maybe Fr}
+  → R-instr pre s (cond-select b a c) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (cond-select b a c))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+cond-select-fwd {s = s} {b = b} {a = a} {c = c}
+                (r-cond-select {sel = sel} {av = av-spec} {bv = cv-spec}
+                                lb-bind la lc) =
+  let mem     = Preprocessed.memory s
+      out-val = if sel then av-spec else cv-spec
+      (bv , lbv-pre , to-bv) = extract-bit-lookup mem b lb-bind
+  in ( bv , av-spec , cv-spec , out-val
+     , lookup-extends mem (out-val ∷ []) b lbv-pre
+     , lookup-extends mem (out-val ∷ []) a la
+     , lookup-extends mem (out-val ∷ []) c lc
+     , lookup-new     mem out-val
+     , to-bool→is-bit to-bv
+     , select-equation sel bv av-spec cv-spec to-bv
+     ) ∷ᴬ []ᴬ
+
+-- Backward direction.  Case-splits on the bit value witnessed by
+-- `is-bit bv'` and applies the corresponding select-equation lemma to
+-- recover the output value.  No producer obligation needed: the
+-- §6.5 footnote observes that the V1 lowering for cond-select's bit
+-- operand silently rejects non-bit values, so the constraint itself
+-- enforces what's needed for the backward direction.
+cond-select-bwd : ∀ {pre s b a c bv av cv v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) b ≡ just bv
+  → mem-lookup (Preprocessed.memory s) a ≡ just av
+  → mem-lookup (Preprocessed.memory s) c ≡ just cv
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (cond-select b a c))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → R-instr pre s (cond-select b a c) (push-mem s v)
+cond-select-bwd {pre = pre} {s = s} {b = b} {a = a} {c = c}
+                {bv = bv} {av = av} {cv = cv} {v = v}
+                lb la lc
+                ((bv' , av' , cv' , ov , lb' , la' , lc' , lout
+                                       , inj₁ bv'≡0 , eq) ∷ᴬ _) =
+  -- Case bv' ≡ 0ᶠ ⇒ sel = false ⇒ output = cv.
+  let mem    = Preprocessed.memory s
+      bv≡bv' = extend-uniq mem (v ∷ []) b lb lb'
+      cv≡cv' = extend-uniq mem (v ∷ []) c lc lc'
+      v≡ov   = new-uniq mem v lout
+      bv≡0   = trans bv≡bv' bv'≡0
+      ov≡cv' = trans (subst (λ z → ov ≡ (z *ᶠ av') +ᶠ ((1ᶠ +ᶠ (-ᶠ z)) *ᶠ cv'))
+                             bv'≡0 eq)
+                      (select-eq-false av' cv')
+      v≡cv : v ≡ cv
+      v≡cv   = trans v≡ov (trans ov≡cv' (sym cv≡cv'))
+      to-bv  = subst (λ z → to-bool z ≡ just false) (sym bv≡0) to-bool-of-0ᶠ
+      lb-bind : (mem-lookup mem b >>= to-bool) ≡ just false
+      lb-bind = trans (cong (λ m → m >>= to-bool) lb) to-bv
+      r-fired : R-instr pre s (cond-select b a c) (push-mem s cv)
+      r-fired = r-cond-select {sel = false} lb-bind la lc
+  in subst (R-instr pre s (cond-select b a c))
+           (cong (push-mem s) (sym v≡cv))
+           r-fired
+cond-select-bwd {pre = pre} {s = s} {b = b} {a = a} {c = c}
+                {bv = bv} {av = av} {cv = cv} {v = v}
+                lb la lc
+                ((bv' , av' , cv' , ov , lb' , la' , lc' , lout
+                                       , inj₂ bv'≡1 , eq) ∷ᴬ _) =
+  -- Case bv' ≡ 1ᶠ ⇒ sel = true ⇒ output = av.
+  let mem    = Preprocessed.memory s
+      bv≡bv' = extend-uniq mem (v ∷ []) b lb lb'
+      av≡av' = extend-uniq mem (v ∷ []) a la la'
+      v≡ov   = new-uniq mem v lout
+      bv≡1   = trans bv≡bv' bv'≡1
+      ov≡av' = trans (subst (λ z → ov ≡ (z *ᶠ av') +ᶠ ((1ᶠ +ᶠ (-ᶠ z)) *ᶠ cv'))
+                             bv'≡1 eq)
+                      (select-eq-true av' cv')
+      v≡av : v ≡ av
+      v≡av   = trans v≡ov (trans ov≡av' (sym av≡av'))
+      to-bv  = subst (λ z → to-bool z ≡ just true) (sym bv≡1) to-bool-of-1ᶠ
+      lb-bind : (mem-lookup mem b >>= to-bool) ≡ just true
+      lb-bind = trans (cong (λ m → m >>= to-bool) lb) to-bv
+      r-fired : R-instr pre s (cond-select b a c) (push-mem s av)
+      r-fired = r-cond-select {sel = true} lb-bind la lc
+  in subst (R-instr pre s (cond-select b a c))
+           (cong (push-mem s) (sym v≡av))
+           r-fired
+
+------------------------------------------------------------------------
+-- declare-pub-input(v)             (state-dependent: nr-declared-pi)
+--
+-- Lowering: emits `constraint-pi-from-wire entry v` where
+--   entry = preamble-pi-count hc + nr-declared-pi  (synth-state field).
+-- Operational: append M[v] to `pis`; Δmem = 0.
+--
+-- The forward lemma threads the synth-state's `nr-declared-pi`
+-- explicitly via `single-instr-constraints-with-decl`, and requires the
+-- consistency precondition that the operational `pis` length matches
+-- the synth-state's PI count, which the program-level inductive
+-- invariant discharges.
+------------------------------------------------------------------------
+
+declare-pub-input-fwd : ∀ {pre s s' v hc d} {rand : Maybe Fr}
+  → length (Preprocessed.pis s) ≡ preamble-pi-count hc + d
+  → R-instr pre s (declare-pub-input v) s'
+  → satisfies-constraints
+      (single-instr-constraints-with-decl hc (length (Preprocessed.memory s)) d
+         (declare-pub-input v))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+declare-pub-input-fwd {s = s} {v = v} {hc = hc} {d = d}
+                      pi-len (r-declare-pub-input {v = wv} la) =
+  -- post-state: memory unchanged; pis = s.pis ++ (wv ∷ []).
+  let entry  = preamble-pi-count hc + d
+      pis-eq : pi-lookup (Preprocessed.pis s ++ (wv ∷ [])) entry ≡ just wv
+      pis-eq = subst (λ k → pi-lookup (Preprocessed.pis s ++ (wv ∷ [])) k
+                              ≡ just wv)
+                     pi-len (lookup-new (Preprocessed.pis s) wv)
+  in (wv , wv , la , pis-eq , refl) ∷ᴬ []ᴬ
+
+-- Backward direction.  From the constraint we extract: the PI vector
+-- extends `s.pis` with exactly the value bound to wire `v`, and the
+-- `entry` index points at it via `pi-lookup`.  Uniqueness of
+-- `mem-lookup` then identifies `wv` with the operational value.
+declare-pub-input-bwd : ∀ {pre s v wv hc d ext} {rand : Maybe Fr}
+  → length (Preprocessed.pis s) ≡ preamble-pi-count hc + d
+  → mem-lookup (Preprocessed.memory s) v ≡ just wv
+  → satisfies-constraints
+      (single-instr-constraints-with-decl hc (length (Preprocessed.memory s)) d
+         (declare-pub-input v))
+      (mk-witness (Preprocessed.memory s)
+                  (Preprocessed.pis s ++ (ext ∷ [])) rand)
+  → (ext ≡ wv) × R-instr pre s (declare-pub-input v)
+                                (record s
+                                  { pis        = Preprocessed.pis s ++ (ext ∷ [])
+                                  ; pub-in-idx = suc (Preprocessed.pub-in-idx s) })
+declare-pub-input-bwd {pre = pre} {s = s} {v = v} {wv = wv} {hc = hc} {d = d}
+                      {ext = ext} pi-len lv
+                      ((wv' , pv , lv' , pi-eq , pv≡wv') ∷ᴬ _) =
+  let wv≡wv' = lookup-uniq (Preprocessed.memory s) v lv lv'
+      entry  = preamble-pi-count hc + d
+      pis-new : pi-lookup (Preprocessed.pis s ++ (ext ∷ [])) (length (Preprocessed.pis s))
+                  ≡ just ext
+      pis-new = lookup-new (Preprocessed.pis s) ext
+      -- Transport `pis-new` along `pi-len : length (pis s) ≡ entry`.
+      pis-at-entry : pi-lookup (Preprocessed.pis s ++ (ext ∷ [])) entry ≡ just ext
+      pis-at-entry = subst (λ k → pi-lookup (Preprocessed.pis s ++ (ext ∷ [])) k
+                                    ≡ just ext)
+                           pi-len pis-new
+      pv≡ext = just-injective (trans (sym pi-eq) pis-at-entry)
+      ext≡wv : ext ≡ wv
+      ext≡wv = trans (sym pv≡ext) (trans pv≡wv' (sym wv≡wv'))
+      r-fired : R-instr pre s (declare-pub-input v)
+                  (record s
+                    { pis        = Preprocessed.pis s ++ (wv ∷ [])
+                    ; pub-in-idx = suc (Preprocessed.pub-in-idx s) })
+      r-fired = r-declare-pub-input lv
+  in ext≡wv
+   , subst (λ z → R-instr pre s (declare-pub-input v)
+                    (record s
+                      { pis        = Preprocessed.pis s ++ (z ∷ [])
+                      ; pub-in-idx = suc (Preprocessed.pub-in-idx s) }))
+           (sym ext≡wv) r-fired
+
+------------------------------------------------------------------------
+-- public-input nothing                  (no constraints)
+--
+-- Operational: r-public-input-active fires with guard ≡ just true.
+-- Lowering: emits no constraint (`bump-wires` only).
+------------------------------------------------------------------------
+
+public-input-nothing-fwd : ∀ {pre s s' hc} {rand : Maybe Fr}
+  → R-instr pre s (public-input nothing) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (public-input nothing))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+public-input-nothing-fwd _ = []ᴬ
+
+-- Backward: no constraints to invert — `CircuitProof` fires
+-- `r-public-input-active` directly (`eval-guard _ nothing ≡ just true`
+-- by definition; the transcript is the source of `v`).
+
+------------------------------------------------------------------------
+-- public-input (just g)                 (guard-disj constraint)
+--
+-- Operational: two rules — active (guard = true, output from transcript)
+-- and inactive (guard = false, output = 0ᶠ).
+-- Lowering: emits `constraint-guard-disj out g`, satisfied by either
+--   (out = 0) ∨ (⟦g⟧ = 1).
+--
+-- Forward needs the active/inactive split; the active case must
+-- characterize `consume-pub-out` to compute the post-state's memory.
+------------------------------------------------------------------------
+
+public-input-just-fwd : ∀ {pre s s' g hc} {rand : Maybe Fr}
+  → R-instr pre s (public-input (just g)) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (public-input (just g)))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+public-input-just-fwd {s = s} {g = g} {hc = hc}
+                      (r-public-input-inactive eg) =
+  -- Inactive: post-state memory = s.memory ++ [0ᶠ]; out value is 0ᶠ.
+  let mem  = Preprocessed.memory s
+      (gv , lg , to-gv) = extract-bit-lookup mem g eg
+  in ( 0ᶠ , gv
+     , lookup-new mem 0ᶠ
+     , lookup-extends mem (0ᶠ ∷ []) g lg
+     , to-bool→is-bit to-gv
+     , inj₁ refl
+     ) ∷ᴬ []ᴬ
+public-input-just-fwd {s = s} {g = g} {hc = hc} {rand = rand}
+                      (r-public-input-active {v = v} {s₁ = s₁} eg cp) =
+  -- Active: consume-pub-out yields v; post-state memory = s.memory ++ [v].
+  let mem    = Preprocessed.memory s
+      mem-eq : Preprocessed.memory s₁ ≡ mem
+      mem-eq = consume-pub-out-mem s cp
+      (gv , lg , to-gv) = extract-bit-lookup mem g eg
+      gv≡1   : gv ≡ 1ᶠ
+      gv≡1   = to-bool-true to-gv
+      -- Rewrite `push-mem s₁ v` so its memory shape is `mem ++ (v ∷ [])`.
+      mem'   = mem ++ (v ∷ [])
+      mem₁-eq : Preprocessed.memory (push-mem s₁ v) ≡ mem'
+      mem₁-eq = cong (_++ (v ∷ [])) mem-eq
+  in subst (λ m → satisfies-constraints
+             (single-instr-constraints hc (length mem) (public-input (just g)))
+             (mk-witness m (Preprocessed.pis (push-mem s₁ v)) rand))
+           (sym mem₁-eq)
+           (( v , gv
+            , lookup-new mem v
+            , lookup-extends mem (v ∷ []) g lg
+            , to-bool→is-bit to-gv
+            , inj₂ gv≡1
+            ) ∷ᴬ []ᴬ)
+
+-- Backward direction for `public-input (just g)`: the guard-disj
+-- constraint alone does not determine which operational rule (active /
+-- inactive) fits — the *operational* `consume-pub-out` shape does — so
+-- `CircuitProof` fires `r-public-input-{active,inactive}` directly
+-- from the side data in scope.
+
+------------------------------------------------------------------------
+-- private-input nothing / (just g)
+--
+-- Identical pattern to `public-input`, swapping `consume-pub-out` for
+-- `consume-priv` and the active rule accordingly.
+------------------------------------------------------------------------
+
+private-input-nothing-fwd : ∀ {pre s s' hc} {rand : Maybe Fr}
+  → R-instr pre s (private-input nothing) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (private-input nothing))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+private-input-nothing-fwd _ = []ᴬ
+
+private-input-just-fwd : ∀ {pre s s' g hc} {rand : Maybe Fr}
+  → R-instr pre s (private-input (just g)) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (private-input (just g)))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+private-input-just-fwd {s = s} {g = g}
+                       (r-private-input-inactive eg) =
+  let mem  = Preprocessed.memory s
+      (gv , lg , to-gv) = extract-bit-lookup mem g eg
+  in ( 0ᶠ , gv
+     , lookup-new mem 0ᶠ
+     , lookup-extends mem (0ᶠ ∷ []) g lg
+     , to-bool→is-bit to-gv
+     , inj₁ refl
+     ) ∷ᴬ []ᴬ
+private-input-just-fwd {s = s} {g = g} {hc = hc} {rand = rand}
+                       (r-private-input-active {v = v} {s₁ = s₁} eg cp) =
+  let mem    = Preprocessed.memory s
+      mem-eq : Preprocessed.memory s₁ ≡ mem
+      mem-eq = consume-priv-mem s cp
+      (gv , lg , to-gv) = extract-bit-lookup mem g eg
+      gv≡1   : gv ≡ 1ᶠ
+      gv≡1   = to-bool-true to-gv
+      mem'   = mem ++ (v ∷ [])
+      mem₁-eq : Preprocessed.memory (push-mem s₁ v) ≡ mem'
+      mem₁-eq = cong (_++ (v ∷ [])) mem-eq
+  in subst (λ m → satisfies-constraints
+             (single-instr-constraints hc (length mem) (private-input (just g)))
+             (mk-witness m (Preprocessed.pis (push-mem s₁ v)) rand))
+           (sym mem₁-eq)
+           (( v , gv
+            , lookup-new mem v
+            , lookup-extends mem (v ∷ []) g lg
+            , to-bool→is-bit to-gv
+            , inj₂ gv≡1
+            ) ∷ᴬ []ᴬ)
+
+------------------------------------------------------------------------
+-- assert(c)
+--
+-- Lowering: ⟦c⟧ ≠ 0
+-- Operational: precondition `bool(M[c]) = true`, i.e. M[c] = 1; Δmem = 0.
+--
+-- Forward: the operational rule witnesses M[c] = 1ᶠ via `to-bool`, and
+-- `1ᶠ ≢ 0ᶠ` discharges the constraint.
+--
+-- Backward: the constraint only gives `v ≠ 0ᶠ`, while the operational rule
+-- needs `v ∈ {0, 1} ∧ v ≠ 0`, so it requires `is-bit v` (producer
+-- obligation O2).
+------------------------------------------------------------------------
+
+assert-fwd : ∀ {pre s s' c hc} {rand : Maybe Fr}
+  → R-instr pre s (assert c) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (assert c))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+assert-fwd {s = s} {c = c} (r-assert la-bind) =
+  let mem    = Preprocessed.memory s
+      (vv , lvv , to-vv) = extract-bit-lookup mem c la-bind
+      vv≡1   : vv ≡ 1ᶠ
+      vv≡1   = to-bool-true to-vv
+      vv≢0   : ¬ (vv ≡ 0ᶠ)
+      vv≢0   = λ vv≡0 → 1ᶠ≢0ᶠ (trans (sym vv≡1) vv≡0)
+  in (vv , lvv , vv≢0) ∷ᴬ []ᴬ
+
+-- Backward direction.
+--
+-- Requires `is-bit v` (Circuit.is-bit, i.e. (v ≡ 0ᶠ) ⊎ (v ≡ 1ᶠ)), the
+-- per-instruction O2 hypothesis guaranteeing the operand lies in
+-- {0, 1}.  Combined with the constraint's `v ≠ 0ᶠ`, we case-split and rule
+-- out `inj₁`, then discharge the operational rule using `to-bool-of-1ᶠ`.
+assert-bwd : ∀ {pre s c v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) c ≡ just v
+  → is-bit v
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s)) (assert c))
+      (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) rand)
+  → R-instr pre s (assert c) s
+assert-bwd {pre = pre} {s = s} {c = c} {v = v}
+           lv (inj₁ v≡0) ((v' , lv' , v'≢0) ∷ᴬ _) =
+  -- v ≡ 0 contradicts the constraint's `v' ≢ 0` once we identify v with v'.
+  let mem    = Preprocessed.memory s
+      v≡v'   = lookup-uniq mem c lv lv'
+      v'≡0   = trans (sym v≡v') v≡0
+  in ⊥-elim (v'≢0 v'≡0)
+assert-bwd {pre = pre} {s = s} {c = c} {v = v}
+           lv (inj₂ v≡1) _ =
+  -- v ≡ 1 — fire `r-assert` with the `to-bool-of-1ᶠ` evidence.
+  let to-bind : (mem-lookup (Preprocessed.memory s) c >>= to-bool) ≡ just true
+      to-bind = trans (cong (λ m → m >>= to-bool) lv)
+                      (subst (λ z → to-bool z ≡ just true)
+                             (sym v≡1) to-bool-of-1ᶠ)
+  in r-assert to-bind
+
+------------------------------------------------------------------------
+-- div-mod-power-of-two(v, n)
+--
+-- Lowering: emits `constraint-div-mod q r v bits` with q = nr-wires,
+--           r = nr-wires + 1, bits = n.
+-- Operational: append `divisor := from-le-bits (drop bits (to-le-bits v))`
+--              then `modulus := from-le-bits (take bits (to-le-bits v))`;
+--              Δmem = 2.
+--
+-- The forward direction relies on four bit-decomposition facts:
+--   • `bits-decomp-split`         — the arithmetic identity (canonical
+--                                   decomposition satisfies the constraint);
+--   • `fits-from-le-bits-take`    — modulus fits in `bits` bits;
+--   • `fits-from-le-bits-drop`    — divisor fits in `FR_BITS − bits` bits;
+--   • `divmod-canonical-noWrap`   — the canonical recombination value is
+--                                   `valFr v < |Fr|`, so it does not wrap.
+-- The backward direction lives in `CircuitProof` (reads the canonical
+-- decomposition off the operational side-data); see its note below.
+------------------------------------------------------------------------
+
+div-mod-power-of-two-fwd : ∀ {pre s s' var bits hc} {rand : Maybe Fr}
+  → R-instr pre s (div-mod-power-of-two var bits) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (div-mod-power-of-two var bits))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+div-mod-power-of-two-fwd {s = s} {var = var} {bits = bits}
+  (r-div-mod-power-of-two {v = vv} la _) =
+  let mem      = Preprocessed.memory s
+      divisor  = from-le-bits (drop bits (to-le-bits vv))
+      modulus  = from-le-bits (take bits (to-le-bits vv))
+      -- post-mem = (mem ++ (divisor ∷ [])) ++ (modulus ∷ [])
+      mem'     = (mem ++ (divisor ∷ [])) ++ (modulus ∷ [])
+      -- q = length mem, r = suc (length mem).
+      lq       : mem-lookup mem' (length mem) ≡ just divisor
+      lq       = lookup-new-fst mem divisor modulus
+      lr       : mem-lookup mem' (suc (length mem)) ≡ just modulus
+      lr       = lookup-new-snd mem divisor modulus
+      la-ext   : mem-lookup mem' var ≡ just vv
+      la-ext   = lookup-extends (mem ++ (divisor ∷ [])) (modulus ∷ []) var
+                   (lookup-extends mem (divisor ∷ []) var la)
+  in ( divisor , modulus , vv
+     , lq , lr , la-ext
+     , fits-from-le-bits-take (to-le-bits vv) bits
+     , fits-from-le-bits-drop vv bits
+     , divmod-canonical-noWrap vv bits
+     , bits-decomp-split vv bits
+     ) ∷ᴬ []ᴬ
+
+-- Backward direction.
+--
+-- Handled directly in `CircuitProof.satisfies→R-instr-step`: the
+-- canonical decomposition (`x ≡ canon-q`, `y ≡ canon-r`) is read off the
+-- operational side-data recorded by `R-instr→tr-step`, then the rule
+-- fires via `r-div-mod-power-of-two`.  No separate backward lemma — and,
+-- crucially, no uniqueness-of-division axiom: `constraint-div-mod` is
+-- underconstrained (no in-field check, like `constraint-reconstitute`), so
+-- distinct (q, r) pairs can satisfy it under modular wraparound; the
+-- side-data, not the constraint, is what pins the values.
+
+------------------------------------------------------------------------
+-- reconstitute-field(d, m, n)         (§6.3)
+--
+-- Lowering: emits `constraint-reconstitute out d m bits` with no overflow
+--           check.
+-- Operational: requires `Fits-in mv bits`, `Fits-in dv (FR_BITS − bits)`,
+--              and `BitsInField (mv-bits ++ dv-bits)`.
+--              Output: `from-le-bits (mv-bits ++ dv-bits)`.
+--
+-- Forward direction uses `reconstitute-no-overflow` to extract the
+-- field equation from the operational premise.  Backward requires
+-- producer obligation O3 to recover the in-field check.
+------------------------------------------------------------------------
+
+reconstitute-field-fwd : ∀ {pre s s' d m bits hc} {rand : Maybe Fr}
+  → R-instr pre s (reconstitute-field d m bits) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (reconstitute-field d m bits))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+reconstitute-field-fwd {s = s} {d = d} {m = m} {bits = bits}
+  (r-reconstitute-field {dv = dv} {mv = mv} ld lm _ _ fits-and-in-field) =
+  let mem    = Preprocessed.memory s
+      ov     = from-le-bits (take bits (to-le-bits mv) ++
+                              take (FR-BITS ∸ bits) (to-le-bits dv))
+      (fits-mv , fits-dv , _) = fits-and-in-field
+      -- ov ≡ dv · 2^bits + mv.
+      ov-eq : ov ≡ (dv *ᶠ pow2-fr bits) +ᶠ mv
+      ov-eq = reconstitute-no-overflow dv mv bits fits-mv fits-dv
+  in ( dv , mv , ov
+     , lookup-extends mem (ov ∷ []) d ld
+     , lookup-extends mem (ov ∷ []) m lm
+     , lookup-new     mem ov
+     , fits-dv , fits-mv , ov-eq
+     ) ∷ᴬ []ᴬ
+
+-- Backward direction.
+--
+-- Requires `BitsInField (mv-bits ++ dv-bits)` (producer obligation
+-- O3).  The constraint supplies the fits-in bounds and the
+-- arithmetic equation; combined with the no-overflow hypothesis, we
+-- can identify the constraint's output with the canonical
+-- `from-le-bits (mv-bits ++ dv-bits)` and fire `r-reconstitute-field`.
+reconstitute-field-bwd : ∀ {pre s d m bits dv mv v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) d ≡ just dv
+  → mem-lookup (Preprocessed.memory s) m ≡ just mv
+  → 1 ≤ bits
+  → bits ≤ FR-STORED-BITS
+  → BitsInField
+      (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv))
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (reconstitute-field d m bits))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (v ≡ from-le-bits
+           (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv)))
+  × R-instr pre s (reconstitute-field d m bits)
+      (push-mem s (from-le-bits
+                    (take bits (to-le-bits mv) ++
+                     take (FR-BITS ∸ bits) (to-le-bits dv))))
+reconstitute-field-bwd {pre = pre} {s = s} {d = d} {m = m} {bits = bits}
+                       {dv = dv} {mv = mv} {v = v}
+  ld lm ge1 le in-field
+  ((dv' , mv' , ov , ld' , lm' , lout , fits-dv , fits-mv , ov-eq) ∷ᴬ _) =
+  let mem    = Preprocessed.memory s
+      dv≡dv' = extend-uniq mem (v ∷ []) d ld ld'
+      mv≡mv' = extend-uniq mem (v ∷ []) m lm lm'
+      v≡ov   = new-uniq mem v lout
+      -- Canonical reconstitution.
+      canon  = from-le-bits
+                 (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv))
+      -- Pull `fits-mv`, `fits-dv` back to `mv`, `dv`.
+      fits-mv-mv : Fits-in mv bits
+      fits-mv-mv = subst (λ z → Fits-in z bits) (sym mv≡mv') fits-mv
+      fits-dv-dv : Fits-in dv (FR-BITS ∸ bits)
+      fits-dv-dv = subst (λ z → Fits-in z (FR-BITS ∸ bits))
+                         (sym dv≡dv') fits-dv
+      -- canon ≡ dv · 2^bits + mv.
+      canon-eq : canon ≡ (dv *ᶠ pow2-fr bits) +ᶠ mv
+      canon-eq = reconstitute-no-overflow dv mv bits fits-mv-mv fits-dv-dv
+      -- v ≡ ov ≡ dv' · 2^bits + mv' ≡ dv · 2^bits + mv ≡ canon.
+      ov≡sum : ov ≡ (dv *ᶠ pow2-fr bits) +ᶠ mv
+      ov≡sum = trans ov-eq (cong₂ _+ᶠ_ (cong (_*ᶠ pow2-fr bits) (sym dv≡dv'))
+                                        (sym mv≡mv'))
+      v≡canon : v ≡ canon
+      v≡canon = trans v≡ov (trans ov≡sum (sym canon-eq))
+      r-fired : R-instr pre s (reconstitute-field d m bits)
+                  (push-mem s canon)
+      r-fired = r-reconstitute-field ld lm ge1 le (fits-mv-mv , fits-dv-dv , in-field)
+  in v≡canon , r-fired
+
+------------------------------------------------------------------------
+-- less-than(a, b, n)                  (§5.2-footnote)
+--
+-- Lowering: emits `constraint-less-than out a b bits` using the *padded*
+--           bit count `lt-bits bits`.
+-- Operational: requires `Fits-in av bits` and `Fits-in bv bits`,
+--              outputs `from-bool (bits-lt (take bits …) (take bits …))`.
+--
+-- Forward direction: pad the bit-bounds via `fits-in-lt-bits`, and
+-- transport the comparison via `bits-lt-pad`.  Backward requires the
+-- operand bit-bounds (the in-circuit constraint is strictly weaker than
+-- the operational rule).
+------------------------------------------------------------------------
+
+less-than-fwd : ∀ {pre s s' a b bits hc} {rand : Maybe Fr}
+  → R-instr pre s (less-than a b bits) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (less-than a b bits))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+less-than-fwd {s = s} {a = a} {b = b} {bits = bits}
+  (r-less-than {av = av} {bv = bv} la lb _ fits) =
+  let mem        = Preprocessed.memory s
+      (fits-av , fits-bv) = fits
+      -- Operational output value.
+      op-out     = from-bool (bits-lt (take bits (to-le-bits av))
+                                       (take bits (to-le-bits bv)))
+      -- Padded output value (what the constraint refers to).
+      padded-lt  = bits-lt (take (lt-bits bits) (to-le-bits av))
+                            (take (lt-bits bits) (to-le-bits bv))
+      -- Padding preserves the comparison.
+      pad-eq : padded-lt
+             ≡ bits-lt (take bits (to-le-bits av))
+                       (take bits (to-le-bits bv))
+      pad-eq = bits-lt-pad av bv bits fits-av fits-bv
+      -- ov ≡ from-bool padded-lt, derived from op-out ≡ from-bool padded-lt.
+      out-eq : op-out ≡ from-bool padded-lt
+      out-eq = sym (cong from-bool pad-eq)
+  in ( av , bv , op-out
+     , lookup-extends mem (op-out ∷ []) a la
+     , lookup-extends mem (op-out ∷ []) b lb
+     , lookup-new     mem op-out
+     , fits-in-lt-bits av bits fits-av
+     , fits-in-lt-bits bv bits fits-bv
+     , out-eq
+     ) ∷ᴬ []ᴬ
+
+-- Backward direction.
+--
+-- Requires the operand bit-bounds `Fits-in av bits` and `Fits-in bv
+-- bits` (the *unpadded* bounds; the constraint only carries `lt-bits
+-- bits`).  These let us apply `bits-lt-pad` to bridge the padded
+-- constraint-side comparison to the unpadded operational one.
+less-than-bwd : ∀ {pre s a b bits av bv v hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a ≡ just av
+  → mem-lookup (Preprocessed.memory s) b ≡ just bv
+  → bits < FR-BITS
+  → Fits-in av bits
+  → Fits-in bv bits
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (less-than a b bits))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (v ≡ from-bool (bits-lt (take bits (to-le-bits av))
+                             (take bits (to-le-bits bv))))
+  × R-instr pre s (less-than a b bits)
+      (push-mem s (from-bool (bits-lt (take bits (to-le-bits av))
+                                       (take bits (to-le-bits bv)))))
+less-than-bwd {pre = pre} {s = s} {a = a} {b = b} {bits = bits}
+              {av = av} {bv = bv} {v = v}
+  la lb bound fits-av fits-bv
+  ((av' , bv' , ov , la' , lb' , lout , _ , _ , ov-eq) ∷ᴬ _) =
+  let mem    = Preprocessed.memory s
+      av≡av' = extend-uniq mem (v ∷ []) a la la'
+      bv≡bv' = extend-uniq mem (v ∷ []) b lb lb'
+      v≡ov   = new-uniq mem v lout
+      -- Operational output value (the canonical, unpadded one).
+      op-out = from-bool (bits-lt (take bits (to-le-bits av))
+                                   (take bits (to-le-bits bv)))
+      -- bits-lt-pad bridges the padded constraint-side comparison to the
+      -- unpadded operational one.
+      pad-eq : bits-lt (take (lt-bits bits) (to-le-bits av))
+                       (take (lt-bits bits) (to-le-bits bv))
+             ≡ bits-lt (take bits (to-le-bits av))
+                       (take bits (to-le-bits bv))
+      pad-eq = bits-lt-pad av bv bits fits-av fits-bv
+      -- ov = from-bool (bits-lt-padded(av', bv'))
+      --    = from-bool (bits-lt-padded(av,  bv))    (subst on av, bv)
+      --    = from-bool (bits-lt(av, bv))            (pad-eq)
+      --    = op-out.
+      ov-padded : ov ≡ from-bool (bits-lt (take (lt-bits bits) (to-le-bits av))
+                                           (take (lt-bits bits) (to-le-bits bv)))
+      ov-padded = trans ov-eq
+                   (cong₂ (λ x y → from-bool (bits-lt (take (lt-bits bits) (to-le-bits x))
+                                                       (take (lt-bits bits) (to-le-bits y))))
+                          (sym av≡av') (sym bv≡bv'))
+      ov≡op : ov ≡ op-out
+      ov≡op = trans ov-padded (cong from-bool pad-eq)
+      v≡op  : v ≡ op-out
+      v≡op  = trans v≡ov ov≡op
+      r-fired : R-instr pre s (less-than a b bits) (push-mem s op-out)
+      r-fired = r-less-than la lb bound (fits-av , fits-bv)
+  in v≡op , r-fired
+
+------------------------------------------------------------------------
+-- transient-hash(inputs)
+--
+-- Lowering: emits `constraint-transient-hash out inputs` with out = nr-wires.
+-- Operational: append `transient-hash-fn vs`, where
+--   `mem-lookups (Preprocessed.memory s) inputs ≡ just vs`; Δmem = 1.
+--
+-- Mechanical lookup-plumbing — the constraint references the same
+-- `transient-hash-fn` as the operational rule.
+------------------------------------------------------------------------
+
+transient-hash-fwd : ∀ {pre s s' inputs hc} {rand : Maybe Fr}
+  → R-instr pre s (transient-hash inputs) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (transient-hash inputs))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+transient-hash-fwd {s = s} {inputs = inputs}
+  (r-transient-hash {vs = vs} lvs) =
+  let mem = Preprocessed.memory s
+      ov  = transient-hash-fn vs
+  in ( vs , ov
+     , mem-lookups-extends mem (ov ∷ []) inputs lvs
+     , lookup-new mem ov
+     , refl
+     ) ∷ᴬ []ᴬ
+
+transient-hash-bwd : ∀ {pre s inputs vs v hc} {rand : Maybe Fr}
+  → mem-lookups (Preprocessed.memory s) inputs ≡ just vs
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (transient-hash inputs))
+      (mk-witness (Preprocessed.memory s ++ (v ∷ []))
+                  (Preprocessed.pis s) rand)
+  → (v ≡ transient-hash-fn vs)
+  × R-instr pre s (transient-hash inputs) (push-mem s (transient-hash-fn vs))
+transient-hash-bwd {pre = pre} {s = s} {inputs = inputs} {vs = vs} {v = v}
+  lvs ((vs' , ov , lvs' , lout , ov-eq) ∷ᴬ _) =
+  let mem      = Preprocessed.memory s
+      lvs-ext  = mem-lookups-extends mem (v ∷ []) inputs lvs
+      vs≡vs'   = just-injective (trans (sym lvs-ext) lvs')
+      v≡ov     = new-uniq mem v lout
+      v≡hash   : v ≡ transient-hash-fn vs
+      v≡hash   = trans v≡ov (trans ov-eq (cong transient-hash-fn (sym vs≡vs')))
+  in v≡hash , r-transient-hash lvs
+
+------------------------------------------------------------------------
+-- persistent-hash(alignment, inputs)
+--
+-- Lowering: emits `constraint-persistent-hash h₁ h₂ α inputs` with
+--           h₁ = nr-wires, h₂ = suc nr-wires.
+-- Operational: append `(h₁ , h₂) = persistent-hash-fn α vs` with
+--   `mem-lookups (Preprocessed.memory s) inputs ≡ just vs`; Δmem = 2.
+------------------------------------------------------------------------
+
+persistent-hash-fwd : ∀ {pre s s' α inputs hc} {rand : Maybe Fr}
+  → R-instr pre s (persistent-hash α inputs) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (persistent-hash α inputs))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+persistent-hash-fwd {s = s} {α = α} {inputs = inputs} {hc = hc} {rand = rand}
+  (r-persistent-hash {vs = vs} {h₁ = h₁} {h₂ = h₂} lvs hash-eq) =
+  let mem    = Preprocessed.memory s
+      assoc  = push-mem2-assoc mem h₁ h₂  -- mem ++ h₁ ∷ h₂ ∷ [] ≡ (mem ++ h₁ ∷ []) ++ h₂ ∷ []
+      lvs-ext = mem-lookups-extends (mem ++ (h₁ ∷ [])) (h₂ ∷ []) inputs
+                  (mem-lookups-extends mem (h₁ ∷ []) inputs lvs)
+  in subst (λ m → satisfies-constraints
+             (single-instr-constraints hc (length mem) (persistent-hash α inputs))
+             (mk-witness m (Preprocessed.pis s) rand))
+           (sym assoc)
+           (( vs , h₁ , h₂
+            , lvs-ext
+            , lookup-new-fst mem h₁ h₂
+            , lookup-new-snd mem h₁ h₂
+            , hash-eq
+            ) ∷ᴬ []ᴬ)
+
+persistent-hash-bwd : ∀ {pre s α inputs vs x y hc} {rand : Maybe Fr}
+  → mem-lookups (Preprocessed.memory s) inputs ≡ just vs
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (persistent-hash α inputs))
+      (mk-witness ((Preprocessed.memory s ++ (x ∷ [])) ++ (y ∷ []))
+                  (Preprocessed.pis s) rand)
+  → persistent-hash-fn α vs ≡ (x , y)
+  × R-instr pre s (persistent-hash α inputs) (push-mem2 s x y)
+persistent-hash-bwd {pre = pre} {s = s} {α = α} {inputs = inputs}
+  {vs = vs} {x = x} {y = y}
+  lvs ((vs' , v1 , v2 , lvs' , lh₁ , lh₂ , hash-eq) ∷ᴬ _) =
+  let mem      = Preprocessed.memory s
+      lvs-ext  = mem-lookups-extends (mem ++ (x ∷ [])) (y ∷ []) inputs
+                   (mem-lookups-extends mem (x ∷ []) inputs lvs)
+      vs≡vs'   = just-injective (trans (sym lvs-ext) lvs')
+      x≡v1     = new2-uniq-fst mem x y lh₁
+      y≡v2     = new2-uniq-snd mem x y lh₂
+      hash-eq' : persistent-hash-fn α vs ≡ (x , y)
+      hash-eq' = trans (cong (persistent-hash-fn α) vs≡vs')
+                       (trans hash-eq
+                              (cong₂ _,_ (sym x≡v1) (sym y≡v2)))
+  in hash-eq' , r-persistent-hash lvs hash-eq'
+
+------------------------------------------------------------------------
+-- hash-to-curve(inputs)
+--
+-- Lowering: emits `constraint-hash-to-curve c-x c-y inputs` with
+--           c-x = nr-wires, c-y = suc nr-wires.
+-- Operational: append `(cx, cy) = hash-to-curve-fn vs` with mem-lookups;
+--              Δmem = 2.
+------------------------------------------------------------------------
+
+hash-to-curve-fwd : ∀ {pre s s' inputs hc} {rand : Maybe Fr}
+  → R-instr pre s (hash-to-curve inputs) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (hash-to-curve inputs))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+hash-to-curve-fwd {s = s} {inputs = inputs} {hc = hc} {rand = rand}
+  (r-hash-to-curve {vs = vs} {cx = cx} {cy = cy} lvs hash-eq) =
+  let mem    = Preprocessed.memory s
+      assoc  = push-mem2-assoc mem cx cy
+      lvs-ext = mem-lookups-extends (mem ++ (cx ∷ [])) (cy ∷ []) inputs
+                  (mem-lookups-extends mem (cx ∷ []) inputs lvs)
+  in subst (λ m → satisfies-constraints
+             (single-instr-constraints hc (length mem) (hash-to-curve inputs))
+             (mk-witness m (Preprocessed.pis s) rand))
+           (sym assoc)
+           (( vs , cx , cy
+            , lvs-ext
+            , lookup-new-fst mem cx cy
+            , lookup-new-snd mem cx cy
+            , hash-eq
+            ) ∷ᴬ []ᴬ)
+
+hash-to-curve-bwd : ∀ {pre s inputs vs x y hc} {rand : Maybe Fr}
+  → mem-lookups (Preprocessed.memory s) inputs ≡ just vs
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (hash-to-curve inputs))
+      (mk-witness ((Preprocessed.memory s ++ (x ∷ [])) ++ (y ∷ []))
+                  (Preprocessed.pis s) rand)
+  → hash-to-curve-fn vs ≡ (x , y)
+  × R-instr pre s (hash-to-curve inputs) (push-mem2 s x y)
+hash-to-curve-bwd {pre = pre} {s = s} {inputs = inputs}
+  {vs = vs} {x = x} {y = y}
+  lvs ((vs' , cx , cy , lvs' , lcx , lcy , hash-eq) ∷ᴬ _) =
+  let mem      = Preprocessed.memory s
+      lvs-ext  = mem-lookups-extends (mem ++ (x ∷ [])) (y ∷ []) inputs
+                   (mem-lookups-extends mem (x ∷ []) inputs lvs)
+      vs≡vs'   = just-injective (trans (sym lvs-ext) lvs')
+      x≡cx     = new2-uniq-fst mem x y lcx
+      y≡cy     = new2-uniq-snd mem x y lcy
+      hash-eq' : hash-to-curve-fn vs ≡ (x , y)
+      hash-eq' = trans (cong hash-to-curve-fn vs≡vs')
+                       (trans hash-eq
+                              (cong₂ _,_ (sym x≡cx) (sym y≡cy)))
+  in hash-eq' , r-hash-to-curve lvs hash-eq'
+
+------------------------------------------------------------------------
+-- ec-add(a-x, a-y, b-x, b-y)
+--
+-- Lowering: emits `constraint-ec-add c-x c-y a-x a-y b-x b-y` with
+--           c-x = nr-wires, c-y = suc nr-wires.
+-- Operational: requires `ec-add-pts ax ay bx by ≡ just (cx , cy)`;
+--              Δmem = 2.
+--
+-- The chip primitive `ec-add-pts` is partial (returns `nothing` for
+-- off-curve inputs).  Constraint and operational rule both carry the
+-- `≡ just (cx , cy)` premise.
+------------------------------------------------------------------------
+
+ec-add-fwd : ∀ {pre s s' a-x a-y b-x b-y hc} {rand : Maybe Fr}
+  → R-instr pre s (ec-add a-x a-y b-x b-y) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (ec-add a-x a-y b-x b-y))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+ec-add-fwd {s = s} {a-x = a-x} {a-y = a-y} {b-x = b-x} {b-y = b-y}
+           {hc = hc} {rand = rand}
+  (r-ec-add {ax = ax} {ay = ay} {bx = bx} {by = by}
+            {cx = cx} {cy = cy} lax lay lbx lby add-eq) =
+  let mem    = Preprocessed.memory s
+      assoc  = push-mem2-assoc mem cx cy
+  in subst (λ m → satisfies-constraints
+             (single-instr-constraints hc (length mem) (ec-add a-x a-y b-x b-y))
+             (mk-witness m (Preprocessed.pis s) rand))
+           (sym assoc)
+           (( ax , ay , bx , by , cx , cy
+            , lookup-extend2 mem cx cy a-x lax
+            , lookup-extend2 mem cx cy a-y lay
+            , lookup-extend2 mem cx cy b-x lbx
+            , lookup-extend2 mem cx cy b-y lby
+            , lookup-new-fst mem cx cy
+            , lookup-new-snd mem cx cy
+            , add-eq
+            ) ∷ᴬ []ᴬ)
+
+ec-add-bwd : ∀ {pre s a-x a-y b-x b-y ax ay bx by x y hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a-x ≡ just ax
+  → mem-lookup (Preprocessed.memory s) a-y ≡ just ay
+  → mem-lookup (Preprocessed.memory s) b-x ≡ just bx
+  → mem-lookup (Preprocessed.memory s) b-y ≡ just by
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (ec-add a-x a-y b-x b-y))
+      (mk-witness ((Preprocessed.memory s ++ (x ∷ [])) ++ (y ∷ []))
+                  (Preprocessed.pis s) rand)
+  → ec-add-pts ax ay bx by ≡ just (x , y)
+  × R-instr pre s (ec-add a-x a-y b-x b-y) (push-mem2 s x y)
+ec-add-bwd {pre = pre} {s = s} {a-x = a-x} {a-y = a-y} {b-x = b-x} {b-y = b-y}
+           {ax = ax} {ay = ay} {bx = bx} {by = by} {x = x} {y = y}
+  lax lay lbx lby
+  ((ax' , ay' , bx' , by' , cx , cy
+    , lax' , lay' , lbx' , lby' , lcx , lcy , add-eq) ∷ᴬ _) =
+  let mem    = Preprocessed.memory s
+      mem'   = (mem ++ (x ∷ [])) ++ (y ∷ [])
+      ax≡ax' = lookup-uniq mem' a-x (lookup-extend2 mem x y a-x lax) lax'
+      ay≡ay' = lookup-uniq mem' a-y (lookup-extend2 mem x y a-y lay) lay'
+      bx≡bx' = lookup-uniq mem' b-x (lookup-extend2 mem x y b-x lbx) lbx'
+      by≡by' = lookup-uniq mem' b-y (lookup-extend2 mem x y b-y lby) lby'
+      x≡cx   = new2-uniq-fst mem x y lcx
+      y≡cy   = new2-uniq-snd mem x y lcy
+      add-eq' : ec-add-pts ax ay bx by ≡ just (x , y)
+      add-eq' = trans (cong₄ ec-add-pts ax≡ax' ay≡ay' bx≡bx' by≡by')
+                      (trans add-eq (cong just (cong₂ _,_ (sym x≡cx) (sym y≡cy))))
+  in add-eq' , r-ec-add lax lay lbx lby add-eq'
+
+------------------------------------------------------------------------
+-- ec-mul(a-x, a-y, scalar)
+--
+-- Same shape as ec-add but with 3 input wires.
+------------------------------------------------------------------------
+
+ec-mul-fwd : ∀ {pre s s' a-x a-y scalar hc} {rand : Maybe Fr}
+  → R-instr pre s (ec-mul a-x a-y scalar) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (ec-mul a-x a-y scalar))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+ec-mul-fwd {s = s} {a-x = a-x} {a-y = a-y} {scalar = scalar}
+           {hc = hc} {rand = rand}
+  (r-ec-mul {ax = ax} {ay = ay} {sc = sc} {cx = cx} {cy = cy}
+            lax lay lsc mul-eq) =
+  let mem    = Preprocessed.memory s
+      assoc  = push-mem2-assoc mem cx cy
+  in subst (λ m → satisfies-constraints
+             (single-instr-constraints hc (length mem) (ec-mul a-x a-y scalar))
+             (mk-witness m (Preprocessed.pis s) rand))
+           (sym assoc)
+           (( ax , ay , sc , cx , cy
+            , lookup-extend2 mem cx cy a-x lax
+            , lookup-extend2 mem cx cy a-y lay
+            , lookup-extend2 mem cx cy scalar lsc
+            , lookup-new-fst mem cx cy
+            , lookup-new-snd mem cx cy
+            , mul-eq
+            ) ∷ᴬ []ᴬ)
+
+ec-mul-bwd : ∀ {pre s a-x a-y scalar ax ay sc x y hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) a-x ≡ just ax
+  → mem-lookup (Preprocessed.memory s) a-y ≡ just ay
+  → mem-lookup (Preprocessed.memory s) scalar ≡ just sc
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (ec-mul a-x a-y scalar))
+      (mk-witness ((Preprocessed.memory s ++ (x ∷ [])) ++ (y ∷ []))
+                  (Preprocessed.pis s) rand)
+  → ec-mul-pt ax ay sc ≡ just (x , y)
+  × R-instr pre s (ec-mul a-x a-y scalar) (push-mem2 s x y)
+ec-mul-bwd {pre = pre} {s = s} {a-x = a-x} {a-y = a-y} {scalar = scalar}
+           {ax = ax} {ay = ay} {sc = sc} {x = x} {y = y}
+  lax lay lsc
+  ((ax' , ay' , sc' , cx , cy
+    , lax' , lay' , lsc' , lcx , lcy , mul-eq) ∷ᴬ _) =
+  let mem    = Preprocessed.memory s
+      mem'   = (mem ++ (x ∷ [])) ++ (y ∷ [])
+      ax≡ax' = lookup-uniq mem' a-x   (lookup-extend2 mem x y a-x   lax) lax'
+      ay≡ay' = lookup-uniq mem' a-y   (lookup-extend2 mem x y a-y   lay) lay'
+      sc≡sc' = lookup-uniq mem' scalar (lookup-extend2 mem x y scalar lsc) lsc'
+      x≡cx   = new2-uniq-fst mem x y lcx
+      y≡cy   = new2-uniq-snd mem x y lcy
+      mul-eq' : ec-mul-pt ax ay sc ≡ just (x , y)
+      mul-eq' = trans (cong₃ ec-mul-pt ax≡ax' ay≡ay' sc≡sc')
+                      (trans mul-eq (cong just (cong₂ _,_ (sym x≡cx) (sym y≡cy))))
+  in mul-eq' , r-ec-mul lax lay lsc mul-eq'
+
+------------------------------------------------------------------------
+-- ec-mul-generator(scalar)
+--
+-- Lowering: emits `constraint-ec-mul-generator c-x c-y scalar` with
+--           c-x = nr-wires, c-y = suc nr-wires.
+-- Operational: append `(cx, cy) = ec-mul-gen sc` (total function);
+--              Δmem = 2.
+------------------------------------------------------------------------
+
+ec-mul-generator-fwd : ∀ {pre s s' scalar hc} {rand : Maybe Fr}
+  → R-instr pre s (ec-mul-generator scalar) s'
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (ec-mul-generator scalar))
+      (mk-witness (Preprocessed.memory s') (Preprocessed.pis s') rand)
+ec-mul-generator-fwd {s = s} {scalar = scalar} {hc = hc} {rand = rand}
+  (r-ec-mul-generator {sc = sc} {cx = cx} {cy = cy} lsc gen-eq) =
+  let mem    = Preprocessed.memory s
+      assoc  = push-mem2-assoc mem cx cy
+  in subst (λ m → satisfies-constraints
+             (single-instr-constraints hc (length mem) (ec-mul-generator scalar))
+             (mk-witness m (Preprocessed.pis s) rand))
+           (sym assoc)
+           (( sc , cx , cy
+            , lookup-extend2 mem cx cy scalar lsc
+            , lookup-new-fst mem cx cy
+            , lookup-new-snd mem cx cy
+            , gen-eq
+            ) ∷ᴬ []ᴬ)
+
+ec-mul-generator-bwd : ∀ {pre s scalar sc x y hc} {rand : Maybe Fr}
+  → mem-lookup (Preprocessed.memory s) scalar ≡ just sc
+  → satisfies-constraints
+      (single-instr-constraints hc (length (Preprocessed.memory s))
+         (ec-mul-generator scalar))
+      (mk-witness ((Preprocessed.memory s ++ (x ∷ [])) ++ (y ∷ []))
+                  (Preprocessed.pis s) rand)
+  → ec-mul-gen sc ≡ (x , y)
+  × R-instr pre s (ec-mul-generator scalar) (push-mem2 s x y)
+ec-mul-generator-bwd {pre = pre} {s = s} {scalar = scalar}
+                     {sc = sc} {x = x} {y = y}
+  lsc ((sc' , cx , cy , lsc' , lcx , lcy , gen-eq) ∷ᴬ _) =
+  let mem    = Preprocessed.memory s
+      mem'   = (mem ++ (x ∷ [])) ++ (y ∷ [])
+      sc≡sc' = lookup-uniq mem' scalar (lookup-extend2 mem x y scalar lsc) lsc'
+      x≡cx   = new2-uniq-fst mem x y lcx
+      y≡cy   = new2-uniq-snd mem x y lcy
+      gen-eq' : ec-mul-gen sc ≡ (x , y)
+      gen-eq' = trans (cong ec-mul-gen sc≡sc')
+                      (trans gen-eq (cong₂ _,_ (sym x≡cx) (sym y≡cy)))
+  in gen-eq' , r-ec-mul-generator lsc gen-eq'

--- a/formal/src/zkir-v2/CircuitProof.agda
+++ b/formal/src/zkir-v2/CircuitProof.agda
@@ -1,0 +1,5073 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.CircuitProof (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v2.FieldProperties ⋯
+open import zkir-v2.Encoding ⋯
+
+------------------------------------------------------------------------
+-- Circuit-faithfulness bridging
+--
+-- This module carries the program-level induction that connects the
+-- operational relation `R src pre s` to the in-circuit satisfaction
+-- relation `satisfies (circuit src) (witness-of s pre)` (spec §6.2).
+-- `circuit-faithful` is exported as a logical equivalence (`_⇔_`) and
+-- re-exported from `Properties`.  It comprises:
+--
+--   • the forward direction: R-instrs ⇒ satisfies-constraints;
+--   • soundness of O2 / O3 over R-instrs traces;
+--   • the backward direction: satisfies-constraints ⇒ R-instrs (D1/D2),
+--     and the top-level `circuit-faithful-bwd` (D3), quantified over
+--     the §5.3 `preprocess-shaped` states with the §3.3 WF1 arity
+--     hypothesis and a `transcripts-consumed` shape conjunct (both
+--     required — see the notes at D3).
+--
+-- No axioms are introduced here: every lemma is discharged by an
+-- inductive or equational proof, resting only on the field/crypto
+-- assumptions in the `Assumptions` record.
+------------------------------------------------------------------------
+
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+open import zkir-v2.Circuit ⋯ hiding (witness-of; comm-rand-of)
+open import zkir-v2.Circuit ⋯ public using (witness-of; comm-rand-of)
+open import zkir-v2.SemanticsLemmas ⋯
+  using ( lookup-extends; mem-lookups-extends; push-mem2-assoc
+        ; consume-pub-out-mem; consume-pub-out-pis
+        ; consume-priv-mem; consume-priv-pis
+        ; consume-pub-out-outputs; consume-priv-outputs
+        ; init-state-memory; init-state-num-inputs
+        ; init-state-outputs; init-state-inv; InitInv )
+open import zkir-v2.CircuitFaithfulness ⋯
+open import zkir-v2.Obligations ⋯
+  using ( producer-safe
+        ; wire-disc; WireOK; wireOK?; wire-step; wire-scan
+        ; Wire-Trace; wire-done; wire-cons
+        ; Δmem; GuardOK
+        ; InstrShape; shape-Δmem; shape-Δpis
+        ; ShapeView; shapeView; shape-of
+        ; sv-pure0; sv-pure1; sv-pure2; sv-declare
+        ; sv-output; sv-skip; sv-pub-in; sv-priv-in
+        ; IndexSet; PartialMap; lookupᵐ
+        ; O2-check; O3OK; o3OK?; require-∈
+        ; O2-step; O3-step
+        ; O2-Trace; o2-done; o2-step
+        ; O3-Trace; o3-done; o3-step
+        ; O2-Runs; O3-Runs
+        ; O2-bool→Runs; O3-bool→Runs
+        )
+open import zkir-v2.ObligationsSoundness ⋯
+  using ( producer-safe-wire-disc
+        ; producer-safe-O2; producer-safe-O3
+        ; o2-inv-init; o3-inv-init
+        ; O2-Inv; O3-Inv
+        ; o2-known-is-bit; o3-known-fits
+        ; o2-preserve; o3-preserve
+        )
+
+open import Data.Bool    using (Bool; true; false; if_then_else_; T)
+import Data.Bool as Bool
+import Data.Bool.Properties
+open import Data.List    using (List; []; _∷_; _++_; _∷ʳ_; length; map; take; drop)
+open import Data.List.Properties using (++-assoc; ++-identityʳ)
+open import Data.Maybe   using (Maybe; nothing; just; _>>=_)
+open import Data.Maybe.Properties using (just-injective)
+open import Data.Nat     using (ℕ; suc; zero; _+_; _∸_; _<_; _≡ᵇ_)
+import Data.Nat
+-- Decidable propositional membership on `IndexSet = List Index`, matching
+-- the instance used in `Obligations`/`ObligationsSoundness`.
+open import Data.List.Membership.DecPropositional (Data.Nat._≟_) using (_∈_; _∈?_)
+-- `All` for the list-operand wire-discipline predicate (`WireOK`'s hash
+-- cases).  Constructors renamed to avoid clashing with `Data.List`.
+open import Data.List.Relation.Unary.All using (All)
+  renaming ([] to []ᴬ; _∷_ to _∷ᴬ_; map to mapᴬ; head to headᴬ)
+open import Data.List.Relation.Unary.All.Properties using (++⁻)
+  renaming (++⁺ to ++ᴬ)
+open import Data.Nat.Properties using (+-suc; +-identityʳ; +-comm; m≤n⇒m≤n+o; <-≤-trans)
+import Data.Nat.Properties
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax; Σ)
+open import Data.Sum     using (_⊎_; inj₁; inj₂)
+open import Data.Unit    using (⊤; tt)
+open import Data.Empty   using (⊥; ⊥-elim)
+open import Function.Bundles using (_⇔_; mk⇔)
+import Function.Bundles
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; cong₂; subst; subst₂)
+open import Relation.Nullary using (¬_; yes; no)
+
+------------------------------------------------------------------------
+-- Section A.  Witness-of:  Preprocessed × ProofPreimage  →  Witness.
+--
+-- The witness assignment produced by an operational execution.  Three
+-- fields:
+--
+--   • mem        : Preprocessed.memory s    (all allocated wire values)
+--   • pis        : Preprocessed.pis    s    (verifier-supplied entries)
+--   • comm-rand  : the randomness portion of the optional commitment.
+--
+-- Note: `witness-of` does NOT depend on the `IrSource`.  The
+-- *circuit*'s `has-comm` flag determines the expected shape of
+-- `comm-rand`, and the `Maybe-shape` predicate in `satisfies` enforces
+-- the match.  Producer-safety (+ the operational `init-state`
+-- precondition) is what guarantees the shapes line up at the top level.
+------------------------------------------------------------------------
+
+-- Bridge from the propositional equality `b ≡ true` to the `T b` check,
+-- used where a `with`/`subst` that drives shape computation off the
+-- equality must hand its result to a Bool obligation phrased as `T`.
+private
+  ≡→T : ∀ {b} → b ≡ true → T b
+  ≡→T refl = tt
+
+------------------------------------------------------------------------
+-- Section B.  Synth-state invariants.
+--
+-- During the induction along an `R-instrs pre s₀ is s_end` trace, we
+-- maintain a *parallel* synth-state evolved by `circuit-instrs hc`.
+-- The forward lemma asserts that the synth-state's accumulated constraints
+-- are all satisfied by the assignment derived from the *post*-trace
+-- preprocessed state.
+--
+-- Two structural invariants get threaded:
+--
+--   I-mem  :  SynthState.nr-wires   ≡  length (Preprocessed.memory)
+--   I-pi   :  preamble-pi-count hc + SynthState.nr-declared-pi
+--             ≡  length (Preprocessed.pis)
+--
+-- I-mem says every wire allocated by synthesis corresponds to a memory
+-- cell in the operational state; I-pi says the PI-vector length that
+-- synthesis tracks (preamble plus declares) matches the operational
+-- `pis` — needed so that `bind` references a valid PI entry.
+--
+-- The forward induction discharges these from the per-instruction
+-- faithfulness lemmas in `CircuitFaithfulness.agda`.
+------------------------------------------------------------------------
+
+-- Memory-length invariant.
+mem-inv : Preprocessed → SynthState → Set
+mem-inv s st = SynthState.nr-wires st ≡ length (Preprocessed.memory s)
+
+-- PI-length invariant.  Parameterized on `has-comm`.
+pi-inv : Bool → Preprocessed → SynthState → Set
+pi-inv hc s st =
+  length (Preprocessed.pis s) ≡ preamble-pi-count hc + SynthState.nr-declared-pi st
+
+------------------------------------------------------------------------
+-- Section B.5.  Memory/PI monotonicity along R-instrs.
+--
+-- Auxiliary lemmas used by both the forward dispatcher and the
+-- top-level comm-commitment gluing.
+------------------------------------------------------------------------
+
+private
+
+  -- Evaluation of a field expression is preserved by appending a suffix
+  -- to the memory: every wire reference resolves through `mem-lookup`,
+  -- which is monotone (`lookup-extends`).  Used by the `gate` case of
+  -- `holds-mem-extends`.
+  eval-mem-extends : ∀ {mem suffix} (e : Expr) {v}
+    → eval mem e ≡ just v
+    → eval (mem ++ suffix) e ≡ just v
+  eval-mem-extends {mem} {suffix} (wire i) ev = lookup-extends mem suffix i ev
+  eval-mem-extends (con k) ev = ev
+  eval-mem-extends {mem} {suffix} (l ⊕ r) ev
+    with x , y , el , er , v≡ ← eval-⊕ mem l r ev
+    rewrite eval-mem-extends {mem} {suffix} l el
+          | eval-mem-extends {mem} {suffix} r er = cong just (sym v≡)
+  eval-mem-extends {mem} {suffix} (l ⊗ r) ev
+    with x , y , el , er , v≡ ← eval-⊗ mem l r ev
+    rewrite eval-mem-extends {mem} {suffix} l el
+          | eval-mem-extends {mem} {suffix} r er = cong just (sym v≡)
+  eval-mem-extends {mem} {suffix} (⊝ e) ev
+    with x , ee , v≡ ← eval-⊝ mem e ev
+    rewrite eval-mem-extends {mem} {suffix} e ee = cong just (sym v≡)
+
+  -- Every wire referenced by `e` is `< n`.  The bound premise for the
+  -- `gate` case of `holds-mem-shrink`.
+  expr-mem-fits : Expr → ℕ → Set
+  expr-mem-fits (wire i)  n = i < n
+  expr-mem-fits (con _)   _ = ⊤
+  expr-mem-fits (l ⊕ r)   n = expr-mem-fits l n × expr-mem-fits r n
+  expr-mem-fits (l ⊗ r)   n = expr-mem-fits l n × expr-mem-fits r n
+  expr-mem-fits (⊝ e)     n = expr-mem-fits e n
+
+  -- Dual of `eval-mem-extends`: when every wire of `e` fits within
+  -- `length mem`, an evaluation over `mem ++ suffix` pulls back to `mem`.
+  eval-mem-shrink : ∀ (mem suffix : List Fr) (e : Expr) {v}
+    → expr-mem-fits e (length mem)
+    → eval (mem ++ suffix) e ≡ just v
+    → eval mem e ≡ just v
+  eval-mem-shrink mem suf (wire i) i< ev = lookup-shrink mem suf i ev i<
+  eval-mem-shrink mem suf (con k) _ ev = ev
+  eval-mem-shrink mem suf (l ⊕ r) (lf , rf) ev
+    with x , y , el , er , v≡ ← eval-⊕ (mem ++ suf) l r ev
+    rewrite eval-mem-shrink mem suf l lf el
+          | eval-mem-shrink mem suf r rf er = cong just (sym v≡)
+  eval-mem-shrink mem suf (l ⊗ r) (lf , rf) ev
+    with x , y , el , er , v≡ ← eval-⊗ (mem ++ suf) l r ev
+    rewrite eval-mem-shrink mem suf l lf el
+          | eval-mem-shrink mem suf r rf er = cong just (sym v≡)
+  eval-mem-shrink mem suf (⊝ e) ef ev
+    with x , ee , v≡ ← eval-⊝ (mem ++ suf) e ev
+    rewrite eval-mem-shrink mem suf e ef ee = cong just (sym v≡)
+
+  -- One R-instr step's memory only grows: post-mem = pre-mem ++ suffix
+  -- for some suffix.  This is a single existential lemma; we package
+  -- the suffix as a List Fr.
+  mem-extends-R-instr : ∀ {pre s i s'}
+    → R-instr pre s i s'
+    → Σ (List Fr) λ suf →
+        Preprocessed.memory s' ≡ Preprocessed.memory s ++ suf
+  mem-extends-R-instr (r-assert _)                       = [] , sym (++-identityʳ _)
+  mem-extends-R-instr (r-cond-select {av = av} {bv = bv} _ _ _) =
+    _ ∷ [] , refl
+  mem-extends-R-instr (r-constrain-bits _ _ _)             = [] , sym (++-identityʳ _)
+  mem-extends-R-instr (r-constrain-eq _ _ _)             = [] , sym (++-identityʳ _)
+  mem-extends-R-instr (r-constrain-to-boolean _)         = [] , sym (++-identityʳ _)
+  mem-extends-R-instr (r-copy {v = v} _)                 = v ∷ [] , refl
+  mem-extends-R-instr (r-declare-pub-input _)            = [] , sym (++-identityʳ _)
+  mem-extends-R-instr (r-pi-skip-active _ _)             = [] , sym (++-identityʳ _)
+  mem-extends-R-instr (r-pi-skip-inactive _)             = [] , sym (++-identityʳ _)
+  mem-extends-R-instr (r-ec-add {cx = cx} {cy = cy} _ _ _ _ _) =
+    cx ∷ cy ∷ [] , refl
+  mem-extends-R-instr (r-ec-mul {cx = cx} {cy = cy} _ _ _ _) =
+    cx ∷ cy ∷ [] , refl
+  mem-extends-R-instr (r-ec-mul-generator {cx = cx} {cy = cy} _ _) =
+    cx ∷ cy ∷ [] , refl
+  mem-extends-R-instr (r-hash-to-curve {cx = cx} {cy = cy} _ _) =
+    cx ∷ cy ∷ [] , refl
+  mem-extends-R-instr (r-load-imm {imm = imm})          = imm ∷ [] , refl
+  mem-extends-R-instr {s = s} (r-div-mod-power-of-two {bits = bits} {v = vv} _ _) =
+    let mem = Preprocessed.memory s
+        divisor = from-le-bits (drop bits (to-le-bits vv))
+        modulus = from-le-bits (take bits (to-le-bits vv))
+    in divisor ∷ modulus ∷ [] , ++-assoc mem (divisor ∷ []) (modulus ∷ [])
+  mem-extends-R-instr (r-reconstitute-field _ _ _ _ _)       = _ ∷ [] , refl
+  mem-extends-R-instr (r-output _)                       = [] , sym (++-identityʳ _)
+  mem-extends-R-instr (r-transient-hash {vs = vs} _)     = transient-hash-fn vs ∷ [] , refl
+  mem-extends-R-instr (r-persistent-hash {h₁ = h₁} {h₂ = h₂} _ _) =
+    h₁ ∷ h₂ ∷ [] , refl
+  mem-extends-R-instr (r-test-eq _ _)                    = _ ∷ [] , refl
+  mem-extends-R-instr (r-add _ _)                        = _ ∷ [] , refl
+  mem-extends-R-instr (r-mul _ _)                        = _ ∷ [] , refl
+  mem-extends-R-instr (r-neg _)                          = _ ∷ [] , refl
+  mem-extends-R-instr (r-not _)                          = _ ∷ [] , refl
+  mem-extends-R-instr (r-less-than _ _ _ _)                = _ ∷ [] , refl
+  mem-extends-R-instr (r-public-input-inactive _)        = 0ᶠ ∷ [] , refl
+  mem-extends-R-instr {s = s} (r-public-input-active {v = v} {s₁ = s₁} _ cp) =
+    v ∷ [] , cong (_++ (v ∷ [])) (consume-pub-out-mem s cp)
+  mem-extends-R-instr (r-private-input-inactive _)       = 0ᶠ ∷ [] , refl
+  mem-extends-R-instr {s = s} (r-private-input-active {v = v} {s₁ = s₁} _ cp) =
+    v ∷ [] , cong (_++ (v ∷ [])) (consume-priv-mem s cp)
+
+  -- Holds is preserved by extending the witness's memory with a suffix.
+  -- The pis and comm-rand fields are unchanged.  By case analysis on the
+  -- constraint: every constraint uses `mem-lookup` (or `mem-lookups`) on the
+  -- witness's memory, and these are monotone.
+  holds-mem-extends : ∀ {mem suffix pis rand} (cl : Constraint)
+    → holds (mk-witness mem pis rand) cl
+    → holds (mk-witness (mem ++ suffix) pis rand) cl
+  holds-mem-extends {mem} {suffix} (non-zero c)
+    (v , lv , v≢0) =
+    v , lookup-extends mem suffix c lv , v≢0
+  holds-mem-extends {mem} {suffix} (select out b a c)
+    (bv , av , cv , ov , lb , la , lc , lout , bit , eq) =
+    bv , av , cv , ov
+    , lookup-extends mem suffix b lb
+    , lookup-extends mem suffix a la
+    , lookup-extends mem suffix c lc
+    , lookup-extends mem suffix out lout
+    , bit , eq
+  holds-mem-extends {mem} {suffix} (in-range v bits)
+    (vv , lv , fits) =
+    vv , lookup-extends mem suffix v lv , fits
+  holds-mem-extends {mem} {suffix} (gate e) h = eval-mem-extends e h
+  holds-mem-extends {mem} {suffix} (boolean v)
+    (vv , lv , bit) =
+    vv , lookup-extends mem suffix v lv , bit
+  holds-mem-extends {mem} {suffix} (ec-add c-x c-y a-x a-y b-x b-y)
+    (ax , ay , bx , by , cx , cy , lax , lay , lbx , lby , lcx , lcy , add-eq) =
+    ax , ay , bx , by , cx , cy
+    , lookup-extends mem suffix a-x lax
+    , lookup-extends mem suffix a-y lay
+    , lookup-extends mem suffix b-x lbx
+    , lookup-extends mem suffix b-y lby
+    , lookup-extends mem suffix c-x lcx
+    , lookup-extends mem suffix c-y lcy
+    , add-eq
+  holds-mem-extends {mem} {suffix} (ec-mul c-x c-y a-x a-y scalar)
+    (ax , ay , sc , cx , cy , lax , lay , lsc , lcx , lcy , mul-eq) =
+    ax , ay , sc , cx , cy
+    , lookup-extends mem suffix a-x lax
+    , lookup-extends mem suffix a-y lay
+    , lookup-extends mem suffix scalar lsc
+    , lookup-extends mem suffix c-x lcx
+    , lookup-extends mem suffix c-y lcy
+    , mul-eq
+  holds-mem-extends {mem} {suffix} (ec-gen c-x c-y scalar)
+    (sc , cx , cy , lsc , lcx , lcy , gen-eq) =
+    sc , cx , cy
+    , lookup-extends mem suffix scalar lsc
+    , lookup-extends mem suffix c-x lcx
+    , lookup-extends mem suffix c-y lcy
+    , gen-eq
+  holds-mem-extends {mem} {suffix} (h2c c-x c-y inputs)
+    (vs , cx , cy , lvs , lcx , lcy , hash-eq) =
+    vs , cx , cy
+    , mem-lookups-extends mem suffix inputs lvs
+    , lookup-extends mem suffix c-x lcx
+    , lookup-extends mem suffix c-y lcy
+    , hash-eq
+  holds-mem-extends {mem} {suffix} (div-mod q r v bits)
+    (qv , rv , vv , lq , lr , lv , fr , fq , nw , eq) =
+    qv , rv , vv
+    , lookup-extends mem suffix q lq
+    , lookup-extends mem suffix r lr
+    , lookup-extends mem suffix v lv
+    , fr , fq , nw , eq
+  holds-mem-extends {mem} {suffix} (reconstitute out d m bits)
+    (dv , mv , ov , ld , lm , lout , fd , fm , eq) =
+    dv , mv , ov
+    , lookup-extends mem suffix d ld
+    , lookup-extends mem suffix m lm
+    , lookup-extends mem suffix out lout
+    , fd , fm , eq
+  holds-mem-extends {mem} {suffix} (poseidon out inputs)
+    (vs , ov , lvs , lout , eq) =
+    vs , ov
+    , mem-lookups-extends mem suffix inputs lvs
+    , lookup-extends mem suffix out lout
+    , eq
+  holds-mem-extends {mem} {suffix} (sha256 h₁ h₂ alignment inputs)
+    (vs , v1 , v2 , lvs , lh₁ , lh₂ , hash-eq) =
+    vs , v1 , v2
+    , mem-lookups-extends mem suffix inputs lvs
+    , lookup-extends mem suffix h₁ lh₁
+    , lookup-extends mem suffix h₂ lh₂
+    , hash-eq
+  holds-mem-extends {mem} {suffix} (test-eq out a b)
+    (av , bv , ov , la , lb , lout , eq) =
+    av , bv , ov
+    , lookup-extends mem suffix a la
+    , lookup-extends mem suffix b lb
+    , lookup-extends mem suffix out lout
+    , eq
+  holds-mem-extends {mem} {suffix} (is-zero out a)
+    (av , ov , la , lout , eq) =
+    av , ov
+    , lookup-extends mem suffix a la
+    , lookup-extends mem suffix out lout
+    , eq
+  holds-mem-extends {mem} {suffix} (less-than out a b bits)
+    (av , bv , ov , la , lb , lout , fa , fb , eq) =
+    av , bv , ov
+    , lookup-extends mem suffix a la
+    , lookup-extends mem suffix b lb
+    , lookup-extends mem suffix out lout
+    , fa , fb , eq
+  holds-mem-extends {mem} {suffix} (guard-disj out i)
+    (ov , iv , lout , li , bit , disj) =
+    ov , iv
+    , lookup-extends mem suffix out lout
+    , lookup-extends mem suffix i li
+    , bit , disj
+  holds-mem-extends {mem} {suffix} (bind entry widx)
+    (wv , pv , lw , lpi , eq) =
+    wv , pv , lookup-extends mem suffix widx lw , lpi , eq
+  holds-mem-extends {mem} {suffix} (comm inputs outputs)
+    (ivs , ovs , rv , pv , livs , lovs , crv , lpv , eq) =
+    ivs , ovs , rv , pv
+    , mem-lookups-extends mem suffix inputs livs
+    , mem-lookups-extends mem suffix outputs lovs
+    , crv , lpv , eq
+
+  -- Satisfaction of a list of constraints is preserved under mem extension.
+  satisfies-constraints-mem-extends : ∀ {mem suffix pis rand} (cls : List Constraint)
+    → satisfies-constraints cls (mk-witness mem pis rand)
+    → satisfies-constraints cls (mk-witness (mem ++ suffix) pis rand)
+  satisfies-constraints-mem-extends _ = mapᴬ (λ {c} → holds-mem-extends c)
+
+  -- Holds is preserved by extending the witness's pis with a suffix.
+  -- Only `bind` and `comm` mention pis.
+  holds-pis-extends : ∀ {mem pis suffix rand} (cl : Constraint)
+    → holds (mk-witness mem pis rand) cl
+    → holds (mk-witness mem (pis ++ suffix) rand) cl
+  holds-pis-extends (gate _) h = h
+  holds-pis-extends (non-zero c) h = h
+  holds-pis-extends (select _ _ _ _) h = h
+  holds-pis-extends (in-range _ _) h = h
+  holds-pis-extends (boolean _) h = h
+  holds-pis-extends (ec-add _ _ _ _ _ _) h = h
+  holds-pis-extends (ec-mul _ _ _ _ _) h = h
+  holds-pis-extends (ec-gen _ _ _) h = h
+  holds-pis-extends (h2c _ _ _) h = h
+  holds-pis-extends (div-mod _ _ _ _) h = h
+  holds-pis-extends (reconstitute _ _ _ _) h = h
+  holds-pis-extends (poseidon _ _) h = h
+  holds-pis-extends (sha256 _ _ _ _) h = h
+  holds-pis-extends (test-eq _ _ _) h = h
+  holds-pis-extends (is-zero _ _) h = h
+  holds-pis-extends (less-than _ _ _ _) h = h
+  holds-pis-extends (guard-disj _ _) h = h
+  holds-pis-extends {pis = pis} {suffix = suffix} (bind entry widx)
+    (wv , pv , lw , lpi , eq) =
+    wv , pv , lw , lookup-extends pis suffix entry lpi , eq
+  holds-pis-extends {pis = pis} {suffix = suffix} (comm inputs outputs)
+    (ivs , ovs , rv , pv , livs , lovs , crv , lpv , eq) =
+    ivs , ovs , rv , pv
+    , livs , lovs , crv
+    , lookup-extends pis suffix 1 lpv
+    , eq
+
+  satisfies-constraints-pis-extends : ∀ {mem pis suffix rand} (cls : List Constraint)
+    → satisfies-constraints cls (mk-witness mem pis rand)
+    → satisfies-constraints cls (mk-witness mem (pis ++ suffix) rand)
+  satisfies-constraints-pis-extends _ = mapᴬ (λ {c} → holds-pis-extends c)
+
+  ------------------------------------------------------------------------
+  -- Mem / pis SHRINK direction.
+  --
+  -- `holds-mem-shrink`/`-pis-shrink` are the duals of `-extends`.  Given
+  -- a constraint whose referenced indices all fit within `length mem`
+  -- (resp. `length pis`), and a `holds` at the extended witness, derive
+  -- `holds` at the pre-extension witness.  Used by D2 (the per-list
+  -- backward dispatcher) to peel off the satisfies-constraints for the
+  -- head instruction from the satisfies-constraints over the *full*
+  -- accumulated extension.
+  ------------------------------------------------------------------------
+
+  -- Predicate: every index referenced by `cl` is strictly less
+  -- than `n`.  For constraints with PI references (pi-from-wire,
+  -- comm-commitment), this is only about memory indices.
+  constraint-mem-fits : Constraint → ℕ → Set
+  constraint-mem-fits (gate e)                     n = expr-mem-fits e n
+  constraint-mem-fits (non-zero c)               n = c < n
+  constraint-mem-fits (select out b a c)           n =
+    (out < n) × (b < n) × (a < n) × (c < n)
+  constraint-mem-fits (in-range v _)                  n = v < n
+  constraint-mem-fits (boolean v)                          n = v < n
+  constraint-mem-fits (ec-add cx cy ax ay bx by)        n =
+    (cx < n) × (cy < n) × (ax < n) × (ay < n) × (bx < n) × (by < n)
+  constraint-mem-fits (ec-mul cx cy ax ay s)            n =
+    (cx < n) × (cy < n) × (ax < n) × (ay < n) × (s < n)
+  constraint-mem-fits (ec-gen cx cy s)        n =
+    (cx < n) × (cy < n) × (s < n)
+  constraint-mem-fits (h2c cx cy inputs)      n =
+    (cx < n) × (cy < n) × All (_< n) inputs
+  constraint-mem-fits (div-mod q r v _)                 n =
+    (q < n) × (r < n) × (v < n)
+  constraint-mem-fits (reconstitute out d m _)          n =
+    (out < n) × (d < n) × (m < n)
+  constraint-mem-fits (poseidon out inputs)       n =
+    (out < n) × All (_< n) inputs
+  constraint-mem-fits (sha256 h₁ h₂ _ inputs)  n =
+    (h₁ < n) × (h₂ < n) × All (_< n) inputs
+  constraint-mem-fits (test-eq out a b)                 n =
+    (out < n) × (a < n) × (b < n)
+  constraint-mem-fits (is-zero out a)                       n =
+    (out < n) × (a < n)
+  constraint-mem-fits (less-than out a b _)             n =
+    (out < n) × (a < n) × (b < n)
+  constraint-mem-fits (guard-disj out i)                n =
+    (out < n) × (i < n)
+  constraint-mem-fits (bind _ widx)             n = widx < n
+  constraint-mem-fits (comm inputs outputs)  n =
+    All (_< n) inputs × All (_< n) outputs
+
+  -- The dual of `holds-mem-extends`.  All lookups in `cl` are at indices
+  -- `< length mem` (encoded as `constraint-mem-fits cl (length mem)`),
+  -- so they pull back from `mem ++ suffix` to `mem`.
+  --
+  -- Implementation note:  each case mirrors `holds-mem-extends`, except
+  -- it calls `lookup-shrink` (not `lookup-extends`) and threads the
+  -- bound premise extracted from `constraint-mem-fits cl (length mem)`.
+  holds-mem-shrink : ∀ {pis rand} (mem suffix : List Fr) (cl : Constraint)
+    → constraint-mem-fits cl (length mem)
+    → holds (mk-witness (mem ++ suffix) pis rand) cl
+    → holds (mk-witness mem pis rand) cl
+  holds-mem-shrink mem suf (gate e) e< h = eval-mem-shrink mem suf e e< h
+  holds-mem-shrink mem suf (non-zero c) c<
+    (v , lv , v≢0) =
+    v , lookup-shrink mem suf c lv c< , v≢0
+  holds-mem-shrink mem suf (select out b a c) (out< , b< , a< , c<)
+    (bv , av , cv , ov , lb , la , lc , lout , bit , eq) =
+    bv , av , cv , ov
+    , lookup-shrink mem suf b lb b<
+    , lookup-shrink mem suf a la a<
+    , lookup-shrink mem suf c lc c<
+    , lookup-shrink mem suf out lout out<
+    , bit , eq
+  holds-mem-shrink mem suf (in-range v _) v<
+    (vv , lv , fits-eq) =
+    vv , lookup-shrink mem suf v lv v< , fits-eq
+  holds-mem-shrink mem suf (boolean v) v<
+    (vv , lv , bit) =
+    vv , lookup-shrink mem suf v lv v< , bit
+  holds-mem-shrink mem suf (ec-add cx cy ax ay bx by)
+    (cx< , cy< , ax< , ay< , bx< , by<)
+    (axv , ayv , bxv , byv , cxv , cyv ,
+     lax , lay , lbx , lby , lcx , lcy , add-eq) =
+    axv , ayv , bxv , byv , cxv , cyv
+    , lookup-shrink mem suf ax lax ax<
+    , lookup-shrink mem suf ay lay ay<
+    , lookup-shrink mem suf bx lbx bx<
+    , lookup-shrink mem suf by lby by<
+    , lookup-shrink mem suf cx lcx cx<
+    , lookup-shrink mem suf cy lcy cy<
+    , add-eq
+  holds-mem-shrink mem suf (ec-mul cx cy ax ay sc)
+    (cx< , cy< , ax< , ay< , sc<)
+    (axv , ayv , scv , cxv , cyv ,
+     lax , lay , lsc , lcx , lcy , mul-eq) =
+    axv , ayv , scv , cxv , cyv
+    , lookup-shrink mem suf ax lax ax<
+    , lookup-shrink mem suf ay lay ay<
+    , lookup-shrink mem suf sc lsc sc<
+    , lookup-shrink mem suf cx lcx cx<
+    , lookup-shrink mem suf cy lcy cy<
+    , mul-eq
+  holds-mem-shrink mem suf (ec-gen cx cy sc) (cx< , cy< , sc<)
+    (scv , cxv , cyv , lsc , lcx , lcy , gen-eq) =
+    scv , cxv , cyv
+    , lookup-shrink mem suf sc lsc sc<
+    , lookup-shrink mem suf cx lcx cx<
+    , lookup-shrink mem suf cy lcy cy<
+    , gen-eq
+  holds-mem-shrink mem suf (h2c cx cy inputs) (cx< , cy< , in<)
+    (vs , cxv , cyv , lvs , lcx , lcy , hash-eq) =
+    vs , cxv , cyv
+    , mem-lookups-shrink mem suf inputs in< lvs
+    , lookup-shrink mem suf cx lcx cx<
+    , lookup-shrink mem suf cy lcy cy<
+    , hash-eq
+  holds-mem-shrink mem suf (div-mod q r v _) (q< , r< , v<)
+    (qv , rv , vv , lq , lr , lv , fr , fq , nw , eq) =
+    qv , rv , vv
+    , lookup-shrink mem suf q lq q<
+    , lookup-shrink mem suf r lr r<
+    , lookup-shrink mem suf v lv v<
+    , fr , fq , nw , eq
+  holds-mem-shrink mem suf (reconstitute out d m _) (out< , d< , m<)
+    (dv , mv , ov , ld , lm , lout , fd , fm , eq) =
+    dv , mv , ov
+    , lookup-shrink mem suf d ld d<
+    , lookup-shrink mem suf m lm m<
+    , lookup-shrink mem suf out lout out<
+    , fd , fm , eq
+  holds-mem-shrink mem suf (poseidon out inputs) (out< , in<)
+    (vs , ov , lvs , lout , eq) =
+    vs , ov
+    , mem-lookups-shrink mem suf inputs in< lvs
+    , lookup-shrink mem suf out lout out<
+    , eq
+  holds-mem-shrink mem suf (sha256 h₁ h₂ _ inputs) (h1< , h2< , in<)
+    (vs , v1 , v2 , lvs , lh₁ , lh₂ , hash-eq) =
+    vs , v1 , v2
+    , mem-lookups-shrink mem suf inputs in< lvs
+    , lookup-shrink mem suf h₁ lh₁ h1<
+    , lookup-shrink mem suf h₂ lh₂ h2<
+    , hash-eq
+  holds-mem-shrink mem suf (test-eq out a b) (out< , a< , b<)
+    (av , bv , ov , la , lb , lout , eq) =
+    av , bv , ov
+    , lookup-shrink mem suf a la a<
+    , lookup-shrink mem suf b lb b<
+    , lookup-shrink mem suf out lout out<
+    , eq
+  holds-mem-shrink mem suf (is-zero out a) (out< , a<)
+    (av , ov , la , lout , eq) =
+    av , ov
+    , lookup-shrink mem suf a la a<
+    , lookup-shrink mem suf out lout out<
+    , eq
+  holds-mem-shrink mem suf (less-than out a b _) (out< , a< , b<)
+    (av , bv , ov , la , lb , lout , fa , fb , eq) =
+    av , bv , ov
+    , lookup-shrink mem suf a la a<
+    , lookup-shrink mem suf b lb b<
+    , lookup-shrink mem suf out lout out<
+    , fa , fb , eq
+  holds-mem-shrink mem suf (guard-disj out i) (out< , i<)
+    (ov , iv , lout , li , bit , disj) =
+    ov , iv
+    , lookup-shrink mem suf out lout out<
+    , lookup-shrink mem suf i li i<
+    , bit , disj
+  holds-mem-shrink mem suf (bind entry widx) widx<
+    (wv , pv , lw , lpi , eq) =
+    wv , pv
+    , lookup-shrink mem suf widx lw widx<
+    , lpi , eq
+  holds-mem-shrink mem suf (comm inputs outputs) (in< , out<)
+    (ivs , ovs , rv , pv , livs , lovs , crv , lpv , eq) =
+    ivs , ovs , rv , pv
+    , mem-lookups-shrink mem suf inputs in< livs
+    , mem-lookups-shrink mem suf outputs out< lovs
+    , crv , lpv , eq
+
+  -- All constraints fit: pointwise predicate, AND'd over the list.
+  constraints-mem-fit : List Constraint → ℕ → Set
+  constraints-mem-fit []       _ = ⊤
+  constraints-mem-fit (c ∷ cs) n = constraint-mem-fits c n × constraints-mem-fit cs n
+
+  -- Satisfaction shrinks under suffix removal, given pointwise bounds.
+  satisfies-constraints-mem-shrink : ∀ {pis rand}
+    (cls : List Constraint) (mem suf : List Fr)
+    → constraints-mem-fit cls (length mem)
+    → satisfies-constraints cls (mk-witness (mem ++ suf) pis rand)
+    → satisfies-constraints cls (mk-witness mem pis rand)
+  satisfies-constraints-mem-shrink []       _   _   _    _            = []ᴬ
+  satisfies-constraints-mem-shrink (c ∷ cs) mem suf (hd-fit , tl-fit) (hd-h ∷ᴬ tl-s) =
+    holds-mem-shrink mem suf c hd-fit hd-h
+    ∷ᴬ satisfies-constraints-mem-shrink cs mem suf tl-fit tl-s
+
+  ------------------------------------------------------------------------
+  -- Pis shrink direction.
+  --
+  -- Dual of `satisfies-constraints-mem-shrink`.  Only `bind`
+  -- and `comm` mention pis; for all others the
+  -- "fit" predicate is trivially `true` and the shrink is the identity.
+  ------------------------------------------------------------------------
+
+  -- Per-constraint "fits in pis of length n" predicate.  Only the two
+  -- pis-referencing constraints are non-trivial; all others hold trivially.
+  constraint-pis-fit : Constraint → ℕ → Set
+  constraint-pis-fit (bind entry _)  n = entry < n
+  constraint-pis-fit (comm _ _)   n = 1 < n
+  constraint-pis-fit _                              _ = ⊤
+
+  -- Shrink direction for `holds`:  if all pi-references in `cl` are
+  -- < length pis, then `holds (mem, pis ++ suf, rand) cl` implies
+  -- `holds (mem, pis, rand) cl`.
+  holds-pis-shrink : ∀ {mem rand} (pis suf : List Fr) (cl : Constraint)
+    → constraint-pis-fit cl (length pis)
+    → holds (mk-witness mem (pis ++ suf) rand) cl
+    → holds (mk-witness mem pis            rand) cl
+  holds-pis-shrink _ _ (gate _) _ h = h
+  holds-pis-shrink _ _ (non-zero _) _ h = h
+  holds-pis-shrink _ _ (select _ _ _ _) _ h = h
+  holds-pis-shrink _ _ (in-range _ _) _ h = h
+  holds-pis-shrink _ _ (boolean _) _ h = h
+  holds-pis-shrink _ _ (ec-add _ _ _ _ _ _) _ h = h
+  holds-pis-shrink _ _ (ec-mul _ _ _ _ _) _ h = h
+  holds-pis-shrink _ _ (ec-gen _ _ _) _ h = h
+  holds-pis-shrink _ _ (h2c _ _ _) _ h = h
+  holds-pis-shrink _ _ (div-mod _ _ _ _) _ h = h
+  holds-pis-shrink _ _ (reconstitute _ _ _ _) _ h = h
+  holds-pis-shrink _ _ (poseidon _ _) _ h = h
+  holds-pis-shrink _ _ (sha256 _ _ _ _) _ h = h
+  holds-pis-shrink _ _ (test-eq _ _ _) _ h = h
+  holds-pis-shrink _ _ (is-zero _ _) _ h = h
+  holds-pis-shrink _ _ (less-than _ _ _ _) _ h = h
+  holds-pis-shrink _ _ (guard-disj _ _) _ h = h
+  holds-pis-shrink pis suf (bind entry widx) fits
+    (wv , pv , lw , lpi , eq) =
+    wv , pv , lw
+    , lookup-shrink pis suf entry lpi fits
+    , eq
+  holds-pis-shrink pis suf (comm inputs outputs) fits
+    (ivs , ovs , rv , pv , livs , lovs , crv , lpv , eq) =
+    ivs , ovs , rv , pv , livs , lovs , crv
+    , lookup-shrink pis suf 1 lpv fits
+    , eq
+
+  -- All constraints fit (pis-side): pointwise predicate AND'd over the list.
+  constraints-pis-fit : List Constraint → ℕ → Set
+  constraints-pis-fit []       _ = ⊤
+  constraints-pis-fit (c ∷ cs) n = constraint-pis-fit c n × constraints-pis-fit cs n
+
+  -- List-level shrink for pis suffix.
+  satisfies-constraints-pis-shrink : ∀ {mem rand}
+    (cls : List Constraint) (pis suf : List Fr)
+    → constraints-pis-fit cls (length pis)
+    → satisfies-constraints cls (mk-witness mem (pis ++ suf) rand)
+    → satisfies-constraints cls (mk-witness mem pis            rand)
+  satisfies-constraints-pis-shrink []       _   _   _    _            = []ᴬ
+  satisfies-constraints-pis-shrink (c ∷ cs) pis suf (hd-fit , tl-fit) (hd-h ∷ᴬ tl-s) =
+    holds-pis-shrink pis suf c hd-fit hd-h
+    ∷ᴬ satisfies-constraints-pis-shrink cs pis suf tl-fit tl-s
+
+  -- Distributivity of satisfies-constraints over list concatenation.
+  satisfies-constraints-++ : ∀ {w} (xs ys : List Constraint)
+    → satisfies-constraints xs w
+    → satisfies-constraints ys w
+    → satisfies-constraints (xs ++ ys) w
+  satisfies-constraints-++ _ _ = ++ᴬ
+
+  -- Splitting direction of `satisfies-constraints-++`.  Used by the
+  -- backward dispatcher D1 to peel off the prior constraints (which are
+  -- satisfied at the post-state witness as a consequence of monotonicity)
+  -- from the new constraints (which the dispatcher actually inverts).
+  satisfies-constraints-split : ∀ {w} (xs ys : List Constraint)
+    → satisfies-constraints (xs ++ ys) w
+    → satisfies-constraints xs w × satisfies-constraints ys w
+  satisfies-constraints-split xs _ = ++⁻ xs
+
+  -- length-of-append for explicit nat arithmetic on mem-inv.
+  length-++-1 : ∀ (xs : List Fr) y → length (xs ++ (y ∷ [])) ≡ suc (length xs)
+  length-++-1 []       y = refl
+  length-++-1 (x ∷ xs) y = cong suc (length-++-1 xs y)
+
+  length-++-2 : ∀ (xs : List Fr) y z → length (xs ++ (y ∷ z ∷ [])) ≡ suc (suc (length xs))
+  length-++-2 []       y z = refl
+  length-++-2 (x ∷ xs) y z = cong suc (length-++-2 xs y z)
+
+  -- Build the post-state mem-inv from the pre-state one for a Δmem = 1 instruction.
+  mem-inv-step-1 : ∀ {st : SynthState} {mem : List Fr} {v : Fr}
+    → SynthState.nr-wires st ≡ length mem
+    → SynthState.nr-wires st + 1 ≡ length (mem ++ (v ∷ []))
+  mem-inv-step-1 {st} {mem} {v} mi =
+    trans (+-comm (SynthState.nr-wires st) 1)
+          (trans (cong suc mi) (sym (length-++-1 mem v)))
+
+  -- Δmem = 2 instruction (push-mem2 form: mem ++ (x ∷ y ∷ [])).
+  mem-inv-step-2 : ∀ {st : SynthState} {mem : List Fr} {x y : Fr}
+    → SynthState.nr-wires st ≡ length mem
+    → SynthState.nr-wires st + 2 ≡ length (mem ++ (x ∷ y ∷ []))
+  mem-inv-step-2 {st} {mem} {x} {y} mi =
+    trans (+-comm (SynthState.nr-wires st) 2)
+          (trans (cong (suc ∘ suc) mi) (sym (length-++-2 mem x y)))
+    where open import Function using (_∘_)
+
+  -- Δmem = 2 instruction (iterated push-mem form: (mem ++ (x ∷ [])) ++ (y ∷ [])).
+  mem-inv-step-2' : ∀ {st : SynthState} {mem : List Fr} {x y : Fr}
+    → SynthState.nr-wires st ≡ length mem
+    → SynthState.nr-wires st + 2 ≡ length ((mem ++ (x ∷ [])) ++ (y ∷ []))
+  mem-inv-step-2' {st} {mem} {x} {y} mi =
+    trans (mem-inv-step-2 {st} {mem} {x} {y} mi)
+          (cong length (push-mem2-assoc mem x y))
+
+  -- Discharge pattern shared (hand-expanded) by the
+  -- "memory-only-extends" dispatcher cases below.  An instruction `i`
+  -- whose `R-instr` evidence yields a memory suffix `suf` and whose
+  -- `circuit-instr hc i st` only appends new constraints (no
+  -- `nr-declared-pi` or `output-wires` change) is discharged by:
+  --
+  --   1. Lift prior-sat to (mem ++ suf, pis, rand) via mem-extends.
+  --   2. Apply the per-instruction forward lemma to get satisfaction
+  --      of the *new* constraints at (mem ++ suf, pis, rand).
+  --   3. Concatenate via `satisfies-constraints-++`.
+  --
+  -- The pattern's preconditions ensure
+  -- `constraints (circuit-instr hc i st) = constraints st ++ newcls`, which
+  -- holds by definition for all instructions except `pi-skip` and
+  -- `output` (which emit no constraints) and `public-input nothing` and
+  -- `private-input nothing` (which also emit no constraints but still
+  -- bump `nr-wires`).
+
+  -- The PI vector along an R-instr step extends pre-pis with a suffix.
+  -- Only `declare-pub-input` extends the pis (with one cell); all others
+  -- leave them unchanged.
+  pis-extends-R-instr : ∀ {pre s i s'}
+    → R-instr pre s i s'
+    → Σ (List Fr) λ suf →
+        Preprocessed.pis s' ≡ Preprocessed.pis s ++ suf
+  pis-extends-R-instr (r-assert _)                   = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-cond-select _ _ _)          = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-constrain-bits _ _ _)         = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-constrain-eq _ _ _)         = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-constrain-to-boolean _)     = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-copy _)                     = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-declare-pub-input {v = v} _) = v ∷ [] , refl
+  pis-extends-R-instr (r-pi-skip-active _ _)         = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-pi-skip-inactive _)         = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-ec-add _ _ _ _ _)           = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-ec-mul _ _ _ _)             = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-ec-mul-generator _ _)       = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-hash-to-curve _ _)          = [] , sym (++-identityʳ _)
+  pis-extends-R-instr r-load-imm                     = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-div-mod-power-of-two _ _)     = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-reconstitute-field _ _ _ _ _)   = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-output _)                   = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-transient-hash _)           = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-persistent-hash _ _)        = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-test-eq _ _)                = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-add _ _)                    = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-mul _ _)                    = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-neg _)                      = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-not _)                      = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-less-than _ _ _ _)            = [] , sym (++-identityʳ _)
+  pis-extends-R-instr (r-public-input-inactive _)    = [] , sym (++-identityʳ _)
+  pis-extends-R-instr {s = s} (r-public-input-active {s₁ = s₁} _ cp) =
+    [] , trans (consume-pub-out-pis s cp) (sym (++-identityʳ _))
+  pis-extends-R-instr (r-private-input-inactive _)   = [] , sym (++-identityʳ _)
+  pis-extends-R-instr {s = s} (r-private-input-active {s₁ = s₁} _ cp) =
+    [] , trans (consume-priv-pis s cp) (sym (++-identityʳ _))
+
+------------------------------------------------------------------------
+-- Section C.  Forward direction.
+--
+-- Two layers:
+--
+--   • `R-instrs→satisfies-constraints`     instruction-list induction
+--   • `circuit-faithful-fwd`           top-level (incl. comm-commitment)
+------------------------------------------------------------------------
+
+-- Sub-lemma 1: a single R-instr step preserves the satisfaction of any
+-- prior constraint list, and the new constraints emitted by `circuit-instr` for
+-- that step are satisfied by the post-state assignment.
+--
+-- This is essentially the conjunction of the 26 forward lemmas in
+-- `CircuitFaithfulness.agda`, generalized to thread:
+--
+--   • the constraints accumulated by earlier instructions (they stay
+--     satisfied because they only mention indices < length pre-mem, and
+--     pre-mem is a prefix of post-mem);
+--   • the invariants I-mem and I-pi (which the synthesis-state record
+--     also obeys clause-by-clause).
+--
+-- The `prior-sat` hypothesis is what lets the per-step proof lift the
+-- earlier-emitted constraints to the post-state's larger memory.  The
+-- forward direction needs no producer-obligation hypotheses; those are
+-- only required by the backward direction of the four §6.5 cases
+-- (assert, not, reconstitute-field, less-than).
+
+-- Concrete-state version of `single-instr-constraints-with-decl`: applies
+-- the synthesis function to an arbitrary `st`, returning the *new*
+-- constraints emitted (i.e. `constraints st`-suffix).  Definitionally equal to
+-- `single-instr-constraints-with-decl hc (nr-wires st) (nr-declared-pi st) i`
+-- (this is what `circuit-instr` does, up to the prior constraints prefix).
+--
+-- The actual proof discharges via direct case analysis on `i`.
+
+-- Shared closing moves for the per-instruction cases, isolating the
+-- otherwise copy-pasted `subst`/`++`/lift plumbing.  Each takes the
+-- per-instruction `*-fwd` result (`sat-new`) already stated at
+-- `single-instr-constraints hc (length (memory s)) i`, together with the
+-- memory / pi invariants, and assembles the post-state triple.  The
+-- output's constraint list is written as
+-- `constraints st ++ single-instr-constraints hc (nr-wires st) i`, which
+-- coincides definitionally with `constraints (circuit-instr hc i st)` once
+-- `i` is a concrete instruction at the call site.
+private
+
+  -- Instruction that appends a memory suffix `suf` and no PI entries.
+  fwd-mem-step
+    : ∀ {hc} (pre : ProofPreimage) (s : Preprocessed) (i : Instruction)
+        (st : SynthState) (suf : List Fr)
+    → SynthState.nr-wires st ≡ length (Preprocessed.memory s)
+    → SynthState.nr-wires (circuit-instr hc i st)
+        ≡ length (Preprocessed.memory s ++ suf)
+    → length (Preprocessed.pis s)
+        ≡ preamble-pi-count hc + SynthState.nr-declared-pi (circuit-instr hc i st)
+    → satisfies-constraints (SynthState.constraints st)
+        (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) (comm-rand-of pre))
+    → satisfies-constraints
+        (single-instr-constraints hc (length (Preprocessed.memory s)) i)
+        (mk-witness (Preprocessed.memory s ++ suf) (Preprocessed.pis s)
+                    (comm-rand-of pre))
+    →   (SynthState.nr-wires (circuit-instr hc i st)
+           ≡ length (Preprocessed.memory s ++ suf))
+      × (length (Preprocessed.pis s)
+           ≡ preamble-pi-count hc
+             + SynthState.nr-declared-pi (circuit-instr hc i st))
+      × satisfies-constraints
+          (SynthState.constraints st
+             ++ single-instr-constraints hc (SynthState.nr-wires st) i)
+          (mk-witness (Preprocessed.memory s ++ suf) (Preprocessed.pis s)
+                      (comm-rand-of pre))
+  fwd-mem-step {hc} pre s i st suf mi mi-res pi-res prior-sat sat-new =
+      mi-res , pi-res ,
+      satisfies-constraints-++ (SynthState.constraints st) _
+        (satisfies-constraints-mem-extends (SynthState.constraints st) prior-sat)
+        (subst (λ cls → satisfies-constraints cls
+                  (mk-witness (Preprocessed.memory s ++ suf)
+                              (Preprocessed.pis s) (comm-rand-of pre)))
+               (sym (cong (λ n → single-instr-constraints hc n i) mi))
+               sat-new)
+
+  -- Instruction that leaves memory and pis unchanged.
+  fwd-nogrow-step
+    : ∀ {hc} (pre : ProofPreimage) (s : Preprocessed) (i : Instruction)
+        (st : SynthState)
+    → SynthState.nr-wires st ≡ length (Preprocessed.memory s)
+    → satisfies-constraints (SynthState.constraints st)
+        (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) (comm-rand-of pre))
+    → satisfies-constraints
+        (single-instr-constraints hc (length (Preprocessed.memory s)) i)
+        (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) (comm-rand-of pre))
+    → satisfies-constraints
+        (SynthState.constraints st
+           ++ single-instr-constraints hc (SynthState.nr-wires st) i)
+        (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) (comm-rand-of pre))
+  fwd-nogrow-step {hc} pre s i st mi prior-sat sat-new =
+      satisfies-constraints-++ (SynthState.constraints st) _ prior-sat
+        (subst (λ cls → satisfies-constraints cls
+                  (mk-witness (Preprocessed.memory s) (Preprocessed.pis s)
+                              (comm-rand-of pre)))
+               (sym (cong (λ n → single-instr-constraints hc n i) mi))
+               sat-new)
+
+  -- Transcript-active input instruction: `s'` differs from a state that
+  -- shares memory / pis with `s` only by appending the read value `v`.
+  -- Rebuilds the invariants and lifts prior-sat across the two equations.
+  input-active-frame
+    : ∀ {hc} (pre : ProofPreimage) (s s' : Preprocessed) (st : SynthState)
+        {v : Fr}
+    → Preprocessed.memory s' ≡ Preprocessed.memory s ++ (v ∷ [])
+    → Preprocessed.pis s' ≡ Preprocessed.pis s
+    → SynthState.nr-wires st ≡ length (Preprocessed.memory s)
+    → pi-inv hc s st
+    → satisfies-constraints (SynthState.constraints st)
+        (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) (comm-rand-of pre))
+    →   (SynthState.nr-wires st + 1 ≡ length (Preprocessed.memory s'))
+      × (length (Preprocessed.pis s')
+           ≡ preamble-pi-count hc + SynthState.nr-declared-pi st)
+      × satisfies-constraints (SynthState.constraints st)
+          (mk-witness (Preprocessed.memory s') (Preprocessed.pis s')
+                      (comm-rand-of pre))
+  input-active-frame {hc} pre s s' st {v} mem-s' pis-s' mi pi prior-sat =
+      subst (λ m → SynthState.nr-wires st + 1 ≡ length m) (sym mem-s')
+            (mem-inv-step-1 {st} {Preprocessed.memory s} {v} mi)
+    , subst (λ p → length p
+              ≡ preamble-pi-count hc + SynthState.nr-declared-pi st)
+            (sym pis-s') pi
+    , subst (λ p → satisfies-constraints (SynthState.constraints st)
+              (mk-witness (Preprocessed.memory s') p (comm-rand-of pre)))
+            (sym pis-s')
+            (subst (λ m → satisfies-constraints (SynthState.constraints st)
+                     (mk-witness m (Preprocessed.pis s) (comm-rand-of pre)))
+                   (sym mem-s')
+                   (satisfies-constraints-mem-extends {suffix = v ∷ []}
+                      (SynthState.constraints st) prior-sat))
+
+R-instr→satisfies-step
+  : ∀ {hc} (pre : ProofPreimage) (s s' : Preprocessed) (i : Instruction)
+  → (st : SynthState)
+  → mem-inv s st
+  → pi-inv  hc s st
+  → satisfies-constraints (SynthState.constraints st)
+      (mk-witness (Preprocessed.memory s)
+                  (Preprocessed.pis    s)
+                  (comm-rand-of pre))
+  → R-instr pre s i s'
+  →   mem-inv s' (circuit-instr hc i st)
+    × pi-inv  hc s' (circuit-instr hc i st)
+    × satisfies-constraints
+        (SynthState.constraints (circuit-instr hc i st))
+        (mk-witness (Preprocessed.memory s')
+                    (Preprocessed.pis    s')
+                    (comm-rand-of pre))
+-- For each case, we use the helpers built up above:
+--   • `mem-extends-R-instr` to identify the suffix appended to memory;
+--   • the corresponding `*-fwd` lemma from CircuitFaithfulness;
+--   • `satisfies-constraints-mem-extends` / `-pis-extends` to lift prior-sat;
+--   • `satisfies-constraints-++` to combine.
+
+-- Pattern-matching helper: each case applies the appropriate forward
+-- lemma to the new constraints and concatenates with the lifted prior-sat.
+
+-- assert(c): mem and pis unchanged.  newcls = [non-zero c].
+R-instr→satisfies-step {hc} pre s .s (assert c) st mi pi prior-sat r@(r-assert _) =
+  mi , pi ,
+  fwd-nogrow-step {hc} pre s (assert c) st mi prior-sat
+    (assert-fwd {pre = pre} {s = s} {s' = s} {c = c} {hc = hc}
+                {rand = comm-rand-of pre} r)
+
+-- constrain-bits(v, n): mem and pis unchanged.
+R-instr→satisfies-step {hc} pre s .s (constrain-bits v n) st mi pi prior-sat r@(r-constrain-bits _ _ _) =
+  mi , pi ,
+  fwd-nogrow-step {hc} pre s (constrain-bits v n) st mi prior-sat
+    (constrain-bits-fwd {pre = pre} {s = s} {s' = s}
+                        {v = v} {n = n} {hc = hc} {rand = comm-rand-of pre} r)
+
+-- constrain-eq(a, b): mem and pis unchanged.
+R-instr→satisfies-step {hc} pre s .s (constrain-eq a b) st mi pi prior-sat r@(r-constrain-eq _ _ _) =
+  mi , pi ,
+  fwd-nogrow-step {hc} pre s (constrain-eq a b) st mi prior-sat
+    (constrain-eq-fwd {pre = pre} {s = s} {s' = s}
+                      {a = a} {b = b} {hc = hc} {rand = comm-rand-of pre} r)
+
+-- constrain-to-boolean(v): mem and pis unchanged.
+R-instr→satisfies-step {hc} pre s .s (constrain-to-boolean v) st mi pi prior-sat r@(r-constrain-to-boolean _) =
+  mi , pi ,
+  fwd-nogrow-step {hc} pre s (constrain-to-boolean v) st mi prior-sat
+    (constrain-to-boolean-fwd {pre = pre} {s = s} {s' = s}
+                              {v = v} {hc = hc} {rand = comm-rand-of pre} r)
+
+-- copy(v): Δmem = 1, pis unchanged.
+R-instr→satisfies-step {hc} pre s s' (copy v) st mi pi prior-sat r@(r-copy {v = v0} _) =
+  fwd-mem-step {hc} pre s (copy v) st (v0 ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {v0} mi) pi prior-sat
+    (copy-fwd {pre = pre} {s = s} {s' = s'} {v = v} {hc = hc}
+              {rand = comm-rand-of pre} r)
+
+-- load-imm(imm): Δmem = 1, pis unchanged.
+R-instr→satisfies-step {hc} pre s s' (load-imm imm) st mi pi prior-sat r@r-load-imm =
+  fwd-mem-step {hc} pre s (load-imm imm) st (imm ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {imm} mi) pi prior-sat
+    (load-imm-fwd {pre = pre} {s = s} {s' = s'} {k = imm} {hc = hc}
+                  {rand = comm-rand-of pre} r)
+
+-- add(a, b): Δmem = 1, pis unchanged.
+R-instr→satisfies-step {hc} pre s s' (add a b) st mi pi prior-sat r@(r-add {av = av} {bv = bv} _ _) =
+  fwd-mem-step {hc} pre s (add a b) st ((av +ᶠ bv) ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {av +ᶠ bv} mi) pi prior-sat
+    (add-fwd {pre = pre} {s = s} {s' = s'} {a = a} {b = b} {hc = hc}
+             {rand = comm-rand-of pre} r)
+
+-- mul(a, b)
+R-instr→satisfies-step {hc} pre s s' (mul a b) st mi pi prior-sat r@(r-mul {av = av} {bv = bv} _ _) =
+  fwd-mem-step {hc} pre s (mul a b) st ((av *ᶠ bv) ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {av *ᶠ bv} mi) pi prior-sat
+    (mul-fwd {pre = pre} {s = s} {s' = s'} {a = a} {b = b} {hc = hc}
+             {rand = comm-rand-of pre} r)
+
+-- neg(a)
+R-instr→satisfies-step {hc} pre s s' (neg a) st mi pi prior-sat r@(r-neg {av = av} _) =
+  fwd-mem-step {hc} pre s (neg a) st ((-ᶠ av) ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} { -ᶠ av } mi) pi prior-sat
+    (neg-fwd {pre = pre} {s = s} {s' = s'} {a = a} {hc = hc}
+             {rand = comm-rand-of pre} r)
+
+-- test-eq(a, b)
+R-instr→satisfies-step {hc} pre s s' (test-eq a b) st mi pi prior-sat r@(r-test-eq {av = av} {bv = bv} _ _) =
+  fwd-mem-step {hc} pre s (test-eq a b) st (from-bool (av ≡ᶠ? bv) ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {from-bool (av ≡ᶠ? bv)} mi)
+    pi prior-sat
+    (test-eq-fwd {pre = pre} {s = s} {s' = s'} {a = a} {b = b} {hc = hc}
+                 {rand = comm-rand-of pre} r)
+
+-- not(a)
+R-instr→satisfies-step {hc} pre s s' (not a) st mi pi prior-sat r@(r-not {b = b0} _) =
+  fwd-mem-step {hc} pre s (not a) st (from-bool (Bool.not b0) ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {from-bool (Bool.not b0)} mi)
+    pi prior-sat
+    (not-fwd {pre = pre} {s = s} {s' = s'} {a = a} {hc = hc}
+             {rand = comm-rand-of pre} r)
+
+-- cond-select(b, a, c): Δmem = 1.  Output value is `if sel then av else bv`.
+R-instr→satisfies-step {hc} pre s s' (cond-select b a c) st mi pi prior-sat
+  r@(r-cond-select {sel = sel} {av = av} {bv = bv} _ _ _) =
+  fwd-mem-step {hc} pre s (cond-select b a c) st ((if sel then av else bv) ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {if sel then av else bv} mi)
+    pi prior-sat
+    (cond-select-fwd {pre = pre} {s = s} {s' = s'} {b = b} {a = a} {c = c}
+                     {hc = hc} {rand = comm-rand-of pre} r)
+
+-- less-than(a, b, n): Δmem = 1.  Output value: `from-bool (bits-lt ...)`.
+R-instr→satisfies-step {hc} pre s s' (less-than a b bits) st mi pi prior-sat
+  r@(r-less-than {av = av} {bv = bv} _ _ _ _) =
+  fwd-mem-step {hc} pre s (less-than a b bits) st
+    (from-bool (bits-lt (take bits (to-le-bits av)) (take bits (to-le-bits bv))) ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s}
+         {from-bool (bits-lt (take bits (to-le-bits av)) (take bits (to-le-bits bv)))} mi)
+    pi prior-sat
+    (less-than-fwd {pre = pre} {s = s} {s' = s'} {a = a} {b = b} {bits = bits}
+                   {hc = hc} {rand = comm-rand-of pre} r)
+
+-- transient-hash(inputs): Δmem = 1.  Output value: transient-hash-fn vs.
+R-instr→satisfies-step {hc} pre s s' (transient-hash inputs) st mi pi prior-sat
+  r@(r-transient-hash {vs = vs} _) =
+  fwd-mem-step {hc} pre s (transient-hash inputs) st (transient-hash-fn vs ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {transient-hash-fn vs} mi)
+    pi prior-sat
+    (transient-hash-fwd {pre = pre} {s = s} {s' = s'} {inputs = inputs}
+                        {hc = hc} {rand = comm-rand-of pre} r)
+
+-- reconstitute-field(d, m, bits): Δmem = 1.
+R-instr→satisfies-step {hc} pre s s' (reconstitute-field d m bits) st mi pi prior-sat
+  r@(r-reconstitute-field {dv = dv} {mv = mv} _ _ _ _ _) =
+  fwd-mem-step {hc} pre s (reconstitute-field d m bits) st
+    (from-le-bits (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv)) ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s}
+         {from-le-bits (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv))} mi)
+    pi prior-sat
+    (reconstitute-field-fwd {pre = pre} {s = s} {s' = s'} {d = d} {m = m} {bits = bits}
+                            {hc = hc} {rand = comm-rand-of pre} r)
+
+-- ec-add: Δmem = 2 (push-mem2 form, mem ++ x ∷ y ∷ []).
+R-instr→satisfies-step {hc} pre s s' (ec-add a-x a-y b-x b-y) st mi pi prior-sat
+  r@(r-ec-add {cx = cx} {cy = cy} _ _ _ _ _) =
+  fwd-mem-step {hc} pre s (ec-add a-x a-y b-x b-y) st (cx ∷ cy ∷ [])
+    mi (mem-inv-step-2 {st} {Preprocessed.memory s} {cx} {cy} mi) pi prior-sat
+    (ec-add-fwd {pre = pre} {s = s} {s' = s'} {a-x = a-x} {a-y = a-y}
+                {b-x = b-x} {b-y = b-y} {hc = hc} {rand = comm-rand-of pre} r)
+
+-- ec-mul
+R-instr→satisfies-step {hc} pre s s' (ec-mul a-x a-y scalar) st mi pi prior-sat
+  r@(r-ec-mul {cx = cx} {cy = cy} _ _ _ _) =
+  fwd-mem-step {hc} pre s (ec-mul a-x a-y scalar) st (cx ∷ cy ∷ [])
+    mi (mem-inv-step-2 {st} {Preprocessed.memory s} {cx} {cy} mi) pi prior-sat
+    (ec-mul-fwd {pre = pre} {s = s} {s' = s'} {a-x = a-x} {a-y = a-y}
+                {scalar = scalar} {hc = hc} {rand = comm-rand-of pre} r)
+
+-- ec-mul-generator
+R-instr→satisfies-step {hc} pre s s' (ec-mul-generator scalar) st mi pi prior-sat
+  r@(r-ec-mul-generator {cx = cx} {cy = cy} _ _) =
+  fwd-mem-step {hc} pre s (ec-mul-generator scalar) st (cx ∷ cy ∷ [])
+    mi (mem-inv-step-2 {st} {Preprocessed.memory s} {cx} {cy} mi) pi prior-sat
+    (ec-mul-generator-fwd {pre = pre} {s = s} {s' = s'} {scalar = scalar}
+                          {hc = hc} {rand = comm-rand-of pre} r)
+
+-- hash-to-curve
+R-instr→satisfies-step {hc} pre s s' (hash-to-curve inputs) st mi pi prior-sat
+  r@(r-hash-to-curve {cx = cx} {cy = cy} _ _) =
+  fwd-mem-step {hc} pre s (hash-to-curve inputs) st (cx ∷ cy ∷ [])
+    mi (mem-inv-step-2 {st} {Preprocessed.memory s} {cx} {cy} mi) pi prior-sat
+    (hash-to-curve-fwd {pre = pre} {s = s} {s' = s'} {inputs = inputs}
+                       {hc = hc} {rand = comm-rand-of pre} r)
+
+-- persistent-hash
+R-instr→satisfies-step {hc} pre s s' (persistent-hash alignment inputs) st mi pi prior-sat
+  r@(r-persistent-hash {h₁ = h₁} {h₂ = h₂} _ _) =
+  fwd-mem-step {hc} pre s (persistent-hash alignment inputs) st (h₁ ∷ h₂ ∷ [])
+    mi (mem-inv-step-2 {st} {Preprocessed.memory s} {h₁} {h₂} mi) pi prior-sat
+    (persistent-hash-fwd {pre = pre} {s = s} {s' = s'} {α = alignment}
+                         {inputs = inputs} {hc = hc} {rand = comm-rand-of pre} r)
+
+-- div-mod-power-of-two: Δmem = 2, iterated push-mem form.  The
+-- post-state's memory is (mem ++ (divisor ∷ [])) ++ (modulus ∷ []) per
+-- `r-div-mod-power-of-two`.  The forward lemma matches that shape.
+R-instr→satisfies-step {hc} pre s s' (div-mod-power-of-two var bits) st mi pi prior-sat
+  r@(r-div-mod-power-of-two {v = vv} _ _) =
+  let mem  = Preprocessed.memory s ; pis = Preprocessed.pis s
+      rand = comm-rand-of pre
+      divisor = from-le-bits (drop bits (to-le-bits vv))
+      modulus = from-le-bits (take bits (to-le-bits vv))
+      mem' = (mem ++ (divisor ∷ [])) ++ (modulus ∷ [])
+      w'   = mk-witness mem' pis rand
+      newcls-eq : single-instr-constraints hc (SynthState.nr-wires st) (div-mod-power-of-two var bits)
+                 ≡ single-instr-constraints hc (length mem) (div-mod-power-of-two var bits)
+      newcls-eq = cong (λ k → single-instr-constraints hc k (div-mod-power-of-two var bits)) mi
+      sat-new = subst (λ cls → satisfies-constraints cls w') (sym newcls-eq)
+                       (div-mod-power-of-two-fwd {pre = pre} {s = s} {s' = s'}
+                                                  {var = var} {bits = bits}
+                                                  {hc = hc} {rand = rand} r)
+      lifted-prior = satisfies-constraints-mem-extends
+                       {suffix = modulus ∷ []}
+                       (SynthState.constraints st)
+                       (satisfies-constraints-mem-extends
+                          {suffix = divisor ∷ []}
+                          (SynthState.constraints st) prior-sat)
+  in mem-inv-step-2' {st} {mem} {divisor} {modulus} mi , pi ,
+     satisfies-constraints-++ (SynthState.constraints st) _ lifted-prior sat-new
+
+-- output(v): no constraints.  push-output appends to s.outputs but leaves
+-- memory and pis unchanged.  Only `output-wires` changes in the synth
+-- state — irrelevant to `constraints`/`nr-wires`/`nr-declared-pi`.
+R-instr→satisfies-step {hc} pre s s' (output v) st mi pi prior-sat r@(r-output _) =
+  -- s' = push-output s _, whose memory ≡ memory s and pis ≡ pis s
+  -- (push-output only modifies the `outputs` field).
+  -- circuit-instr _ (output v) st = record st { output-wires = … },
+  -- so its constraints ≡ st.constraints, nr-wires ≡ st.nr-wires, nr-declared-pi ≡ st.nr-declared-pi.
+  mi , pi , prior-sat
+
+-- pi-skip(guard, count): no constraints, no Δmem.  But the operational rule
+-- does change the synth state's record (pi-skips, possibly pub-in-idx).
+-- All effects on `Preprocessed` happen via `push-skip` which doesn't
+-- change `memory` or `pis`.  The synth state is left entirely untouched
+-- by `circuit-instr _ (pi-skip _ _) st = st`.
+R-instr→satisfies-step {hc} pre s s' (pi-skip g n) st mi pi prior-sat
+  (r-pi-skip-active _ _) =
+  -- Post-state: push-skip s nothing.  push-skip leaves memory/pis unchanged.
+  -- nr-wires st unchanged ≡ length (push-skip-memory) = length mem.
+  mi , pi , prior-sat
+R-instr→satisfies-step {hc} pre s s' (pi-skip g n) st mi pi prior-sat
+  (r-pi-skip-inactive _) =
+  mi , pi , prior-sat
+
+-- public-input nothing: Δmem = 1, no constraints.  Fires r-public-input-active
+-- since `eval-guard _ nothing ≡ just true` by definition.
+R-instr→satisfies-step {hc} pre s s' (public-input nothing) st mi pi prior-sat
+  (r-public-input-active {v = v} {s₁ = s₁} _ cp) =
+  input-active-frame {hc} pre s s' st {v}
+    (cong (_++ (v ∷ [])) (consume-pub-out-mem s cp))
+    (consume-pub-out-pis s cp) mi pi prior-sat
+
+-- private-input nothing: identical pattern to public-input nothing.
+R-instr→satisfies-step {hc} pre s s' (private-input nothing) st mi pi prior-sat
+  (r-private-input-active {v = v} {s₁ = s₁} _ cp) =
+  input-active-frame {hc} pre s s' st {v}
+    (cong (_++ (v ∷ [])) (consume-priv-mem s cp))
+    (consume-priv-pis s cp) mi pi prior-sat
+
+-- public-input (just g) — inactive: Δmem = 1, push-mem s 0ᶠ.
+R-instr→satisfies-step {hc} pre s s' (public-input (just g)) st mi pi prior-sat
+  r@(r-public-input-inactive _) =
+  fwd-mem-step {hc} pre s (public-input (just g)) st (0ᶠ ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {0ᶠ} mi) pi prior-sat
+    (public-input-just-fwd {pre = pre} {s = s} {s' = s'} {g = g} {hc = hc}
+                           {rand = comm-rand-of pre} r)
+
+-- public-input (just g) — active: Δmem = 1, push-mem s₁ v where s₁ shares mem/pis with s.
+R-instr→satisfies-step {hc} pre s s' (public-input (just g)) st mi pi prior-sat
+  r@(r-public-input-active {v = v} {s₁ = s₁} _ cp) =
+  let mem-s' = cong (_++ (v ∷ [])) (consume-pub-out-mem s cp)
+      pis-s' = consume-pub-out-pis s cp
+      (mi' , pi' , lifted-prior) =
+        input-active-frame {hc} pre s s' st {v} mem-s' pis-s' mi pi prior-sat
+      sat-new-st =
+        subst (λ cls → satisfies-constraints cls
+                (mk-witness (Preprocessed.memory s') (Preprocessed.pis s')
+                            (comm-rand-of pre)))
+              (sym (cong (λ k → single-instr-constraints hc k (public-input (just g))) mi))
+              (public-input-just-fwd {pre = pre} {s = s} {s' = s'} {g = g}
+                                     {hc = hc} {rand = comm-rand-of pre} r)
+  in mi' , pi' ,
+     satisfies-constraints-++ (SynthState.constraints st) _ lifted-prior sat-new-st
+
+-- private-input (just g) — inactive
+R-instr→satisfies-step {hc} pre s s' (private-input (just g)) st mi pi prior-sat
+  r@(r-private-input-inactive _) =
+  fwd-mem-step {hc} pre s (private-input (just g)) st (0ᶠ ∷ [])
+    mi (mem-inv-step-1 {st} {Preprocessed.memory s} {0ᶠ} mi) pi prior-sat
+    (private-input-just-fwd {pre = pre} {s = s} {s' = s'} {g = g} {hc = hc}
+                            {rand = comm-rand-of pre} r)
+
+-- private-input (just g) — active
+R-instr→satisfies-step {hc} pre s s' (private-input (just g)) st mi pi prior-sat
+  r@(r-private-input-active {v = v} {s₁ = s₁} _ cp) =
+  let mem-s' = cong (_++ (v ∷ [])) (consume-priv-mem s cp)
+      pis-s' = consume-priv-pis s cp
+      (mi' , pi' , lifted-prior) =
+        input-active-frame {hc} pre s s' st {v} mem-s' pis-s' mi pi prior-sat
+      sat-new-st =
+        subst (λ cls → satisfies-constraints cls
+                (mk-witness (Preprocessed.memory s') (Preprocessed.pis s')
+                            (comm-rand-of pre)))
+              (sym (cong (λ k → single-instr-constraints hc k (private-input (just g))) mi))
+              (private-input-just-fwd {pre = pre} {s = s} {s' = s'} {g = g}
+                                      {hc = hc} {rand = comm-rand-of pre} r)
+  in mi' , pi' ,
+     satisfies-constraints-++ (SynthState.constraints st) _ lifted-prior sat-new-st
+
+-- declare-pub-input(v): pis grows by 1 cell with the value of wire v.
+-- Mem unchanged.  Uses `single-instr-constraints-with-decl`.  nr-declared-pi
+-- in synth state increments by 1.
+R-instr→satisfies-step {hc} pre s s' (declare-pub-input v) st mi pi prior-sat
+  r@(r-declare-pub-input {v = wv} _) =
+  -- s' = push-pi s wv, whose memory ≡ memory s, pis ≡ pis s ++ (wv ∷ []).
+  let mem  = Preprocessed.memory s ; pis-s = Preprocessed.pis s
+      rand = comm-rand-of pre
+      pis' = pis-s ++ (wv ∷ [])
+      w'   = mk-witness mem pis' rand
+      newcls-st = single-instr-constraints-with-decl hc (SynthState.nr-wires st)
+                    (SynthState.nr-declared-pi st) (declare-pub-input v)
+      newcls'   = single-instr-constraints-with-decl hc (length mem)
+                    (SynthState.nr-declared-pi st) (declare-pub-input v)
+      newcls-eq : newcls-st ≡ newcls'
+      newcls-eq = cong (λ k → single-instr-constraints-with-decl hc k
+                                  (SynthState.nr-declared-pi st) (declare-pub-input v)) mi
+      sat-new' = declare-pub-input-fwd {pre = pre} {s = s} {s' = s'} {v = v} {hc = hc}
+                                        {d = SynthState.nr-declared-pi st} {rand = rand} pi r
+      sat-new = subst (λ cls → satisfies-constraints cls w') (sym newcls-eq) sat-new'
+      lifted-prior = satisfies-constraints-pis-extends {suffix = wv ∷ []}
+                       (SynthState.constraints st) prior-sat
+      -- mem unchanged so mem-inv straightforward.
+      mi' : mem-inv s' (circuit-instr hc (declare-pub-input v) st)
+      mi' = mi  -- nr-wires unchanged, mem unchanged
+      -- pis grows by 1; nr-declared-pi grows by 1.
+      -- length (pis ++ wv ∷ []) = suc (length pis)
+      -- = suc (preamble-pi-count hc + nr-declared-pi st)
+      -- = preamble-pi-count hc + suc (nr-declared-pi st)
+      pi' : length (pis-s ++ (wv ∷ [])) ≡ preamble-pi-count hc + suc (SynthState.nr-declared-pi st)
+      pi' = trans (length-++-1 pis-s wv)
+                  (trans (cong suc pi) (sym (+-suc (preamble-pi-count hc) (SynthState.nr-declared-pi st))))
+  in mi' , pi' ,
+     satisfies-constraints-++ (SynthState.constraints st) _ lifted-prior sat-new
+
+-- Sub-lemma 2: iteration of the per-step lemma along an `R-instrs` trace.
+-- Yields satisfaction of *all* constraints accumulated by `circuit-instrs`
+-- against the final state's assignment.  Straightforward induction on
+-- the `R-instrs` derivation tree, calling `R-instr→satisfies-step` at
+-- each `r-step`.
+R-instrs→satisfies-constraints
+  : ∀ {hc} (pre : ProofPreimage) (s₀ s : Preprocessed)
+    (is : List Instruction) (st₀ : SynthState)
+  → mem-inv s₀ st₀
+  → pi-inv  hc s₀ st₀
+  → satisfies-constraints (SynthState.constraints st₀)
+      (mk-witness (Preprocessed.memory s₀)
+                  (Preprocessed.pis    s₀)
+                  (comm-rand-of pre))
+  → R-instrs pre s₀ is s
+  →   mem-inv s (circuit-instrs hc is st₀)
+    × pi-inv  hc s (circuit-instrs hc is st₀)
+    × satisfies-constraints
+        (SynthState.constraints (circuit-instrs hc is st₀))
+        (mk-witness (Preprocessed.memory s)
+                    (Preprocessed.pis    s)
+                    (comm-rand-of pre))
+R-instrs→satisfies-constraints pre s₀ .s₀ [] st₀ mi pi sat r-done =
+  mi , pi , sat
+R-instrs→satisfies-constraints {hc} pre s₀ s (i ∷ is) st₀ mi pi sat (r-step {s₁ = s₁} r-head r-tail) =
+  let mi₁ , pi₁ , sat₁ = R-instr→satisfies-step {hc = hc} pre s₀ s₁ i st₀ mi pi sat r-head
+  in R-instrs→satisfies-constraints {hc = hc} pre s₁ s is
+       (circuit-instr hc i st₀) mi₁ pi₁ sat₁ r-tail
+
+------------------------------------------------------------------------
+-- Top-level comm-commitment alignment.
+--
+-- If `do-communications-commitment src ≡ true`, then `R src pre s`
+-- carries `T (comm-ok src pre s)`, i.e. the *operational*
+-- commitment satisfies
+--
+--   pre.comm-commitment = just (c , r)
+--   c ≡ transient-commit (pre.inputs ++ s.outputs) r
+--
+-- and `init-state` puts `c` at index 1 of `pis`.  The circuit's
+-- `comm cm-inputs out-wires` requires
+--
+--   pis[1] ≡ transient-commit (ivs ++ ovs) rv
+--
+-- where `ivs = lookup mem [0..num-inputs)` and
+-- `ovs = lookup mem out-wires`.  The match rests on three facts:
+--
+--   • `out-wires` (the indices recorded by `circuit-instr (output v)`)
+--     evaluate via `mem-lookups` to exactly `Preprocessed.outputs s`;
+--
+--   • the wires `[0 .. num-inputs)` evaluate to `pre.inputs`
+--     (consequence of `init-state-memory` + structure of `mem`);
+--
+--   • `transient-commit` and the in-circuit Poseidon are definitionally
+--     the same canonical function (spec §5.3 trust boundary; already
+--     baked in by `holds` using `transient-commit` directly).
+--
+-- The first two are the auxiliary lemmas below; the third holds
+-- definitionally.
+------------------------------------------------------------------------
+
+-- Memory monotonicity for `mem-lookups` along R-instrs.  Discharged by
+-- induction; each step's memory is a suffix extension of the prior.
+mem-lookups-mono-R-instrs
+  : ∀ (pre : ProofPreimage) (s s' : Preprocessed)
+    (is : List Instruction) (xs : List Index) (vs : List Fr)
+  → R-instrs pre s is s'
+  → mem-lookups (Preprocessed.memory s)  xs ≡ just vs
+  → mem-lookups (Preprocessed.memory s') xs ≡ just vs
+mem-lookups-mono-R-instrs pre s .s [] xs vs r-done lookup-eq = lookup-eq
+mem-lookups-mono-R-instrs pre s s' (i ∷ is) xs vs (r-step {s₁ = s₁} r-head r-tail) lookup-eq =
+  let suf , eq = mem-extends-R-instr r-head   -- eq : mem s₁ ≡ mem s ++ suf
+      lookup-s₁ : mem-lookups (Preprocessed.memory s₁) xs ≡ just vs
+      lookup-s₁ = subst (λ m → mem-lookups m xs ≡ just vs)
+                         (sym eq)
+                         (mem-lookups-extends (Preprocessed.memory s) suf xs lookup-eq)
+  in mem-lookups-mono-R-instrs pre s₁ s' is xs vs r-tail lookup-s₁
+
+-- pi-lookup monotonicity along R-instrs.  Each step's `pis` is either
+-- unchanged or extended (only `r-declare-pub-input` extends it).
+pi-lookup-mono-R-instrs
+  : ∀ (pre : ProofPreimage) (s s' : Preprocessed)
+    (is : List Instruction) (idx : ℕ) (v : Fr)
+  → R-instrs pre s is s'
+  → pi-lookup (Preprocessed.pis s)  idx ≡ just v
+  → pi-lookup (Preprocessed.pis s') idx ≡ just v
+pi-lookup-mono-R-instrs pre s .s [] idx v r-done lk = lk
+pi-lookup-mono-R-instrs pre s s' (i ∷ is) idx v
+  (r-step {s₁ = s₁} r-head r-tail) lk =
+  let suf , eq = pis-extends-R-instr r-head   -- eq : pis s₁ ≡ pis s ++ suf
+      lk-s₁ : pi-lookup (Preprocessed.pis s₁) idx ≡ just v
+      lk-s₁ = subst (λ p → pi-lookup p idx ≡ just v)
+                     (sym eq)
+                     (lookup-extends (Preprocessed.pis s) suf idx lk)
+  in pi-lookup-mono-R-instrs pre s₁ s' is idx v r-tail lk-s₁
+
+------------------------------------------------------------------------
+-- Section C.2.  Helpers for the top-level forward proof.
+--
+-- These bridge the per-step iteration result (`R-instrs→satisfies-constraints`)
+-- with the top-level comm-commitment constraint and the initial invariants.
+------------------------------------------------------------------------
+
+private
+
+  -- mem-lookups distributes over snoc on the index list.
+  mem-lookups-snoc : ∀ (mem : List Fr) (is : List Index) (i : Index) {vs v}
+    → mem-lookups mem is ≡ just vs
+    → mem-lookup mem i ≡ just v
+    → mem-lookups mem (is ∷ʳ i) ≡ just (vs ∷ʳ v)
+  mem-lookups-snoc mem [] i {vs} {v} lk lkv
+    rewrite just-injective (sym lk) | lkv = refl
+  mem-lookups-snoc mem (j ∷ js) i {vs} {v} lk lkv =
+    aux (mem-lookup mem j)    refl
+        (mem-lookups mem js)  refl
+        lk
+    where
+      aux : ∀ (m : Maybe Fr) → mem-lookup mem j ≡ m
+          → (ms : Maybe (List Fr)) → mem-lookups mem js ≡ ms
+          → (m >>= λ v' → ms >>= λ vs' → just (v' ∷ vs')) ≡ just vs
+          → mem-lookups mem ((j ∷ js) ∷ʳ i) ≡ just (vs ∷ʳ v)
+      aux nothing   _    _          _    ()
+      aux (just _)  _    nothing    _    ()
+      aux (just w)  m-eq (just ws)  ms-eq refl
+        rewrite m-eq | ms-eq
+              | mem-lookups-snoc mem js i {ws} {v} ms-eq lkv
+        = refl
+
+  -- length-respecting decomposition of a non-empty list into snoc form.
+  -- Used to enable snoc-induction over `nat-range`.
+  snoc-of-length : ∀ (xs : List Fr) (n : ℕ)
+    → length xs ≡ suc n
+    → Σ (List Fr) (λ xs' → Σ Fr (λ x →
+        (length xs' ≡ n) × (xs ≡ xs' ∷ʳ x)))
+  snoc-of-length []           n  ()
+  snoc-of-length (x ∷ [])     zero    refl =
+    [] , x , refl , refl
+  snoc-of-length (x ∷ [])     (suc _) ()
+  snoc-of-length (x ∷ y ∷ ys) zero    ()
+  snoc-of-length (x ∷ y ∷ ys) (suc n) p =
+    let xs' , z , q , eq = snoc-of-length (y ∷ ys) n (Data.Nat.Properties.suc-injective p)
+                           -- eq : y ∷ ys ≡ xs' ∷ʳ z
+    in x ∷ xs' , z , cong suc q , cong (x ∷_) eq
+
+  -- mem-lookup at exactly `length xs` in `xs ∷ʳ y` is `just y`.
+  -- Used inductively to feed `mem-lookups-snoc`.
+  mem-lookup-snoc-at-len : ∀ (xs : List Fr) (y : Fr)
+    → mem-lookup (xs ∷ʳ y) (length xs) ≡ just y
+  mem-lookup-snoc-at-len []       y = refl
+  mem-lookup-snoc-at-len (x ∷ xs) y = mem-lookup-snoc-at-len xs y
+
+  -- The wires `[0 .. length xs)` of `xs` look up to exactly `xs`.
+  -- Proved by induction on `length xs`, decomposed via `snoc-of-length`.
+  mem-lookups-nat-range-len : ∀ (n : ℕ) (xs : List Fr)
+    → length xs ≡ n
+    → mem-lookups xs (nat-range n) ≡ just xs
+  mem-lookups-nat-range-len zero []       refl = refl
+  mem-lookups-nat-range-len zero (_ ∷ _)  ()
+  mem-lookups-nat-range-len (suc n) xs    p
+    with snoc-of-length xs n p
+  ... | xs' , y , len' , refl
+    -- Goal: mem-lookups (xs' ∷ʳ y) (nat-range n ∷ʳ n) ≡ just (xs' ∷ʳ y)
+    -- Use mem-lookups-nat-range-len n xs' len' (terminating: n < suc n).
+    = mem-lookups-snoc (xs' ∷ʳ y) (nat-range n) n
+        {vs = xs'} {v = y}
+        (mem-lookups-extends xs' (y ∷ []) (nat-range n)
+           {vs = xs'}
+           (mem-lookups-nat-range-len n xs' len'))
+        (subst (λ k → mem-lookup (xs' ∷ʳ y) k ≡ just y) len'
+               (mem-lookup-snoc-at-len xs' y))
+
+  -- Specialised: when `length xs ≡ n`, the wires `[0 .. n)` look up to `xs`.
+  mem-lookups-nat-range : ∀ (xs : List Fr)
+    → mem-lookups xs (nat-range (length xs)) ≡ just xs
+  mem-lookups-nat-range xs = mem-lookups-nat-range-len (length xs) xs refl
+
+  -- Initial `pis` length: `1` (hc = false, `[binding-input]`) or `2`
+  -- (hc = true, `[binding-input, c]`).  Read off `InitInv.pis-shape`.
+  init-state-pis-length : ∀ src pre s₀
+    → init-state src pre ≡ just s₀
+    → length (Preprocessed.pis s₀)
+       ≡ preamble-pi-count (IrSource.do-communications-commitment src)
+  init-state-pis-length src pre s₀ eq
+    with InitInv.pis-shape (init-state-inv src pre eq)
+  ... | inj₁ (hc≡ , pis≡) =
+        trans (cong length pis≡) (sym (cong preamble-pi-count hc≡))
+  ... | inj₂ (_ , _ , hc≡ , _ , pis≡) =
+        trans (cong length pis≡) (sym (cong preamble-pi-count hc≡))
+
+  -- For each R-instr step, the outputs grow by 0 (for non-output instructions)
+  -- or by 1 (for output instructions).  We need a uniform lift of the
+  -- IH from `s` to `s₁` when output-wires (and outputs) don't change.
+
+  -- Specialised step lemma for the "non-output" cases.  The caller
+  -- discharges `out-eq` (definitional for all but r-output) and uses the
+  -- fact that, for non-output instructions, `circuit-instr` doesn't
+  -- modify `output-wires` (so `output-wires (circuit-instr ...) ≡
+  -- output-wires st` reduces definitionally to `refl`).
+  --
+  -- Both `i` and `st` are explicit so reduction of `circuit-instr` at the
+  -- call site triggers normalisation of `output-wires (circuit-instr …)`.
+  output-wires-non-output-step
+    : ∀ {pre s s₁} (i : Instruction) (st : SynthState)
+    → R-instr pre s i s₁
+    → Preprocessed.outputs s₁ ≡ Preprocessed.outputs s
+    → mem-lookups (Preprocessed.memory s) (SynthState.output-wires st)
+        ≡ just (Preprocessed.outputs s)
+    → mem-lookups (Preprocessed.memory s₁) (SynthState.output-wires st)
+      ≡ just (Preprocessed.outputs s₁)
+  output-wires-non-output-step {pre} {s} {s₁} i st r-head out-eq H =
+    let suf , mem-eq = mem-extends-R-instr r-head
+                       -- mem-eq : memory s₁ ≡ memory s ++ suf
+    in subst (λ m → mem-lookups m (SynthState.output-wires st)
+                      ≡ just (Preprocessed.outputs s₁))
+              (sym mem-eq)
+              (subst (λ ov → mem-lookups (Preprocessed.memory s ++ suf)
+                               (SynthState.output-wires st)
+                               ≡ just ov)
+                      (sym out-eq)
+                      (mem-lookups-extends (Preprocessed.memory s) suf
+                         (SynthState.output-wires st) H))
+
+-- The generalized version of `output-wires-coincide`, allowing arbitrary
+-- starting `output-wires st₀`.
+output-wires-coincide-gen
+  : ∀ {hc} (pre : ProofPreimage) (s₀ s : Preprocessed)
+    (is : List Instruction) (st₀ : SynthState)
+  → R-instrs pre s₀ is s
+  → mem-lookups (Preprocessed.memory s₀) (SynthState.output-wires st₀)
+      ≡ just (Preprocessed.outputs s₀)
+  → mem-lookups (Preprocessed.memory s)
+      (SynthState.output-wires (circuit-instrs hc is st₀))
+    ≡ just (Preprocessed.outputs s)
+output-wires-coincide-gen pre s₀ .s₀ [] st₀ r-done H = H
+output-wires-coincide-gen {hc} pre s₀ s (i ∷ is) st₀
+  (r-step {s₁ = s₁} r-head r-tail) H =
+  output-wires-coincide-gen {hc} pre s₁ s is (circuit-instr hc i st₀) r-tail
+    (step-IH i r-head)
+  where
+    -- For each non-output instruction, `circuit-instr hc i st₀`'s
+    -- `output-wires` field reduces to `SynthState.output-wires st₀`
+    -- definitionally; the helper's result is the IH at `s₁`.
+    step-IH : ∀ (i : Instruction) {s₁} → R-instr pre s₀ i s₁
+      → mem-lookups (Preprocessed.memory s₁)
+          (SynthState.output-wires (circuit-instr hc i st₀))
+        ≡ just (Preprocessed.outputs s₁)
+    step-IH (assert cond)            r@(r-assert _)          =
+      output-wires-non-output-step (assert cond) st₀ r refl H
+    step-IH (cond-select b a c)      r@(r-cond-select _ _ _) =
+      output-wires-non-output-step (cond-select b a c) st₀ r refl H
+    step-IH (constrain-bits v n)     r@(r-constrain-bits _ _ _) =
+      output-wires-non-output-step (constrain-bits v n) st₀ r refl H
+    step-IH (constrain-eq a b)       r@(r-constrain-eq _ _ _) =
+      output-wires-non-output-step (constrain-eq a b) st₀ r refl H
+    step-IH (constrain-to-boolean v) r@(r-constrain-to-boolean _) =
+      output-wires-non-output-step (constrain-to-boolean v) st₀ r refl H
+    step-IH (copy v)                 r@(r-copy _)            =
+      output-wires-non-output-step (copy v) st₀ r refl H
+    step-IH (declare-pub-input v)    r@(r-declare-pub-input _) =
+      output-wires-non-output-step (declare-pub-input v) st₀ r refl H
+    step-IH (pi-skip g n)            r@(r-pi-skip-active _ _) =
+      output-wires-non-output-step (pi-skip g n) st₀ r refl H
+    step-IH (pi-skip g n)            r@(r-pi-skip-inactive _) =
+      output-wires-non-output-step (pi-skip g n) st₀ r refl H
+    step-IH (ec-add a-x a-y b-x b-y) r@(r-ec-add _ _ _ _ _)  =
+      output-wires-non-output-step (ec-add a-x a-y b-x b-y) st₀ r refl H
+    step-IH (ec-mul a-x a-y sc)      r@(r-ec-mul _ _ _ _)    =
+      output-wires-non-output-step (ec-mul a-x a-y sc) st₀ r refl H
+    step-IH (ec-mul-generator sc)    r@(r-ec-mul-generator _ _) =
+      output-wires-non-output-step (ec-mul-generator sc) st₀ r refl H
+    step-IH (hash-to-curve inputs)   r@(r-hash-to-curve _ _) =
+      output-wires-non-output-step (hash-to-curve inputs) st₀ r refl H
+    step-IH (load-imm imm)           r@r-load-imm            =
+      output-wires-non-output-step (load-imm imm) st₀ r refl H
+    step-IH (div-mod-power-of-two v bits) r@(r-div-mod-power-of-two _ _) =
+      output-wires-non-output-step (div-mod-power-of-two v bits) st₀ r refl H
+    step-IH (reconstitute-field d m bits) r@(r-reconstitute-field _ _ _ _ _) =
+      output-wires-non-output-step (reconstitute-field d m bits) st₀ r refl H
+    -- output v: the synth state pushes `v` to output-wires, the operational
+    -- state pushes its value to outputs.  Combine via mem-lookups-snoc.
+    step-IH (output var) (r-output {v = v} la) =
+      -- circuit-instr _ (output var) st₀ = record st₀ { output-wires = ow ∷ʳ var }
+      -- s₁ = push-output s₀ v, memory unchanged, outputs s₁ = outputs s₀ ∷ʳ v.
+      mem-lookups-snoc (Preprocessed.memory s₀)
+                        (SynthState.output-wires st₀) var
+                        {vs = Preprocessed.outputs s₀} {v = v}
+                        H la
+    step-IH (transient-hash inputs)  r@(r-transient-hash _)  =
+      output-wires-non-output-step (transient-hash inputs) st₀ r refl H
+    step-IH (persistent-hash al inputs) r@(r-persistent-hash _ _) =
+      output-wires-non-output-step (persistent-hash al inputs) st₀ r refl H
+    step-IH (test-eq a b)            r@(r-test-eq _ _)       =
+      output-wires-non-output-step (test-eq a b) st₀ r refl H
+    step-IH (add a b)                r@(r-add _ _)           =
+      output-wires-non-output-step (add a b) st₀ r refl H
+    step-IH (mul a b)                r@(r-mul _ _)           =
+      output-wires-non-output-step (mul a b) st₀ r refl H
+    step-IH (neg a)                  r@(r-neg _)             =
+      output-wires-non-output-step (neg a) st₀ r refl H
+    step-IH (not a)                  r@(r-not _)             =
+      output-wires-non-output-step (not a) st₀ r refl H
+    step-IH (less-than a b bits)     r@(r-less-than _ _ _ _)   =
+      output-wires-non-output-step (less-than a b bits) st₀ r refl H
+    step-IH (public-input nothing)   r@(r-public-input-inactive _) =
+      output-wires-non-output-step (public-input nothing) st₀ r refl H
+    step-IH (public-input nothing)   r@(r-public-input-active _ cp) =
+      output-wires-non-output-step (public-input nothing) st₀ r
+        (consume-pub-out-outputs s₀ cp) H
+    step-IH (public-input (just g))  r@(r-public-input-inactive _) =
+      output-wires-non-output-step (public-input (just g)) st₀ r refl H
+    step-IH (public-input (just g))  r@(r-public-input-active _ cp) =
+      output-wires-non-output-step (public-input (just g)) st₀ r
+        (consume-pub-out-outputs s₀ cp) H
+    step-IH (private-input nothing)  r@(r-private-input-inactive _) =
+      output-wires-non-output-step (private-input nothing) st₀ r refl H
+    step-IH (private-input nothing)  r@(r-private-input-active _ cp) =
+      output-wires-non-output-step (private-input nothing) st₀ r
+        (consume-priv-outputs s₀ cp) H
+    step-IH (private-input (just g)) r@(r-private-input-inactive _) =
+      output-wires-non-output-step (private-input (just g)) st₀ r refl H
+    step-IH (private-input (just g)) r@(r-private-input-active _ cp) =
+      output-wires-non-output-step (private-input (just g)) st₀ r
+        (consume-priv-outputs s₀ cp) H
+
+-- Top-level specialisation: when synth state starts with no recorded
+-- output wires, the looked-up output wires match the operational outputs.
+output-wires-coincide
+  : ∀ {hc} (pre : ProofPreimage) (s₀ s : Preprocessed)
+    (is : List Instruction) (st₀ : SynthState)
+  → R-instrs pre s₀ is s
+  → SynthState.output-wires st₀ ≡ []
+  → Preprocessed.outputs s₀ ≡ []
+  → mem-lookups (Preprocessed.memory s)
+      (SynthState.output-wires (circuit-instrs hc is st₀))
+    ≡ just (Preprocessed.outputs s)
+output-wires-coincide {hc} pre s₀ s is st₀ Rs ow-empty out-empty =
+  output-wires-coincide-gen {hc} pre s₀ s is st₀ Rs
+    (subst (λ ows → mem-lookups (Preprocessed.memory s₀) ows
+                      ≡ just (Preprocessed.outputs s₀))
+            (sym ow-empty)
+            (subst (λ os → mem-lookups (Preprocessed.memory s₀) [] ≡ just os)
+                    (sym out-empty)
+                    refl))
+
+-- The wires `[0 .. n)` of the initial memory look up to exactly
+-- `inputs pre`.  Uses `mem-lookups-nat-range` + `init-state-memory`
+-- + the WF1 length enforcement extracted by `init-state-num-inputs`.
+inputs-lookup-init
+  : ∀ (src : IrSource) (pre : ProofPreimage) (s₀ : Preprocessed)
+  → init-state src pre ≡ just s₀
+  → mem-lookups (Preprocessed.memory s₀) (nat-range (IrSource.num-inputs src))
+    ≡ just (ProofPreimage.inputs pre)
+inputs-lookup-init src pre s₀ eq =
+  let mem≡       = init-state-memory src pre s₀ eq
+      len-eq     = init-state-num-inputs src pre s₀ eq  -- length inputs ≡ num-inputs
+      -- Step 1: mem-lookups (inputs pre) (nat-range (length (inputs pre))) ≡ just (inputs pre)
+      lk : mem-lookups (ProofPreimage.inputs pre)
+                       (nat-range (length (ProofPreimage.inputs pre)))
+           ≡ just (ProofPreimage.inputs pre)
+      lk = mem-lookups-nat-range (ProofPreimage.inputs pre)
+      -- Step 2: rewrite (length inputs) to (num-inputs src) via len-eq.
+      lk' : mem-lookups (ProofPreimage.inputs pre)
+                        (nat-range (IrSource.num-inputs src))
+            ≡ just (ProofPreimage.inputs pre)
+      lk' = subst (λ n → mem-lookups (ProofPreimage.inputs pre) (nat-range n)
+                          ≡ just (ProofPreimage.inputs pre))
+                   len-eq lk
+      -- Step 3: rewrite (inputs pre) to (memory s₀) via mem≡.
+  in subst (λ m → mem-lookups m (nat-range (IrSource.num-inputs src))
+                    ≡ just (ProofPreimage.inputs pre))
+            (sym mem≡) lk'
+
+------------------------------------------------------------------------
+-- Top-level forward.
+--
+-- The proof decomposes
+-- `R src pre s` into its `init-eq`, body trace `Rs`, transcript-
+-- consumption, and comm-ok components, runs `R-instrs→satisfies-constraints`
+-- to discharge the bulk of the constraints, and glues in the top-level
+-- `comm` (when `has-comm = true`).
+------------------------------------------------------------------------
+
+-- Helper: from `init-state src pre ≡ just s₀` with `hc = true` and
+-- `comm-commitment pre ≡ just (c, r)`, the initial pis has `c` at index 1.
+private
+  init-state-pi-1 : ∀ src pre s₀ c r
+    → IrSource.do-communications-commitment src ≡ true
+    → ProofPreimage.comm-commitment pre ≡ just (c , r)
+    → init-state src pre ≡ just s₀
+    → pi-lookup (Preprocessed.pis s₀) 1 ≡ just c
+  init-state-pi-1 src pre s₀ c r hc-true cc-just eq
+    with InitInv.pis-shape (init-state-inv src pre eq)
+  ... | inj₂ (_ , _ , _ , cc≡ , pis≡) =
+        trans (cong (λ p → pi-lookup p 1) pis≡)
+              (cong just
+                (cong proj₁ (just-injective (trans (sym cc≡) cc-just))))
+  ... | inj₁ (hc≡ , _) with trans (sym hc≡) hc-true
+  ...   | ()
+
+-- Forward direction, hc=false branch.
+private
+  circuit-faithful-fwd-false
+    : ∀ (src : IrSource) (pre : ProofPreimage) (s s₀ : Preprocessed)
+    → IrSource.do-communications-commitment src ≡ false
+    → init-state src pre ≡ just s₀
+    → R-instrs pre s₀ (IrSource.instructions src) s
+    → satisfies (circuit src) (witness-of s pre)
+  circuit-faithful-fwd-false src pre s s₀ hc-false init-eq Rs =
+    mk-sat pi-length-eq mem-length-eq rand-shape-eq constraints-ok
+    where
+      n  = IrSource.num-inputs src
+      st₀ : SynthState
+      st₀ = mk-synth n [] 0 []
+      instrs = IrSource.instructions src
+      mem≡    = init-state-memory src pre s₀ init-eq
+      len-eq  = init-state-num-inputs src pre s₀ init-eq
+      mi₀ : SynthState.nr-wires st₀ ≡ length (Preprocessed.memory s₀)
+      mi₀ = sym (trans (cong length mem≡) len-eq)
+      -- pi₀: length (pis s₀) ≡ preamble + nr-declared-pi st₀.
+      -- preamble false = 1, nr-declared-pi st₀ = 0.
+      pi₀-pre : length (Preprocessed.pis s₀)
+                  ≡ preamble-pi-count (IrSource.do-communications-commitment src)
+      pi₀-pre = init-state-pis-length src pre s₀ init-eq
+      pi₀ : length (Preprocessed.pis s₀)
+              ≡ preamble-pi-count false + SynthState.nr-declared-pi st₀
+      pi₀ = subst (λ b → length (Preprocessed.pis s₀) ≡ preamble-pi-count b + 0)
+                   hc-false
+                   (trans pi₀-pre
+                          (sym (+-identityʳ (preamble-pi-count
+                                  (IrSource.do-communications-commitment src)))))
+      result = R-instrs→satisfies-constraints {hc = false} pre s₀ s instrs st₀
+                 mi₀ pi₀ []ᴬ Rs
+      pi-end  = proj₁ (proj₂ result)
+      sat-end = proj₂ (proj₂ result)
+      -- Now we need to transport pi-end and sat-end through the
+      -- (currently-abstract) hc.  The `Circuit.pi-len (circuit src)` and
+      -- `Circuit.constraints (circuit src)` both depend on hc; using `hc-false`
+      -- we substitute.
+      circuit-eq : circuit src ≡
+        mk-circuit
+          (SynthState.nr-wires (circuit-instrs false instrs st₀))
+          (SynthState.constraints (circuit-instrs false instrs st₀))
+          (1 + SynthState.nr-declared-pi (circuit-instrs false instrs st₀))
+          false
+      circuit-eq = circuit-instantiate-false hc-false
+        where
+          -- Substitute `hc = false` into `circuit src`'s definition.
+          -- The `if false then ... else cls` reduces to `cls`,
+          -- `preamble-pi-count false = 1`, so we get the matching record.
+          circuit-instantiate-false :
+            IrSource.do-communications-commitment src ≡ false
+            → circuit src ≡
+              mk-circuit
+                (SynthState.nr-wires (circuit-instrs false instrs st₀))
+                (SynthState.constraints (circuit-instrs false instrs st₀))
+                (1 + SynthState.nr-declared-pi (circuit-instrs false instrs st₀))
+                false
+          circuit-instantiate-false refl = refl
+      mem-length-eq : length (Preprocessed.memory s)
+                        ≡ Circuit.nr-wires (circuit src)
+      mem-length-eq = trans (sym (proj₁ result))
+                            (sym (cong Circuit.nr-wires circuit-eq))
+      pi-length-eq : length (Preprocessed.pis s) ≡ Circuit.pi-len (circuit src)
+      pi-length-eq = trans pi-end (cong Circuit.pi-len (sym circuit-eq))
+      rand-shape-eq : Maybe-shape (Circuit.has-comm (circuit src))
+                                   (Witness.comm-rand (witness-of s pre))
+      rand-shape-eq =
+        subst (λ c → Maybe-shape (Circuit.has-comm c) (comm-rand-of pre))
+              (sym circuit-eq) tt
+      constraints-ok : satisfies-constraints (Circuit.constraints (circuit src))
+                                       (witness-of s pre)
+      constraints-ok = subst (λ c → satisfies-constraints (Circuit.constraints c)
+                                                    (witness-of s pre))
+                         (sym circuit-eq) sat-end
+
+-- Forward direction, hc=true branch with comm-commitment = just (c, r).
+private
+  circuit-faithful-fwd-true
+    : ∀ (src : IrSource) (pre : ProofPreimage) (s s₀ : Preprocessed) c r
+    → IrSource.do-communications-commitment src ≡ true
+    → ProofPreimage.comm-commitment pre ≡ just (c , r)
+    → init-state src pre ≡ just s₀
+    → R-instrs pre s₀ (IrSource.instructions src) s
+    → T (c ≡ᶠ? transient-commit (ProofPreimage.inputs pre ++ Preprocessed.outputs s) r)
+    → satisfies (circuit src) (witness-of s pre)
+  circuit-faithful-fwd-true src pre s s₀ c r hc-true cc-just init-eq Rs co-eq =
+    mk-sat pi-length-eq mem-length-eq rand-shape-eq constraints-ok
+    where
+      n  = IrSource.num-inputs src
+      st₀ : SynthState
+      st₀ = mk-synth n [] 0 []
+      instrs = IrSource.instructions src
+      mem≡    = init-state-memory src pre s₀ init-eq
+      len-eq  = init-state-num-inputs src pre s₀ init-eq
+      mi₀ : SynthState.nr-wires st₀ ≡ length (Preprocessed.memory s₀)
+      mi₀ = sym (trans (cong length mem≡) len-eq)
+      pi₀-pre : length (Preprocessed.pis s₀)
+                  ≡ preamble-pi-count (IrSource.do-communications-commitment src)
+      pi₀-pre = init-state-pis-length src pre s₀ init-eq
+      pi₀ : length (Preprocessed.pis s₀)
+              ≡ preamble-pi-count true + SynthState.nr-declared-pi st₀
+      pi₀ = subst (λ b → length (Preprocessed.pis s₀) ≡ preamble-pi-count b + 0)
+                   hc-true
+                   (trans pi₀-pre
+                          (sym (+-identityʳ (preamble-pi-count
+                                  (IrSource.do-communications-commitment src)))))
+      result = R-instrs→satisfies-constraints {hc = true} pre s₀ s instrs st₀
+                 mi₀ pi₀ []ᴬ Rs
+      pi-end  = proj₁ (proj₂ result)
+      sat-end = proj₂ (proj₂ result)
+      st-end  = circuit-instrs true instrs st₀
+      cm-inputs = nat-range n
+      out-wires = SynthState.output-wires st-end
+      -- The comm-constraint witness:
+      ivs-lookup : mem-lookups (Preprocessed.memory s) cm-inputs
+                    ≡ just (ProofPreimage.inputs pre)
+      ivs-lookup = mem-lookups-mono-R-instrs pre s₀ s instrs cm-inputs
+                     (ProofPreimage.inputs pre) Rs
+                     (inputs-lookup-init src pre s₀ init-eq)
+      ovs-lookup : mem-lookups (Preprocessed.memory s) out-wires
+                    ≡ just (Preprocessed.outputs s)
+      ovs-lookup = output-wires-coincide {hc = true} pre s₀ s instrs st₀ Rs
+                     refl
+                     (init-state-outputs src pre s₀ init-eq)
+      pi-1-init : pi-lookup (Preprocessed.pis s₀) 1 ≡ just c
+      pi-1-init = init-state-pi-1 src pre s₀ c r hc-true cc-just init-eq
+      pi-1-final : pi-lookup (Preprocessed.pis s) 1 ≡ just c
+      pi-1-final = pi-lookup-mono-R-instrs pre s₀ s instrs 1 c Rs pi-1-init
+      c≡tc : c ≡ transient-commit (ProofPreimage.inputs pre ++ Preprocessed.outputs s) r
+      c≡tc = ≡ᶠ?-true co-eq
+      w = witness-of s pre
+      rand≡ : Witness.comm-rand w ≡ just r
+      rand≡ = cong (Data.Maybe.map (λ (_ , r) → r)) cc-just
+      holds-comm : holds w (comm cm-inputs out-wires)
+      holds-comm =
+        ProofPreimage.inputs pre
+        , Preprocessed.outputs s
+        , r
+        , c
+        , ivs-lookup
+        , ovs-lookup
+        , rand≡
+        , pi-1-final
+        , c≡tc
+      body-constraints = SynthState.constraints st-end
+      -- circuit src reduces, under hc-true, to its hc=true shape.
+      circuit-eq : circuit src ≡
+        mk-circuit
+          (SynthState.nr-wires st-end)
+          (body-constraints ∷ʳ comm cm-inputs out-wires)
+          (2 + SynthState.nr-declared-pi st-end)
+          true
+      circuit-eq = circuit-instantiate-true hc-true
+        where
+          circuit-instantiate-true :
+            IrSource.do-communications-commitment src ≡ true
+            → circuit src ≡
+              mk-circuit
+                (SynthState.nr-wires st-end)
+                (body-constraints ∷ʳ comm cm-inputs out-wires)
+                (2 + SynthState.nr-declared-pi st-end)
+                true
+          circuit-instantiate-true refl = refl
+      mem-length-eq : length (Preprocessed.memory s)
+                        ≡ Circuit.nr-wires (circuit src)
+      mem-length-eq = trans (sym (proj₁ result))
+                            (sym (cong Circuit.nr-wires circuit-eq))
+      pi-length-eq : length (Preprocessed.pis s) ≡ Circuit.pi-len (circuit src)
+      pi-length-eq = trans pi-end (cong Circuit.pi-len (sym circuit-eq))
+      rand-shape-eq : Maybe-shape (Circuit.has-comm (circuit src))
+                                   (Witness.comm-rand w)
+      rand-shape-eq =
+        subst (λ cc → Maybe-shape (Circuit.has-comm cc) (Witness.comm-rand w))
+              (sym circuit-eq)
+              (subst (λ rd → Maybe-shape true rd) (sym rand≡) tt)
+      constraints-ok-body++ : satisfies-constraints
+        (body-constraints ∷ʳ comm cm-inputs out-wires) w
+      constraints-ok-body++ = satisfies-constraints-++ body-constraints
+        (comm cm-inputs out-wires ∷ [])
+        sat-end
+        (holds-comm ∷ᴬ []ᴬ)
+      constraints-ok : satisfies-constraints (Circuit.constraints (circuit src)) w
+      constraints-ok = subst (λ c' → satisfies-constraints (Circuit.constraints c') w)
+                          (sym circuit-eq) constraints-ok-body++
+
+-- Reconstitute the comm-ok equality at the hc=true / just (c,r) branch.
+private
+  extract-comm-ok-eq : ∀ src pre s c r
+    → IrSource.do-communications-commitment src ≡ true
+    → ProofPreimage.comm-commitment pre ≡ just (c , r)
+    → T (comm-ok src pre s)
+    → T (c ≡ᶠ? transient-commit (ProofPreimage.inputs pre ++ Preprocessed.outputs s) r)
+  extract-comm-ok-eq src pre s c r hc-eq cc-eq co
+    with IrSource.do-communications-commitment src
+       | ProofPreimage.comm-commitment pre
+       | hc-eq | cc-eq
+  ... | true | just .(c , r) | _ | refl = co
+
+  -- comm-ok with hc=true and comm-commitment=nothing is impossible.
+  no-comm-contra : ∀ src pre s
+    → IrSource.do-communications-commitment src ≡ true
+    → ProofPreimage.comm-commitment pre ≡ nothing
+    → T (comm-ok src pre s)
+    → ⊥
+  no-comm-contra src pre s hc-eq cc-eq co
+    with IrSource.do-communications-commitment src
+       | ProofPreimage.comm-commitment pre
+       | hc-eq | cc-eq
+  ... | true | nothing | _ | _ = co
+
+  -- Discriminate on Bool (for use after extracting `do-comm src`).
+  bool-cases : (b : Bool) → (b ≡ true) ⊎ (b ≡ false)
+  bool-cases true  = inj₁ refl
+  bool-cases false = inj₂ refl
+
+  -- Discriminate on Maybe (Fr × Fr).
+  maybe-cases : (m : Maybe (Fr × Fr))
+    → (m ≡ nothing) ⊎ (Σ Fr λ c → Σ Fr λ r → m ≡ just (c , r))
+  maybe-cases nothing         = inj₁ refl
+  maybe-cases (just (c , r))  = inj₂ (c , r , refl)
+
+-- The top-level forward lemma.  Note there is no producer-safety
+-- hypothesis: the forward direction (completeness of the lowering)
+-- holds for ALL circuits, producer-safe or not (spec §6.2).
+circuit-faithful-fwd
+  : ∀ (src : IrSource) (pre : ProofPreimage) (s : Preprocessed)
+  → R src pre s
+  → satisfies (circuit src) (witness-of s pre)
+circuit-faithful-fwd src pre s (s₀ , init-eq , Rs , _tc , co)
+  with bool-cases (IrSource.do-communications-commitment src)
+... | inj₂ hc-false =
+  circuit-faithful-fwd-false src pre s s₀ hc-false init-eq Rs
+... | inj₁ hc-true with maybe-cases (ProofPreimage.comm-commitment pre)
+...   | inj₁ cc-none =
+        ⊥-elim (no-comm-contra src pre s hc-true cc-none co)
+...   | inj₂ (c , r , cc-just) =
+        circuit-faithful-fwd-true src pre s s₀ c r
+          hc-true cc-just init-eq Rs
+          (extract-comm-ok-eq src pre s c r hc-true cc-just co)
+
+------------------------------------------------------------------------
+-- Section C.5.  Wire-discipline soundness.
+--
+-- The backward dispatcher needs, for each per-instruction case, a bound
+-- `operand < length (memory s)` to pull pre-state lookups back from
+-- post-state lookups in the satisfies-constraints witness.  The producer
+-- obligation `wire-disc` (Obligations.agda) supplies this as a static
+-- linear scan: each instruction's operand indices are checked against
+-- the current wire count, which is `length (memory s)` on the
+-- operational side under `mem-inv`.
+--
+-- `wire-disc-sound` lifts `T (wire-disc src)` to a `Wire-Trace`
+-- predicate threaded along the instruction list; pairing this with
+-- `mem-inv` then gives per-step `WireOK instr (length mem)`,
+-- which `lookup-shrink` from CircuitFaithfulness then converts into the
+-- needed pre-state lookups.
+------------------------------------------------------------------------
+
+private
+
+  -- Reconstruct a Wire-Trace from the Bool scan.
+  wire-scan→trace : ∀ is n {final}
+    → wire-scan is n ≡ just final
+    → Wire-Trace is n final
+  wire-scan→trace []       n refl = wire-done
+  wire-scan→trace (i ∷ is) n eq
+    with wire-step i n in step-eq
+  ... | just n' = wire-cons step-eq (wire-scan→trace is n' eq)
+
+  -- Bool → Wire-Trace witness extractor (mirrors O2-bool→Runs).
+  wire-bool→trace : ∀ {src} → T (wire-disc src)
+    → ∃-syntax λ final →
+        Wire-Trace (IrSource.instructions src) (IrSource.num-inputs src) final
+  wire-bool→trace {src} eq
+    with wire-scan (IrSource.instructions src) (IrSource.num-inputs src)
+         in scan-eq
+  ... | just final =
+        final , wire-scan→trace (IrSource.instructions src)
+                                 (IrSource.num-inputs src) scan-eq
+
+  -- Soundness: `producer-safe` gives a Wire-Trace.
+  wire-disc-sound : ∀ {src} → T (producer-safe src)
+    → ∃-syntax λ final →
+        Wire-Trace (IrSource.instructions src) (IrSource.num-inputs src) final
+  wire-disc-sound {src} ps = wire-bool→trace {src} (producer-safe-wire-disc {src} ps)
+
+  -- Per-step extractor: a Wire-Trace covering `instr ∷ rest` gives both
+  -- the `WireOK instr n` premise and the residual trace at the bumped
+  -- counter.  Splitting `wireOK? instr n` reduces `wire-step instr n` and
+  -- refines the just-equation simultaneously; the `no` case is impossible
+  -- (`wire-step` would be `nothing`, contradicting the cons step).
+  wire-trace-head : ∀ {instr is n final}
+    → Wire-Trace (instr ∷ is) n final
+    → WireOK instr n
+        × Wire-Trace is (n + Δmem instr) final
+  wire-trace-head {instr} {is} {n} (wire-cons {n' = n'} step-eq tail)
+    with wireOK? instr n | step-eq
+  ... | yes ok | refl = ok , tail
+
+------------------------------------------------------------------------
+-- Section D.  Backward direction (statements only).
+--
+-- The backward direction needs the same
+-- invariants threaded the other way: from a satisfying assignment +
+-- `T (producer-safe src)`, recover an `R-instrs` derivation.
+--
+-- The four obligation-bearing backward proofs in
+-- `CircuitFaithfulness.agda` (`assert-bwd`, `not-bwd`,
+-- `reconstitute-field-bwd`, `less-than-bwd`) each take an
+-- obligation-evidence hypothesis explicitly.
+--
+-- The wire-discipline obligation is threaded in `Obligations.agda` and
+-- discharged by `wire-disc-sound` above; D1's signature takes
+-- `WireOK instr (nr-wires st)` as a per-step premise.  D1's body
+-- (`satisfies→R-instr-step` below) dispatches all 26 instruction cases
+-- directly to the corresponding `*-bwd` lemma in
+-- `CircuitFaithfulness.agda`.  The signature uses explicit suffix
+-- decomposition:
+--   • `mem-suf : List Fr`  — memory extension
+--   • `pis-suf : List Fr`  — pis extension (= [] for non-pi cases)
+-- and outputs Σ s' with `memory s' ≡ memory s ++ mem-suf` and
+-- `pis s' ≡ pis s ++ pis-suf`.
+------------------------------------------------------------------------
+
+-- Signature shape: the dispatcher *produces* the post-state `s'` rather
+-- than consuming it.  The witness in the input satisfies-constraints is
+-- over `(memory s ++ suf, pis')` — the suffix is the concrete memory
+-- extension committed to by the satisfying witness.
+--
+-- Output Σ packages:
+--   • `s'`              — the recovered post-state,
+--   • `mem-eq`          — `memory s' ≡ memory s ++ suf`,
+--   • `pis-eq`          — `pis s' ≡ pis'`,
+--   • `R-instr pre s i s'`  — the operational reconstruction.
+--
+-- `WireOK i (nr-wires st)` is the per-step consequence of
+-- the producer's `wire-disc` obligation (threaded by D2 via
+-- `wire-trace-head`).  Combined with `mem-inv : nr-wires st ≡ length
+-- (memory s)` this lets each case extract pre-state lookups from
+-- post-state ones via `lookup-shrink`.
+--
+-- The dispatcher discharges all 26 instruction cases directly, using
+-- the corresponding `*-bwd` lemma in CircuitFaithfulness.agda.  The
+-- obligation-bearing cases (assert, not, reconstitute-field, less-than)
+-- consume the O2/O3 evidence threaded through the signature; the
+-- side-data cases (output, pi-skip, public-input, private-input) read
+-- the transcript/skip data off the `op-side-data` payload `sd`.
+
+private
+
+  -- O2 obligation-check extraction.  For the obligation-bearing
+  -- instructions (`assert`, `not`, `cond-select`), the check is
+  -- `require-∈ c bk`; a `≡ just bk` premise forces the membership.
+  o2-check-mem? : ∀ (c : Index) (bk : IndexSet)
+    → require-∈ c bk ≡ just bk
+    → c ∈ bk
+  o2-check-mem? c bk eq with c ∈? bk
+  ... | yes p = p
+  ... | no  _ with eq
+  ...           | ()
+
+
+
+-- Per-instruction operational side data supplied to the backward
+-- dispatcher.  For most instructions this is `⊤` (no side data needed);
+-- for the four "side-data instructions" (`output`, `pi-skip`,
+-- `public-input`, `private-input`) it carries the per-step evidence
+-- that the in-circuit witness alone doesn't determine — namely a
+-- memory lookup (for `output`), a guard evaluation result (for
+-- `pi-skip`, `public-input`, `private-input`), a transcript-prefix
+-- match (for active `pi-skip`), and the consumed transcript entry
+-- (for active `public-input` / `private-input`).
+--
+-- Shape encoding by instruction:
+--   • Δmem=0, Δpis=0   →  (mem-suf ≡ []) × (pis-suf ≡ [])
+--   • Δmem=1, Δpis=0   →  Σ Fr (λ w → mem-suf ≡ w ∷ []) × (pis-suf ≡ [])
+--   • Δmem=2, Δpis=0   →  Σ Fr (λ x → Σ Fr (λ y → mem-suf ≡ x ∷ y ∷ [])) × (pis-suf ≡ [])
+--   • Δmem=0, Δpis=1 (declare-pub-input)
+--                      →  (mem-suf ≡ []) × Σ Fr (λ wv → pis-suf ≡ wv ∷ [])
+-- For the four "side-data instructions" the shape Σ wraps the
+-- operational payload (mem-lookup / eval-guard / consume-pub-out /
+-- consume-priv).
+-- `osd-of` gives the side-data Set for each bookkeeping shape; the pure
+-- shapes only pin the suffix lengths, the four side-channel shapes carry
+-- the channel payload.  `op-side-data` routes each instruction through
+-- its `shapeView`, so `op-side-data (add a b) …` reduces to the pure1
+-- shape exactly as a per-instruction table would.
+osd-of : ∀ {i} → ShapeView i → ProofPreimage → Preprocessed
+       → (mem-suf pis-suf : List Fr) → Set
+-- Δmem=0, Δpis=0 (no payload).
+osd-of sv-pure0 _ _ ms ps = (ms ≡ []) × (ps ≡ [])
+-- Δmem=1, Δpis=0 (push-mem).
+osd-of sv-pure1 _ _ ms ps = Σ Fr (λ w → ms ≡ w ∷ []) × (ps ≡ [])
+-- Δmem=2, Δpis=0 (push-mem2).  `div-mod-power-of-two` shares this free
+-- pushed pair; its constraint pins (q, r) to the unique non-wrapping
+-- decomposition (`Encoding.divmod-canon`), which the backward dispatcher
+-- recovers from the constraint satisfaction rather than from `sd`.
+osd-of sv-pure2 _ _ ms ps =
+  Σ Fr (λ x → Σ Fr (λ y → ms ≡ x ∷ y ∷ [])) × (ps ≡ [])
+-- Δmem=0, Δpis=1 (declare-pub-input).
+osd-of sv-declare _ _ ms ps =
+  (ms ≡ []) × Σ Fr (λ wv → ps ≡ wv ∷ [])
+-- output v: Δmem=0, Δpis=0; carries a mem-lookup proof producing `val`.
+osd-of (sv-output {v}) _ s ms ps =
+  Σ Fr (λ val → mem-lookup (Preprocessed.memory s) v ≡ just val)
+  × (ms ≡ []) × (ps ≡ [])
+-- pi-skip: Δmem=0, Δpis=0; payload = guard's truth value and
+-- (if active) the transcript prefix-match check.
+osd-of (sv-skip {g} {c}) pre s ms ps =
+  (ms ≡ []) × (ps ≡ [])
+  × Σ Bool (λ active →
+        eval-guard (Preprocessed.memory s) g ≡ just active
+      × (if active
+         then T (drop (length (Preprocessed.pis s) ∸ c) (Preprocessed.pis s)
+                  ≡ᶠ-list?
+                take c (drop (Preprocessed.pub-in-idx s ∸ c)
+                                  (ProofPreimage.pub-transcript-inputs pre)))
+         else ⊤))
+-- public-input g: Δmem=1, Δpis=0; the single memory cell `w` is bound
+-- by the outer Σ so the payload (consume-pub-out producing `w`) can
+-- reference it.
+osd-of (sv-pub-in {g}) pre s ms ps =
+  Σ Fr (λ w → (ms ≡ w ∷ []) × (ps ≡ [])
+    × Σ Bool (λ active →
+          eval-guard (Preprocessed.memory s) g ≡ just active
+        × (if active
+           then Σ Preprocessed (λ s₁ → consume-pub-out s ≡ just (w , s₁))
+           else (w ≡ 0ᶠ))))
+-- private-input g: symmetric to public-input.
+osd-of (sv-priv-in {g}) pre s ms ps =
+  Σ Fr (λ w → (ms ≡ w ∷ []) × (ps ≡ [])
+    × Σ Bool (λ active →
+          eval-guard (Preprocessed.memory s) g ≡ just active
+        × (if active
+           then Σ Preprocessed (λ s₁ → consume-priv s ≡ just (w , s₁))
+           else (w ≡ 0ᶠ))))
+
+op-side-data : Instruction → ProofPreimage → Preprocessed
+             → (mem-suf pis-suf : List Fr) → Set
+op-side-data i = osd-of (shapeView i)
+
+------------------------------------------------------------------------
+-- `next-state-from-osd`
+--
+-- Computes the canonical post-state produced by each D1 case directly
+-- from the inputs (`i`, `pre`, `s`, `mem-suf`, `pis-suf`, `sd`).  This
+-- is the post-state that the corresponding `satisfies→R-instr-step`
+-- branch returns (as the existential `s'`).  Because `op-side-data-list`
+-- threads this *computed* next state into the recursive call, D2's
+-- cons-case reconciles the mid-state with D1's output by definitional
+-- equality.
+--
+-- The function pattern-matches on the same shape as D1 (instruction +
+-- suffixes + side-data).  Ill-shaped inputs fall through to `s` (this
+-- branch is never reached in practice — D2 only invokes it on the
+-- shapes that `op-side-data-list` guarantees).
+------------------------------------------------------------------------
+-- `nso′` computes the post-state for each shape; `next-state-from-osd`
+-- routes each instruction through its `shapeView`.  Pattern-matching on
+-- the view exposes the shape's payload (the pushed cell(s), the declared
+-- input, the transcript split) directly.
+nso′ : ∀ {i} (v : ShapeView i) (pre : ProofPreimage) (s : Preprocessed)
+       (mem-suf pis-suf : List Fr)
+     → osd-of v pre s mem-suf pis-suf → Preprocessed
+-- Δmem=0, Δpis=0 (state unchanged).
+nso′ sv-pure0 _ s _ _ _ = s
+-- Δmem=1 (push-mem).  Extract `w` from sd.
+nso′ sv-pure1 _ s _ _ ((w , _) , _) = push-mem s w
+-- Δmem=2 (push-mem2).  Extract `x` and `y` from sd.
+nso′ sv-pure2 _ s _ _ ((x , y , _) , _) = push-mem2 s x y
+-- Δpis=1 (declare-pub-input).  Extract `wv` from sd.
+nso′ sv-declare _ s _ _ (_ , wv , _) =
+  record s
+    { pis        = Preprocessed.pis s ++ (wv ∷ [])
+    ; pub-in-idx = suc (Preprocessed.pub-in-idx s)
+    }
+-- output v: outputs += val.
+nso′ sv-output _ s _ _ ((val , _) , _ , _) =
+  record s { outputs = Preprocessed.outputs s ++ (val ∷ []) }
+-- pi-skip g count: splits on `active`.
+nso′ sv-skip _ s _ _ (_ , _ , (true  , _ , _)) =
+  record s { pi-skips = Preprocessed.pi-skips s ++ (nothing ∷ []) }
+nso′ (sv-skip {c = count}) _ s _ _ (_ , _ , (false , _ , _)) =
+  record s
+    { pi-skips   = Preprocessed.pi-skips s ++ (just count ∷ [])
+    ; pub-in-idx = Preprocessed.pub-in-idx s ∸ count
+    }
+-- public-input g: splits on `active`.
+nso′ sv-pub-in _ s _ _ (w , _ , _ , (true , _ , (s₁ , _))) =
+  record s₁ { memory = Preprocessed.memory s₁ ++ (w ∷ []) }
+nso′ sv-pub-in _ s _ _ (w , _ , _ , (false , _ , _)) =
+  record s { memory = Preprocessed.memory s ++ (w ∷ []) }
+-- private-input g: symmetric.
+nso′ sv-priv-in _ s _ _ (w , _ , _ , (true , _ , (s₁ , _))) =
+  record s₁ { memory = Preprocessed.memory s₁ ++ (w ∷ []) }
+nso′ sv-priv-in _ s _ _ (w , _ , _ , (false , _ , _)) =
+  record s { memory = Preprocessed.memory s ++ (w ∷ []) }
+
+next-state-from-osd
+  : (i : Instruction) (pre : ProofPreimage) (s : Preprocessed)
+    (mem-suf pis-suf : List Fr)
+  → op-side-data i pre s mem-suf pis-suf
+  → Preprocessed
+next-state-from-osd i = nso′ (shapeView i)
+
+-- Reshape the split-off new-constraint satisfaction (`sat-new`, from
+-- `satisfies-constraints-split`) into the exact shape every per-instruction
+-- `*-bwd` lemma expects.  Two orthogonal rewrites, shared verbatim by
+-- every push-mem / push-mem2 case of D1 below:
+--   • shift the constraint's wire index `n` to `length (memory s)`, via the
+--     memory invariant `mi : n ≡ length (memory s)`; and
+--   • drop the trailing `++ []` on the witness's pis (every non-pis
+--     instruction has `pis-suf = []`).
+-- `ms` is the memory suffix the instruction appends (`w ∷ []` for Δmem=1,
+-- `x ∷ y ∷ []` for Δmem=2).
+private
+  reshape-core
+    : ∀ {hc} {rand : Maybe Fr} (s : Preprocessed) (instr : Instruction)
+        (ms : List Fr) {n : ℕ}
+    → n ≡ length (Preprocessed.memory s)
+    → satisfies-constraints (single-instr-constraints hc n instr)
+        (mk-witness (Preprocessed.memory s ++ ms)
+                    (Preprocessed.pis s ++ []) rand)
+    → satisfies-constraints
+        (single-instr-constraints hc (length (Preprocessed.memory s)) instr)
+        (mk-witness (Preprocessed.memory s ++ ms)
+                    (Preprocessed.pis s) rand)
+  reshape-core {hc} {rand} s instr ms mi sat =
+    subst (λ p → satisfies-constraints
+                   (single-instr-constraints hc (length (Preprocessed.memory s)) instr)
+                   (mk-witness (Preprocessed.memory s ++ ms) p rand))
+          (++-identityʳ (Preprocessed.pis s))
+          (subst (λ k → satisfies-constraints
+                          (single-instr-constraints hc k instr)
+                          (mk-witness (Preprocessed.memory s ++ ms)
+                                      (Preprocessed.pis s ++ []) rand))
+                 mi sat)
+
+  -- Δmem=2 variant: additionally bridge the witness memory from the
+  -- `mem ++ (x ∷ y ∷ [])` form (produced by `op-side-data`) to the
+  -- iterated `(mem ++ (x ∷ [])) ++ (y ∷ [])` form the `*-bwd` lemmas use.
+  reshape-push2
+    : ∀ {hc} {rand : Maybe Fr} (s : Preprocessed) (instr : Instruction)
+        (x y : Fr) {n : ℕ}
+    → n ≡ length (Preprocessed.memory s)
+    → satisfies-constraints (single-instr-constraints hc n instr)
+        (mk-witness (Preprocessed.memory s ++ (x ∷ y ∷ []))
+                    (Preprocessed.pis s ++ []) rand)
+    → satisfies-constraints
+        (single-instr-constraints hc (length (Preprocessed.memory s)) instr)
+        (mk-witness ((Preprocessed.memory s ++ (x ∷ [])) ++ (y ∷ []))
+                    (Preprocessed.pis s) rand)
+  reshape-push2 {hc} {rand} s instr x y mi sat =
+    subst (λ m → satisfies-constraints
+                   (single-instr-constraints hc (length (Preprocessed.memory s)) instr)
+                   (mk-witness m (Preprocessed.pis s) rand))
+          (push-mem2-assoc (Preprocessed.memory s) x y)
+          (reshape-core {hc} {rand} s instr (x ∷ y ∷ []) mi sat)
+
+  -- Δmem=0 variant: the instruction grows neither memory nor pis, so in
+  -- addition to the index shift and pis-drop we also drop the trailing
+  -- `++ []` on the witness memory.
+  reshape-nogrow
+    : ∀ {hc} {rand : Maybe Fr} (s : Preprocessed) (instr : Instruction) {n : ℕ}
+    → n ≡ length (Preprocessed.memory s)
+    → satisfies-constraints (single-instr-constraints hc n instr)
+        (mk-witness (Preprocessed.memory s ++ [])
+                    (Preprocessed.pis s ++ []) rand)
+    → satisfies-constraints
+        (single-instr-constraints hc (length (Preprocessed.memory s)) instr)
+        (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) rand)
+  reshape-nogrow {hc} {rand} s instr mi sat =
+    subst (λ m → satisfies-constraints
+                   (single-instr-constraints hc (length (Preprocessed.memory s)) instr)
+                   (mk-witness m (Preprocessed.pis s) rand))
+          (++-identityʳ (Preprocessed.memory s))
+          (reshape-core {hc} {rand} s instr [] mi sat)
+
+  -- The two cells a push-mem2 step appends sit at indices `length xs`
+  -- and `suc (length xs)` of `xs ++ (a ∷ b ∷ [])`.  Used by the div-mod
+  -- backward step to identify the constraint's (q, r) output values with the
+  -- appended cells.
+  lookup-skip1 : ∀ (xs : List Fr) (a b : Fr)
+    → mem-lookup (xs ++ (a ∷ b ∷ [])) (length xs) ≡ just a
+  lookup-skip1 []       a b = refl
+  lookup-skip1 (x ∷ xs) a b = lookup-skip1 xs a b
+  lookup-skip2 : ∀ (xs : List Fr) (a b : Fr)
+    → mem-lookup (xs ++ (a ∷ b ∷ [])) (suc (length xs)) ≡ just b
+  lookup-skip2 []       a b = refl
+  lookup-skip2 (x ∷ xs) a b = lookup-skip2 xs a b
+
+-- Per-instruction backward step.  Returns a Σ existential because the
+-- post-state `s'` is recovered from the satisfaction witness's memory
+-- shape; each case applies the appropriate `*-bwd` lemma.
+-- `mem-suf` and `pis-suf` are the memory/pis extensions committed to
+-- by the witness; D2 threads them per-instruction.
+--
+-- The four extra premises `O2-Inv`, `O3-Inv`, `O2-check i bk ≡ just bk`,
+-- `O3OK i bm` are the per-step shadows of the producer-safety
+-- conditions; D2 threads them via `o2-preserve` / `o3-preserve` and
+-- extracts the `_∈_` / `lookupᵐ` facts from the corresponding
+-- `O2-Trace` / `O3-Trace` step.  For the 18 non-obligation-bearing
+-- cases (arithmetic, EC, hashing, copy, declare-pub-input, etc.) the
+-- premises are trivially `refl` and unused; the four obligation-
+-- bearing cases (`assert`, `not`, `reconstitute-field`, `less-than`)
+-- consume O2-Inv via `o2-known-is-bit` and / or O3-Inv via
+-- `o3-known-fits`.
+satisfies→R-instr-step
+  : ∀ {hc} (pre : ProofPreimage) (s : Preprocessed) (i : Instruction)
+    (st : SynthState) (mem-suf : List Fr) (pis-suf : List Fr)
+    {wf2 : WF2-instr i}            -- WF2 bit-bound for this instruction
+  → mem-inv s st
+  → pi-inv  hc s st
+  → WireOK i (SynthState.nr-wires st)
+  → ∀ {bk : IndexSet} {bm : PartialMap}
+  → O2-Inv (SynthState.nr-wires st , bk) s
+  → O3-Inv (SynthState.nr-wires st , bm) s
+  → O2-check i bk ≡ just bk
+  → O3OK i bm
+  → (sd : op-side-data i pre s mem-suf pis-suf)
+  → satisfies-constraints
+      (SynthState.constraints (circuit-instr hc i st))
+      (mk-witness (Preprocessed.memory s ++ mem-suf)
+                  (Preprocessed.pis    s ++ pis-suf)
+                  (comm-rand-of pre))
+  → let s' = next-state-from-osd i pre s mem-suf pis-suf sd in
+        (Preprocessed.memory s' ≡ Preprocessed.memory s ++ mem-suf)
+      × (Preprocessed.pis    s' ≡ Preprocessed.pis    s ++ pis-suf)
+      × R-instr pre s i s'
+-- D1 dispatcher cases.  Each instruction's case follows this template:
+--   1. Pattern-match `i` and `suf`; unfold `circuit-instr hc i st`.
+--   2. Apply `satisfies-constraints-split` to peel off prior-constraint sat.
+--   3. Project the `WireOK` premise `wc` and `subst` with `mi` to get
+--      per-operand bounds `suc operand ≤ length (memory s)`.
+--   4. Destructure the new-constraints satisfaction; pull post-state
+--      lookups via `lookup-shrink` to get pre-state lookups.
+--   5. Call the `*-bwd` lemma to produce `R-instr pre s i s'`.
+--   6. Package the Σ output (s', mem-eq, pis-eq, R-instr).
+
+-- ─── add(a, b) ─────────────────────────────────────────────────────
+-- Δmem = 1; pis unchanged.
+satisfies→R-instr-step {hc} pre s (add a b) st _ _ mi pii wc _ _ _ _ ((w , refl) , refl) sat
+  with wc
+... | a<n , b<n =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      a≤len  = subst (suc a Data.Nat.≤_) mi a<n
+      b≤len  = subst (suc b Data.Nat.≤_) mi b<n
+      -- Peel the new constraint off `sat`:  constraints (circuit-instr hc (add a b) st)
+      -- = constraints st ++ [the add gate].
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      ((wire n ≑ wire a ⊕ wire b) ∷ [])
+                      sat
+      gate-h = headᴬ sat-new
+      (av , bv , _ , la-post , lb-post , _ , _) =
+        ≑⊕-inv (mem ++ (w ∷ [])) {n} {a} {b} gate-h
+      la-pre  : mem-lookup mem a ≡ just av
+      la-pre  = lookup-shrink mem (w ∷ []) a la-post a≤len
+      lb-pre  : mem-lookup mem b ≡ just bv
+      lb-pre  = lookup-shrink mem (w ∷ []) b lb-post b≤len
+      _ , r-add-ev = add-bwd {pre = pre} {s = s} {a = a} {b = b}
+                              {av = av} {bv = bv} {v = w} {hc = hc}
+                              {rand = comm-rand-of pre}
+                              la-pre lb-pre
+                              (reshape-core {hc} {comm-rand-of pre} s (add a b) (w ∷ []) mi sat-new)
+      s' = push-mem s w
+      pis-eq : Preprocessed.pis s' ≡ Preprocessed.pis s ++ []
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-add-ev
+
+-- ─── mul(a, b) ─────────────────────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (mul a b) st _ _ mi pii wc _ _ _ _ ((w , refl) , refl) sat
+  with wc
+... | a<n , b<n =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      a≤len  = subst (suc a Data.Nat.≤_) mi a<n
+      b≤len  = subst (suc b Data.Nat.≤_) mi b<n
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      ((wire n ≑ wire a ⊗ wire b) ∷ []) sat
+      gate-h = headᴬ sat-new
+      (av , bv , _ , la-post , lb-post , _ , _) =
+        ≑⊗-inv (mem ++ (w ∷ [])) {n} {a} {b} gate-h
+      la-pre  = lookup-shrink mem (w ∷ []) a la-post a≤len
+      lb-pre  = lookup-shrink mem (w ∷ []) b lb-post b≤len
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (mul a b) (w ∷ []) mi sat-new
+      _ , r-ev = mul-bwd {pre = pre} {s = s} {a = a} {b = b}
+                          {av = av} {bv = bv} {v = w} {hc = hc}
+                          {rand = comm-rand-of pre}
+                          la-pre lb-pre sat-pis
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── neg(a) ────────────────────────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (neg a) st _ _ mi pii wc _ _ _ _ ((w , refl) , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      a≤len  = subst (suc a Data.Nat.≤_) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      ((wire n ≑ ⊝ wire a) ∷ []) sat
+      gate-h = headᴬ sat-new
+      (av , _ , la-post , _ , _) =
+        ≑⊝-inv (mem ++ (w ∷ [])) {n} {a} gate-h
+      la-pre  = lookup-shrink mem (w ∷ []) a la-post a≤len
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (neg a) (w ∷ []) mi sat-new
+      _ , r-ev = neg-bwd {pre = pre} {s = s} {a = a}
+                          {av = av} {v = w} {hc = hc}
+                          {rand = comm-rand-of pre}
+                          la-pre sat-pis
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── test-eq(a, b) ─────────────────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (test-eq a b) st _ _ mi pii wc _ _ _ _ ((w , refl) , refl) sat
+  with wc
+... | a<n , b<n =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      a≤len  = subst (suc a Data.Nat.≤_) mi a<n
+      b≤len  = subst (suc b Data.Nat.≤_) mi b<n
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st) (test-eq n a b ∷ []) sat
+      (av , bv , _ , la-post , lb-post , _) = headᴬ sat-new
+      la-pre  = lookup-shrink mem (w ∷ []) a la-post a≤len
+      lb-pre  = lookup-shrink mem (w ∷ []) b lb-post b≤len
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (test-eq a b) (w ∷ []) mi sat-new
+      _ , r-ev = test-eq-bwd {pre = pre} {s = s} {a = a} {b = b}
+                              {av = av} {bv = bv} {v = w} {hc = hc}
+                              {rand = comm-rand-of pre}
+                              la-pre lb-pre sat-pis
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── copy(v) ───────────────────────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (copy v) st _ _ mi pii wc _ _ _ _ ((w , refl) , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      v≤len  = subst (suc v Data.Nat.≤_) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      ((wire n ≑ wire v) ∷ []) sat
+      gate-h = headᴬ sat-new
+      (vv , _ , la-post , _ , _) =
+        ≑wire-inv (mem ++ (w ∷ [])) {n} {v} gate-h
+      la-pre  = lookup-shrink mem (w ∷ []) v la-post v≤len
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (copy v) (w ∷ []) mi sat-new
+      _ , r-ev = copy-bwd {pre = pre} {s = s} {v = v} {vv = vv} {w = w} {hc = hc}
+                           {rand = comm-rand-of pre}
+                           la-pre sat-pis
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── constrain-eq(a, b) ───────────────────────────────────────────
+-- Δmem = 0; mem/pis unchanged.  Suffix is [].
+satisfies→R-instr-step {hc} pre s (constrain-eq a b) st _ _ mi pii wc _ _ _ _ (refl , refl) sat
+  with wc
+... | a<n , b<n =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      a≤len  = subst (suc a Data.Nat.≤_) mi a<n
+      b≤len  = subst (suc b Data.Nat.≤_) mi b<n
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st) ((wire a ≑ wire b) ∷ []) sat
+      gate-h = headᴬ sat-new
+      (av , bv , la-post , lb-post , _) =
+        ≑vars-inv (mem ++ []) {a} {b} gate-h
+      la-eq : mem-lookup mem a ≡ just av
+      la-eq = subst (λ m → mem-lookup m a ≡ just av)
+                    (++-identityʳ mem) la-post
+      lb-eq : mem-lookup mem b ≡ just bv
+      lb-eq = subst (λ m → mem-lookup m b ≡ just bv)
+                    (++-identityʳ mem) lb-post
+      sat-pis = reshape-nogrow {hc} {comm-rand-of pre} s (constrain-eq a b) mi sat-new
+      r-ev = constrain-eq-bwd {pre = pre} {s = s} {a = a} {b = b}
+                               {av = av} {bv = bv} {hc = hc}
+                               {rand = comm-rand-of pre}
+                               la-eq lb-eq sat-pis
+      mem-eq : Preprocessed.memory s ≡ mem ++ []
+      mem-eq = sym (++-identityʳ mem)
+      pis-eq : Preprocessed.pis s ≡ Preprocessed.pis s ++ []
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in mem-eq , pis-eq , r-ev
+
+-- ─── constrain-bits(v, n) ─────────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (constrain-bits v bits) st _ _ {wf2 = wf2} mi pii wc _ _ _ _ (refl , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      v≤len  = subst (suc v Data.Nat.≤_) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st) (in-range v bits ∷ []) sat
+      (vv , la-post , _) = headᴬ sat-new
+      la-eq : mem-lookup mem v ≡ just vv
+      la-eq = subst (λ m → mem-lookup m v ≡ just vv)
+                    (++-identityʳ mem) la-post
+      sat-pis = reshape-nogrow {hc} {comm-rand-of pre} s (constrain-bits v bits) mi sat-new
+      r-ev = constrain-bits-bwd {pre = pre} {s = s} {v = v} {n = bits}
+                                 {vv = vv} {hc = hc} {rand = comm-rand-of pre}
+                                 la-eq wf2 sat-pis
+      mem-eq = sym (++-identityʳ mem)
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in mem-eq , pis-eq , r-ev
+
+-- ─── constrain-to-boolean(v) ──────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (constrain-to-boolean v) st _ _ mi pii wc _ _ _ _ (refl , refl) sat =
+  let mem    = Preprocessed.memory s
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st) (boolean v ∷ []) sat
+      sat-pis = reshape-nogrow {hc} {comm-rand-of pre} s (constrain-to-boolean v) mi sat-new
+      r-ev = constrain-to-boolean-bwd {pre = pre} {s = s} {v = v} {hc = hc}
+                                       {rand = comm-rand-of pre} sat-pis
+      mem-eq = sym (++-identityʳ mem)
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in mem-eq , pis-eq , r-ev
+
+-- ─── load-imm(imm) ─────────────────────────────────────────────────
+-- No operand wire discipline; `WireOK` always holds for load-imm.
+satisfies→R-instr-step {hc} pre s (load-imm imm) st _ _ mi pii wc _ _ _ _ ((w , refl) , refl) sat =
+  let n      = SynthState.nr-wires st
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      ((wire n ≑ con imm) ∷ []) sat
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (load-imm imm) (w ∷ []) mi sat-new
+      _ , r-ev = load-imm-bwd {pre = pre} {s = s} {k = imm} {w = w} {hc = hc}
+                               {rand = comm-rand-of pre}
+                               sat-pis
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── transient-hash(inputs) ──────────────────────────────────────────
+-- Δmem = 1; pis unchanged.  Inputs witnessed via `mem-lookups`.
+satisfies→R-instr-step {hc} pre s (transient-hash inputs) st _ _ mi pii wc _ _ _ _ ((w , refl) , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      -- `wc : All (_< n) inputs`; retarget the bound to `length mem`.
+      wc-len : All (_< length mem) inputs
+      wc-len = subst (λ k → All (_< k) inputs) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (poseidon n inputs ∷ []) sat
+      (vs , ov , lvs-post , _) = headᴬ sat-new
+      -- Convert the input-vector lookup back to pre-state via mem-lookups-shrink.
+      lvs-pre  : mem-lookups mem inputs ≡ just vs
+      lvs-pre  = mem-lookups-shrink mem (w ∷ []) inputs wc-len lvs-post
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (transient-hash inputs) (w ∷ []) mi sat-new
+      w≡hash , r-ev = transient-hash-bwd {pre = pre} {s = s} {inputs = inputs}
+                                     {vs = vs} {v = w} {hc = hc}
+                                     {rand = comm-rand-of pre}
+                                     lvs-pre sat-pis
+      r-ev' : R-instr pre s (transient-hash inputs) (push-mem s w)
+      r-ev' = subst (λ z → R-instr pre s (transient-hash inputs) (push-mem s z))
+                    (sym w≡hash) r-ev
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev'
+
+-- ─── cond-select(b, a, c) ────────────────────────────────────────────
+-- Δmem = 1; pis unchanged.
+satisfies→R-instr-step {hc} pre s (cond-select b a c) st _ _ mi pii wc _ _ _ _ ((w , refl) , refl) sat
+  with wc
+... | b<n , a<n , c<n =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      b≤len  = subst (suc b Data.Nat.≤_) mi b<n
+      a≤len  = subst (suc a Data.Nat.≤_) mi a<n
+      c≤len  = subst (suc c Data.Nat.≤_) mi c<n
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (select n b a c ∷ []) sat
+      (bv , av , cv , _ , lb-post , la-post , lc-post , _) = headᴬ sat-new
+      lb-pre   = lookup-shrink mem (w ∷ []) b lb-post b≤len
+      la-pre   = lookup-shrink mem (w ∷ []) a la-post a≤len
+      lc-pre   = lookup-shrink mem (w ∷ []) c lc-post c≤len
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (cond-select b a c) (w ∷ []) mi sat-new
+      r-ev = cond-select-bwd {pre = pre} {s = s} {b = b} {a = a} {c = c}
+                              {bv = bv} {av = av} {cv = cv} {v = w} {hc = hc}
+                              {rand = comm-rand-of pre}
+                              lb-pre la-pre lc-pre sat-pis
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── hash-to-curve(inputs) ──────────────────────────────────────────
+-- Δmem = 2; pis unchanged.  Inputs via `mem-lookups`; output 2 cells.
+satisfies→R-instr-step {hc} pre s (hash-to-curve inputs) st _ _ mi pii wc _ _ _ _ ((x , y , refl) , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      wc-len : All (_< length mem) inputs
+      wc-len = subst (λ k → All (_< k) inputs) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (h2c n (suc n) inputs ∷ []) sat
+      (vs , _ , _ , lvs-post , _) = headᴬ sat-new
+      lvs-pre  : mem-lookups mem inputs ≡ just vs
+      lvs-pre  = mem-lookups-shrink mem (x ∷ y ∷ []) inputs wc-len lvs-post
+      -- Shift n → length mem in the constraint.
+      sat-assoc = reshape-push2 {hc} {comm-rand-of pre} s (hash-to-curve inputs) x y mi sat-new
+      _ , r-ev = hash-to-curve-bwd {pre = pre} {s = s} {inputs = inputs}
+                                    {vs = vs} {x = x} {y = y} {hc = hc}
+                                    {rand = comm-rand-of pre}
+                                    lvs-pre sat-assoc
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── persistent-hash(α, inputs) ─────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (persistent-hash α inputs) st _ _ mi pii wc _ _ _ _ ((x , y , refl) , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      wc-len : All (_< length mem) inputs
+      wc-len = subst (λ k → All (_< k) inputs) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (sha256 n (suc n) α inputs ∷ []) sat
+      (vs , _ , _ , lvs-post , _) = headᴬ sat-new
+      lvs-pre  : mem-lookups mem inputs ≡ just vs
+      lvs-pre  = mem-lookups-shrink mem (x ∷ y ∷ []) inputs wc-len lvs-post
+      sat-assoc = reshape-push2 {hc} {comm-rand-of pre} s (persistent-hash α inputs) x y mi sat-new
+      _ , r-ev = persistent-hash-bwd {pre = pre} {s = s} {α = α} {inputs = inputs}
+                                      {vs = vs} {x = x} {y = y} {hc = hc}
+                                      {rand = comm-rand-of pre}
+                                      lvs-pre sat-assoc
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── ec-add(a-x, a-y, b-x, b-y) ─────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (ec-add a-x a-y b-x b-y) st _ _ mi pii wc _ _ _ _ ((x , y , refl) , refl) sat
+  with wc
+... | ax<n , ay<n , bx<n , by<n =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      ax≤len = subst (suc a-x Data.Nat.≤_) mi ax<n
+      ay≤len = subst (suc a-y Data.Nat.≤_) mi ay<n
+      bx≤len = subst (suc b-x Data.Nat.≤_) mi bx<n
+      by≤len = subst (suc b-y Data.Nat.≤_) mi by<n
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (ec-add n (suc n) a-x a-y b-x b-y ∷ []) sat
+      (ax , ay , bx , by , _ , _ , lax-post , lay-post , lbx-post , lby-post , _) = headᴬ sat-new
+      lax-pre  = lookup-shrink mem (x ∷ y ∷ []) a-x lax-post ax≤len
+      lay-pre  = lookup-shrink mem (x ∷ y ∷ []) a-y lay-post ay≤len
+      lbx-pre  = lookup-shrink mem (x ∷ y ∷ []) b-x lbx-post bx≤len
+      lby-pre  = lookup-shrink mem (x ∷ y ∷ []) b-y lby-post by≤len
+      sat-assoc = reshape-push2 {hc} {comm-rand-of pre} s (ec-add a-x a-y b-x b-y) x y mi sat-new
+      _ , r-ev = ec-add-bwd {pre = pre} {s = s}
+                             {a-x = a-x} {a-y = a-y} {b-x = b-x} {b-y = b-y}
+                             {ax = ax} {ay = ay} {bx = bx} {by = by}
+                             {x = x} {y = y} {hc = hc}
+                             {rand = comm-rand-of pre}
+                             lax-pre lay-pre lbx-pre lby-pre sat-assoc
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── ec-mul(a-x, a-y, scalar) ───────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (ec-mul a-x a-y scalar) st _ _ mi pii wc _ _ _ _ ((x , y , refl) , refl) sat
+  with wc
+... | ax<n , ay<n , sc<n =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      ax≤len = subst (suc a-x Data.Nat.≤_) mi ax<n
+      ay≤len = subst (suc a-y Data.Nat.≤_) mi ay<n
+      sc≤len = subst (suc scalar Data.Nat.≤_) mi sc<n
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (ec-mul n (suc n) a-x a-y scalar ∷ []) sat
+      (ax , ay , sc , _ , _ , lax-post , lay-post , lsc-post , _) = headᴬ sat-new
+      lax-pre  = lookup-shrink mem (x ∷ y ∷ []) a-x lax-post ax≤len
+      lay-pre  = lookup-shrink mem (x ∷ y ∷ []) a-y lay-post ay≤len
+      lsc-pre  = lookup-shrink mem (x ∷ y ∷ []) scalar lsc-post sc≤len
+      sat-assoc = reshape-push2 {hc} {comm-rand-of pre} s (ec-mul a-x a-y scalar) x y mi sat-new
+      _ , r-ev = ec-mul-bwd {pre = pre} {s = s}
+                             {a-x = a-x} {a-y = a-y} {scalar = scalar}
+                             {ax = ax} {ay = ay} {sc = sc}
+                             {x = x} {y = y} {hc = hc}
+                             {rand = comm-rand-of pre}
+                             lax-pre lay-pre lsc-pre sat-assoc
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── ec-mul-generator(scalar) ───────────────────────────────────────
+satisfies→R-instr-step {hc} pre s (ec-mul-generator scalar) st _ _ mi pii wc _ _ _ _ ((x , y , refl) , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      sc≤len = subst (suc scalar Data.Nat.≤_) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (ec-gen n (suc n) scalar ∷ []) sat
+      (sc , _ , _ , lsc-post , _) = headᴬ sat-new
+      lsc-pre  = lookup-shrink mem (x ∷ y ∷ []) scalar lsc-post sc≤len
+      sat-assoc = reshape-push2 {hc} {comm-rand-of pre} s (ec-mul-generator scalar) x y mi sat-new
+      _ , r-ev = ec-mul-generator-bwd {pre = pre} {s = s} {scalar = scalar}
+                                       {sc = sc} {x = x} {y = y} {hc = hc}
+                                       {rand = comm-rand-of pre}
+                                       lsc-pre sat-assoc
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev
+
+-- ─── div-mod-power-of-two(var, bits) ────────────────────────────────
+-- Δmem = 2.  The side-data supplies the appended cells (x , y); the
+-- div-mod constraint (peeled off `sat`) supplies the field equation
+-- *plus* the `NoWrap` canonicity guard (faithful to the Rust
+-- `enforce_canonical` bit decomposition).  The field equation alone
+-- would be underconstrained — distinct (q , r) satisfy it under
+-- modular wraparound — but together with `NoWrap`, `divmod-canon` pins
+-- (q , r) to the canonical split of `vv`, forcing x and y to the
+-- values `r-div-mod-power-of-two` produces; we then subst to match
+-- `push-mem2 s x y`.
+satisfies→R-instr-step {hc} pre s (div-mod-power-of-two var bits) st _ _ {wf2 = wf2} mi _ var<n _ _ _ _ ((x , y , refl) , refl) sat =
+  let mem     = Preprocessed.memory s
+      n       = SynthState.nr-wires st
+      var≤len = subst (suc var Data.Nat.≤_) mi var<n
+      -- Peel the div-mod constraint off `sat`.
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (div-mod n (suc n) var bits ∷ []) sat
+      (qv , rv , vv , lq , lr , lv , frv , fqv , nw , veq) = headᴬ sat-new
+      -- The constraint's (q, r) output wires `n`, `suc n` hold the appended
+      -- cells x, y; `var` is in range, so its lookup shrinks to `mem`.
+      qv≡x : qv ≡ x
+      qv≡x = just-injective
+        (trans (sym (subst (λ k → mem-lookup (mem ++ (x ∷ y ∷ [])) k ≡ just qv) mi lq))
+               (lookup-skip1 mem x y))
+      rv≡y : rv ≡ y
+      rv≡y = just-injective
+        (trans (sym (subst (λ k → mem-lookup (mem ++ (x ∷ y ∷ [])) (suc k) ≡ just rv) mi lr))
+               (lookup-skip2 mem x y))
+      la-sd : mem-lookup mem var ≡ just vv
+      la-sd = lookup-shrink mem (x ∷ y ∷ []) var lv var≤len
+      -- The constraint + `NoWrap` pin (q, r) to the canonical split of `vv`.
+      cqv , crv = divmod-canon {qv = qv} {rv = rv} {vv = vv} {bits = bits} frv nw veq
+      xeq : x ≡ from-le-bits (drop bits (to-le-bits vv))
+      xeq = trans (sym qv≡x) cqv
+      yeq : y ≡ from-le-bits (take bits (to-le-bits vv))
+      yeq = trans (sym rv≡y) crv
+      -- R fires producing the canonical decomposition of `vv`.
+      r-ev : R-instr pre s (div-mod-power-of-two var bits)
+               (push-mem (push-mem s (from-le-bits (drop bits (to-le-bits vv))))
+                         (from-le-bits (take bits (to-le-bits vv))))
+      r-ev = r-div-mod-power-of-two la-sd wf2
+      -- We want : R-instr ... (push-mem2 s x y).  Subst x≡canon-q, y≡canon-r.
+      r-ev1 : R-instr pre s (div-mod-power-of-two var bits)
+                (push-mem (push-mem s x) (from-le-bits (take bits (to-le-bits vv))))
+      r-ev1 = subst (λ z → R-instr pre s (div-mod-power-of-two var bits)
+                              (push-mem (push-mem s z) (from-le-bits (take bits (to-le-bits vv)))))
+                    (sym xeq) r-ev
+      r-ev2 : R-instr pre s (div-mod-power-of-two var bits)
+                (push-mem (push-mem s x) y)
+      r-ev2 = subst (λ z → R-instr pre s (div-mod-power-of-two var bits)
+                              (push-mem (push-mem s x) z))
+                    (sym yeq) r-ev1
+      -- push-mem (push-mem s x) y ≡ push-mem2 s x y propositionally —
+      -- their memories differ only by `mem ++ (x ∷ []) ++ (y ∷ [])` vs
+      -- `mem ++ (x ∷ y ∷ [])`.  Convert via cong on Preprocessed.
+      pm-eq : push-mem (push-mem s x) y ≡ push-mem2 s x y
+      pm-eq = cong (λ m → record s { memory = m }) (sym (push-mem2-assoc (Preprocessed.memory s) x y))
+      r-ev3 : R-instr pre s (div-mod-power-of-two var bits) (push-mem2 s x y)
+      r-ev3 = subst (R-instr pre s (div-mod-power-of-two var bits)) pm-eq r-ev2
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev3
+
+-- ─── declare-pub-input(v) ───────────────────────────────────────────
+-- Δmem = 0; pis grows by exactly one cell (wv).
+satisfies→R-instr-step {hc} pre s (declare-pub-input v) st _ _ mi pii wc _ _ _ _ (refl , wv , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      v≤len  = subst (suc v Data.Nat.≤_) mi wc
+      d      = SynthState.nr-declared-pi st
+      -- The dispatcher emits constraints for declare-pub-input via
+      -- `single-instr-constraints-with-decl hc (length mem) d`.  But
+      -- `circuit-instr hc (declare-pub-input v) st` emits
+      -- `bind (preamble-pi-count hc + d) v` at the synth
+      -- state, where d = nr-declared-pi st.  Convert.
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (bind (preamble-pi-count hc + d) v ∷ []) sat
+      (wv' , _ , lv-post , _) = headᴬ sat-new
+      -- Pre-state lookup: mem unchanged so mem-suf = [] gives `mem ++ [] = mem`.
+      lv-pre : mem-lookup mem v ≡ just wv'
+      lv-pre = subst (λ m → mem-lookup m v ≡ just wv')
+                     (++-identityʳ mem) lv-post
+      -- Reshape sat-new to use `length mem` for nr-wires.
+      sat-shifted = subst (λ k → satisfies-constraints
+                                    (bind (preamble-pi-count hc + d) v ∷ [])
+                                    (mk-witness (mem ++ []) (Preprocessed.pis s ++ (wv ∷ []))
+                                                (comm-rand-of pre)))
+                          mi sat-new
+      -- Convert to single-instr-constraints-with-decl form (no wire-count
+      -- subst needed since bind doesn't depend on n).
+      sat-mem = subst (λ m → satisfies-constraints
+                                (single-instr-constraints-with-decl hc (length mem) d
+                                   (declare-pub-input v))
+                                (mk-witness m (Preprocessed.pis s ++ (wv ∷ []))
+                                            (comm-rand-of pre)))
+                      (++-identityʳ mem) sat-shifted
+      -- pi-inv : length (pis s) ≡ preamble-pi-count hc + nr-declared-pi st
+      pi-len : length (Preprocessed.pis s) ≡ preamble-pi-count hc + d
+      pi-len = pii
+      ext≡wv , r-ev = declare-pub-input-bwd
+                        {pre = pre} {s = s} {v = v} {wv = wv'} {hc = hc} {d = d}
+                        {ext = wv} {rand = comm-rand-of pre}
+                        pi-len lv-pre sat-mem
+      mem-eq : Preprocessed.memory s ≡ mem ++ []
+      mem-eq = sym (++-identityʳ mem)
+      s' = record s
+             { pis        = Preprocessed.pis s ++ (wv ∷ [])
+             ; pub-in-idx = suc (Preprocessed.pub-in-idx s)
+             }
+  in mem-eq , refl , r-ev
+
+-- ─── assert(c) ────────────────────────────────────────────────────
+-- Δmem = 0; pis unchanged.  Needs `is-bit v` (O2-Inv) on the operand.
+-- The constraint's `v ≢ 0ᶠ` combines with `is-bit v` (which forces
+-- v ∈ {0, 1}) to imply v ≡ 1ᶠ; then `r-assert` fires.
+satisfies→R-instr-step {hc} pre s (assert c) st _ _ mi pii wc
+                       {bk = bk} o2-inv _ o2-chk _ (refl , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      c≤len  = subst (suc c Data.Nat.≤_) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (non-zero c ∷ []) sat
+      (v , lv-post , v≢0) = headᴬ sat-new
+      -- Pre-state lookup for `c`.
+      lv-pre : mem-lookup mem c ≡ just v
+      lv-pre = subst (λ m → mem-lookup m c ≡ just v)
+                     (++-identityʳ mem) lv-post
+      -- Extract `c ∈ bk` from `O2-check ≡ just bk`.
+      c∈bk : c ∈ bk
+      c∈bk = o2-check-mem? c bk o2-chk
+      -- Apply `o2-known-is-bit`.
+      is-bit-v = o2-known-is-bit {bk = bk} o2-inv c∈bk lv-pre
+      -- Build sat suitable for `assert-bwd`:  shape  (mem, pis, rand)
+      -- with the constraints re-shaped to use `length mem`.
+      sat-pis = reshape-nogrow {hc} {comm-rand-of pre} s (assert c) mi sat-new
+      r-ev = assert-bwd {pre = pre} {s = s} {c = c} {v = v} {hc = hc}
+                         {rand = comm-rand-of pre}
+                         lv-pre is-bit-v sat-pis
+      mem-eq : Preprocessed.memory s ≡ mem ++ []
+      mem-eq = sym (++-identityʳ mem)
+      pis-eq : Preprocessed.pis s ≡ Preprocessed.pis s ++ []
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in mem-eq , pis-eq , r-ev
+
+-- ─── not(a) ───────────────────────────────────────────────────────
+-- Δmem = 1; pis unchanged.  Needs `is-bit av` (O2-Inv) on the operand
+-- `a`.  `not-bwd` packages constraint data into `r-not` once the boolean
+-- precondition is satisfied.
+satisfies→R-instr-step {hc} pre s (not a) st _ _ mi pii wc
+                       {bk = bk} o2-inv _ o2-chk _ ((w , refl) , refl) sat =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      a≤len  = subst (suc a Data.Nat.≤_) mi wc
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (is-zero n a ∷ []) sat
+      (av , _ , la-post , _) = headᴬ sat-new
+      la-pre    : mem-lookup mem a ≡ just av
+      la-pre    = lookup-shrink mem (w ∷ []) a la-post a≤len
+      -- Extract `a ∈ bk` from `O2-check ≡ just bk`.
+      a∈bk : a ∈ bk
+      a∈bk = o2-check-mem? a bk o2-chk
+      -- Apply `o2-known-is-bit` to get `is-bit av`.
+      is-bit-av = o2-known-is-bit {bk = bk} o2-inv a∈bk la-pre
+      -- Re-shape the new-constraints satisfaction for `not-bwd`.
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (not a) (w ∷ []) mi sat-new
+      w≡target , r-ev = not-bwd {pre = pre} {s = s} {a = a} {av = av} {v = w} {hc = hc}
+                          {rand = comm-rand-of pre}
+                          la-pre is-bit-av sat-pis
+      r-ev' : R-instr pre s (not a) (push-mem s w)
+      r-ev' = subst (λ z → R-instr pre s (not a) (push-mem s z))
+                    (sym w≡target) r-ev
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev'
+
+-- ─── less-than(a, b, bits) ───────────────────────────────────────
+-- Δmem = 1; pis unchanged.  `less-than-bwd` needs `Fits-in av bits`
+-- and `Fits-in bv bits`.  We extract these via O3:
+--   O3OK guarantees `lookupᵐ a bm ≡ just ka` with `ka ≤ bits`
+--   (and similarly for b).  `o3-known-fits` lifts to
+--   `Fits-in av ka`.  `fits-in-mono` then pads to
+--   `Fits-in av bits`.
+satisfies→R-instr-step {hc} pre s (less-than a b bits) st _ _ {wf2 = wf2} mi pii wc
+                       {bm = bm} _ o3-inv _ o3-chk ((w , refl) , refl) sat
+  with lookupᵐ a bm in eqa | lookupᵐ b bm in eqb
+... | just ka | just kb
+  with o3-chk | wc
+... | (ka≤b , kb≤b) | (a<n , b<n) =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      a≤len  = subst (suc a Data.Nat.≤_) mi a<n
+      b≤len  = subst (suc b Data.Nat.≤_) mi b<n
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (less-than n a b bits ∷ []) sat
+      (av , bv , _ , la-post , lb-post , _) = headᴬ sat-new
+      la-pre  = lookup-shrink mem (w ∷ []) a la-post a≤len
+      lb-pre  = lookup-shrink mem (w ∷ []) b lb-post b≤len
+      -- Extract fits-in av ka via O3-Inv, then pad to fits-in av bits.
+      fits-av-ka : Fits-in av ka
+      fits-av-ka = o3-known-fits {bm = bm} o3-inv eqa la-pre
+      fits-bv-kb : Fits-in bv kb
+      fits-bv-kb = o3-known-fits {bm = bm} o3-inv eqb lb-pre
+      fits-av : Fits-in av bits
+      fits-av = fits-in-mono fits-av-ka ka≤b
+      fits-bv : Fits-in bv bits
+      fits-bv = fits-in-mono fits-bv-kb kb≤b
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (less-than a b bits) (w ∷ []) mi sat-new
+      w≡target , r-ev = less-than-bwd
+                          {pre = pre} {s = s} {a = a} {b = b} {bits = bits}
+                          {av = av} {bv = bv} {v = w} {hc = hc}
+                          {rand = comm-rand-of pre}
+                          la-pre lb-pre wf2 fits-av fits-bv sat-pis
+      r-ev' : R-instr pre s (less-than a b bits) (push-mem s w)
+      r-ev' = subst (λ z → R-instr pre s (less-than a b bits) (push-mem s z))
+                    (sym w≡target) r-ev
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev'
+
+-- ─── reconstitute-field(d, m, bits) ─────────────────────────────────
+-- Δmem = 1; pis unchanged.  `reconstitute-field-bwd` needs
+-- `BitsInField (mv-bits ++ dv-bits)`.  We extract it via O3:
+--   O3-check guarantees `lookupᵐ d bm ≡ just kd ∧ kd ≤ᵇ (FR-BITS ∸ bits ∸ 1)`
+--   and `lookupᵐ m bm ≡ just km ∧ km ≤ᵇ bits`.  `o3-known-fits` gives
+--   `fits-in dv kd` and `fits-in mv km`; `fits-in-mono` pads them to
+--   the bounds expected by `bits-in-field-from-strict-bound`, which
+--   then supplies the `BitsInField` premise.
+satisfies→R-instr-step {hc} pre s (reconstitute-field d m bits) st _ _ {wf2 = wf2} mi pii wc
+                       {bm = bm} _ o3-inv _ o3-chk ((w , refl) , refl) sat
+  with lookupᵐ d bm in eqd | lookupᵐ m bm in eqm
+... | just kd | just km
+  with o3-chk | wc
+... | (kd≤ , km≤) | (d<n , m<n) =
+  let mem    = Preprocessed.memory s
+      n      = SynthState.nr-wires st
+      d≤len  = subst (suc d Data.Nat.≤_) mi d<n
+      m≤len  = subst (suc m Data.Nat.≤_) mi m<n
+      _ , sat-new = satisfies-constraints-split
+                      (SynthState.constraints st)
+                      (reconstitute n d m bits ∷ []) sat
+      (dv , mv , _ , ld-post , lm-post , _) = headᴬ sat-new
+      ld-pre  = lookup-shrink mem (w ∷ []) d ld-post d≤len
+      lm-pre  = lookup-shrink mem (w ∷ []) m lm-post m≤len
+      -- Extract fits-in dv kd and fits-in mv km via O3-Inv.
+      fits-dv-kd : Fits-in dv kd
+      fits-dv-kd = o3-known-fits {bm = bm} o3-inv eqd ld-pre
+      fits-mv-km : Fits-in mv km
+      fits-mv-km = o3-known-fits {bm = bm} o3-inv eqm lm-pre
+      -- Pad to the bounds required by `bits-in-field-from-strict-bound`:
+      --   fits-in mv bits        (from km ≤ bits)
+      --   fits-in dv (FR-BITS ∸ bits ∸ 1)   (from kd ≤ FR-BITS ∸ bits ∸ 1).
+      fits-mv : Fits-in mv bits
+      fits-mv = fits-in-mono fits-mv-km km≤
+      fits-dv : Fits-in dv (FR-BITS ∸ bits ∸ 1)
+      fits-dv = fits-in-mono fits-dv-kd kd≤
+      -- BitsInField premise.
+      in-field : BitsInField
+                   (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv))
+      in-field = bits-in-field-from-strict-bound {dv = dv} {mv = mv} {n = bits}
+                   fits-mv fits-dv
+      sat-pis = reshape-core {hc} {comm-rand-of pre} s (reconstitute-field d m bits) (w ∷ []) mi sat-new
+      w≡target , r-ev = reconstitute-field-bwd
+                          {pre = pre} {s = s} {d = d} {m = m} {bits = bits}
+                          {dv = dv} {mv = mv} {v = w} {hc = hc}
+                          {rand = comm-rand-of pre}
+                          ld-pre lm-pre (proj₁ wf2) (proj₂ wf2) in-field sat-pis
+      r-ev' : R-instr pre s (reconstitute-field d m bits) (push-mem s w)
+      r-ev' = subst (λ z → R-instr pre s (reconstitute-field d m bits) (push-mem s z))
+                    (sym w≡target) r-ev
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in refl , pis-eq , r-ev'
+
+-- ─── output(v) ────────────────────────────────────────────────────
+-- Δmem = 0; pis unchanged.  Emits no constraints (the wire index is
+-- recorded for the comm-commitment constraint emitted at end of synthesis
+-- if has-comm).  Operational side data: `mem-lookup mem v ≡ just val`
+-- — the value pushed onto `outputs`.
+satisfies→R-instr-step {hc} pre s (output v) st _ _ mi pii wc _ _ _ _ ((val , lv-pre) , refl , refl) sat =
+  let mem = Preprocessed.memory s
+      s'  = record s { outputs = Preprocessed.outputs s ++ (val ∷ []) }
+      r-ev : R-instr pre s (output v) s'
+      r-ev = r-output {pre = pre} {s = s} {var = v} {v = val} lv-pre
+      mem-eq : Preprocessed.memory s' ≡ mem ++ []
+      mem-eq = sym (++-identityʳ mem)
+      pis-eq : Preprocessed.pis s' ≡ Preprocessed.pis s ++ []
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in mem-eq , pis-eq , r-ev
+
+-- ─── pi-skip(g, count) ───────────────────────────────────────────
+-- Δmem = 0; pis unchanged.  Emits no constraints (the pi-skip group is
+-- pure side data for the verifier).  Operational side data: the
+-- guard's evaluation and, if active, the transcript-prefix match.
+satisfies→R-instr-step {hc} pre s (pi-skip g count) st _ _ mi pii wc _ _ _ _
+                       (refl , refl , (true , ev-guard , prefix-match)) sat =
+  let s' = record s { pi-skips = Preprocessed.pi-skips s ++ (nothing ∷ []) }
+      r-ev : R-instr pre s (pi-skip g count) s'
+      r-ev = r-pi-skip-active {pre = pre} {s = s} {guard = g} {count = count}
+                              ev-guard prefix-match
+      mem-eq = sym (++-identityʳ (Preprocessed.memory s))
+      pis-eq = sym (++-identityʳ (Preprocessed.pis    s))
+  in mem-eq , pis-eq , r-ev
+satisfies→R-instr-step {hc} pre s (pi-skip g count) st _ _ mi pii wc _ _ _ _
+                       (refl , refl , (false , ev-guard , _)) sat =
+  let s' = record s
+             { pi-skips    = Preprocessed.pi-skips s ++ (just count ∷ [])
+             ; pub-in-idx  = Preprocessed.pub-in-idx s ∸ count
+             }
+      r-ev : R-instr pre s (pi-skip g count) s'
+      r-ev = r-pi-skip-inactive {pre = pre} {s = s} {guard = g} {count = count}
+                                ev-guard
+      mem-eq = sym (++-identityʳ (Preprocessed.memory s))
+      pis-eq = sym (++-identityʳ (Preprocessed.pis    s))
+  in mem-eq , pis-eq , r-ev
+
+-- ─── public-input(g) ─────────────────────────────────────────────
+-- Δmem = 1; pis unchanged.  Either emits no constraints (`g = nothing`)
+-- or a single guard-disj constraint (`g = just _`).  Operational side
+-- data fixes whether active (consume from `pub-out-rem`) or inactive
+-- (push 0ᶠ).  The witness's memory cell `w` is reconciled to either
+-- the consumed value (active) or 0ᶠ (inactive) via the side data.
+satisfies→R-instr-step {hc} pre s (public-input g) st _ _ mi pii wc _ _ _ _
+                       (w , refl , refl , (true , ev-guard , (s₁ , consume-eq))) sat =
+  let s' = record s₁ { memory = Preprocessed.memory s₁ ++ (w ∷ []) }
+      r-ev : R-instr pre s (public-input g) s'
+      r-ev = r-public-input-active {pre = pre} {s = s} {guard = g}
+                                   {v = w} {s₁ = s₁}
+                                   ev-guard consume-eq
+      -- memory s₁ ≡ memory s definitionally (consume-pub-out only
+      -- touches pub-out-rem); but Agda needs a proof — pin it via the
+      -- `consume-eq` premise's structure.
+      mem-eq : Preprocessed.memory s' ≡ Preprocessed.memory s ++ (w ∷ [])
+      mem-eq = cong (λ m → m ++ (w ∷ []))
+                    (consume-pub-out-mem s consume-eq)
+      pis-eq : Preprocessed.pis s' ≡ Preprocessed.pis s ++ []
+      pis-eq = trans (consume-pub-out-pis s consume-eq)
+                     (sym (++-identityʳ (Preprocessed.pis s)))
+  in mem-eq , pis-eq , r-ev
+satisfies→R-instr-step {hc} pre s (public-input g) st _ _ mi pii wc _ _ _ _
+                       (w , refl , refl , (false , ev-guard , w≡0)) sat =
+  let s' = record s { memory = Preprocessed.memory s ++ (w ∷ []) }
+      r-ev₀ : R-instr pre s (public-input g) (record s { memory = Preprocessed.memory s ++ (0ᶠ ∷ []) })
+      r-ev₀ = r-public-input-inactive {pre = pre} {s = s} {guard = g} ev-guard
+      r-ev : R-instr pre s (public-input g) s'
+      r-ev = subst (λ z → R-instr pre s (public-input g)
+                              (record s { memory = Preprocessed.memory s ++ (z ∷ []) }))
+                   (sym w≡0) r-ev₀
+      mem-eq : Preprocessed.memory s' ≡ Preprocessed.memory s ++ (w ∷ [])
+      mem-eq = refl
+      pis-eq : Preprocessed.pis s' ≡ Preprocessed.pis s ++ []
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in mem-eq , pis-eq , r-ev
+
+-- ─── private-input(g) ────────────────────────────────────────────
+-- Symmetric to public-input but consumes from `priv-rem`.
+satisfies→R-instr-step {hc} pre s (private-input g) st _ _ mi pii wc _ _ _ _
+                       (w , refl , refl , (true , ev-guard , (s₁ , consume-eq))) sat =
+  let s' = record s₁ { memory = Preprocessed.memory s₁ ++ (w ∷ []) }
+      r-ev : R-instr pre s (private-input g) s'
+      r-ev = r-private-input-active {pre = pre} {s = s} {guard = g}
+                                    {v = w} {s₁ = s₁}
+                                    ev-guard consume-eq
+      mem-eq : Preprocessed.memory s' ≡ Preprocessed.memory s ++ (w ∷ [])
+      mem-eq = cong (λ m → m ++ (w ∷ []))
+                    (consume-priv-mem s consume-eq)
+      pis-eq : Preprocessed.pis s' ≡ Preprocessed.pis s ++ []
+      pis-eq = trans (consume-priv-pis s consume-eq)
+                     (sym (++-identityʳ (Preprocessed.pis s)))
+  in mem-eq , pis-eq , r-ev
+satisfies→R-instr-step {hc} pre s (private-input g) st _ _ mi pii wc _ _ _ _
+                       (w , refl , refl , (false , ev-guard , w≡0)) sat =
+  let s' = record s { memory = Preprocessed.memory s ++ (w ∷ []) }
+      r-ev₀ : R-instr pre s (private-input g) (record s { memory = Preprocessed.memory s ++ (0ᶠ ∷ []) })
+      r-ev₀ = r-private-input-inactive {pre = pre} {s = s} {guard = g} ev-guard
+      r-ev : R-instr pre s (private-input g) s'
+      r-ev = subst (λ z → R-instr pre s (private-input g)
+                              (record s { memory = Preprocessed.memory s ++ (z ∷ []) }))
+                   (sym w≡0) r-ev₀
+      mem-eq : Preprocessed.memory s' ≡ Preprocessed.memory s ++ (w ∷ [])
+      mem-eq = refl
+      pis-eq : Preprocessed.pis s' ≡ Preprocessed.pis s ++ []
+      pis-eq = sym (++-identityʳ (Preprocessed.pis s))
+  in mem-eq , pis-eq , r-ev
+
+
+------------------------------------------------------------------------
+-- D2 helpers
+--
+-- Two structural facts about `circuit-instr` / `circuit-instrs`:
+--   (a) one step extends `constraints` by appending a (possibly empty) list;
+--   (b) iterated steps extend `constraints` by an appended list as well.
+--
+-- These are pure computations: (a) follows by case analysis on `i`,
+-- (b) by induction.  Used by D2 to peel off the head step's constraints
+-- from the accumulated constraints list.
+------------------------------------------------------------------------
+
+private
+  -- Per-instruction constraint delta.  Symbolically, the list of constraints
+  -- that `circuit-instr hc i st` appends to `constraints st`.  We use the
+  -- empty list for instructions that emit no constraints
+  -- (output, pi-skip, public-input nothing, private-input nothing) and
+  -- a one-element list for the rest.  `declare-pub-input` is the only
+  -- instruction whose new constraint's content depends on `nr-declared-pi
+  -- st` (the PI-entry index), so the delta is parameterised by that
+  -- field as well as `nr-wires st`.
+  instr-new-constraints : Bool → SynthState → Instruction → List Constraint
+  instr-new-constraints _  st (assert c)               = non-zero c ∷ []
+  instr-new-constraints _  st (cond-select b a c)      =
+    select (SynthState.nr-wires st) b a c ∷ []
+  instr-new-constraints _  st (constrain-bits v bits)  = in-range v bits ∷ []
+  instr-new-constraints _  st (constrain-eq a b)       = (wire a ≑ wire b) ∷ []
+  instr-new-constraints _  st (constrain-to-boolean v) = boolean v ∷ []
+  instr-new-constraints _  st (copy v)                 =
+    (wire (SynthState.nr-wires st) ≑ wire v) ∷ []
+  instr-new-constraints hc st (declare-pub-input v)    =
+    bind (preamble-pi-count hc + SynthState.nr-declared-pi st) v ∷ []
+  instr-new-constraints _  st (pi-skip _ _)            = []
+  instr-new-constraints _  st (ec-add ax ay bx by)     =
+    ec-add (SynthState.nr-wires st) (suc (SynthState.nr-wires st)) ax ay bx by ∷ []
+  instr-new-constraints _  st (ec-mul ax ay s)         =
+    ec-mul (SynthState.nr-wires st) (suc (SynthState.nr-wires st)) ax ay s ∷ []
+  instr-new-constraints _  st (ec-mul-generator s)     =
+    ec-gen (SynthState.nr-wires st) (suc (SynthState.nr-wires st)) s ∷ []
+  instr-new-constraints _  st (hash-to-curve inputs)   =
+    h2c (SynthState.nr-wires st) (suc (SynthState.nr-wires st)) inputs ∷ []
+  instr-new-constraints _  st (load-imm imm)           =
+    (wire (SynthState.nr-wires st) ≑ con imm) ∷ []
+  instr-new-constraints _  st (div-mod-power-of-two v bits) =
+    div-mod (SynthState.nr-wires st) (suc (SynthState.nr-wires st)) v bits ∷ []
+  instr-new-constraints _  st (reconstitute-field d m bits) =
+    reconstitute (SynthState.nr-wires st) d m bits ∷ []
+  instr-new-constraints _  st (output v)               = []
+  instr-new-constraints _  st (transient-hash inputs)  =
+    poseidon (SynthState.nr-wires st) inputs ∷ []
+  instr-new-constraints _  st (persistent-hash α inputs) =
+    sha256 (SynthState.nr-wires st) (suc (SynthState.nr-wires st)) α inputs ∷ []
+  instr-new-constraints _  st (test-eq a b)            =
+    test-eq (SynthState.nr-wires st) a b ∷ []
+  instr-new-constraints _  st (add a b)                =
+    (wire (SynthState.nr-wires st) ≑ wire a ⊕ wire b) ∷ []
+  instr-new-constraints _  st (mul a b)                =
+    (wire (SynthState.nr-wires st) ≑ wire a ⊗ wire b) ∷ []
+  instr-new-constraints _  st (neg a)                  =
+    (wire (SynthState.nr-wires st) ≑ ⊝ wire a) ∷ []
+  instr-new-constraints _  st (not a)                  =
+    is-zero (SynthState.nr-wires st) a ∷ []
+  instr-new-constraints _  st (less-than a b bits)     =
+    less-than (SynthState.nr-wires st) a b bits ∷ []
+  instr-new-constraints _  st (public-input nothing)   = []
+  instr-new-constraints _  st (public-input (just g))  =
+    guard-disj (SynthState.nr-wires st) g ∷ []
+  instr-new-constraints _  st (private-input nothing)  = []
+  instr-new-constraints _  st (private-input (just g)) =
+    guard-disj (SynthState.nr-wires st) g ∷ []
+
+  -- Decomposition: `constraints (circuit-instr hc i st) ≡ constraints st ++
+  -- instr-new-constraints hc st i`.  By case analysis on `i`.  The
+  -- definition of `circuit-instr` makes each case definitionally
+  -- equal to its push-constraint form, so each case proof is `refl`.
+  -- We use a single helper lemma `++-cl` that produces `xs ∷ʳ x ≡ xs ++ (x ∷ [])`
+  -- (which is already definitional).
+  constraints-after-instr-eq : ∀ {hc} (i : Instruction) (st : SynthState)
+    → SynthState.constraints (circuit-instr hc i st)
+      ≡ SynthState.constraints st ++ instr-new-constraints hc st i
+  constraints-after-instr-eq (assert c) st                = refl
+  constraints-after-instr-eq (cond-select b a c) st       = refl
+  constraints-after-instr-eq (constrain-bits v bits) st   = refl
+  constraints-after-instr-eq (constrain-eq a b) st        = refl
+  constraints-after-instr-eq (constrain-to-boolean v) st  = refl
+  constraints-after-instr-eq (copy v) st                  = refl
+  constraints-after-instr-eq (declare-pub-input v) st     = refl
+  constraints-after-instr-eq (pi-skip g count) st         = sym (++-identityʳ _)
+  constraints-after-instr-eq (ec-add ax ay bx by) st      = refl
+  constraints-after-instr-eq (ec-mul ax ay s) st          = refl
+  constraints-after-instr-eq (ec-mul-generator s) st      = refl
+  constraints-after-instr-eq (hash-to-curve inputs) st    = refl
+  constraints-after-instr-eq (load-imm imm) st            = refl
+  constraints-after-instr-eq (div-mod-power-of-two v bits) st = refl
+  constraints-after-instr-eq (reconstitute-field d m bits) st = refl
+  constraints-after-instr-eq (output v) st                = sym (++-identityʳ _)
+  constraints-after-instr-eq (transient-hash inputs) st   = refl
+  constraints-after-instr-eq (persistent-hash α inputs) st = refl
+  constraints-after-instr-eq (test-eq a b) st             = refl
+  constraints-after-instr-eq (add a b) st                 = refl
+  constraints-after-instr-eq (mul a b) st                 = refl
+  constraints-after-instr-eq (neg a) st                   = refl
+  constraints-after-instr-eq (not a) st                   = refl
+  constraints-after-instr-eq (less-than a b bits) st      = refl
+  constraints-after-instr-eq (public-input nothing) st    = sym (++-identityʳ _)
+  constraints-after-instr-eq (public-input (just g)) st   = refl
+  constraints-after-instr-eq (private-input nothing) st   = sym (++-identityʳ _)
+  constraints-after-instr-eq (private-input (just g)) st  = refl
+
+  -- Iterated decomposition.  `constraints (circuit-instrs hc is st) ≡
+  -- constraints st ++ <tail>` for some explicit tail computed by
+  -- `instrs-new-constraints`.  We do not need the explicit form of `tail`;
+  -- just its existence is enough for the satisfies-split.
+  constraints-after-instrs-extends
+    : ∀ {hc} (is : List Instruction) (st : SynthState)
+    → Σ (List Constraint) λ tail →
+        SynthState.constraints (circuit-instrs hc is st)
+          ≡ SynthState.constraints st ++ tail
+  constraints-after-instrs-extends []       st =
+    [] , sym (++-identityʳ _)
+  constraints-after-instrs-extends {hc} (i ∷ is) st =
+    let head-new      = instr-new-constraints hc st i
+        st₁           = circuit-instr hc i st
+        head-eq       = constraints-after-instr-eq {hc} i st
+        tail , tl-eq  = constraints-after-instrs-extends {hc} is st₁
+        combined-eq   : SynthState.constraints (circuit-instrs hc is st₁)
+                      ≡ SynthState.constraints st ++ (head-new ++ tail)
+        combined-eq   = trans tl-eq
+                          (trans (cong (_++ tail) head-eq)
+                                 (++-assoc (SynthState.constraints st) head-new tail))
+    in head-new ++ tail , combined-eq
+
+------------------------------------------------------------------------
+-- Helpers for D2's cons-case discharge.
+------------------------------------------------------------------------
+
+private
+  -- nr-wires after a single instruction = nr-wires before + Δmem.
+  -- Proved by case analysis on the instruction.  Each case is `refl`
+  -- because `circuit-instr` updates `nr-wires` as exactly
+  -- `nr-wires st + Δmem i`, but spelled with explicit `+1`/`+2`
+  -- shorthands rather than `+ Δmem i`.  We bridge via `+1-suc`/`+2-ss`.
+  nr-wires-step : ∀ {hc} (i : Instruction) (st : SynthState)
+    → SynthState.nr-wires (circuit-instr hc i st)
+      ≡ SynthState.nr-wires st + Δmem i
+  nr-wires-step (assert _)                 st = sym (+-identityʳ _)
+  nr-wires-step (constrain-bits _ _)       st = sym (+-identityʳ _)
+  nr-wires-step (constrain-eq _ _)         st = sym (+-identityʳ _)
+  nr-wires-step (constrain-to-boolean _)   st = sym (+-identityʳ _)
+  nr-wires-step (declare-pub-input _)      st = sym (+-identityʳ _)
+  nr-wires-step (pi-skip _ _)              st = sym (+-identityʳ _)
+  nr-wires-step (output _)                 st = sym (+-identityʳ _)
+  nr-wires-step (cond-select _ _ _)        st = refl
+  nr-wires-step (copy _)                   st = refl
+  nr-wires-step (load-imm _)               st = refl
+  nr-wires-step (reconstitute-field _ _ _) st = refl
+  nr-wires-step (transient-hash _)         st = refl
+  nr-wires-step (test-eq _ _)              st = refl
+  nr-wires-step (add _ _)                  st = refl
+  nr-wires-step (mul _ _)                  st = refl
+  nr-wires-step (neg _)                    st = refl
+  nr-wires-step (not _)                    st = refl
+  nr-wires-step (less-than _ _ _)          st = refl
+  nr-wires-step (public-input nothing)     st = refl
+  nr-wires-step (public-input (just _))    st = refl
+  nr-wires-step (private-input nothing)    st = refl
+  nr-wires-step (private-input (just _))   st = refl
+  nr-wires-step (ec-add _ _ _ _)           st = refl
+  nr-wires-step (ec-mul _ _ _)             st = refl
+  nr-wires-step (ec-mul-generator _)       st = refl
+  nr-wires-step (hash-to-curve _)          st = refl
+  nr-wires-step (persistent-hash _ _)      st = refl
+  nr-wires-step (div-mod-power-of-two _ _) st = refl
+
+  -- O2-check extraction.  From `O2-step i (n , bk) ≡ just acc'`
+  -- recover `O2-check i bk ≡ just bk`.  Mechanical case analysis on `i`.
+  --
+  -- The three obligation cases (`assert`, `not`, `cond-select`) split
+  -- on `c ∈? bk`:  the `yes` branch gives `O2-check i bk ≡ just bk`
+  -- directly; the `no` branch makes `O2-step ≡ nothing`, contradicting
+  -- `eq`.  All other 23 cases unfold to `O2-check i bk = just bk` and
+  -- the result is `refl`.
+  o2-check-from-step
+    : ∀ (i : Instruction) {n : ℕ} (bk : IndexSet) {acc'}
+    → O2-step i (n , bk) ≡ just acc'
+    → O2-check i bk ≡ just bk
+  o2-check-from-step (assert c) {n} bk eq with c ∈? bk
+  ... | yes _ = refl
+  ... | no  _ with eq
+  ...            | ()
+  o2-check-from-step (not a) {n} bk eq with a ∈? bk
+  ... | yes _ = refl
+  ... | no  _ with eq
+  ...            | ()
+  o2-check-from-step (cond-select b _ _) {n} bk eq with b ∈? bk
+  ... | yes _ = refl
+  ... | no  _ with eq
+  ...            | ()
+  o2-check-from-step (constrain-bits _ _)     bk eq = refl
+  o2-check-from-step (constrain-eq _ _)       bk eq = refl
+  o2-check-from-step (constrain-to-boolean _) bk eq = refl
+  o2-check-from-step (copy _)                 bk eq = refl
+  o2-check-from-step (declare-pub-input _)    bk eq = refl
+  o2-check-from-step (pi-skip nothing _)      bk eq = refl
+  o2-check-from-step (pi-skip (just g) _)     bk eq with g ∈? bk
+  ... | yes _ = refl
+  ... | no  _ with eq
+  ...            | ()
+  o2-check-from-step (ec-add _ _ _ _)         bk eq = refl
+  o2-check-from-step (ec-mul _ _ _)           bk eq = refl
+  o2-check-from-step (ec-mul-generator _)     bk eq = refl
+  o2-check-from-step (hash-to-curve _)        bk eq = refl
+  o2-check-from-step (load-imm _)             bk eq = refl
+  o2-check-from-step (div-mod-power-of-two _ _) bk eq = refl
+  o2-check-from-step (reconstitute-field _ _ _) bk eq = refl
+  o2-check-from-step (output _)               bk eq = refl
+  o2-check-from-step (transient-hash _)       bk eq = refl
+  o2-check-from-step (persistent-hash _ _)    bk eq = refl
+  o2-check-from-step (test-eq _ _)            bk eq = refl
+  o2-check-from-step (add _ _)                bk eq = refl
+  o2-check-from-step (mul _ _)                bk eq = refl
+  o2-check-from-step (neg _)                  bk eq = refl
+  o2-check-from-step (less-than _ _ _)        bk eq = refl
+  o2-check-from-step (public-input _)         bk eq = refl
+  o2-check-from-step (private-input _)        bk eq = refl
+
+  -- O3-obligation extraction:  from `O3-step i (n , bm) ≡ just acc'`
+  -- recover the `O3OK i bm` witness.  `O3-step` branches on `o3OK? i bm`.
+  o3-check-from-step
+    : ∀ (i : Instruction) {n : ℕ} (bm : PartialMap) {acc'}
+    → O3-step i (n , bm) ≡ just acc'
+    → O3OK i bm
+  o3-check-from-step i bm eq with o3OK? i bm | eq
+  ... | yes ok | _  = ok
+  ... | no  _  | ()
+
+  -- pis-suf = wv ∷ [] after a declare; given `length pis-suf ≡ 1`,
+  -- refine the suffix into its canonical shape and account for the +1
+  -- in nr-declared-pi.
+  pi-inv-add-1-declare : ∀ (hc : Bool) (st : SynthState) (pis : List Fr)
+    → (pis-suf : List Fr)
+    → length pis-suf ≡ 1
+    → length pis ≡ preamble-pi-count hc + SynthState.nr-declared-pi st
+    → length (pis ++ pis-suf)
+      ≡ preamble-pi-count hc + suc (SynthState.nr-declared-pi st)
+  pi-inv-add-1-declare _  _  _   []              ()   _
+  pi-inv-add-1-declare hc st pis (wv ∷ [])       refl pii =
+    trans (length-++-1 pis wv)
+          (trans (cong suc pii)
+                 (sym (+-suc (preamble-pi-count hc)
+                              (SynthState.nr-declared-pi st))))
+  pi-inv-add-1-declare _  _  _   (_ ∷ _ ∷ _)     ()   _
+
+  ------------------------------------------------------------------------
+  -- The new constraints emitted by `circuit-instr hc i st` fit
+  -- in the post-state pis (`length pis-suf` cells extension).
+  --
+  -- For every instruction except `declare-pub-input`, the new constraints
+  -- mention no pis (so `constraints-pis-fit` is trivially `true`).
+  -- For `declare-pub-input v`, the only new constraint is
+  -- `bind (preamble-pi-count hc + nr-declared-pi st) v`;
+  -- with `pi-inv`, the entry is `≡ length (pis s)`, hence
+  -- `entry <ᵇ length (pis s ++ pis-suf)` once `length pis-suf ≡ 1`.
+  ------------------------------------------------------------------------
+
+  -- Δpis is 1 for `declare-pub-input` and 0 for every other instruction.
+  Δpis-of : Instruction → ℕ
+  Δpis-of i = shape-Δpis (shape-of (shapeView i))
+
+  -- Auxiliary:  if `length pis-s ≡ entry` and `length pis-suf ≡ 1`,
+  -- then `length (pis-s ++ pis-suf) ≡ suc entry`.
+  pis-len-succ
+    : ∀ (pis-s : List Fr) (pis-suf : List Fr) (entry : ℕ)
+    → length pis-suf ≡ 1
+    → length pis-s ≡ entry
+    → length (pis-s ++ pis-suf) ≡ suc entry
+  pis-len-succ _      []              _     ()   _
+  pis-len-succ pis-s  (w ∷ [])        entry refl eq =
+    trans (length-++-1 pis-s w) (cong suc eq)
+  pis-len-succ _      (_ ∷ _ ∷ _)     _     ()   _
+
+  constraints-pis-fit-instr
+    : ∀ (hc : Bool) (st : SynthState) (s : Preprocessed) (i : Instruction)
+        (pis-suf : List Fr)
+    → length pis-suf ≡ Δpis-of i
+    → length (Preprocessed.pis s)
+        ≡ preamble-pi-count hc + SynthState.nr-declared-pi st
+    → constraints-pis-fit (instr-new-constraints hc st i)
+                       (length (Preprocessed.pis s ++ pis-suf))
+  -- All but `declare-pub-input` emit constraints with no pi references.
+  constraints-pis-fit-instr hc st s (assert c)               _ _ _ = _
+  constraints-pis-fit-instr hc st s (cond-select _ _ _)      _ _ _ = _
+  constraints-pis-fit-instr hc st s (constrain-bits _ _)     _ _ _ = _
+  constraints-pis-fit-instr hc st s (constrain-eq _ _)       _ _ _ = _
+  constraints-pis-fit-instr hc st s (constrain-to-boolean _) _ _ _ = _
+  constraints-pis-fit-instr hc st s (copy _)                 _ _ _ = _
+  constraints-pis-fit-instr hc st s (pi-skip _ _)            _ _ _ = _
+  constraints-pis-fit-instr hc st s (output _)               _ _ _ = _
+  constraints-pis-fit-instr hc st s (ec-add _ _ _ _)         _ _ _ = _
+  constraints-pis-fit-instr hc st s (ec-mul _ _ _)           _ _ _ = _
+  constraints-pis-fit-instr hc st s (ec-mul-generator _)     _ _ _ = _
+  constraints-pis-fit-instr hc st s (hash-to-curve _)        _ _ _ = _
+  constraints-pis-fit-instr hc st s (load-imm _)             _ _ _ = _
+  constraints-pis-fit-instr hc st s (div-mod-power-of-two _ _) _ _ _ = _
+  constraints-pis-fit-instr hc st s (reconstitute-field _ _ _) _ _ _ = _
+  constraints-pis-fit-instr hc st s (transient-hash _)       _ _ _ = _
+  constraints-pis-fit-instr hc st s (persistent-hash _ _)    _ _ _ = _
+  constraints-pis-fit-instr hc st s (test-eq _ _)            _ _ _ = _
+  constraints-pis-fit-instr hc st s (add _ _)                _ _ _ = _
+  constraints-pis-fit-instr hc st s (mul _ _)                _ _ _ = _
+  constraints-pis-fit-instr hc st s (neg _)                  _ _ _ = _
+  constraints-pis-fit-instr hc st s (not _)                  _ _ _ = _
+  constraints-pis-fit-instr hc st s (less-than _ _ _)        _ _ _ = _
+  constraints-pis-fit-instr hc st s (public-input nothing)   _ _ _ = _
+  constraints-pis-fit-instr hc st s (public-input (just _))  _ _ _ = _
+  constraints-pis-fit-instr hc st s (private-input nothing)  _ _ _ = _
+  constraints-pis-fit-instr hc st s (private-input (just _)) _ _ _ = _
+  -- declare-pub-input: the entry index is `preamble-pi-count hc +
+  -- nr-declared-pi st`.  By `pi-inv`, this equals `length (pis s)`.
+  -- The post-state pis has length `length (pis s) + 1 = suc (length pis s)`.
+  -- So `entry < length (pis s ++ pis-suf) = entry < suc entry`.
+  constraints-pis-fit-instr hc st s (declare-pub-input v) pis-suf lh pii =
+    let entry  = preamble-pi-count hc + SynthState.nr-declared-pi st
+        pis-s  = Preprocessed.pis s
+        len-eq : length (pis-s ++ pis-suf) ≡ suc entry
+        len-eq = pis-len-succ pis-s pis-suf entry lh pii
+        ent< : entry < length (pis-s ++ pis-suf)
+        ent< = subst (λ m → entry < m) (sym len-eq) Data.Nat.Properties.≤-refl
+    in ent< , tt
+
+  ------------------------------------------------------------------------
+  -- mem-inv-next / pi-inv-next.
+  --
+  -- For each of the 26 instructions, given:
+  --   • the shape hypotheses on `mem-suf` and `pis-suf`
+  --     (`length mem-suf ≡ Δmem i`, `length pis-suf ≡ Δpis-of i`),
+  --   • the pre-state invariants (`mem-inv s st`, `pi-inv hc s st`),
+  -- the post-state invariants hold for
+  -- `next-state-from-osd i pre s mem-suf pis-suf sd` and
+  -- `circuit-instr hc i st`.
+  --
+  -- Each case mirrors the corresponding clause of `next-state-from-osd`.
+  -- Ill-shaped combinations are absurd by the shape hypotheses.
+  ------------------------------------------------------------------------
+
+  mem-inv-next
+    : ∀ {hc} (i : Instruction) (pre : ProofPreimage)
+        (s : Preprocessed) (st : SynthState)
+        (mem-suf pis-suf : List Fr)
+        (sd : op-side-data i pre s mem-suf pis-suf)
+    → mem-inv s st
+    → length mem-suf ≡ Δmem i
+    → length pis-suf ≡ Δpis-of i
+    → mem-inv (next-state-from-osd i pre s mem-suf pis-suf sd)
+              (circuit-instr hc i st)
+  -- Δmem = 1, "push-mem" cases.
+  mem-inv-next (add _ _)             _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (mul _ _)             _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (neg _)               _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (copy _)              _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (load-imm _)          _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (test-eq _ _)         _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (transient-hash _)    _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (cond-select _ _ _)   _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (not _)               _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (less-than _ _ _)     _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (reconstitute-field _ _ _) _ s st (w ∷ []) [] ((_ , refl) , _) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  -- Δmem = 2, "push-mem2" cases.
+  mem-inv-next (ec-add _ _ _ _)      _ s st (x ∷ y ∷ []) [] ((_ , _ , refl) , _) mi refl refl =
+    mem-inv-step-2 {st = st} {mem = Preprocessed.memory s} {x = x} {y = y} mi
+  mem-inv-next (ec-mul _ _ _)        _ s st (x ∷ y ∷ []) [] ((_ , _ , refl) , _) mi refl refl =
+    mem-inv-step-2 {st = st} {mem = Preprocessed.memory s} {x = x} {y = y} mi
+  mem-inv-next (ec-mul-generator _)  _ s st (x ∷ y ∷ []) [] ((_ , _ , refl) , _) mi refl refl =
+    mem-inv-step-2 {st = st} {mem = Preprocessed.memory s} {x = x} {y = y} mi
+  mem-inv-next (hash-to-curve _)     _ s st (x ∷ y ∷ []) [] ((_ , _ , refl) , _) mi refl refl =
+    mem-inv-step-2 {st = st} {mem = Preprocessed.memory s} {x = x} {y = y} mi
+  mem-inv-next (persistent-hash _ _) _ s st (x ∷ y ∷ []) [] ((_ , _ , refl) , _) mi refl refl =
+    mem-inv-step-2 {st = st} {mem = Preprocessed.memory s} {x = x} {y = y} mi
+  mem-inv-next (div-mod-power-of-two _ _) _ s st (x ∷ y ∷ []) [] ((_ , _ , refl) , _) mi refl refl =
+    mem-inv-step-2 {st = st} {mem = Preprocessed.memory s} {x = x} {y = y} mi
+  -- Δmem = 0, state unchanged.  `circuit-instr` for these does not
+  -- bump `nr-wires`; the `next-state` for these has memory unchanged.
+  mem-inv-next (constrain-eq _ _)      _ s st [] [] _ mi refl refl = mi
+  mem-inv-next (constrain-bits _ _)    _ s st [] [] _ mi refl refl = mi
+  mem-inv-next (constrain-to-boolean _) _ s st [] [] _ mi refl refl = mi
+  mem-inv-next (assert _)              _ s st [] [] _ mi refl refl = mi
+  -- declare-pub-input:  Δmem = 0; pis += wv (handled via record-update;
+  -- memory unchanged).
+  mem-inv-next (declare-pub-input _) _ s st [] (wv ∷ []) _ mi refl refl = mi
+  -- output v:  Δmem = 0; memory unchanged.
+  mem-inv-next (output _)            _ s st [] [] _ mi refl refl = mi
+  -- pi-skip:  Δmem = 0; memory unchanged (regardless of `active`).
+  mem-inv-next (pi-skip _ _)         _ s st [] [] (_ , _ , (true  , _ , _)) mi refl refl = mi
+  mem-inv-next (pi-skip _ _)         _ s st [] [] (_ , _ , (false , _ , _)) mi refl refl = mi
+  -- public-input / private-input:  Δmem = 1.  Active branch:
+  --   next-state = record s₁ { memory = memory s₁ ++ (w ∷ []) }
+  -- with `consume-pub-out s ≡ just (w, s₁)`, so `memory s₁ ≡ memory s`.
+  -- Inactive branch: memory ++ (w ∷ []) directly.
+  mem-inv-next (public-input nothing) _ s st (w ∷ []) [] (_ , refl , _ , (true , _ , (s₁ , cp))) mi refl refl =
+    let mem-s₁≡mem-s = consume-pub-out-mem s {v = w} {s′ = s₁} cp
+        step₁ : SynthState.nr-wires st + 1 ≡ length (Preprocessed.memory s ++ (w ∷ []))
+        step₁ = mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+    in subst (λ m → SynthState.nr-wires st + 1 ≡ length (m ++ (w ∷ [])))
+             (sym mem-s₁≡mem-s) step₁
+  mem-inv-next (public-input (just _)) _ s st (w ∷ []) [] (_ , refl , _ , (true , _ , (s₁ , cp))) mi refl refl =
+    let mem-s₁≡mem-s = consume-pub-out-mem s {v = w} {s′ = s₁} cp
+        step₁ : SynthState.nr-wires st + 1 ≡ length (Preprocessed.memory s ++ (w ∷ []))
+        step₁ = mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+    in subst (λ m → SynthState.nr-wires st + 1 ≡ length (m ++ (w ∷ [])))
+             (sym mem-s₁≡mem-s) step₁
+  mem-inv-next (public-input nothing) _ s st (w ∷ []) [] (_ , refl , _ , (false , _ , _)) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (public-input (just _)) _ s st (w ∷ []) [] (_ , refl , _ , (false , _ , _)) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (private-input nothing) _ s st (w ∷ []) [] (_ , refl , _ , (true , _ , (s₁ , cp))) mi refl refl =
+    let mem-s₁≡mem-s = consume-priv-mem s {v = w} {s′ = s₁} cp
+        step₁ : SynthState.nr-wires st + 1 ≡ length (Preprocessed.memory s ++ (w ∷ []))
+        step₁ = mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+    in subst (λ m → SynthState.nr-wires st + 1 ≡ length (m ++ (w ∷ [])))
+             (sym mem-s₁≡mem-s) step₁
+  mem-inv-next (private-input (just _)) _ s st (w ∷ []) [] (_ , refl , _ , (true , _ , (s₁ , cp))) mi refl refl =
+    let mem-s₁≡mem-s = consume-priv-mem s {v = w} {s′ = s₁} cp
+        step₁ : SynthState.nr-wires st + 1 ≡ length (Preprocessed.memory s ++ (w ∷ []))
+        step₁ = mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+    in subst (λ m → SynthState.nr-wires st + 1 ≡ length (m ++ (w ∷ [])))
+             (sym mem-s₁≡mem-s) step₁
+  mem-inv-next (private-input nothing) _ s st (w ∷ []) [] (_ , refl , _ , (false , _ , _)) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+  mem-inv-next (private-input (just _)) _ s st (w ∷ []) [] (_ , refl , _ , (false , _ , _)) mi refl refl =
+    mem-inv-step-1 {st = st} {mem = Preprocessed.memory s} {v = w} mi
+
+  pi-inv-next
+    : ∀ {hc} (i : Instruction) (pre : ProofPreimage)
+        (s : Preprocessed) (st : SynthState)
+        (mem-suf pis-suf : List Fr)
+        (sd : op-side-data i pre s mem-suf pis-suf)
+    → pi-inv hc s st
+    → length mem-suf ≡ Δmem i
+    → length pis-suf ≡ Δpis-of i
+    → pi-inv hc (next-state-from-osd i pre s mem-suf pis-suf sd)
+                (circuit-instr hc i st)
+  -- All non-pi instructions:  pis unchanged in both next-state-from-osd
+  -- and circuit-instr.  We feed `pii` (or a small length-rewrite for
+  -- record-update preservations) directly.
+  pi-inv-next (add _ _)              _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (mul _ _)              _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (neg _)                _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (copy _)               _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (load-imm _)           _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (test-eq _ _)          _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (transient-hash _)     _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (cond-select _ _ _)    _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (not _)                _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (less-than _ _ _)      _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (reconstitute-field _ _ _) _ s st (w ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (ec-add _ _ _ _)       _ s st (x ∷ y ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (ec-mul _ _ _)         _ s st (x ∷ y ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (ec-mul-generator _)   _ s st (x ∷ y ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (hash-to-curve _)      _ s st (x ∷ y ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (persistent-hash _ _)  _ s st (x ∷ y ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (div-mod-power-of-two _ _) _ s st (x ∷ y ∷ []) [] _ pii refl refl = pii
+  pi-inv-next (constrain-eq _ _)      _ s st [] [] _ pii refl refl = pii
+  pi-inv-next (constrain-bits _ _)    _ s st [] [] _ pii refl refl = pii
+  pi-inv-next (constrain-to-boolean _) _ s st [] [] _ pii refl refl = pii
+  pi-inv-next (assert _)              _ s st [] [] _ pii refl refl = pii
+  pi-inv-next (output _)              _ s st [] [] _ pii refl refl = pii
+  pi-inv-next (pi-skip _ _)           _ s st [] [] (_ , _ , (true  , _ , _)) pii refl refl = pii
+  pi-inv-next (pi-skip _ _)           _ s st [] [] (_ , _ , (false , _ , _)) pii refl refl = pii
+  -- public-input / private-input: pis unchanged.  Active branch
+  -- requires `pis s₁ ≡ pis s`.
+  pi-inv-next (public-input nothing) _ s st (w ∷ []) [] (_ , refl , _ , (true , _ , (s₁ , cp))) pii refl refl =
+    subst (λ p → length p ≡ _) (sym (consume-pub-out-pis s {v = w} {s′ = s₁} cp)) pii
+  pi-inv-next (public-input (just _)) _ s st (w ∷ []) [] (_ , refl , _ , (true , _ , (s₁ , cp))) pii refl refl =
+    subst (λ p → length p ≡ _) (sym (consume-pub-out-pis s {v = w} {s′ = s₁} cp)) pii
+  pi-inv-next (public-input nothing) _ s st (w ∷ []) [] (_ , refl , _ , (false , _ , _)) pii refl refl = pii
+  pi-inv-next (public-input (just _)) _ s st (w ∷ []) [] (_ , refl , _ , (false , _ , _)) pii refl refl = pii
+  pi-inv-next (private-input nothing) _ s st (w ∷ []) [] (_ , refl , _ , (true , _ , (s₁ , cp))) pii refl refl =
+    subst (λ p → length p ≡ _) (sym (consume-priv-pis s {v = w} {s′ = s₁} cp)) pii
+  pi-inv-next (private-input (just _)) _ s st (w ∷ []) [] (_ , refl , _ , (true , _ , (s₁ , cp))) pii refl refl =
+    subst (λ p → length p ≡ _) (sym (consume-priv-pis s {v = w} {s′ = s₁} cp)) pii
+  pi-inv-next (private-input nothing) _ s st (w ∷ []) [] (_ , refl , _ , (false , _ , _)) pii refl refl = pii
+  pi-inv-next (private-input (just _)) _ s st (w ∷ []) [] (_ , refl , _ , (false , _ , _)) pii refl refl = pii
+  -- declare-pub-input:  Δpis = 1; the post-state's nr-declared-pi is
+  -- `suc (nr-declared-pi st)`; the post-state pis is `pis s ++ (wv ∷ [])`.
+  pi-inv-next {hc} (declare-pub-input _) _ s st [] (wv ∷ []) (_ , _ , refl) pii refl refl =
+    pi-inv-add-1-declare hc st (Preprocessed.pis s) (wv ∷ []) refl pii
+
+------------------------------------------------------------------------
+-- Constraints-fit invariant along `circuit-instrs`.
+--
+-- Three pieces of infrastructure that together establish:
+--
+--   `constraints-mem-fit (constraints (circuit-instrs hc is st₀))
+--                    (nr-wires (circuit-instrs hc is st₀))`
+--
+-- given an analogous fact on `st₀` and a `Wire-Trace`.  This is the
+-- invariant that lets D2's cons case shrink the satisfies-constraints
+-- witness back to the operationally-relevant memory at each step.
+------------------------------------------------------------------------
+
+private
+  ------------------------------------------------------------------------
+  -- Monotonicity of `constraint-mem-fits` / `constraints-mem-fit` along
+  -- `n ↦ n + k` (each operand bound lifted by `m≤n⇒m≤n+o`).
+  ------------------------------------------------------------------------
+
+  -- Monotonicity of `expr-mem-fits` along `n ↦ n + k`.  Each wire
+  -- bound is lifted by `m≤n⇒m≤n+o`; the `gate` case of
+  -- `constraint-mem-fits-mono` defers to it.
+  expr-mem-fits-mono : ∀ (e : Expr) n k
+    → expr-mem-fits e n → expr-mem-fits e (n + k)
+  expr-mem-fits-mono (wire i) n k h = m≤n⇒m≤n+o k h
+  expr-mem-fits-mono (con _)  _ _ h = h
+  expr-mem-fits-mono (l ⊕ r)  n k (hl , hr) =
+    expr-mem-fits-mono l n k hl , expr-mem-fits-mono r n k hr
+  expr-mem-fits-mono (l ⊗ r)  n k (hl , hr) =
+    expr-mem-fits-mono l n k hl , expr-mem-fits-mono r n k hr
+  expr-mem-fits-mono (⊝ e)    n k h = expr-mem-fits-mono e n k h
+
+  -- `constraint-mem-fits cl n → constraint-mem-fits cl (n+k)`.  Each operand
+  -- bound `x < n` is lifted by `m≤n⇒m≤n+o`; list operands by `mapᴬ`.
+  constraint-mem-fits-mono : ∀ (cl : Constraint) n k
+    → constraint-mem-fits cl n → constraint-mem-fits cl (n + k)
+  constraint-mem-fits-mono (gate e) n k h = expr-mem-fits-mono e n k h
+  constraint-mem-fits-mono (non-zero c) n k h = m≤n⇒m≤n+o k h
+  constraint-mem-fits-mono (select out b a c) n k (hout , hb , ha , hc) =
+    m≤n⇒m≤n+o k hout , m≤n⇒m≤n+o k hb , m≤n⇒m≤n+o k ha , m≤n⇒m≤n+o k hc
+  constraint-mem-fits-mono (in-range v _) n k h = m≤n⇒m≤n+o k h
+  constraint-mem-fits-mono (boolean v) n k h = m≤n⇒m≤n+o k h
+  constraint-mem-fits-mono (ec-add cx cy ax ay bx by) n k
+    (hcx , hcy , hax , hay , hbx , hby) =
+    m≤n⇒m≤n+o k hcx , m≤n⇒m≤n+o k hcy , m≤n⇒m≤n+o k hax
+    , m≤n⇒m≤n+o k hay , m≤n⇒m≤n+o k hbx , m≤n⇒m≤n+o k hby
+  constraint-mem-fits-mono (ec-mul cx cy ax ay s) n k
+    (hcx , hcy , hax , hay , hs) =
+    m≤n⇒m≤n+o k hcx , m≤n⇒m≤n+o k hcy , m≤n⇒m≤n+o k hax
+    , m≤n⇒m≤n+o k hay , m≤n⇒m≤n+o k hs
+  constraint-mem-fits-mono (ec-gen cx cy s) n k (hcx , hcy , hs) =
+    m≤n⇒m≤n+o k hcx , m≤n⇒m≤n+o k hcy , m≤n⇒m≤n+o k hs
+  constraint-mem-fits-mono (h2c cx cy inputs) n k (hcx , hcy , hin) =
+    m≤n⇒m≤n+o k hcx , m≤n⇒m≤n+o k hcy , mapᴬ (m≤n⇒m≤n+o k) hin
+  constraint-mem-fits-mono (div-mod q r v _) n k (hq , hr , hv) =
+    m≤n⇒m≤n+o k hq , m≤n⇒m≤n+o k hr , m≤n⇒m≤n+o k hv
+  constraint-mem-fits-mono (reconstitute out d m _) n k (hout , hd , hm) =
+    m≤n⇒m≤n+o k hout , m≤n⇒m≤n+o k hd , m≤n⇒m≤n+o k hm
+  constraint-mem-fits-mono (poseidon out inputs) n k (hout , hin) =
+    m≤n⇒m≤n+o k hout , mapᴬ (m≤n⇒m≤n+o k) hin
+  constraint-mem-fits-mono (sha256 h₁ h₂ _ inputs) n k (hh1 , hh2 , hin) =
+    m≤n⇒m≤n+o k hh1 , m≤n⇒m≤n+o k hh2 , mapᴬ (m≤n⇒m≤n+o k) hin
+  constraint-mem-fits-mono (test-eq out a b) n k (hout , ha , hb) =
+    m≤n⇒m≤n+o k hout , m≤n⇒m≤n+o k ha , m≤n⇒m≤n+o k hb
+  constraint-mem-fits-mono (is-zero out a) n k (hout , ha) =
+    m≤n⇒m≤n+o k hout , m≤n⇒m≤n+o k ha
+  constraint-mem-fits-mono (less-than out a b _) n k (hout , ha , hb) =
+    m≤n⇒m≤n+o k hout , m≤n⇒m≤n+o k ha , m≤n⇒m≤n+o k hb
+  constraint-mem-fits-mono (guard-disj out i) n k (hout , hi) =
+    m≤n⇒m≤n+o k hout , m≤n⇒m≤n+o k hi
+  constraint-mem-fits-mono (bind _ widx) n k h = m≤n⇒m≤n+o k h
+  constraint-mem-fits-mono (comm inputs outputs) n k (hin , hout) =
+    mapᴬ (m≤n⇒m≤n+o k) hin , mapᴬ (m≤n⇒m≤n+o k) hout
+
+  -- The list-level monotonicity:  pointwise from `constraint-mem-fits-mono`.
+  constraints-mem-fits-mono : ∀ (cs : List Constraint) n k
+    → constraints-mem-fit cs n → constraints-mem-fit cs (n + k)
+  constraints-mem-fits-mono []       n k _ = tt
+  constraints-mem-fits-mono (c ∷ cs) n k (hc , htl) =
+    constraint-mem-fits-mono c n k hc , constraints-mem-fits-mono cs n k htl
+
+  ------------------------------------------------------------------------
+  -- Per-step fit: the new constraints emitted by `circuit-instr hc i st`
+  -- fit in `nr-wires st + Δmem i`.  26-case proof.
+  --
+  -- The basic strategy in each case is:
+  --   • project each operand's `_< nr-wires st` bound from `WireOK`;
+  --   • lift it via `m≤n⇒m≤n+o` to `_< nr-wires st + Δmem i`;
+  --   • for the "new output wire" cases (`nr-wires st`, `suc (nr-wires st)`),
+  --     use the explicit `n<n+k` facts below.
+  ------------------------------------------------------------------------
+
+  -- Output-wire fit facts: the freshly-emitted output wire(s) sit below
+  -- the bumped wire count.
+  n<n+1 : ∀ n → n < n + 1
+  n<n+1 zero    = Data.Nat.s≤s Data.Nat.z≤n
+  n<n+1 (suc n) = Data.Nat.s≤s (n<n+1 n)
+
+  n<n+2 : ∀ n → n < n + 2
+  n<n+2 zero    = Data.Nat.s≤s Data.Nat.z≤n
+  n<n+2 (suc n) = Data.Nat.s≤s (n<n+2 n)
+
+  sn<n+2 : ∀ n → suc n < n + 2
+  sn<n+2 zero    = Data.Nat.s≤s (Data.Nat.s≤s Data.Nat.z≤n)
+  sn<n+2 (suc n) = Data.Nat.s≤s (sn<n+2 n)
+
+  constraints-new-fit-step
+    : ∀ (hc : Bool) (st : SynthState) (i : Instruction)
+    → WireOK i (SynthState.nr-wires st)
+    → constraints-mem-fit (instr-new-constraints hc st i)
+                      (SynthState.nr-wires st + Δmem i)
+  -- Δmem=0 cases (constraints use only existing wires; sometimes empty).
+  constraints-new-fit-step hc st (assert c) wc =
+    m≤n⇒m≤n+o 0 wc , tt
+  constraints-new-fit-step hc st (constrain-bits v bits) wc =
+    m≤n⇒m≤n+o 0 wc , tt
+  constraints-new-fit-step hc st (constrain-eq a b) (ha , hb) =
+    (m≤n⇒m≤n+o 0 ha , m≤n⇒m≤n+o 0 hb) , tt
+  constraints-new-fit-step hc st (constrain-to-boolean v) wc =
+    m≤n⇒m≤n+o 0 wc , tt
+  constraints-new-fit-step hc st (declare-pub-input v) wc =
+    m≤n⇒m≤n+o 0 wc , tt
+  constraints-new-fit-step hc st (pi-skip g count) wc = tt
+  constraints-new-fit-step hc st (output v) wc = tt
+  -- Δmem=1 cases that introduce a new output wire at `nr-wires st`.
+  constraints-new-fit-step hc st (cond-select b a c) (hb , ha , hcw) =
+    ( n<n+1 (SynthState.nr-wires st)
+    , m≤n⇒m≤n+o 1 hb , m≤n⇒m≤n+o 1 ha , m≤n⇒m≤n+o 1 hcw ) , tt
+  constraints-new-fit-step hc st (copy v) wc =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 wc ) , tt
+  constraints-new-fit-step hc st (load-imm imm) wc =
+    (n<n+1 (SynthState.nr-wires st) , tt) , tt
+  constraints-new-fit-step hc st (reconstitute-field d m bits) (hd , hm) =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 hd , m≤n⇒m≤n+o 1 hm ) , tt
+  constraints-new-fit-step hc st (transient-hash inputs) wc =
+    ( n<n+1 (SynthState.nr-wires st) , mapᴬ (m≤n⇒m≤n+o 1) wc ) , tt
+  constraints-new-fit-step hc st (test-eq a b) (ha , hb) =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 ha , m≤n⇒m≤n+o 1 hb ) , tt
+  constraints-new-fit-step hc st (add a b) (ha , hb) =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 ha , m≤n⇒m≤n+o 1 hb ) , tt
+  constraints-new-fit-step hc st (mul a b) (ha , hb) =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 ha , m≤n⇒m≤n+o 1 hb ) , tt
+  constraints-new-fit-step hc st (neg a) wc =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 wc ) , tt
+  constraints-new-fit-step hc st (not a) wc =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 wc ) , tt
+  constraints-new-fit-step hc st (less-than a b bits) (ha , hb) =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 ha , m≤n⇒m≤n+o 1 hb ) , tt
+  -- Δmem=1 cases with optional guard:  `public-input` / `private-input`.
+  constraints-new-fit-step hc st (public-input nothing) wc = tt
+  constraints-new-fit-step hc st (public-input (just g)) wc =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 wc ) , tt
+  constraints-new-fit-step hc st (private-input nothing) wc = tt
+  constraints-new-fit-step hc st (private-input (just g)) wc =
+    ( n<n+1 (SynthState.nr-wires st) , m≤n⇒m≤n+o 1 wc ) , tt
+  -- Δmem=2 cases that introduce two new output wires.
+  constraints-new-fit-step hc st (ec-add ax ay bx by) (hax , hay , hbx , hby) =
+    ( n<n+2 (SynthState.nr-wires st)
+    , sn<n+2 (SynthState.nr-wires st)
+    , m≤n⇒m≤n+o 2 hax , m≤n⇒m≤n+o 2 hay , m≤n⇒m≤n+o 2 hbx , m≤n⇒m≤n+o 2 hby ) , tt
+  constraints-new-fit-step hc st (ec-mul ax ay s) (hax , hay , hs) =
+    ( n<n+2 (SynthState.nr-wires st)
+    , sn<n+2 (SynthState.nr-wires st)
+    , m≤n⇒m≤n+o 2 hax , m≤n⇒m≤n+o 2 hay , m≤n⇒m≤n+o 2 hs ) , tt
+  constraints-new-fit-step hc st (ec-mul-generator s) wc =
+    ( n<n+2 (SynthState.nr-wires st)
+    , sn<n+2 (SynthState.nr-wires st)
+    , m≤n⇒m≤n+o 2 wc ) , tt
+  constraints-new-fit-step hc st (hash-to-curve inputs) wc =
+    ( n<n+2 (SynthState.nr-wires st)
+    , sn<n+2 (SynthState.nr-wires st)
+    , mapᴬ (m≤n⇒m≤n+o 2) wc ) , tt
+  constraints-new-fit-step hc st (persistent-hash α inputs) wc =
+    ( n<n+2 (SynthState.nr-wires st)
+    , sn<n+2 (SynthState.nr-wires st)
+    , mapᴬ (m≤n⇒m≤n+o 2) wc ) , tt
+  constraints-new-fit-step hc st (div-mod-power-of-two v bits) wc =
+    ( n<n+2 (SynthState.nr-wires st)
+    , sn<n+2 (SynthState.nr-wires st)
+    , m≤n⇒m≤n+o 2 wc ) , tt
+
+  ------------------------------------------------------------------------
+  -- The iterated constraints-fit invariant.
+  --
+  -- Given:
+  --   • `constraints-mem-fit (constraints st₀) (nr-wires st₀)`;
+  --   • a `Wire-Trace is (nr-wires st₀) final-w` (which witnesses that
+  --     every prefix satisfies `WireOK`).
+  --
+  -- Conclude that
+  --   `constraints-mem-fit (constraints (circuit-instrs hc is st₀))
+  --                    (nr-wires (circuit-instrs hc is st₀))`.
+  --
+  -- The induction step combines `constraints-after-instr-eq` (decomposes
+  -- the post-step constraints), `nr-wires-step` (relates post- and pre-step
+  -- `nr-wires`), and the two monotonicity lemmas.
+  ------------------------------------------------------------------------
+
+  -- Extract the head step's `WireOK` premise and the residual trace from
+  -- a `Wire-Trace`.  Both are projections of `wire-trace-head`.
+  wire-trace-head-ok : ∀ {i is n final}
+    → Wire-Trace (i ∷ is) n final
+    → WireOK i n
+  wire-trace-head-ok wt = proj₁ (wire-trace-head wt)
+
+  wire-trace-tail : ∀ {i is n final}
+    → (wt : Wire-Trace (i ∷ is) n final)
+    → Wire-Trace is (n + Δmem i) final
+  wire-trace-tail wt = proj₂ (wire-trace-head wt)
+
+  -- ∧ combiner concatenated with `constraints-mem-fit-++`:  the fit of
+  -- `xs ++ ys` at `n` decomposes into fit of `xs` at `n` and fit of
+  -- `ys` at `n`.
+  constraints-mem-fit-++
+    : ∀ (xs ys : List Constraint) n
+    → constraints-mem-fit xs n
+    → constraints-mem-fit ys n
+    → constraints-mem-fit (xs ++ ys) n
+  constraints-mem-fit-++ []       ys n _        hy = hy
+  constraints-mem-fit-++ (x ∷ xs) ys n (hx , htl) hy =
+    hx , constraints-mem-fit-++ xs ys n htl hy
+
+  constraints-st-fit-invariant
+    : ∀ {hc} (st₀ : SynthState) (is : List Instruction)
+      {final-w : ℕ}
+    → constraints-mem-fit (SynthState.constraints st₀) (SynthState.nr-wires st₀)
+    → Wire-Trace is (SynthState.nr-wires st₀) final-w
+    → constraints-mem-fit
+        (SynthState.constraints (circuit-instrs hc is st₀))
+        (SynthState.nr-wires (circuit-instrs hc is st₀))
+  -- Empty list:  `circuit-instrs hc [] st₀ = st₀`.
+  constraints-st-fit-invariant {hc} st₀ [] base _ = base
+  -- Cons:  recurse on the post-step state `circuit-instr hc i st₀`,
+  -- threading the lifted base via `constraints-after-instr-eq`,
+  -- `nr-wires-step`, `constraints-mem-fits-mono`, and `constraints-new-fit-step`.
+  constraints-st-fit-invariant {hc} st₀ (i ∷ is) {final-w} base wt =
+    let n₀ = SynthState.nr-wires st₀
+        st₁ = circuit-instr hc i st₀
+        n₁ = SynthState.nr-wires st₁
+        -- Head's WireOK.
+        wc-head = wire-trace-head-ok wt
+        -- Tail's wire trace at `n₀ + Δmem i`.
+        wt-tail : Wire-Trace is (n₀ + Δmem i) final-w
+        wt-tail = wire-trace-tail wt
+        -- Reshape the tail's wire trace from `n₀ + Δmem i` to
+        -- `nr-wires st₁`, using `nr-wires-step`.
+        nw-eq : n₁ ≡ n₀ + Δmem i
+        nw-eq = nr-wires-step {hc} i st₀
+        wt-tail' : Wire-Trace is n₁ final-w
+        wt-tail' = subst (λ m → Wire-Trace is m final-w) (sym nw-eq) wt-tail
+        -- Prior constraints lifted to `n₀ + Δmem i`.
+        prior-lift : constraints-mem-fit (SynthState.constraints st₀)
+                                     (n₀ + Δmem i)
+        prior-lift = constraints-mem-fits-mono (SynthState.constraints st₀) n₀
+                                           (Δmem i) base
+        -- New head constraints fit in `n₀ + Δmem i`.
+        new-fit : constraints-mem-fit (instr-new-constraints hc st₀ i)
+                                  (n₀ + Δmem i)
+        new-fit = constraints-new-fit-step hc st₀ i wc-head
+        -- Combined fit at `n₀ + Δmem i`.
+        combined-at-n0+ : constraints-mem-fit
+                            (SynthState.constraints st₀ ++ instr-new-constraints hc st₀ i)
+                            (n₀ + Δmem i)
+        combined-at-n0+ = constraints-mem-fit-++
+                            (SynthState.constraints st₀)
+                            (instr-new-constraints hc st₀ i)
+                            (n₀ + Δmem i)
+                            prior-lift new-fit
+        -- Rewrite combined fit at `n₁` using `nw-eq`.
+        combined-at-n1 : constraints-mem-fit
+                            (SynthState.constraints st₀ ++ instr-new-constraints hc st₀ i)
+                            n₁
+        combined-at-n1 =
+          subst (λ m → constraints-mem-fit
+                         (SynthState.constraints st₀ ++ instr-new-constraints hc st₀ i)
+                         m)
+                (sym nw-eq) combined-at-n0+
+        -- Rewrite the constraint list using `constraints-after-instr-eq`.
+        post-eq : SynthState.constraints st₁
+                  ≡ SynthState.constraints st₀ ++ instr-new-constraints hc st₀ i
+        post-eq = constraints-after-instr-eq {hc} i st₀
+        base-at-st1 : constraints-mem-fit (SynthState.constraints st₁) n₁
+        base-at-st1 = subst (λ cs → constraints-mem-fit cs n₁)
+                            (sym post-eq) combined-at-n1
+    in constraints-st-fit-invariant {hc} st₁ is base-at-st1 wt-tail'
+
+------------------------------------------------------------------------
+-- Shape extractors and the pis-fit list invariant.
+--
+-- `osd-mem-len` / `osd-pis-len`:  from a per-step `op-side-data`
+-- payload recover the canonical suffix lengths
+-- `length mem-step ≡ Δmem i` and `length pis-step ≡ Δpis-of i`.
+-- These feed `mem-inv-next` / `pi-inv-next` / `constraints-pis-fit-instr`
+-- in the D2 cons-case.  Each constraint matches the shape Σ that
+-- `op-side-data` pins for the instruction; matching the embedded
+-- equalities as `refl` collapses the suffix to its canonical form so
+-- the length is `refl`.
+--
+-- `constraints-pis-fit-invariant`:  the pis-side dual of
+-- `constraints-st-fit-invariant`, maintaining
+-- `constraints-pis-fit (constraints (circuit-instrs hc is st₀))
+--                  (length (pis s'))` along the trace.  Unlike
+-- the mem-side invariant (bounded by the synthesis `nr-wires`), the
+-- pis bound is the *running* `length (pis s)` of the operational
+-- state; only `declare-pub-input` emits a pi-referencing constraint, and
+-- `constraints-pis-fit-instr` shows it fits once the step has appended its
+-- pis cell.  The invariant is threaded through the `op-side-data-list`
+-- structure so the per-step `pi-inv` and the suffix lengths are
+-- available at each node.
+------------------------------------------------------------------------
+
+private
+  -- Δmem suffix length from the side data.
+  osd-mem-len
+    : ∀ (i : Instruction) (pre : ProofPreimage) (s : Preprocessed)
+        (ms ps : List Fr)
+    → op-side-data i pre s ms ps
+    → length ms ≡ Δmem i
+  osd-mem-len i pre s ms ps = go (shapeView i)
+    where
+    go : ∀ {j} (v : ShapeView j) → osd-of v pre s ms ps
+       → length ms ≡ shape-Δmem (shape-of v)
+    go sv-pure0   (refl , _)           = refl
+    go sv-pure1   ((_ , refl) , _)     = refl
+    go sv-pure2   ((_ , _ , refl) , _) = refl
+    go sv-declare (refl , _)           = refl
+    go sv-output  (_ , refl , _)       = refl
+    go sv-skip    (refl , _)           = refl
+    go sv-pub-in  (_ , refl , _)       = refl
+    go sv-priv-in (_ , refl , _)       = refl
+
+  -- Δpis suffix length from the side data.
+  osd-pis-len
+    : ∀ (i : Instruction) (pre : ProofPreimage) (s : Preprocessed)
+        (ms ps : List Fr)
+    → op-side-data i pre s ms ps
+    → length ps ≡ Δpis-of i
+  osd-pis-len i pre s ms ps = go (shapeView i)
+    where
+    go : ∀ {j} (v : ShapeView j) → osd-of v pre s ms ps
+       → length ps ≡ shape-Δpis (shape-of v)
+    go sv-pure0   (_ , refl)         = refl
+    go sv-pure1   (_ , refl)         = refl
+    go sv-pure2   (_ , refl)         = refl
+    go sv-declare (_ , _ , refl)     = refl
+    go sv-output  (_ , _ , refl)     = refl
+    go sv-skip    (_ , refl , _)     = refl
+    go sv-pub-in  (_ , _ , refl , _) = refl
+    go sv-priv-in (_ , _ , refl , _) = refl
+
+  -- pis-side list-level fit invariant, threaded through the operational
+  -- trace structure.  At each node, `pi-inv` supplies the base index
+  -- `length (pis s) ≡ preamble-pi-count hc + nr-declared-pi st`, which
+  -- `constraints-pis-fit-instr` turns into the head-step fit at the
+  -- *post-step* pis length; the prior constraints' fit is preserved because
+  -- pis only ever grows (so a `constraint-pis-fit cl n` still holds at
+  -- the larger length — proved by `constraints-pis-fit-mono` below).
+  constraint-pis-fit-mono : ∀ (cl : Constraint) m n
+    → m Data.Nat.≤ n
+    → constraint-pis-fit cl m → constraint-pis-fit cl n
+  constraint-pis-fit-mono (gate _)           _ _ _ h = h
+  constraint-pis-fit-mono (non-zero _)       _ _ _ h = h
+  constraint-pis-fit-mono (select _ _ _ _)     _ _ _ h = h
+  constraint-pis-fit-mono (in-range _ _)          _ _ _ h = h
+  constraint-pis-fit-mono (boolean _)                  _ _ _ h = h
+  constraint-pis-fit-mono (ec-add _ _ _ _ _ _)      _ _ _ h = h
+  constraint-pis-fit-mono (ec-mul _ _ _ _ _)        _ _ _ h = h
+  constraint-pis-fit-mono (ec-gen _ _ _)  _ _ _ h = h
+  constraint-pis-fit-mono (h2c _ _ _)     _ _ _ h = h
+  constraint-pis-fit-mono (div-mod _ _ _ _)         _ _ _ h = h
+  constraint-pis-fit-mono (reconstitute _ _ _ _)    _ _ _ h = h
+  constraint-pis-fit-mono (poseidon _ _)      _ _ _ h = h
+  constraint-pis-fit-mono (sha256 _ _ _ _) _ _ _ h = h
+  constraint-pis-fit-mono (test-eq _ _ _)           _ _ _ h = h
+  constraint-pis-fit-mono (is-zero _ _)                 _ _ _ h = h
+  constraint-pis-fit-mono (less-than _ _ _ _)       _ _ _ h = h
+  constraint-pis-fit-mono (guard-disj _ _)          _ _ _ h = h
+  constraint-pis-fit-mono (bind entry _)    m n m≤n h = <-≤-trans h m≤n
+  constraint-pis-fit-mono (comm _ _)     m n m≤n h = <-≤-trans h m≤n
+
+  constraints-pis-fit-mono : ∀ (cs : List Constraint) m n
+    → m Data.Nat.≤ n
+    → constraints-pis-fit cs m → constraints-pis-fit cs n
+  constraints-pis-fit-mono []       _ _ _   _ = tt
+  constraints-pis-fit-mono (c ∷ cs) m n m≤n (hc , htl) =
+    constraint-pis-fit-mono c m n m≤n hc , constraints-pis-fit-mono cs m n m≤n htl
+
+  constraints-pis-fit-++
+    : ∀ (xs ys : List Constraint) n
+    → constraints-pis-fit xs n
+    → constraints-pis-fit ys n
+    → constraints-pis-fit (xs ++ ys) n
+  constraints-pis-fit-++ []       ys n _        hy = hy
+  constraints-pis-fit-++ (x ∷ xs) ys n (hx , htl) hy =
+    hx , constraints-pis-fit-++ xs ys n htl hy
+
+  -- `length xs ≤ length (xs ++ ys)`.
+  len-≤-++ : ∀ (xs ys : List Fr) → length xs Data.Nat.≤ length (xs ++ ys)
+  len-≤-++ []       ys = Data.Nat.z≤n
+  len-≤-++ (x ∷ xs) ys = Data.Nat.s≤s (len-≤-++ xs ys)
+
+  -- `length (xs ++ ys) ≡ length xs + length ys`.
+  len-++ : ∀ (xs ys : List Fr) → length (xs ++ ys) ≡ length xs + length ys
+  len-++ []       ys = refl
+  len-++ (x ∷ xs) ys = cong suc (len-++ xs ys)
+
+  -- First components of the per-step accumulators bump by `Δmem i`.
+  o2-step-fst : ∀ (i : Instruction) {n bk acc'}
+    → O2-step i (n , bk) ≡ just acc'
+    → proj₁ acc' ≡ n + Δmem i
+  o2-step-fst i {n} {bk} eq with O2-check i bk | eq
+  ... | just _  | refl = refl
+  ... | nothing | ()
+
+  o3-step-fst : ∀ (i : Instruction) {n bm acc'}
+    → O3-step i (n , bm) ≡ just acc'
+    → proj₁ acc' ≡ n + Δmem i
+  o3-step-fst i {n} {bm} eq with o3OK? i bm | eq
+  ... | yes _ | refl = refl
+  ... | no  _ | ()
+
+  wire-step-fst : ∀ (i : Instruction) (n : ℕ) {n'}
+    → wire-step i n ≡ just n'
+    → n' ≡ n + Δmem i
+  wire-step-fst i n eq with wireOK? i n | eq
+  ... | yes _ | refl = refl
+  ... | no  _ | ()
+
+------------------------------------------------------------------------
+-- D2  —  per-list backward dispatcher.
+--
+-- Signature:
+--
+--   • the post-state `s` is *existential* (mirrors D1), so the
+--     dispatcher can rebuild it from the witness's mem/pis decomposition;
+--   • the witness's memory is `memory s₀ ++ mem-suf` for an explicit
+--     suffix `mem-suf` (and analogously for pis);
+--   • `O2-Inv`, `O3-Inv`, `O2-Trace`, `O3-Trace`, `Wire-Trace` are
+--     threaded as separate hypotheses (D3 derives them from
+--     `T (producer-safe src)`);
+--   • `op-side-data-list`  is the structural trace that supplies the
+--     per-step side data D1 needs for the four "side-data instructions".
+--
+-- The side-data list also decomposes `mem-suf` and `pis-suf` into
+-- per-step pieces.
+------------------------------------------------------------------------
+
+-- Trace of per-step operational side data, jointly threading the
+-- preprocessed-state evolution.  Each `osd-cons` provides:
+--   • the side-data for the head instruction;
+--   • the tail side-data list at the computed next state
+--     (`next-state-from-osd i pre s mem-step pis-step sd`).
+--
+-- The "next state" is computed by `next-state-from-osd` from the head
+-- instruction and its side data (rather than supplied by the caller as
+-- an arbitrary `s'` with separate mem/pis equations).  This makes D2's
+-- cons-case definitional: D1's output and `next-state-from-osd ...`
+-- coincide for each of the 26 instructions.
+--
+-- The list "linearises" the operational trace structure without
+-- carrying the `R-instr` constructors themselves (which D2 reconstructs).
+data op-side-data-list (pre : ProofPreimage) :
+       (s : Preprocessed) (is : List Instruction)
+       (mem-suf pis-suf : List Fr) → Set where
+  osd-nil  : ∀ {s} → op-side-data-list pre s [] [] []
+  osd-cons : ∀ {s i is mem-step pis-step mem-tail pis-tail}
+    → (sd : op-side-data i pre s mem-step pis-step)
+    → op-side-data-list pre
+        (next-state-from-osd i pre s mem-step pis-step sd)
+        is mem-tail pis-tail
+    → op-side-data-list pre s (i ∷ is) (mem-step ++ mem-tail) (pis-step ++ pis-tail)
+
+-- The endpoint reached by folding `next-state-from-osd` along an
+-- `op-side-data-list`.  D2's existential output `s'` is provably this
+-- fold (see the `fold-eq` field added to D2's result below); and a
+-- `Tr-shaped` trace's endpoint index coincides with it too (since
+-- `tr-next ≡ next-state-from-osd`).  This is the bridge that pins D2's
+-- `s'` to the GIVEN state `s` in `circuit-faithful-bwd`.
+osd-fold : ∀ {pre s is ms ps} → op-side-data-list pre s is ms ps → Preprocessed
+osd-fold {s = s} osd-nil = s
+osd-fold (osd-cons {i = i} {mem-step = mem-step} {pis-step = pis-step} sd rest) =
+  osd-fold rest
+
+-- D2 itself.
+--
+-- The four bool-traces and `O2-Inv` / `O3-Inv` are explicit so the
+-- inductive step can refine them via `o2-step ≡ just _` / `o3-step ≡ just _`
+-- and `o2-preserve` / `o3-preserve` (already proven).
+--
+-- Two constraint-fit preconditions (`fit-mem`, `fit-pis`) state that the
+-- synthesis state's *current* constraints fit in the memory / pis lengths
+-- reached so far.  They are
+-- threaded inductively (each step's post-state fit is re-established by
+-- `constraints-st-fit-invariant` / `constraints-pis-fit-instr`) and are
+-- discharged trivially at the top-level call site (`circuit-faithful-bwd`),
+-- where `st₀` is the initial synthesis state with `constraints ≡ []` (so both
+-- fits are `refl`).
+satisfies-constraints→R-instrs
+  : ∀ {hc} (pre : ProofPreimage) (s₀ : Preprocessed)
+    (is : List Instruction) (st₀ : SynthState)
+    (mem-suf pis-suf : List Fr)
+  → mem-inv s₀ st₀
+  → pi-inv  hc s₀ st₀
+  → constraints-mem-fit (SynthState.constraints st₀) (SynthState.nr-wires st₀)
+  → constraints-pis-fit (SynthState.constraints st₀) (length (Preprocessed.pis s₀))
+  → ∀ {bk₀ : IndexSet} {bm₀ : PartialMap}
+  → O2-Inv (SynthState.nr-wires st₀ , bk₀) s₀
+  → O3-Inv (SynthState.nr-wires st₀ , bm₀) s₀
+  → ∀ {final-o2 : ℕ × IndexSet} {final-o3 : ℕ × PartialMap} {final-w : ℕ}
+  → O2-Trace is (SynthState.nr-wires st₀ , bk₀) final-o2
+  → O3-Trace is (SynthState.nr-wires st₀ , bm₀) final-o3
+  → Wire-Trace is (SynthState.nr-wires st₀) final-w
+  → All WF2-instr is                                   -- WF2 (§3.3)
+  → (osd : op-side-data-list pre s₀ is mem-suf pis-suf)
+  → satisfies-constraints
+      (SynthState.constraints (circuit-instrs hc is st₀))
+      (mk-witness (Preprocessed.memory s₀ ++ mem-suf)
+                  (Preprocessed.pis    s₀ ++ pis-suf)
+                  (comm-rand-of pre))
+  → Σ Preprocessed (λ s' →
+        (Preprocessed.memory s' ≡ Preprocessed.memory s₀ ++ mem-suf)
+      × (Preprocessed.pis    s' ≡ Preprocessed.pis    s₀ ++ pis-suf)
+      × R-instrs pre s₀ is s'
+      × (s' ≡ osd-fold osd))
+
+-- The body inducts on the `op-side-data-list` structure.  For `i ∷ is'`
+-- with `osd-cons sd osd-tail`:
+--
+--   1. Peel the head step from the O2 / O3 / wire traces (constructor
+--      match), recovering each per-step `*-step ≡ just acc'` and the
+--      residual tail trace.
+--   2. Establish the head's constraint-fit facts at the post-step memory /
+--      pis lengths (`constraints-st-fit-invariant` for mem,
+--      `constraints-pis-fit-instr` + `constraints-pis-fit-mono`/`-++` for pis)
+--      and shrink the satisfaction witness from the full
+--      `mem-step ++ mem-tail` / `pis-step ++ pis-tail` down to just the
+--      head's `mem-step` / `pis-step` (`satisfies-constraints-mem-shrink`,
+--      `satisfies-constraints-pis-shrink`).  These fits are stated purely in
+--      terms of `mem₀ ++ mem-step` / `pis₀ ++ pis-step` (no reference to
+--      D1's output `s₁`), so there is no circular dependency on D1.
+--   3. Apply D1 (`satisfies→R-instr-step`) to the shrunk head witness,
+--      obtaining `s₁ = next-state-from-osd …`, `memory s₁ ≡ memory s₀ ++
+--      mem-step`, `pis s₁ ≡ pis s₀ ++ pis-step`, and `R-instr pre s₀ i s₁`.
+--   4. Advance the invariants to `s₁` (`mem-inv-next`, `pi-inv-next`,
+--      `o2-preserve`, `o3-preserve`) and recurse on `is'` from `st₁`,
+--      feeding the residual traces (re-indexed by `nr-wires-step` and the
+--      per-step first-component bumps) and the full witness rewritten by
+--      `++-assoc` so its memory / pis read as `memory s₁ ++ mem-tail` /
+--      `pis s₁ ++ pis-tail`.
+--   5. Assemble `R-instrs pre s₀ (i ∷ is') s'` with `r-step`, chaining
+--      the memory / pis equations through `++-assoc`.
+
+-- Empty list:  the witness's mem-suf and pis-suf are forced by
+-- `osd-nil` to be `[]`.  Produce `r-done` and the trivial equations.
+satisfies-constraints→R-instrs pre s₀ [] st₀ .[] .[]
+                            mi pii fit-mem fit-pis _ _ _ _ _ _ osd-nil _ =
+  s₀ , sym (++-identityʳ _) , sym (++-identityʳ _) , r-done , refl
+
+-- Cons case.
+satisfies-constraints→R-instrs {hc} pre s₀ (i ∷ is') st₀ ._ ._
+    mi pii fit-mem fit-pis {bk₀} {bm₀} o2-inv o3-inv {final-o2} {final-o3} {final-w}
+    (o2-step {acc' = o2acc'} o2se o2-tail)
+    (o3-step {acc' = o3acc'} o3se o3-tail)
+    (wire-cons {n' = wn'} wse w-tail)
+    (wf2-head ∷ᴬ wf2-tail)
+    (osd-cons {mem-step = mem-step} {pis-step = pis-step}
+              {mem-tail = mem-tail} {pis-tail = pis-tail} sd osd-tail)
+    sat =
+  let
+    n₀  = SynthState.nr-wires st₀
+    st₁ = circuit-instr hc i st₀
+    n₁  = SynthState.nr-wires st₁
+    mem₀ = Preprocessed.memory s₀
+    pis₀ = Preprocessed.pis s₀
+
+    -- Suffix length facts from the side data.
+    ms-len : length mem-step ≡ Δmem i
+    ms-len = osd-mem-len i pre s₀ mem-step pis-step sd
+    ps-len : length pis-step ≡ Δpis-of i
+    ps-len = osd-pis-len i pre s₀ mem-step pis-step sd
+
+    -- Per-step obligation premises for D1.
+    o2chk : O2-check i bk₀ ≡ just bk₀
+    o2chk = o2-check-from-step i {n = n₀} bk₀ o2se
+    o3chk : O3OK i bm₀
+    o3chk = o3-check-from-step i {n = n₀} bm₀ o3se
+
+    -- Head's `WireOK` from `wse : wire-step i n₀ ≡ just wn'`.
+    wc : WireOK i n₀
+    wc = proj₁ (wire-trace-head (wire-cons wse wire-done))
+
+    -- `nr-wires` after the head step.
+    nw-eq : n₁ ≡ n₀ + Δmem i
+    nw-eq = nr-wires-step {hc} i st₀
+
+    -- `length (mem₀ ++ mem-step) ≡ n₁`.
+    len-mem-eq : length (mem₀ ++ mem-step) ≡ n₁
+    len-mem-eq =
+      trans (len-++ mem₀ mem-step)
+        (trans (cong₂ _+_ (sym mi) ms-len) (sym nw-eq))
+
+    -- mem-fit for `constraints st₁`, stated at `length (mem₀ ++ mem-step)`.
+    fit-mem-st₁-nw : constraints-mem-fit (SynthState.constraints st₁) n₁
+    fit-mem-st₁-nw =
+      constraints-st-fit-invariant {hc} st₀ (i ∷ []) fit-mem
+        (wire-cons wse wire-done)
+    fit-mem-head : constraints-mem-fit (SynthState.constraints st₁)
+                                   (length (mem₀ ++ mem-step))
+    fit-mem-head = subst (λ k → constraints-mem-fit (SynthState.constraints st₁) k)
+                         (sym len-mem-eq) fit-mem-st₁-nw
+
+    -- pis-fit for `constraints st₁`, stated at `length (pis₀ ++ pis-step)`.
+    pis-le : length pis₀ Data.Nat.≤ length (pis₀ ++ pis-step)
+    pis-le = len-≤-++ pis₀ pis-step
+    fit-pis-prior : constraints-pis-fit (SynthState.constraints st₀)
+                                    (length (pis₀ ++ pis-step))
+    fit-pis-prior = constraints-pis-fit-mono (SynthState.constraints st₀)
+                      (length pis₀) (length (pis₀ ++ pis-step)) pis-le fit-pis
+    fit-pis-new : constraints-pis-fit (instr-new-constraints hc st₀ i)
+                                  (length (pis₀ ++ pis-step))
+    fit-pis-new = constraints-pis-fit-instr hc st₀ s₀ i pis-step ps-len pii
+    fit-pis-head : constraints-pis-fit (SynthState.constraints st₁)
+                                   (length (pis₀ ++ pis-step))
+    fit-pis-head =
+      subst (λ cs → constraints-pis-fit cs (length (pis₀ ++ pis-step)))
+            (sym (constraints-after-instr-eq {hc} i st₀))
+            (constraints-pis-fit-++ (SynthState.constraints st₀)
+              (instr-new-constraints hc st₀ i) (length (pis₀ ++ pis-step))
+              fit-pis-prior fit-pis-new)
+
+    -- The full witness satisfies `constraints st₁` (split off the tail
+    -- constraints), re-associated so the head suffix is exposed.
+    sat-full-st₁ : satisfies-constraints (SynthState.constraints st₁)
+        (mk-witness ((mem₀ ++ mem-step) ++ mem-tail)
+                    ((pis₀ ++ pis-step) ++ pis-tail)
+                    (comm-rand-of pre))
+    sat-full-st₁ =
+      let tail , tl-eq = constraints-after-instrs-extends {hc} is' st₁
+          sat-decomp : satisfies-constraints (SynthState.constraints st₁ ++ tail)
+                         (mk-witness (mem₀ ++ (mem-step ++ mem-tail))
+                                     (pis₀ ++ (pis-step ++ pis-tail))
+                                     (comm-rand-of pre))
+          sat-decomp = subst (λ cs → satisfies-constraints cs _) tl-eq sat
+      in subst₂ (λ m p → satisfies-constraints (SynthState.constraints st₁)
+                           (mk-witness m p (comm-rand-of pre)))
+                (sym (++-assoc mem₀ mem-step mem-tail))
+                (sym (++-assoc pis₀ pis-step pis-tail))
+                (proj₁ (satisfies-constraints-split (SynthState.constraints st₁)
+                          tail sat-decomp))
+
+    -- Shrink off the tail suffixes to obtain the head witness D1 wants.
+    sat-head-mem : satisfies-constraints (SynthState.constraints st₁)
+        (mk-witness (mem₀ ++ mem-step) ((pis₀ ++ pis-step) ++ pis-tail)
+                    (comm-rand-of pre))
+    sat-head-mem =
+      satisfies-constraints-mem-shrink (SynthState.constraints st₁)
+        (mem₀ ++ mem-step) mem-tail fit-mem-head sat-full-st₁
+    sat-head : satisfies-constraints (SynthState.constraints st₁)
+        (mk-witness (mem₀ ++ mem-step) (pis₀ ++ pis-step) (comm-rand-of pre))
+    sat-head =
+      satisfies-constraints-pis-shrink (SynthState.constraints st₁)
+        (pis₀ ++ pis-step) pis-tail fit-pis-head sat-head-mem
+
+    -- D1 applied to the head.
+    s₁ = next-state-from-osd i pre s₀ mem-step pis-step sd
+    d1-out :
+        (Preprocessed.memory s₁ ≡ mem₀ ++ mem-step)
+      × (Preprocessed.pis    s₁ ≡ pis₀ ++ pis-step)
+      × R-instr pre s₀ i s₁
+    d1-out = satisfies→R-instr-step {hc} pre s₀ i st₀ mem-step pis-step {wf2 = wf2-head}
+               mi pii wc {bk = bk₀} {bm = bm₀} o2-inv o3-inv o2chk o3chk sd
+               sat-head
+
+    mem-eq₁ , pis-eq₁ , r-head = d1-out
+
+    -- Post-step invariants for the recursion.
+    mi₁ : mem-inv s₁ st₁
+    mi₁ = mem-inv-next {hc} i pre s₀ st₀ mem-step pis-step sd mi ms-len ps-len
+    pii₁ : pi-inv hc s₁ st₁
+    pii₁ = pi-inv-next {hc} i pre s₀ st₀ mem-step pis-step sd pii ms-len ps-len
+
+    -- The recorded O2 / O3 accumulators after the step, transported to `s₁`
+    -- and re-indexed so the first component reads `n₁`.
+    o2-fst : proj₁ o2acc' ≡ n₀ + Δmem i
+    o2-fst = o2-step-fst i {n = n₀} {bk = bk₀} o2se
+    o3-fst : proj₁ o3acc' ≡ n₀ + Δmem i
+    o3-fst = o3-step-fst i {n = n₀} {bm = bm₀} o3se
+    o2acc-eq : o2acc' ≡ (n₁ , proj₂ o2acc')
+    o2acc-eq = cong (_, proj₂ o2acc') (trans o2-fst (sym nw-eq))
+    o3acc-eq : o3acc' ≡ (n₁ , proj₂ o3acc')
+    o3acc-eq = cong (_, proj₂ o3acc') (trans o3-fst (sym nw-eq))
+
+    o2-inv₁ : O2-Inv (n₁ , proj₂ o2acc') s₁
+    o2-inv₁ = subst (λ a → O2-Inv a s₁) o2acc-eq (o2-preserve o2-inv r-head o2se)
+    o3-inv₁ : O3-Inv (n₁ , proj₂ o3acc') s₁
+    o3-inv₁ = subst (λ a → O3-Inv a s₁) o3acc-eq (o3-preserve o3-inv r-head o3se)
+
+    o2-tail₁ : O2-Trace is' (n₁ , proj₂ o2acc') final-o2
+    o2-tail₁ = subst (λ a → O2-Trace is' a final-o2) o2acc-eq o2-tail
+    o3-tail₁ : O3-Trace is' (n₁ , proj₂ o3acc') final-o3
+    o3-tail₁ = subst (λ a → O3-Trace is' a final-o3) o3acc-eq o3-tail
+    w-tail₁ : Wire-Trace is' n₁ final-w
+    w-tail₁ = subst (λ k → Wire-Trace is' k final-w)
+                (trans (wire-step-fst i n₀ wse) (sym nw-eq)) w-tail
+
+    -- The full witness over `s₁`'s mem / pis plus the tails.
+    sat-rec : satisfies-constraints
+        (SynthState.constraints (circuit-instrs hc is' st₁))
+        (mk-witness (Preprocessed.memory s₁ ++ mem-tail)
+                    (Preprocessed.pis    s₁ ++ pis-tail)
+                    (comm-rand-of pre))
+    sat-rec =
+      subst₂ (λ m p → satisfies-constraints
+                        (SynthState.constraints (circuit-instrs hc is' st₁))
+                        (mk-witness m p (comm-rand-of pre)))
+             (sym (trans (cong (_++ mem-tail) mem-eq₁)
+                         (++-assoc mem₀ mem-step mem-tail)))
+             (sym (trans (cong (_++ pis-tail) pis-eq₁)
+                         (++-assoc pis₀ pis-step pis-tail)))
+             sat
+
+    -- Recurse.
+    fit-pis-rec : constraints-pis-fit (SynthState.constraints st₁)
+                                  (length (Preprocessed.pis s₁))
+    fit-pis-rec = subst (λ p → constraints-pis-fit (SynthState.constraints st₁)
+                                 (length p))
+                        (sym pis-eq₁) fit-pis-head
+
+    -- Recurse.
+    rec = satisfies-constraints→R-instrs {hc} pre s₁ is' st₁ mem-tail pis-tail
+            mi₁ pii₁ fit-mem-st₁-nw fit-pis-rec
+            {bk₀ = proj₂ o2acc'} {bm₀ = proj₂ o3acc'}
+            o2-inv₁ o3-inv₁ o2-tail₁ o3-tail₁ w-tail₁ wf2-tail osd-tail sat-rec
+
+    s' , mem-eq' , pis-eq' , r-tail , fold-eq' = rec
+  in
+    s'
+    , trans mem-eq'
+        (trans (cong (_++ mem-tail) mem-eq₁)
+               (++-assoc mem₀ mem-step mem-tail))
+    , trans pis-eq'
+        (trans (cong (_++ pis-tail) pis-eq₁)
+               (++-assoc pis₀ pis-step pis-tail))
+    , r-step r-head r-tail
+    -- `osd-fold (osd-cons sd osd-tail)` reduces to `osd-fold osd-tail`,
+    -- which is `rec`'s fold endpoint.  But `rec` was taken at `s₁ =
+    -- next-state-from-osd i …` whereas the osd-tail in THIS list is
+    -- rooted at the same `s₁` — the two `osd-fold`s coincide definitionally.
+    , fold-eq'
+
+------------------------------------------------------------------------
+-- Part 2′.  The transcript-consistency predicate `preprocess-shaped`.
+--
+-- The backward direction (`circuit-faithful-bwd`) over an *arbitrary*
+-- `s : Preprocessed` is unprovable because in-circuit satisfaction
+-- (`satisfies`) is *blind* to the transcript-read wires:
+-- `public-input` / `private-input` emit no
+-- constraint for the value read off the transcript, and `pi-skip`'s
+-- transcript-match check has no in-circuit shadow.  The spec (§5.3,
+-- line 809) sidesteps this by quantifying `Σ` over "preprocess-state-
+-- shaped assignments"; the predicate below is the Agda rendering of
+-- that quantifier restriction.
+--
+-- `preprocess-shaped src pre s` asserts the existence of an operational
+-- *shape* trace from the initial state to `s` in which:
+--
+--   • transcript-read instructions (`public-input` / `private-input`
+--     when active, `pi-skip` when active) consume the preimage
+--     transcripts in order and pass their guard / prefix-match checks;
+--   • EVERY OTHER instruction merely appends some *free* memory / pis
+--     cells of the correct arity — their VALUES are left UNCONSTRAINED.
+--
+-- Design notes.
+--
+--   • NON-VACUOUS / NON-CIRCULAR.  This is strictly WEAKER than
+--     `R-instrs pre s₀ instrs s`: a `tr-step` for `add` / `mul` /
+--     `ec-add` / `hash` / `declare-pub-input` / … pins only the
+--     *length* of the appended suffix (`w ∷ []`, `x ∷ y ∷ []`), NEVER
+--     the computed value (`av +ᶠ bv`, `ec-add-pts …`, …).  Those values
+--     are pinned by `satisfies` via D1/D2.  So `satisfies` remains fully
+--     load-bearing.  It does NOT hand back an `R-instrs` trace.
+--
+--   • IMPLEMENTATION-INDEPENDENT.  The predicate is stated purely in
+--     `Semantics` vocabulary (`Preprocessed`, `mem-lookup`, `eval-guard`,
+--     `consume-pub-out`, `consume-priv`, `≡ᶠ-list?`).  It mentions no
+--     in-circuit construct (`SynthState`, constraints, `op-side-data`).
+--
+--   • STRONG ENOUGH.  The per-step `tr-step` payloads are arranged to
+--     coincide *definitionally* with the corresponding `op-side-data`
+--     payloads and `tr-next` with `next-state-from-osd`, so the internal
+--     bridge converts a `Tr-shaped` trace to an `op-side-data-list`
+--     structurally (two cases), supplying exactly the transcript gaps
+--     D2 needs.
+------------------------------------------------------------------------
+
+-- Per-step shape obligation and post-state, as definitional aliases of
+-- `op-side-data` / `next-state-from-osd` (same payloads, same
+-- `Semantics` vocabulary).  Every downstream reference (`Tr-shaped`,
+-- `R-instr→tr-step`, `tr-step-mem`/`-pis`, the fold) reduces through the
+-- alias to the original, so the internal bridge to `op-side-data` is
+-- the identity.
+tr-step : Instruction → ProofPreimage → Preprocessed
+        → (mem-suf pis-suf : List Fr) → Set
+tr-step = op-side-data
+
+tr-next : (i : Instruction) (pre : ProofPreimage) (s : Preprocessed)
+          (mem-suf pis-suf : List Fr) → tr-step i pre s mem-suf pis-suf → Preprocessed
+tr-next = next-state-from-osd
+
+-- The list closure.  Structurally identical to `op-side-data-list` but
+-- built from the clean `tr-step` / `tr-next` (which coincide
+-- definitionally with `op-side-data` / `next-state-from-osd`), and
+-- additionally ENDPOINT-INDEXED: `Tr-shaped pre s₀ is s ms ps` says the
+-- shape walk from `s₀` over `is`, appending `ms` / `ps`, ends exactly at
+-- `s`.  The endpoint index pins ALL of `s`'s fields (memory, pis, and the
+-- transcript bookkeeping) — this is what the backward direction needs to
+-- recover `R src pre s` for the GIVEN `s` (not merely a state with the
+-- same memory/pis prefix).
+data Tr-shaped (pre : ProofPreimage) :
+       (s₀ : Preprocessed) (is : List Instruction) (s : Preprocessed)
+       (mem-suf pis-suf : List Fr) → Set where
+  tr-nil  : ∀ {s} → Tr-shaped pre s [] s [] []
+  tr-cons : ∀ {s₀ i is s mem-step pis-step mem-tail pis-tail}
+    → (sd : tr-step i pre s₀ mem-step pis-step)
+    → Tr-shaped pre (tr-next i pre s₀ mem-step pis-step sd) is s mem-tail pis-tail
+    → Tr-shaped pre s₀ (i ∷ is) s (mem-step ++ mem-tail) (pis-step ++ pis-tail)
+
+-- A shape walk with existential suffixes: some memory / pis suffixes
+-- together with a `Tr-shaped` walk appending exactly those.
+record Shape-walk (pre : ProofPreimage) (s₀ : Preprocessed)
+                  (is : List Instruction) (s : Preprocessed) : Set where
+  constructor mk-shape-walk
+  field
+    mem-suf : List Fr
+    pis-suf : List Fr
+    walk    : Tr-shaped pre s₀ is s mem-suf pis-suf
+
+-- The user-facing predicate: there is an initial state `start` and a
+-- shape walk from `start` over the instruction stream that ends EXACTLY
+-- at `s`, consuming the transcripts.  The suffixes are existential
+-- (fields of the `Shape-walk`).
+--
+-- The conjunct `T (transcripts-consumed pre s)` is required because the
+-- `Tr-shaped` walk alone does NOT force the three transcript cursors of
+-- `s` to be fully consumed (a walk in which every `public-input` /
+-- `private-input` / `pi-skip` guard is inactive consumes nothing), and
+-- `satisfies` is blind to the cursors.  Yet `R src pre s` carries
+-- `T (transcripts-consumed pre s)` as a top-level conjunct
+-- (Semantics.agda:632), so the backward direction must reproduce it.  It
+-- is not derivable from `satisfies` + the trace + producer-safety
+-- (none of O1/O2/O3/wire-disc constrains the transcript cursors), so —
+-- like the WF1 arity hypothesis and the transcript-read-wire blindness
+-- handled by the trace — it must be supplied.  This is faithful to the
+-- spec §5.3 "preprocess-state-shaped Σ": those states are reached by a
+-- SUCCESSFUL `preprocess`, which by definition passed
+-- `transcripts-consumed` (Semantics.agda:452).  `comm-ok` is NOT folded
+-- in: it is recoverable from `satisfies` (the `comm`
+-- constraint; see part 4 below), so it stays derived to keep `satisfies`
+-- load-bearing.
+record preprocess-shaped (src : IrSource) (pre : ProofPreimage)
+                         (s : Preprocessed) : Set where
+  constructor mk-shaped
+  field
+    start    : Preprocessed
+    init≡    : init-state src pre ≡ just start
+    shaped   : Shape-walk pre start (IrSource.instructions src) s
+    consumed : T (transcripts-consumed pre s)
+
+------------------------------------------------------------------------
+-- `R ⇒ preprocess-shaped`.
+--
+-- The forward field of the bundled `circuit-faithful` `↔` produces
+-- `satisfies` from `R`; the extra `preprocess-shaped` hypothesis it is
+-- handed is then redundant.  But the *bundle's* statement carries
+-- `preprocess-shaped` as a top-level hypothesis (so the two directions
+-- share preconditions), and we want it derivable from `R` directly so
+-- callers in possession of `R` need not supply it separately.  This
+-- lemma provides that: an `R-instrs` trace is a fortiori a `Tr-shaped`
+-- trace (it pins strictly more — including the computed values).
+------------------------------------------------------------------------
+
+private
+  -- `push-mem2 s x y ≡ push-mem (push-mem s x) y`.  Both set only the
+  -- `memory` field; they differ by `++`-associativity on the suffix.
+  push-mem2-iter : ∀ (s : Preprocessed) x y
+    → push-mem2 s x y ≡ push-mem (push-mem s x) y
+  push-mem2-iter s x y =
+    cong (λ m → record s { memory = m })
+         (push-mem2-assoc (Preprocessed.memory s) x y)
+
+  -- Per-step conversion.  From `R-instr pre s i s'` build the shape
+  -- payload `sd` plus the suffix decomposition and a proof that
+  -- `tr-next … sd ≡ s'`.
+  R-instr→tr-step
+    : ∀ (pre : ProofPreimage) (s : Preprocessed) (i : Instruction) (s' : Preprocessed)
+    → R-instr pre s i s'
+    → Σ (List Fr) (λ ms → Σ (List Fr) (λ ps →
+          (Preprocessed.memory s' ≡ Preprocessed.memory s ++ ms)
+        × (Preprocessed.pis    s' ≡ Preprocessed.pis    s ++ ps)
+        × Σ (tr-step i pre s ms ps) (λ sd →
+            tr-next i pre s ms ps sd ≡ s')))
+  R-instr→tr-step pre s .(assert _) .s (r-assert _) =
+    [] , [] , sym (++-identityʳ _) , sym (++-identityʳ _) , (refl , refl) , refl
+  R-instr→tr-step pre s .(constrain-bits _ _) .s (r-constrain-bits _ _ _) =
+    [] , [] , sym (++-identityʳ _) , sym (++-identityʳ _) , (refl , refl) , refl
+  R-instr→tr-step pre s .(constrain-eq _ _) .s (r-constrain-eq _ _ _) =
+    [] , [] , sym (++-identityʳ _) , sym (++-identityʳ _) , (refl , refl) , refl
+  R-instr→tr-step pre s .(constrain-to-boolean _) .s (r-constrain-to-boolean _) =
+    [] , [] , sym (++-identityʳ _) , sym (++-identityʳ _) , (refl , refl) , refl
+  -- push-mem cases (Δmem=1): ms = [the appended value], ps = [].
+  R-instr→tr-step pre s (cond-select _ _ _) _ (r-cond-select {sel = sel} {av} {bv} _ _ _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  R-instr→tr-step pre s (copy _) _ (r-copy {v = v} _) =
+    v ∷ [] , [] , refl , sym (++-identityʳ _) , ((v , refl) , refl) , refl
+  R-instr→tr-step pre s (load-imm _) _ (r-load-imm {imm = imm}) =
+    imm ∷ [] , [] , refl , sym (++-identityʳ _) , ((imm , refl) , refl) , refl
+  R-instr→tr-step pre s (test-eq _ _) _ (r-test-eq {av = av} {bv} _ _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  R-instr→tr-step pre s (transient-hash _) _ (r-transient-hash {vs = vs} _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  R-instr→tr-step pre s (add _ _) _ (r-add {av = av} {bv} _ _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  R-instr→tr-step pre s (mul _ _) _ (r-mul {av = av} {bv} _ _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  R-instr→tr-step pre s (neg _) _ (r-neg {av = av} _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  R-instr→tr-step pre s (not _) _ (r-not {b = b} _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  R-instr→tr-step pre s (less-than _ _ _) _ (r-less-than {av = av} {bv} _ _ _ _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  R-instr→tr-step pre s (reconstitute-field _ _ _) _ (r-reconstitute-field {dv = dv} {mv} _ _ _ _ _) =
+    _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , refl) , refl) , refl
+  -- push-mem2 cases (Δmem=2): ms = [x, y], ps = [].
+  R-instr→tr-step pre s (ec-add _ _ _ _) _ (r-ec-add {cx = cx} {cy} _ _ _ _ _) =
+    _ ∷ _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , _ , refl) , refl) , refl
+  R-instr→tr-step pre s (ec-mul _ _ _) _ (r-ec-mul {cx = cx} {cy} _ _ _ _) =
+    _ ∷ _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , _ , refl) , refl) , refl
+  R-instr→tr-step pre s (ec-mul-generator _) _ (r-ec-mul-generator {cx = cx} {cy} _ _) =
+    _ ∷ _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , _ , refl) , refl) , refl
+  R-instr→tr-step pre s (hash-to-curve _) _ (r-hash-to-curve {cx = cx} {cy} _ _) =
+    _ ∷ _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , _ , refl) , refl) , refl
+  R-instr→tr-step pre s (persistent-hash _ _) _ (r-persistent-hash {h₁ = h₁} {h₂} _ _) =
+    _ ∷ _ ∷ [] , [] , refl , sym (++-identityʳ _) , ((_ , _ , refl) , refl) , refl
+  R-instr→tr-step pre s (div-mod-power-of-two var bits) _ (r-div-mod-power-of-two {v = v} la _) =
+    let d = from-le-bits (drop bits (to-le-bits v))
+        m = from-le-bits (take bits (to-le-bits v))
+    in d ∷ m ∷ [] , []
+       , sym (push-mem2-assoc (Preprocessed.memory s) d m)
+       , sym (++-identityʳ _)
+       , ((d , m , refl) , refl)
+       , push-mem2-iter s d m
+  -- declare-pub-input (Δpis=1): ms = [], ps = [the value].
+  R-instr→tr-step pre s (declare-pub-input _) _ (r-declare-pub-input {v = v} _) =
+    [] , v ∷ [] , sym (++-identityʳ _) , refl , (refl , v , refl) , refl
+  -- output: no suffix; carry the lookup evidence.
+  R-instr→tr-step pre s (output _) _ (r-output {v = v} lk) =
+    [] , [] , sym (++-identityʳ _) , sym (++-identityʳ _)
+    , ((v , lk) , refl , refl) , refl
+  -- pi-skip active / inactive.
+  R-instr→tr-step pre s (pi-skip _ _) _ (r-pi-skip-active g-eq match) =
+    [] , [] , sym (++-identityʳ _) , sym (++-identityʳ _)
+    , (refl , refl , (true , g-eq , match)) , refl
+  R-instr→tr-step pre s (pi-skip _ count) _ (r-pi-skip-inactive g-eq) =
+    [] , [] , sym (++-identityʳ _) , sym (++-identityʳ _)
+    , (refl , refl , (false , g-eq , tt)) , refl
+  -- public-input active / inactive.
+  R-instr→tr-step pre s (public-input _) _ (r-public-input-active {v = v} {s₁} g-eq c-eq) =
+    v ∷ [] , []
+    , cong (_++ (v ∷ [])) (consume-pub-out-mem s c-eq)
+    , trans (consume-pub-out-pis s c-eq) (sym (++-identityʳ _))
+    , (v , refl , refl , (true , g-eq , (s₁ , c-eq))) , refl
+  R-instr→tr-step pre s (public-input _) _ (r-public-input-inactive g-eq) =
+    0ᶠ ∷ [] , [] , refl , sym (++-identityʳ _)
+    , (0ᶠ , refl , refl , (false , g-eq , refl)) , refl
+  -- private-input active / inactive.
+  R-instr→tr-step pre s (private-input _) _ (r-private-input-active {v = v} {s₁} g-eq c-eq) =
+    v ∷ [] , []
+    , cong (_++ (v ∷ [])) (consume-priv-mem s c-eq)
+    , trans (consume-priv-pis s c-eq) (sym (++-identityʳ _))
+    , (v , refl , refl , (true , g-eq , (s₁ , c-eq))) , refl
+  R-instr→tr-step pre s (private-input _) _ (r-private-input-inactive g-eq) =
+    0ᶠ ∷ [] , [] , refl , sym (++-identityʳ _)
+    , (0ᶠ , refl , refl , (false , g-eq , refl)) , refl
+
+  -- Fold the per-step conversion along an `R-instrs` trace.  The
+  -- endpoint `s` is pinned by the trace, so the result carries it as the
+  -- `Tr-shaped` endpoint index (no memory/pis equations needed here).
+  R-instrs→Shape-walk
+    : ∀ (pre : ProofPreimage) (s₀ s : Preprocessed) (is : List Instruction)
+    → R-instrs pre s₀ is s
+    → Shape-walk pre s₀ is s
+  R-instrs→Shape-walk pre s₀ .s₀ [] r-done = mk-shape-walk [] [] tr-nil
+  R-instrs→Shape-walk pre s₀ s (i ∷ is) (r-step {s₁ = s₁} r-head r-tail) =
+    let ms , ps , _mem-eq₁ , _pis-eq₁ , sd , tn-eq = R-instr→tr-step pre s₀ i s₁ r-head
+        -- The tail trace starts from `s₁`; rewrite it to start from
+        -- `tr-next … sd` (which equals `s₁` by `tn-eq`).
+        r-tail' : R-instrs pre (tr-next i pre s₀ ms ps sd) is s
+        r-tail' = subst (λ z → R-instrs pre z is s) (sym tn-eq) r-tail
+        (mk-shape-walk ms-t ps-t tr-tail) =
+          R-instrs→Shape-walk pre (tr-next i pre s₀ ms ps sd) s is r-tail'
+    in mk-shape-walk (ms ++ ms-t) (ps ++ ps-t) (tr-cons sd tr-tail)
+
+-- `R ⇒ preprocess-shaped`.
+R⇒preprocess-shaped : ∀ (src : IrSource) (pre : ProofPreimage) (s : Preprocessed)
+  → R src pre s → preprocess-shaped src pre s
+R⇒preprocess-shaped src pre s (s₀ , init-eq , Rs , tc , _co) =
+  mk-shaped s₀ init-eq
+    (R-instrs→Shape-walk pre s₀ s (IrSource.instructions src) Rs) tc
+
+------------------------------------------------------------------------
+-- Internal bridge, step 0:  `Tr-shaped` ⇒ `op-side-data-list`.
+--
+-- Because `tr-step` / `tr-next` are definitional aliases of
+-- `op-side-data` / `next-state-from-osd`, the two relations have
+-- definitionally-equal index expressions.  The
+-- conversion is therefore a trivial structural map (two cases): a
+-- `tr-step` payload IS an `op-side-data` payload, and
+-- `tr-next … sd` reduces to `next-state-from-osd … sd`.
+------------------------------------------------------------------------
+
+private
+  -- After matching `i` to a concrete constructor, `tr-step i` and
+  -- `op-side-data i` reduce to the SAME RHS (they are aliases), and
+  -- likewise `tr-next i` ≡ `next-state-from-osd i`.  So in each case the
+  -- `tr-step` payload `sd` IS an `op-side-data` payload and the tail's
+  -- start state coincides — `osd-cons sd (rec tr-tail)` typechecks
+  -- directly with no transport (for `pi-skip` / `public-input` /
+  -- `private-input` the recursion is transported by `tr-next≡nso`).
+  Tr-shaped→osd-list
+    : ∀ (pre : ProofPreimage) (s₀ : Preprocessed) (is : List Instruction)
+        (s : Preprocessed) (mem-suf pis-suf : List Fr)
+    → Tr-shaped pre s₀ is s mem-suf pis-suf
+    → op-side-data-list pre s₀ is mem-suf pis-suf
+  Tr-shaped→osd-list pre s₀ .[] .s₀ .[] .[] tr-nil = osd-nil
+  Tr-shaped→osd-list pre s₀ (i ∷ is) s-end ._ ._
+      (tr-cons {mem-step = ms} {pis-step = ps} sd t) =
+    osd-cons {mem-step = ms} {pis-step = ps} sd
+      (Tr-shaped→osd-list pre _ is s-end _ _ t)
+
+  -- The fold endpoint of the bridged list equals the `Tr-shaped`
+  -- endpoint index `s`.  This pins D2's existential `s'` (which D2 proves
+  -- `≡ osd-fold osd`) to the GIVEN state `s` in `circuit-faithful-bwd`.
+  --
+  -- Proof by induction on `Tr-shaped`.  In each `tr-cons` case the bridge
+  -- reduces to `osd-cons sd (rec t)` (matching the instruction), so
+  -- `osd-fold` reduces to `osd-fold (rec t)`, discharged by the IH on
+  -- `t`.  The endpoint index `s-end` is threaded unchanged, so the IH
+  -- gives `osd-fold (rec t) ≡ s-end` directly.
+  Tr-shaped→osd-list-fold
+    : ∀ (pre : ProofPreimage) (s₀ : Preprocessed) (is : List Instruction)
+        (s : Preprocessed) (mem-suf pis-suf : List Fr)
+    → (tr : Tr-shaped pre s₀ is s mem-suf pis-suf)
+    → osd-fold (Tr-shaped→osd-list pre s₀ is s mem-suf pis-suf tr) ≡ s
+  Tr-shaped→osd-list-fold pre s₀ .[] .s₀ .[] .[] tr-nil = refl
+  Tr-shaped→osd-list-fold pre s₀ (i ∷ is) s-end ._ ._ (tr-cons sd t) =
+    Tr-shaped→osd-list-fold pre _ is s-end _ _ t
+
+  -- Per-step memory equation:  `memory (tr-next i …) ≡ memory s ++ ms`.
+  -- Mirrors `tr-next`; the `sd` payload supplies `ms`'s shape, and for
+  -- the transcript-active cases `consume-*-mem` shows the consumed state
+  -- leaves memory unchanged.
+  -- `xs ≡ xs ++ ys` for an empty suffix, and `xs ++ zs ≡ xs ++ ys` for
+  -- `ys ≡ zs`.  These isolate the append plumbing that every per-step
+  -- memory / pis clause shares; each clause differs only in how it
+  -- projects the suffix equation out of the side-data payload `sd`.
+  cat-refl : ∀ {A : Set} (xs : List A) {ys} → ys ≡ [] → xs ≡ xs ++ ys
+  cat-refl xs eq = sym (trans (cong (xs ++_) eq) (++-identityʳ _))
+
+  cat-cong : ∀ {A : Set} (xs : List A) {ys zs} → ys ≡ zs → xs ++ zs ≡ xs ++ ys
+  cat-cong xs eq = cong (xs ++_) (sym eq)
+
+  tr-step-mem
+    : ∀ (i : Instruction) (pre : ProofPreimage) (s : Preprocessed)
+        (ms ps : List Fr) (sd : tr-step i pre s ms ps)
+    → Preprocessed.memory (tr-next i pre s ms ps sd)
+        ≡ Preprocessed.memory s ++ ms
+  tr-step-mem i pre s ms ps = go (shapeView i)
+    where
+    go : ∀ {j} (v : ShapeView j) (sd : osd-of v pre s ms ps)
+       → Preprocessed.memory (nso′ v pre s ms ps sd)
+           ≡ Preprocessed.memory s ++ ms
+    go sv-pure0   (mn , _)           = cat-refl (Preprocessed.memory s) mn
+    go sv-pure1   ((w , me) , _)     = cat-cong (Preprocessed.memory s) me
+    go sv-pure2   ((x , y , me) , _) = cat-cong (Preprocessed.memory s) me
+    go sv-declare (mn , _)           = cat-refl (Preprocessed.memory s) mn
+    go sv-output  ((_ , _) , mn , _) = cat-refl (Preprocessed.memory s) mn
+    go sv-skip (mn , _ , (true , _ , _)) = cat-refl (Preprocessed.memory s) mn
+    go sv-skip (mn , _ , (false , _ , _)) = cat-refl (Preprocessed.memory s) mn
+    go sv-pub-in  (w , me , _ , (true , _ , (s₁ , ce))) =
+      trans (cong (_++ (w ∷ [])) (consume-pub-out-mem s ce))
+            (cat-cong (Preprocessed.memory s) me)
+    go sv-pub-in  (w , me , _ , (false , _ , _)) =
+      cat-cong (Preprocessed.memory s) me
+    go sv-priv-in (w , me , _ , (true , _ , (s₁ , ce))) =
+      trans (cong (_++ (w ∷ [])) (consume-priv-mem s ce))
+            (cat-cong (Preprocessed.memory s) me)
+    go sv-priv-in (w , me , _ , (false , _ , _)) =
+      cat-cong (Preprocessed.memory s) me
+
+  -- Per-step pis equation:  `pis (tr-next i …) ≡ pis s ++ ps`.
+  tr-step-pis
+    : ∀ (i : Instruction) (pre : ProofPreimage) (s : Preprocessed)
+        (ms ps : List Fr) (sd : tr-step i pre s ms ps)
+    → Preprocessed.pis (tr-next i pre s ms ps sd)
+        ≡ Preprocessed.pis s ++ ps
+  tr-step-pis i pre s ms ps = go (shapeView i)
+    where
+    go : ∀ {j} (v : ShapeView j) (sd : osd-of v pre s ms ps)
+       → Preprocessed.pis (nso′ v pre s ms ps sd)
+           ≡ Preprocessed.pis s ++ ps
+    go sv-pure0   (_ , pn)         = cat-refl (Preprocessed.pis s) pn
+    go sv-pure1   (_ , pn)         = cat-refl (Preprocessed.pis s) pn
+    go sv-pure2   (_ , pn)         = cat-refl (Preprocessed.pis s) pn
+    go sv-declare (_ , wv , pe)    = cat-cong (Preprocessed.pis s) pe
+    go sv-output  ((_ , _) , _ , pn) = cat-refl (Preprocessed.pis s) pn
+    go sv-skip    (_ , pn , (true  , _ , _)) = cat-refl (Preprocessed.pis s) pn
+    go sv-skip    (_ , pn , (false , _ , _)) = cat-refl (Preprocessed.pis s) pn
+    go sv-pub-in  (w , _ , pn , (true , _ , (s₁ , ce))) =
+      trans (consume-pub-out-pis s ce) (cat-refl (Preprocessed.pis s) pn)
+    go sv-pub-in  (w , _ , pn , (false , _ , _)) =
+      cat-refl (Preprocessed.pis s) pn
+    go sv-priv-in (w , _ , pn , (true , _ , (s₁ , ce))) =
+      trans (consume-priv-pis s ce) (cat-refl (Preprocessed.pis s) pn)
+    go sv-priv-in (w , _ , pn , (false , _ , _)) =
+      cat-refl (Preprocessed.pis s) pn
+
+  -- Fold the per-step memory / pis equations along a `Tr-shaped` trace.
+  Tr-shaped→mem
+    : ∀ (pre : ProofPreimage) (s₀ s : Preprocessed) (is : List Instruction)
+        (ms ps : List Fr)
+    → Tr-shaped pre s₀ is s ms ps
+    → Preprocessed.memory s ≡ Preprocessed.memory s₀ ++ ms
+  Tr-shaped→mem pre s₀ .s₀ .[] .[] .[] tr-nil = sym (++-identityʳ _)
+  Tr-shaped→mem pre s₀ s (i ∷ is) ._ ._
+      (tr-cons {mem-step = mst} {pis-step = pst} {mem-tail = mtl} sd t) =
+    let s₁ = tr-next i pre s₀ mst pst sd in
+    trans (Tr-shaped→mem pre s₁ s is mtl _ t)
+      (trans (cong (_++ mtl) (tr-step-mem i pre s₀ mst pst sd))
+             (++-assoc (Preprocessed.memory s₀) mst mtl))
+
+  Tr-shaped→pis
+    : ∀ (pre : ProofPreimage) (s₀ s : Preprocessed) (is : List Instruction)
+        (ms ps : List Fr)
+    → Tr-shaped pre s₀ is s ms ps
+    → Preprocessed.pis s ≡ Preprocessed.pis s₀ ++ ps
+  Tr-shaped→pis pre s₀ .s₀ .[] .[] .[] tr-nil = sym (++-identityʳ _)
+  Tr-shaped→pis pre s₀ s (i ∷ is) ._ ._
+      (tr-cons {mem-step = mst} {pis-step = pst} {pis-tail = ptl} sd t) =
+    let s₁ = tr-next i pre s₀ mst pst sd in
+    trans (Tr-shaped→pis pre s₁ s is _ ptl t)
+      (trans (cong (_++ ptl) (tr-step-pis i pre s₀ mst pst sd))
+             (++-assoc (Preprocessed.pis s₀) pst ptl))
+
+-- ───────────────────────────────────────────────────────────────────
+-- The backward direction.
+--
+-- `circuit-faithful-bwd` is FALSE over an *arbitrary* `s : Preprocessed`
+-- for two reasons, each addressed by an extra hypothesis:
+--
+--   • `satisfies` is blind to transcript-read wires (`public-input` /
+--     `private-input` active emit no constraint; `pi-skip` active's
+--     transcript-match has no in-circuit shadow), so an arbitrary `s`
+--     can satisfy the circuit while its transcript wires hold garbage.
+--     The `preprocess-shaped` hypothesis (§5.3) pins the operational
+--     shape walk ending exactly at `s`.
+--
+--   • `T (transcripts-consumed pre s)` is a top-level conjunct of `R`
+--     (Semantics.agda:632) yet is NOT entailed by `satisfies` + the
+--     trace + producer-safety (no obligation constrains the transcript
+--     cursors; an all-inactive walk consumes nothing).  It is folded
+--     into `preprocess-shaped` (faithful: §5.3 quantifies over states
+--     reached by a SUCCESSFUL `preprocess`, which passed
+--     `transcripts-consumed`).
+--
+-- With those two and WF1 (§3.3) in hand the proof runs:
+--   1. `preprocess-shaped` ⇒ its fields: the start state `s₀`, its
+--      `init-state` equation, the shape walk `(ms, ps, tr)`, and `tc`.
+--   2. `osd = Tr-shaped→osd-list … tr`;  memory / pis of `s` reshape as
+--      `memory s₀ ++ ms` / `pis s₀ ++ ps` (`Tr-shaped→mem` / `→pis`).
+--   3. invariants at the initial synth state `st₀` (mem-inv, pi-inv,
+--      O2/O3-Inv via `o2/o3-inv-init`, the three traces via
+--      `O2/O3-bool→Runs` ∘ `producer-safe-O2/-O3` and `wire-disc-sound`,
+--      fits ≡ refl since `constraints st₀ ≡ []`).
+--   4. invert `satisfies` (split off the comm constraint when hc) to feed the
+--      body `satisfies-constraints` to D2 (`satisfies-constraints→R-instrs`).
+--   5. D2 ⇒ `s'`, mem/pis eqs, `R-instrs pre s₀ instrs s'`, `s' ≡ osd-fold osd`.
+--   6. pin `s' ≡ s`: `s' ≡ osd-fold osd ≡ s` (`Tr-shaped→osd-list-fold`),
+--      so `subst` the trace to end at `s`.
+--   7. `T (transcripts-consumed pre s)` = the `tc` hypothesis.
+--   8. `T (comm-ok src pre s)` by inverting the comm constraint
+--      (`inputs-lookup-init`, `output-wires-coincide`, `init-state-pi-1`,
+--      `≡ᶠ?-refl`), mirroring the forward `circuit-faithful-fwd-true`.
+-- ───────────────────────────────────────────────────────────────────
+
+private
+  -- D2 packaged for the body, returning the trace pinned to end at the
+  -- GIVEN `s` (via `s' ≡ osd-fold osd ≡ s`).  Independent of `hc`'s comm
+  -- constraint: it consumes the *body* constraint satisfaction only.
+  bwd-body-trace
+    : ∀ {hc} (pre : ProofPreimage) (src : IrSource) (s s₀ : Preprocessed)
+        (ms ps : List Fr)
+    → T (producer-safe src)
+    → length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src
+    → WF2 src
+    → init-state src pre ≡ just s₀
+    → (tr : Tr-shaped pre s₀ (IrSource.instructions src) s ms ps)
+    → IrSource.do-communications-commitment src ≡ hc
+    → satisfies-constraints
+        (SynthState.constraints
+          (circuit-instrs hc (IrSource.instructions src) (mk-synth (IrSource.num-inputs src) [] 0 [])))
+        (mk-witness (Preprocessed.memory s₀ ++ ms)
+                    (Preprocessed.pis s₀ ++ ps)
+                    (comm-rand-of pre))
+    → R-instrs pre s₀ (IrSource.instructions src) s
+  bwd-body-trace {hc} pre src s s₀ ms ps ps-safe wf1 wf2 init-eq tr hc-eq sat-body =
+    let
+      n   = IrSource.num-inputs src
+      st₀ = mk-synth n [] 0 []
+      instrs = IrSource.instructions src
+      mem≡   = init-state-memory src pre s₀ init-eq
+      len-eq = init-state-num-inputs src pre s₀ init-eq
+      mi₀ : mem-inv s₀ st₀
+      mi₀ = sym (trans (cong length mem≡) len-eq)
+      pi₀-pre : length (Preprocessed.pis s₀)
+                  ≡ preamble-pi-count (IrSource.do-communications-commitment src)
+      pi₀-pre = init-state-pis-length src pre s₀ init-eq
+      pi₀ : pi-inv hc s₀ st₀
+      pi₀ = subst (λ b → length (Preprocessed.pis s₀) ≡ preamble-pi-count b + 0)
+                  hc-eq
+                  (trans pi₀-pre
+                         (sym (+-identityʳ (preamble-pi-count
+                                 (IrSource.do-communications-commitment src)))))
+      -- Initial obligation invariants at `s₀` (`bk₀ = bm₀ = []`).
+      o2-inv₀ : O2-Inv (n , []) s₀
+      o2-inv₀ = o2-inv-init {src} {pre} {s₀} init-eq wf1
+      o3-inv₀ : O3-Inv (n , []) s₀
+      o3-inv₀ = o3-inv-init {src} {pre} {s₀} init-eq wf1
+      -- The three producer traces at `(n , [])` / `n`.
+      o2-tr : O2-Trace instrs (n , []) (O2-Runs.final (O2-bool→Runs {src} (producer-safe-O2 {src} ps-safe)))
+      o2-tr = O2-Runs.trace (O2-bool→Runs {src} (producer-safe-O2 {src} ps-safe))
+      o3-tr : O3-Trace instrs (n , []) (O3-Runs.final (O3-bool→Runs {src} (producer-safe-O3 {src} ps-safe)))
+      o3-tr = O3-Runs.trace (O3-bool→Runs {src} (producer-safe-O3 {src} ps-safe))
+      w-tr : Wire-Trace instrs n (proj₁ (wire-disc-sound {src} ps-safe))
+      w-tr = proj₂ (wire-disc-sound {src} ps-safe)
+      -- The osd-list and the fold endpoint = `s`.
+      osd : op-side-data-list pre s₀ instrs ms ps
+      osd = Tr-shaped→osd-list pre s₀ instrs s ms ps tr
+      fold≡s : osd-fold osd ≡ s
+      fold≡s = Tr-shaped→osd-list-fold pre s₀ instrs s ms ps tr
+      -- D2.
+      d2 = satisfies-constraints→R-instrs {hc} pre s₀ instrs st₀ ms ps
+             mi₀ pi₀ tt tt {bk₀ = []} {bm₀ = []} o2-inv₀ o3-inv₀
+             o2-tr o3-tr w-tr wf2 osd sat-body
+      s' , _ , _ , Rs' , fold-eq = d2
+      s'≡s : s' ≡ s
+      s'≡s = trans fold-eq fold≡s
+    in subst (R-instrs pre s₀ instrs) s'≡s Rs'
+
+  -- `comm-rand-of pre ≡ just r` when `comm-commitment pre ≡ just (c, r)`.
+  comm-rand-of-just : ∀ (pre : ProofPreimage) c r
+    → ProofPreimage.comm-commitment pre ≡ just (c , r)
+    → comm-rand-of pre ≡ just r
+  comm-rand-of-just pre c r eq = cong (Data.Maybe.map (λ (_ , r) → r)) eq
+
+  -- `circuit src` reduces to its hc-specific record shape.  (These are
+  -- the backward-usable forms of the forward's `circuit-instantiate-*`,
+  -- lifted out of the body's `let` since `where` is illegal there.)
+  circuit-eq-false : ∀ (src : IrSource)
+    → IrSource.do-communications-commitment src ≡ false
+    → circuit src ≡
+      mk-circuit
+        (SynthState.nr-wires (circuit-instrs false (IrSource.instructions src)
+                                (mk-synth (IrSource.num-inputs src) [] 0 [])))
+        (SynthState.constraints (circuit-instrs false (IrSource.instructions src)
+                                (mk-synth (IrSource.num-inputs src) [] 0 [])))
+        (1 + SynthState.nr-declared-pi (circuit-instrs false (IrSource.instructions src)
+                                (mk-synth (IrSource.num-inputs src) [] 0 [])))
+        false
+  circuit-eq-false src refl = refl
+
+  circuit-eq-true : ∀ (src : IrSource)
+    → IrSource.do-communications-commitment src ≡ true
+    → circuit src ≡
+      mk-circuit
+        (SynthState.nr-wires (circuit-instrs true (IrSource.instructions src)
+                                (mk-synth (IrSource.num-inputs src) [] 0 [])))
+        (SynthState.constraints (circuit-instrs true (IrSource.instructions src)
+                                (mk-synth (IrSource.num-inputs src) [] 0 []))
+          ∷ʳ comm (nat-range (IrSource.num-inputs src))
+              (SynthState.output-wires (circuit-instrs true (IrSource.instructions src)
+                                (mk-synth (IrSource.num-inputs src) [] 0 []))))
+        (2 + SynthState.nr-declared-pi (circuit-instrs true (IrSource.instructions src)
+                                (mk-synth (IrSource.num-inputs src) [] 0 [])))
+        true
+  circuit-eq-true src refl = refl
+
+  -- `comm-ok` is `true` definitionally when `do-comm ≡ false`.
+  comm-ok-false : ∀ (src : IrSource) (pre : ProofPreimage) (s : Preprocessed)
+    → IrSource.do-communications-commitment src ≡ false
+    → T (comm-ok src pre s)
+  comm-ok-false src pre s e with IrSource.do-communications-commitment src | e
+  ... | false | refl = tt
+
+  -- Invert the comm constraint to recover `T (comm-ok src pre s)`.
+  -- hc=false branch is `tt`; hc=true requires the `holds` witness.
+  bwd-comm-ok-true
+    : ∀ (src : IrSource) (pre : ProofPreimage) (s s₀ : Preprocessed) c r
+    → IrSource.do-communications-commitment src ≡ true
+    → ProofPreimage.comm-commitment pre ≡ just (c , r)
+    → init-state src pre ≡ just s₀
+    → R-instrs pre s₀ (IrSource.instructions src) s
+    → holds (witness-of s pre)
+        (comm (nat-range (IrSource.num-inputs src))
+          (SynthState.output-wires
+            (circuit-instrs true (IrSource.instructions src)
+              (mk-synth (IrSource.num-inputs src) [] 0 []))))
+    → T (comm-ok src pre s)
+  bwd-comm-ok-true src pre s s₀ c r hc-true cc-just init-eq Rs
+      (ivs , ovs , rv , pv , ivs-lk , ovs-lk , rand≡ , pi1≡ , pv≡tc) =
+    let
+      n  = IrSource.num-inputs src
+      st₀ = mk-synth n [] 0 []
+      instrs = IrSource.instructions src
+      cm-inputs = nat-range n
+      out-wires = SynthState.output-wires (circuit-instrs true instrs st₀)
+      -- `ivs ≡ inputs pre`.
+      ivs-init : mem-lookups (Preprocessed.memory s) cm-inputs
+                   ≡ just (ProofPreimage.inputs pre)
+      ivs-init = mem-lookups-mono-R-instrs pre s₀ s instrs cm-inputs
+                   (ProofPreimage.inputs pre) Rs (inputs-lookup-init src pre s₀ init-eq)
+      ivs≡ : ivs ≡ ProofPreimage.inputs pre
+      ivs≡ = just-injective (trans (sym ivs-lk) ivs-init)
+      -- `ovs ≡ outputs s`.
+      ovs-coin : mem-lookups (Preprocessed.memory s) out-wires
+                   ≡ just (Preprocessed.outputs s)
+      ovs-coin = output-wires-coincide {hc = true} pre s₀ s instrs st₀ Rs refl
+                   (init-state-outputs src pre s₀ init-eq)
+      ovs≡ : ovs ≡ Preprocessed.outputs s
+      ovs≡ = just-injective (trans (sym ovs-lk) ovs-coin)
+      -- `rv ≡ r`: `comm-rand-of pre ≡ just r` (cc-just) and `≡ just rv`.
+      rof≡ : comm-rand-of pre ≡ just r
+      rof≡ = comm-rand-of-just pre c r cc-just
+      rv≡ : rv ≡ r
+      rv≡ = just-injective (trans (sym rand≡) rof≡)
+      -- `pv ≡ c`: `pi-lookup (pis s) 1 ≡ just c` and `≡ just pv`.
+      pi1-init : pi-lookup (Preprocessed.pis s₀) 1 ≡ just c
+      pi1-init = init-state-pi-1 src pre s₀ c r hc-true cc-just init-eq
+      pi1-final : pi-lookup (Preprocessed.pis s) 1 ≡ just c
+      pi1-final = pi-lookup-mono-R-instrs pre s₀ s instrs 1 c Rs pi1-init
+      pv≡c : pv ≡ c
+      pv≡c = just-injective (trans (sym pi1≡) pi1-final)
+      -- `c ≡ transient-commit (inputs pre ++ outputs s) r`.
+      c≡tc : c ≡ transient-commit (ProofPreimage.inputs pre ++ Preprocessed.outputs s) r
+      c≡tc = trans (sym pv≡c)
+               (trans pv≡tc
+                 (cong₂ (λ vs rr → transient-commit vs rr)
+                        (cong₂ _++_ ivs≡ ovs≡) rv≡))
+      -- Reduce `comm-ok` under hc=true / cc=just to the `≡ᶠ?` check, true
+      -- by reflexivity rewritten along `c≡tc`.
+      goal : (c ≡ᶠ? transient-commit (ProofPreimage.inputs pre ++ Preprocessed.outputs s) r) ≡ true
+      goal = subst (λ x → (c ≡ᶠ? x) ≡ true) c≡tc ≡ᶠ?-refl
+    in comm-ok-reduce src pre s c r hc-true cc-just goal
+    where
+      -- `comm-ok src pre s` reduces to the `≡ᶠ?` check at hc=true/cc=just.
+      comm-ok-reduce : ∀ src pre s c r
+        → IrSource.do-communications-commitment src ≡ true
+        → ProofPreimage.comm-commitment pre ≡ just (c , r)
+        → (c ≡ᶠ? transient-commit (ProofPreimage.inputs pre ++ Preprocessed.outputs s) r) ≡ true
+        → T (comm-ok src pre s)
+      comm-ok-reduce src pre s c r hc-true cc-just chk
+        with IrSource.do-communications-commitment src
+           | ProofPreimage.comm-commitment pre
+           | hc-true | cc-just
+      ... | true | just .(c , r) | _ | refl = ≡→T chk
+
+  -- hc=true with comm-commitment=nothing is ruled out by `satisfies`'s
+  -- rand-shape (`Maybe-shape true nothing ≡ ⊥`).
+  bwd-no-comm-contra
+    : ∀ (src : IrSource) (pre : ProofPreimage) (s : Preprocessed)
+    → IrSource.do-communications-commitment src ≡ true
+    → ProofPreimage.comm-commitment pre ≡ nothing
+    → Maybe-shape (IrSource.do-communications-commitment src) (comm-rand-of pre)
+    → ⊥
+  bwd-no-comm-contra src pre s hc-true cc-none msh
+    with IrSource.do-communications-commitment src
+       | ProofPreimage.comm-commitment pre
+       | hc-true | cc-none
+  ... | true | nothing | _ | refl = msh
+
+circuit-faithful-bwd
+  : ∀ (src : IrSource) (pre : ProofPreimage) (s : Preprocessed)
+  → T (producer-safe src)
+  → length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src   -- WF1 (§3.3)
+  → WF2 src                                                       -- WF2 (§3.3)
+  → preprocess-shaped src pre s                                   -- §5.3
+  → satisfies (circuit src) (witness-of s pre)
+  → R src pre s
+circuit-faithful-bwd src pre s ps-safe wf1 wf2
+    (mk-shaped s₀ init-eq (mk-shape-walk ms ps tr) tc)
+    (mk-sat _pi-len _mem-len rand-shape constraint-ok)
+  with bool-cases (IrSource.do-communications-commitment src)
+... | inj₂ hc-false =
+  let
+    n   = IrSource.num-inputs src
+    st₀ = mk-synth n [] 0 []
+    instrs = IrSource.instructions src
+    mem-eq-s : Preprocessed.memory s ≡ Preprocessed.memory s₀ ++ ms
+    mem-eq-s = Tr-shaped→mem pre s₀ s instrs ms ps tr
+    pis-eq-s : Preprocessed.pis s ≡ Preprocessed.pis s₀ ++ ps
+    pis-eq-s = Tr-shaped→pis pre s₀ s instrs ms ps tr
+    -- `circuit src` reduces to its hc=false body constraints; constraint-ok is
+    -- satisfaction of exactly those constraints by `witness-of s pre`.
+    circuit-eq : circuit src ≡
+      mk-circuit (SynthState.nr-wires (circuit-instrs false instrs st₀))
+                 (SynthState.constraints (circuit-instrs false instrs st₀))
+                 (1 + SynthState.nr-declared-pi (circuit-instrs false instrs st₀))
+                 false
+    circuit-eq = circuit-eq-false src hc-false
+    sat-body-s : satisfies-constraints
+      (SynthState.constraints (circuit-instrs false instrs st₀))
+      (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) (comm-rand-of pre))
+    sat-body-s = subst (λ c → satisfies-constraints (Circuit.constraints c)
+                                 (witness-of s pre))
+                       circuit-eq constraint-ok
+    sat-body : satisfies-constraints
+      (SynthState.constraints (circuit-instrs false instrs st₀))
+      (mk-witness (Preprocessed.memory s₀ ++ ms) (Preprocessed.pis s₀ ++ ps) (comm-rand-of pre))
+    sat-body = subst₂ (λ m p → satisfies-constraints
+                                  (SynthState.constraints (circuit-instrs false instrs st₀))
+                                  (mk-witness m p (comm-rand-of pre)))
+                      mem-eq-s pis-eq-s sat-body-s
+    Rs : R-instrs pre s₀ instrs s
+    Rs = bwd-body-trace {false} pre src s s₀ ms ps ps-safe wf1 wf2 init-eq tr hc-false sat-body
+    co : T (comm-ok src pre s)
+    co = comm-ok-false src pre s hc-false
+  in s₀ , init-eq , Rs , tc , co
+... | inj₁ hc-true with maybe-cases (ProofPreimage.comm-commitment pre)
+...   | inj₁ cc-none =
+        ⊥-elim (bwd-no-comm-contra src pre s hc-true cc-none rand-shape)
+...   | inj₂ (c , r , cc-just) =
+  let
+    n   = IrSource.num-inputs src
+    st₀ = mk-synth n [] 0 []
+    instrs = IrSource.instructions src
+    st-end = circuit-instrs true instrs st₀
+    cm-inputs = nat-range n
+    out-wires = SynthState.output-wires st-end
+    body-constraints = SynthState.constraints st-end
+    mem-eq-s : Preprocessed.memory s ≡ Preprocessed.memory s₀ ++ ms
+    mem-eq-s = Tr-shaped→mem pre s₀ s instrs ms ps tr
+    pis-eq-s : Preprocessed.pis s ≡ Preprocessed.pis s₀ ++ ps
+    pis-eq-s = Tr-shaped→pis pre s₀ s instrs ms ps tr
+    circuit-eq : circuit src ≡
+      mk-circuit (SynthState.nr-wires st-end)
+                 (body-constraints ∷ʳ comm cm-inputs out-wires)
+                 (2 + SynthState.nr-declared-pi st-end)
+                 true
+    circuit-eq = circuit-eq-true src hc-true
+    -- Satisfaction of the FULL constraint list (body ++ [comm]) by `witness-of s pre`.
+    sat-full : satisfies-constraints
+      (body-constraints ∷ʳ comm cm-inputs out-wires)
+      (mk-witness (Preprocessed.memory s) (Preprocessed.pis s) (comm-rand-of pre))
+    sat-full = subst (λ c → satisfies-constraints (Circuit.constraints c) (witness-of s pre))
+                     circuit-eq constraint-ok
+    -- Split off the comm constraint.
+    split = satisfies-constraints-split body-constraints
+              (comm cm-inputs out-wires ∷ []) sat-full
+    -- sat-body-s : satisfies-constraints body-constraints (witness at s)
+    -- holds-comm : holds (witness at s) (comm cm-inputs out-wires)
+    (sat-body-s , comm-sat) = split
+    holds-comm = headᴬ comm-sat
+    sat-body : satisfies-constraints body-constraints
+      (mk-witness (Preprocessed.memory s₀ ++ ms) (Preprocessed.pis s₀ ++ ps) (comm-rand-of pre))
+    sat-body = subst₂ (λ m p → satisfies-constraints body-constraints
+                                  (mk-witness m p (comm-rand-of pre)))
+                      mem-eq-s pis-eq-s sat-body-s
+    Rs : R-instrs pre s₀ instrs s
+    Rs = bwd-body-trace {true} pre src s s₀ ms ps ps-safe wf1 wf2 init-eq tr hc-true sat-body
+    co : T (comm-ok src pre s)
+    co = bwd-comm-ok-true src pre s s₀ c r hc-true cc-just init-eq Rs holds-comm
+  in s₀ , init-eq , Rs , tc , co
+
+------------------------------------------------------------------------
+-- Section E.
+------------------------------------------------------------------------
+
+-- The bundled biconditional (spec §6.2, P5 — "`preprocess(S,P)=Σ` iff
+-- `Σ ⊨ C_S(π_Σ)`").  The spec states P5 as an *iff* of propositions, i.e.
+-- a logical equivalence, which `Function.Bundles._⇔_` captures exactly:
+-- it bundles the two implications `to` / `from` with only their (trivial)
+-- congruence laws — no round-trip identity is asserted.
+--
+-- We deliberately do NOT use the stronger `_↔_` (type isomorphism): a
+-- genuine `↔` additionally demands the inverse equations `to (from x) ≡ x`
+-- / `from (to r) ≡ r`, propositional equalities between *proofs* of the
+-- `Set`-valued relations `R` / `satisfies`.  Those proofs are not unique,
+-- so the inverse laws are not derivable without a proof-irrelevance
+-- postulate — which the no-postulate discipline forbids and which the
+-- spec's "iff" never required.
+--
+-- `to` is the forward direction; it ignores the extra `preprocess-shaped`
+-- hypothesis (redundant given `R`, by `R⇒preprocess-shaped`).  `from` is
+-- the backward direction (`circuit-faithful-bwd`).
+--
+-- WF2 (bit-count bounds, §3.3) is a hypothesis of the backward
+-- direction.  Both `R` and the functional `preprocess` reject a
+-- bit count outside the per-instruction bounds (`WF2-instr`), faithfully
+-- to the Rust runtime, whereas the circuit's `in-range` /
+-- `div-mod` / `reconstitute` stay satisfiable for an
+-- excessive `bits`.  So circuit satisfaction alone cannot recover `R`
+-- for an ill-formed `bits`; `WF2 src` supplies the missing bound that
+-- `satisfies→R-instr-step` feeds to the bit-bound rules.  The forward
+-- direction needs no WF2 hypothesis: `R` already carries the bound.
+circuit-faithful
+  : ∀ (src : IrSource) (pre : ProofPreimage) (s : Preprocessed)
+  → T (producer-safe src)
+  → length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src   -- WF1 (§3.3)
+  → WF2 src                                                       -- WF2 (§3.3)
+  → preprocess-shaped src pre s                                   -- §5.3
+  → R src pre s ⇔ satisfies (circuit src) (witness-of s pre)
+circuit-faithful src pre s ps-safe wf1 wf2 pps =
+  mk⇔ (circuit-faithful-fwd src pre s)
+      (circuit-faithful-bwd src pre s ps-safe wf1 wf2 pps)

--- a/formal/src/zkir-v2/Encoding.agda
+++ b/formal/src/zkir-v2/Encoding.agda
@@ -1,0 +1,501 @@
+{-# OPTIONS --safe #-}
+
+------------------------------------------------------------------------
+-- Encoding facts of the zkir-v2 formalization
+--
+-- Consequences of the `Assumptions` encoding / valuation laws: the
+-- operational characterization of `to-bool`, the
+-- `fits-from-le-bits-*` truncation facts, and the bit-arithmetic
+-- identities discharged against the valuation laws
+-- (`bits-decomp-split`, `reconstitute-no-overflow`, `bits-lt-pad`, …).
+--
+-- Parameterized by an `Assumptions` value; consumers
+-- `open import zkir-v2.Encoding ⋯`.
+------------------------------------------------------------------------
+
+open import zkir-v2.Assumptions
+
+module zkir-v2.Encoding (⋯ : Assumptions) (open Assumptions ⋯) where
+
+open import Data.Bool  using (Bool; true; false; if_then_else_)
+open import Data.Empty using (⊥-elim)
+open import Data.List  using (List; []; _∷_; _++_; take; drop; reverse; length)
+open import Data.Maybe using (Maybe; nothing; just)
+open import Data.Nat   using (ℕ; zero; suc; _+_; _∸_; _%_; _⊓_; _≤_; _<_; _*_; _^_; NonZero)
+open import Data.Nat.Properties  using ( ≤-trans; ≤-<-trans; <-≤-trans; ≤-reflexive
+                                        ; <⇒≤; ≮⇒≥; m≤n⇒m∸n≡0; m∸n≤m; m≤n⇒m⊓n≡m
+                                        ; n<1⇒n≡0; *-zeroʳ; +-identityʳ; +-identityˡ
+                                        ; +-comm; *-comm; m≤m*n; m≤n+m; m≤m+n; m^n≢0
+                                        ; *-cancelʳ-≡; +-cancelˡ-≡; _<?_; <-cmp )
+open import Data.Nat.DivMod      using (m%n≤m; m<n⇒m%n≡m; %-distribˡ-+; %-distribˡ-*
+                                        ; m%n%n≡m%n; m*n%n≡0)
+open import Data.Product using (_×_; _,_)
+open import Data.List.Properties using (length-take; length-reverse)
+open import Relation.Binary.Definitions using (tri<; tri≈; tri>)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; subst; subst₂; module ≡-Reasoning)
+open import Relation.Nullary using (yes; no)
+open ≡-Reasoning
+
+open import zkir-v2.FieldProperties ⋯
+
+----------------------------------------------------------------------
+-- Operational characterization of `to-bool`.
+--
+-- `to-bool` is the nested `with` on `_≡ᶠ?_ = does ∘ _≟ᶠ_`, so each fact
+-- is discharged by case analysis on `v ≟ᶠ 0ᶠ` / `v ≟ᶠ 1ᶠ`: in the
+-- `to-bool-{true,false}` directions the scrutinees are carried into the
+-- `with` alongside the hypothesis (so its type reduces with the branch),
+-- and the off-branches are absurd `Maybe Bool` equalities.  `to-bool 1ᶠ`
+-- additionally needs `1ᶠ≢0ᶠ` to rule out the `1ᶠ ≡ᶠ? 0ᶠ` branch.
+----------------------------------------------------------------------
+
+to-bool-true : ∀ {v} → to-bool v ≡ just true → v ≡ 1ᶠ
+to-bool-true {v} eq with v ≟ᶠ 0ᶠ | eq
+... | yes _ | ()
+... | no  _ | eq₁ with v ≟ᶠ 1ᶠ | eq₁
+...   | yes q | _  = q
+...   | no  _ | ()
+
+to-bool-false : ∀ {v} → to-bool v ≡ just false → v ≡ 0ᶠ
+to-bool-false {v} eq with v ≟ᶠ 0ᶠ | eq
+... | yes p | _  = p
+... | no  _ | eq₁ with v ≟ᶠ 1ᶠ | eq₁
+...   | yes _ | ()
+...   | no  _ | ()
+
+to-bool-of-0ᶠ : to-bool 0ᶠ ≡ just false
+to-bool-of-0ᶠ with 0ᶠ ≟ᶠ 0ᶠ
+... | yes _  = refl
+... | no ¬p = ⊥-elim (¬p refl)
+
+to-bool-of-1ᶠ : to-bool 1ᶠ ≡ just true
+to-bool-of-1ᶠ with 1ᶠ ≟ᶠ 0ᶠ
+... | yes p = ⊥-elim (1ᶠ≢0ᶠ p)
+... | no  _ with 1ᶠ ≟ᶠ 1ᶠ
+...   | yes _  = refl
+...   | no ¬q = ⊥-elim (¬q refl)
+
+----------------------------------------------------------------------
+-- Derived encoding facts: `fits-from-le-bits-{take,drop}`.
+--
+-- Both follow from `from-le-bits-roundtrip` and the bit-value bounds in
+-- `FieldProperties`: the canonical value of `from-le-bits (take n bs)` is
+-- `bits-to-ℕ (take n bs) % FR-ORDER ≤ bits-to-ℕ (take n bs) < 2^n`, so
+-- it fits in n bits — and likewise for `drop`.  Reduction mod the field
+-- order can only shrink the value (`m%n≤m`), so no bound on FR-ORDER is
+-- needed.
+----------------------------------------------------------------------
+
+fits-from-le-bits-take : ∀ bs n
+  → Fits-in (from-le-bits (take n bs)) n
+fits-from-le-bits-take bs n =
+  subst (_< 2 ^ n) (sym (from-le-bits-roundtrip (take n bs)))
+    (≤-<-trans (m%n≤m (bits-to-ℕ (take n bs)) FR-ORDER)
+               (take-bound n bs))
+
+fits-from-le-bits-drop : ∀ v n
+  → Fits-in (from-le-bits (drop n (to-le-bits v))) (FR-BITS ∸ n)
+fits-from-le-bits-drop v n =
+  subst (_< 2 ^ (FR-BITS ∸ n))
+        (sym (from-le-bits-roundtrip (drop n (to-le-bits v))))
+    (≤-<-trans
+      (m%n≤m (bits-to-ℕ (drop n (to-le-bits v))) FR-ORDER)
+      (subst (λ L → bits-to-ℕ (drop n (to-le-bits v)) < 2 ^ (L ∸ n))
+             (to-le-bits-length v)
+             (drop-bound n (to-le-bits v))))
+
+----------------------------------------------------------------------
+-- Arithmetic bit-facts, discharged against the valuation laws.
+----------------------------------------------------------------------
+
+-- `valFr (pow2-fr n) ≡ 2^n mod FR-ORDER`, by induction using `valFr-+`
+-- and `valFr-1` (`pow2-fr` doubles at each step).
+valFr-pow2 : ∀ n → valFr (pow2-fr n) ≡ 2 ^ n % FR-ORDER
+valFr-pow2 zero    = valFr-1
+valFr-pow2 (suc k) =
+  trans (valFr-+ (pow2-fr k) (pow2-fr k))
+  (trans (cong (λ z → (z + z) % FR-ORDER) (valFr-pow2 k))
+  (trans (sym (%-distribˡ-+ (2 ^ k) (2 ^ k) FR-ORDER))
+         (cong (_% FR-ORDER) (sym (cong (2 ^ k +_) (+-identityʳ (2 ^ k)))))))
+
+-- Splitting a field element at `bits` and rebuilding it as
+-- (high · 2^bits + low) recovers it.  By valuation injectivity: both
+-- sides have value `bits-to-ℕ (to-le-bits v) mod FR-ORDER`, which is
+-- `valFr v` since `valFr v < FR-ORDER`.
+bits-decomp-split : ∀ v bits
+  → v ≡ (from-le-bits (drop bits (to-le-bits v)) *ᶠ pow2-fr bits)
+      +ᶠ from-le-bits (take bits (to-le-bits v))
+bits-decomp-split v bits = valFr-inj (sym (begin
+  valFr ((D *ᶠ P) +ᶠ M)
+    ≡⟨ valFr-+ (D *ᶠ P) M ⟩
+  (valFr (D *ᶠ P) + valFr M) % FR-ORDER
+    ≡⟨ cong (λ z → (z + valFr M) % FR-ORDER) (valFr-* D P) ⟩
+  ((valFr D * valFr P) % FR-ORDER + valFr M) % FR-ORDER
+    ≡⟨ cong (λ z → ((valFr D * z) % FR-ORDER + valFr M) % FR-ORDER) (valFr-pow2 bits) ⟩
+  ((valFr D * (2 ^ bits % FR-ORDER)) % FR-ORDER + valFr M) % FR-ORDER
+    ≡⟨ cong (λ z → ((z * (2 ^ bits % FR-ORDER)) % FR-ORDER + valFr M) % FR-ORDER)
+            (from-le-bits-roundtrip (drop bits (to-le-bits v))) ⟩
+  ((dN % FR-ORDER * (2 ^ bits % FR-ORDER)) % FR-ORDER + valFr M) % FR-ORDER
+    ≡⟨ cong (λ z → ((dN % FR-ORDER * (2 ^ bits % FR-ORDER)) % FR-ORDER + z) % FR-ORDER)
+            (from-le-bits-roundtrip (take bits (to-le-bits v))) ⟩
+  ((dN % FR-ORDER * (2 ^ bits % FR-ORDER)) % FR-ORDER + tN % FR-ORDER) % FR-ORDER
+    ≡⟨ cong (λ z → (z + tN % FR-ORDER) % FR-ORDER) (sym (%-distribˡ-* dN (2 ^ bits) FR-ORDER)) ⟩
+  ((dN * 2 ^ bits) % FR-ORDER + tN % FR-ORDER) % FR-ORDER
+    ≡⟨ sym (%-distribˡ-+ (dN * 2 ^ bits) tN FR-ORDER) ⟩
+  (dN * 2 ^ bits + tN) % FR-ORDER
+    ≡⟨ cong (_% FR-ORDER) (sym (bits-to-ℕ-split bits (to-le-bits v))) ⟩
+  valFr v % FR-ORDER
+    ≡⟨ m<n⇒m%n≡m (valFr-bound v) ⟩
+  valFr v ∎))
+  where
+    D  = from-le-bits (drop bits (to-le-bits v))
+    M  = from-le-bits (take bits (to-le-bits v))
+    P  = pow2-fr bits
+    dN = bits-to-ℕ (drop bits (to-le-bits v))
+    tN = bits-to-ℕ (take bits (to-le-bits v))
+
+----------------------------------------------------------------------
+-- The non-wrapping recombination guard `NoWrap` and the uniqueness it
+-- buys for `constraint-div-mod`.
+----------------------------------------------------------------------
+
+-- The canonical decomposition of `v` recombines (in ℕ) to exactly
+-- `valFr v`, with no reduction modulo the field order.  The two pieces
+-- `dN`, `tN` are each ≤ `valFr v < FR-ORDER`, so `from-le-bits`'s modular
+-- round trip is the identity on them.
+divmod-canonical-value : ∀ v bits
+  → valFr (from-le-bits (drop bits (to-le-bits v))) * 2 ^ bits
+    + valFr (from-le-bits (take bits (to-le-bits v)))
+    ≡ valFr v
+divmod-canonical-value v bits = begin
+  valFr (from-le-bits (drop bits BV)) * 2 ^ bits
+    + valFr (from-le-bits (take bits BV))
+    ≡⟨ cong (λ z → z * 2 ^ bits + valFr (from-le-bits (take bits BV)))
+            (from-le-bits-roundtrip (drop bits BV)) ⟩
+  dN % FR-ORDER * 2 ^ bits + valFr (from-le-bits (take bits BV))
+    ≡⟨ cong (λ z → dN % FR-ORDER * 2 ^ bits + z)
+            (from-le-bits-roundtrip (take bits BV)) ⟩
+  dN % FR-ORDER * 2 ^ bits + tN % FR-ORDER
+    ≡⟨ cong (λ z → z * 2 ^ bits + tN % FR-ORDER) (m<n⇒m%n≡m dN<order) ⟩
+  dN * 2 ^ bits + tN % FR-ORDER
+    ≡⟨ cong (dN * 2 ^ bits +_) (m<n⇒m%n≡m tN<order) ⟩
+  dN * 2 ^ bits + tN
+    ≡⟨ sym (bits-to-ℕ-split bits BV) ⟩
+  valFr v ∎
+  where
+    BV = to-le-bits v
+    dN = bits-to-ℕ (drop bits BV)
+    tN = bits-to-ℕ (take bits BV)
+    -- valFr v = dN·2^bits + tN, so both pieces are ≤ valFr v < FR-ORDER.
+    dN≤val : dN * 2 ^ bits + tN ≡ valFr v
+    dN≤val = sym (bits-to-ℕ-split bits BV)
+    dN<order : dN < FR-ORDER
+    dN<order = ≤-<-trans
+      (≤-trans (m≤m*n dN (2 ^ bits) {{m^n≢0 2 bits}})
+               (subst (dN * 2 ^ bits ≤_) dN≤val
+                      (m≤m+n (dN * 2 ^ bits) tN)))
+      (valFr-bound v)
+    tN<order : tN < FR-ORDER
+    tN<order = ≤-<-trans
+      (subst (tN ≤_) dN≤val (m≤n+m tN (dN * 2 ^ bits)))
+      (valFr-bound v)
+
+-- The canonical decomposition satisfies the in-circuit `NoWrap` guard.
+divmod-canonical-noWrap : ∀ v bits
+  → NoWrap (from-le-bits (drop bits (to-le-bits v)))
+           (from-le-bits (take bits (to-le-bits v))) bits
+divmod-canonical-noWrap v bits =
+  subst (_< FR-ORDER) (sym (divmod-canonical-value v bits)) (valFr-bound v)
+
+-- ℕ Euclidean uniqueness: with `r, r' < d` a common recombination
+-- `a·d + r ≡ a'·d + r'` forces `a ≡ a'` and `r ≡ r'`.
+private
+  mod-recombine : ∀ a r d .{{_ : NonZero d}} → r < d → (a * d + r) % d ≡ r
+  mod-recombine a r d r<d = begin
+    (a * d + r) % d
+      ≡⟨ %-distribˡ-+ (a * d) r d ⟩
+    ((a * d) % d + r % d) % d
+      ≡⟨ cong (λ z → (z + r % d) % d) (m*n%n≡0 a d) ⟩
+    (0 + r % d) % d
+      ≡⟨ cong (_% d) (+-identityˡ (r % d)) ⟩
+    (r % d) % d
+      ≡⟨ m%n%n≡m%n r d ⟩
+    r % d
+      ≡⟨ m<n⇒m%n≡m r<d ⟩
+    r ∎
+
+  euclid-unique : ∀ a r a' r' d .{{_ : NonZero d}}
+    → r < d → r' < d → a * d + r ≡ a' * d + r' → (a ≡ a') × (r ≡ r')
+  euclid-unique a r a' r' d r<d r'<d eq = aeq , req
+    where
+      req : r ≡ r'
+      req = trans (sym (mod-recombine a r d r<d))
+            (trans (cong (_% d) eq) (mod-recombine a' r' d r'<d))
+      eq2 : a * d + r ≡ a' * d + r
+      eq2 = trans eq (cong (a' * d +_) (sym req))
+      eq3 : r + a * d ≡ r + a' * d
+      eq3 = trans (+-comm r (a * d)) (trans eq2 (+-comm (a' * d) r))
+      aeq : a ≡ a'
+      aeq = *-cancelʳ-≡ a a' d (+-cancelˡ-≡ r (a * d) (a' * d) eq3)
+
+-- Value of the reconstitution concatenation under the fits premises.
+concat-value : ∀ mv dv n
+  → Fits-in mv n
+  → Fits-in dv (FR-BITS ∸ n)
+  → bits-to-ℕ (take n (to-le-bits mv) ++ take (FR-BITS ∸ n) (to-le-bits dv))
+    ≡ valFr mv + 2 ^ (n ⊓ FR-BITS) * valFr dv
+concat-value mv dv n fmv fdv = begin
+  bits-to-ℕ (take n (to-le-bits mv) ++ take (FR-BITS ∸ n) (to-le-bits dv))
+    ≡⟨ bits-to-ℕ-++ (take n (to-le-bits mv)) (take (FR-BITS ∸ n) (to-le-bits dv)) ⟩
+  bits-to-ℕ (take n (to-le-bits mv))
+    + 2 ^ length (take n (to-le-bits mv))
+        * bits-to-ℕ (take (FR-BITS ∸ n) (to-le-bits dv))
+    ≡⟨ cong (λ z → z + 2 ^ length (take n (to-le-bits mv))
+                       * bits-to-ℕ (take (FR-BITS ∸ n) (to-le-bits dv)))
+            (fits→take-full mv n fmv) ⟩
+  valFr mv + 2 ^ length (take n (to-le-bits mv))
+               * bits-to-ℕ (take (FR-BITS ∸ n) (to-le-bits dv))
+    ≡⟨ cong (λ z → valFr mv + 2 ^ length (take n (to-le-bits mv)) * z)
+            (fits→take-full dv (FR-BITS ∸ n) fdv) ⟩
+  valFr mv + 2 ^ length (take n (to-le-bits mv)) * valFr dv
+    ≡⟨ cong (λ L → valFr mv + 2 ^ L * valFr dv)
+            (trans (length-take n (to-le-bits mv)) (cong (n ⊓_) (to-le-bits-length mv))) ⟩
+  valFr mv + 2 ^ (n ⊓ FR-BITS) * valFr dv ∎
+
+-- Strict divisor bound ⇒ the concatenated value is < FR-ORDER, hence
+-- in field.  When n < FR_BITS the value is < 2^(FR_BITS−1) ≤ |Fr|;
+-- when n ≥ FR_BITS the divisor is forced to 0 and the value is `valFr mv`.
+bits-in-field-from-strict-bound : ∀ {dv mv n}
+  → Fits-in mv n
+  → Fits-in dv (FR-BITS ∸ n ∸ 1)
+  → BitsInField
+      (take n (to-le-bits mv) ++ take (FR-BITS ∸ n) (to-le-bits dv))
+bits-in-field-from-strict-bound {dv} {mv} {n} fmv fdv =
+  -- `BitsInField bs` is definitionally `bits-to-ℕ bs < FR-ORDER`, so the
+  -- value bound *is* the witness.
+  subst (_< FR-ORDER) (sym (concat-value mv dv n fmv fdv')) value-bound
+  where
+    fdv' : Fits-in dv (FR-BITS ∸ n)
+    fdv' = fits-in-mono fdv (m∸n≤m (FR-BITS ∸ n) 1)
+
+    value-bound : valFr mv + 2 ^ (n ⊓ FR-BITS) * valFr dv < FR-ORDER
+    value-bound with n <? FR-BITS
+    ... | yes n<FB =
+      subst (λ e → valFr mv + 2 ^ e * valFr dv < FR-ORDER)
+            (sym (m≤n⇒m⊓n≡m (<⇒≤ n<FB)))
+            (<-≤-trans
+              (combine-bound (valFr mv) (valFr dv) n (FR-BITS ∸ n ∸ 1)
+                 fmv
+                 fdv)
+              (≤-trans (≤-reflexive (cong (2 ^_) (exp-sum n n<FB))) order-lb))
+    ... | no n≥FB =
+      subst (λ z → valFr mv + 2 ^ (n ⊓ FR-BITS) * z < FR-ORDER) (sym dv≡0)
+        (subst (_< FR-ORDER) eq2 (valFr-bound mv))
+      where
+        FBn1≡0 : FR-BITS ∸ n ∸ 1 ≡ 0
+        FBn1≡0 = cong (_∸ 1) (m≤n⇒m∸n≡0 (≮⇒≥ n≥FB))
+        dv≡0 : valFr dv ≡ 0
+        dv≡0 = n<1⇒n≡0 (subst (λ z → valFr dv < 2 ^ z) FBn1≡0
+                              fdv)
+        eq2 : valFr mv ≡ valFr mv + 2 ^ (n ⊓ FR-BITS) * 0
+        eq2 = sym (trans (cong (valFr mv +_) (*-zeroʳ (2 ^ (n ⊓ FR-BITS))))
+                         (+-identityʳ (valFr mv)))
+
+-- Modular helpers: reducing a factor / summand mod FR-ORDER before the
+-- outer mod is a no-op.
+private
+  mul-mod-r : ∀ a b → (a * (b % FR-ORDER)) % FR-ORDER ≡ (a * b) % FR-ORDER
+  mul-mod-r a b =
+    trans (%-distribˡ-* a (b % FR-ORDER) FR-ORDER)
+    (trans (cong (λ z → (a % FR-ORDER * z) % FR-ORDER) (m%n%n≡m%n b FR-ORDER))
+           (sym (%-distribˡ-* a b FR-ORDER)))
+
+  add-mod-l : ∀ a b → (a % FR-ORDER + b) % FR-ORDER ≡ (a + b) % FR-ORDER
+  add-mod-l a b =
+    trans (%-distribˡ-+ (a % FR-ORDER) b FR-ORDER)
+    (trans (cong (λ z → (z + b % FR-ORDER) % FR-ORDER) (m%n%n≡m%n a FR-ORDER))
+           (sym (%-distribˡ-+ a b FR-ORDER)))
+
+-- Reconstitution: the field value of the concatenated pattern is
+-- exactly `dv·2^bits + mv`.  By valuation injectivity, both sides have
+-- value `(valFr dv · 2^bits + valFr mv) mod FR-ORDER` — the equality
+-- holds modulo FR-ORDER unconditionally, with no in-field (no-overflow)
+-- hypothesis.
+reconstitute-no-overflow : ∀ dv mv bits
+  → Fits-in mv bits
+  → Fits-in dv (FR-BITS ∸ bits)
+  → from-le-bits
+      (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv))
+    ≡ (dv *ᶠ pow2-fr bits) +ᶠ mv
+reconstitute-no-overflow dv mv bits fmv fdv = valFr-inj (begin
+  valFr (from-le-bits C)
+    ≡⟨ from-le-bits-roundtrip C ⟩
+  bits-to-ℕ C % FR-ORDER
+    ≡⟨ cong (_% FR-ORDER) (concat-value mv dv bits fmv fdv) ⟩
+  (valFr mv + 2 ^ (bits ⊓ FR-BITS) * valFr dv) % FR-ORDER
+    ≡⟨ value-eq ⟩
+  (valFr dv * 2 ^ bits + valFr mv) % FR-ORDER
+    ≡⟨ sym rhs-val ⟩
+  valFr ((dv *ᶠ pow2-fr bits) +ᶠ mv) ∎)
+  where
+    C = take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv)
+
+    rhs-val : valFr ((dv *ᶠ pow2-fr bits) +ᶠ mv)
+            ≡ (valFr dv * 2 ^ bits + valFr mv) % FR-ORDER
+    rhs-val = begin
+      valFr ((dv *ᶠ pow2-fr bits) +ᶠ mv)
+        ≡⟨ valFr-+ (dv *ᶠ pow2-fr bits) mv ⟩
+      (valFr (dv *ᶠ pow2-fr bits) + valFr mv) % FR-ORDER
+        ≡⟨ cong (λ z → (z + valFr mv) % FR-ORDER) (valFr-* dv (pow2-fr bits)) ⟩
+      ((valFr dv * valFr (pow2-fr bits)) % FR-ORDER + valFr mv) % FR-ORDER
+        ≡⟨ cong (λ z → ((valFr dv * z) % FR-ORDER + valFr mv) % FR-ORDER) (valFr-pow2 bits) ⟩
+      ((valFr dv * (2 ^ bits % FR-ORDER)) % FR-ORDER + valFr mv) % FR-ORDER
+        ≡⟨ cong (λ z → (z + valFr mv) % FR-ORDER) (mul-mod-r (valFr dv) (2 ^ bits)) ⟩
+      ((valFr dv * 2 ^ bits) % FR-ORDER + valFr mv) % FR-ORDER
+        ≡⟨ add-mod-l (valFr dv * 2 ^ bits) (valFr mv) ⟩
+      (valFr dv * 2 ^ bits + valFr mv) % FR-ORDER ∎
+
+    value-eq : (valFr mv + 2 ^ (bits ⊓ FR-BITS) * valFr dv) % FR-ORDER
+             ≡ (valFr dv * 2 ^ bits + valFr mv) % FR-ORDER
+    value-eq with bits <? FR-BITS
+    ... | yes bits<FB =
+      subst (λ e → (valFr mv + 2 ^ e * valFr dv) % FR-ORDER
+                 ≡ (valFr dv * 2 ^ bits + valFr mv) % FR-ORDER)
+            (sym (m≤n⇒m⊓n≡m (<⇒≤ bits<FB)))
+            (cong (_% FR-ORDER)
+                  (trans (+-comm (valFr mv) (2 ^ bits * valFr dv))
+                         (cong (_+ valFr mv) (*-comm (2 ^ bits) (valFr dv)))))
+    ... | no bits≥FB =
+      subst (λ z → (valFr mv + 2 ^ (bits ⊓ FR-BITS) * z) % FR-ORDER
+                 ≡ (z * 2 ^ bits + valFr mv) % FR-ORDER)
+            (sym dv≡0)
+            (cong (_% FR-ORDER)
+                  (trans (cong (valFr mv +_) (*-zeroʳ (2 ^ (bits ⊓ FR-BITS))))
+                         (+-identityʳ (valFr mv))))
+      where
+        dv≡0 : valFr dv ≡ 0
+        dv≡0 = n<1⇒n≡0 (subst (λ z → valFr dv < 2 ^ z)
+                              (m≤n⇒m∸n≡0 (≮⇒≥ bits≥FB))
+                              fdv)
+
+----------------------------------------------------------------------
+-- Padding a `bits-lt` comparison from n to lt-bits n bits (≥ n) leaves
+-- it unchanged when both operands fit in n bits.  `bits-lt` reduces to
+-- numeric `<` on `valFr`, and `take m (to-le-bits x) = valFr x` for any
+-- m ≥ n when x fits in n bits, so both comparisons compare `valFr av`
+-- with `valFr bv`.
+----------------------------------------------------------------------
+private
+  -- Length of the reversed truncation, common to both operands.
+  tklen : ∀ m x → length (reverse (take m (to-le-bits x))) ≡ m ⊓ FR-BITS
+  tklen m x = trans (length-reverse (take m (to-le-bits x)))
+                    (trans (length-take m (to-le-bits x)) (cong (m ⊓_) (to-le-bits-length x)))
+
+  -- `msbval` of the reversed truncation = `valFr x`, when x fits in m.
+  tkval : ∀ m x → Fits-in x m → msbval (reverse (take m (to-le-bits x))) ≡ valFr x
+  tkval m x fx = trans (msbval-reverse (take m (to-le-bits x))) (fits→take-full x m fx)
+
+  bits-lt-true-side : ∀ m av bv → Fits-in av m → Fits-in bv m
+    → valFr av < valFr bv
+    → bits-lt (take m (to-le-bits av)) (take m (to-le-bits bv)) ≡ true
+  bits-lt-true-side m av bv fav fbv lt =
+    bits-cmp-true (reverse (take m (to-le-bits av))) (reverse (take m (to-le-bits bv)))
+      (trans (tklen m av) (sym (tklen m bv)))
+      (subst₂ _<_ (sym (tkval m av fav)) (sym (tkval m bv fbv)) lt)
+
+  bits-lt-false-side : ∀ m av bv → Fits-in av m → Fits-in bv m
+    → valFr bv ≤ valFr av
+    → bits-lt (take m (to-le-bits av)) (take m (to-le-bits bv)) ≡ false
+  bits-lt-false-side m av bv fav fbv le =
+    bits-cmp-false (reverse (take m (to-le-bits av))) (reverse (take m (to-le-bits bv)))
+      (trans (tklen m av) (sym (tklen m bv)))
+      (subst₂ _≤_ (sym (tkval m bv fbv)) (sym (tkval m av fav)) le)
+
+bits-lt-pad : ∀ av bv n
+  → Fits-in av n
+  → Fits-in bv n
+  → bits-lt (take (lt-bits n) (to-le-bits av)) (take (lt-bits n) (to-le-bits bv))
+    ≡ bits-lt (take n (to-le-bits av)) (take n (to-le-bits bv))
+bits-lt-pad av bv n fav fbv with <-cmp (valFr av) (valFr bv)
+... | tri< a<b _ _ =
+  trans (bits-lt-true-side (lt-bits n) av bv (fits-in-lt-bits av n fav) (fits-in-lt-bits bv n fbv) a<b)
+        (sym (bits-lt-true-side n av bv fav fbv a<b))
+... | tri≈ _ a≡b _ =
+  trans (bits-lt-false-side (lt-bits n) av bv (fits-in-lt-bits av n fav) (fits-in-lt-bits bv n fbv)
+           (≤-reflexive (sym a≡b)))
+        (sym (bits-lt-false-side n av bv fav fbv (≤-reflexive (sym a≡b))))
+... | tri> _ _ b<a =
+  trans (bits-lt-false-side (lt-bits n) av bv (fits-in-lt-bits av n fav) (fits-in-lt-bits bv n fbv)
+           (<⇒≤ b<a))
+        (sym (bits-lt-false-side n av bv fav fbv (<⇒≤ b<a)))
+
+----------------------------------------------------------------------
+-- Uniqueness of the guarded `constraint-div-mod` decomposition.
+----------------------------------------------------------------------
+
+-- Under `NoWrap`, the field equation `v = q·2^bits + r` lifts to a
+-- non-wrapping ℕ equation `valFr v = valFr q · 2^bits + valFr r`.
+private
+  recombine-value : ∀ qv rv bits
+    → NoWrap qv rv bits
+    → valFr ((qv *ᶠ pow2-fr bits) +ᶠ rv)
+      ≡ valFr qv * 2 ^ bits + valFr rv
+  recombine-value qv rv bits nw = begin
+    valFr ((qv *ᶠ pow2-fr bits) +ᶠ rv)
+      ≡⟨ valFr-+ (qv *ᶠ pow2-fr bits) rv ⟩
+    (valFr (qv *ᶠ pow2-fr bits) + valFr rv) % FR-ORDER
+      ≡⟨ cong (λ z → (z + valFr rv) % FR-ORDER) (valFr-* qv (pow2-fr bits)) ⟩
+    ((valFr qv * valFr (pow2-fr bits)) % FR-ORDER + valFr rv) % FR-ORDER
+      ≡⟨ cong (λ z → ((valFr qv * z) % FR-ORDER + valFr rv) % FR-ORDER)
+              (valFr-pow2 bits) ⟩
+    ((valFr qv * (2 ^ bits % FR-ORDER)) % FR-ORDER + valFr rv) % FR-ORDER
+      ≡⟨ cong (λ z → (z + valFr rv) % FR-ORDER)
+              (mul-mod-r (valFr qv) (2 ^ bits)) ⟩
+    ((valFr qv * 2 ^ bits) % FR-ORDER + valFr rv) % FR-ORDER
+      ≡⟨ add-mod-l (valFr qv * 2 ^ bits) (valFr rv) ⟩
+    (valFr qv * 2 ^ bits + valFr rv) % FR-ORDER
+      ≡⟨ m<n⇒m%n≡m nw ⟩
+    valFr qv * 2 ^ bits + valFr rv ∎
+
+-- For a fixed `v`, any two (q, r) satisfying the constraint's value
+-- equation, the range bound on r, and the `NoWrap` guard are equal:
+-- both recombine without wrapping to `valFr v`, so they are the same
+-- Euclidean split of `valFr v`; `valFr-inj` lifts the value equalities
+-- back to `Fr`.
+div-mod-constraint-unique : ∀ {qv rv qv' rv' v bits}
+  → Fits-in rv bits
+  → Fits-in rv' bits
+  → NoWrap qv rv bits
+  → NoWrap qv' rv' bits
+  → v ≡ (qv *ᶠ pow2-fr bits) +ᶠ rv
+  → v ≡ (qv' *ᶠ pow2-fr bits) +ᶠ rv'
+  → (qv ≡ qv') × (rv ≡ rv')
+div-mod-constraint-unique {qv} {rv} {qv'} {rv'} {v} {bits}
+  fr fr' nw nw' eq eq' =
+  let value-eq : valFr qv * 2 ^ bits + valFr rv
+               ≡ valFr qv' * 2 ^ bits + valFr rv'
+      value-eq = trans (sym (recombine-value qv rv bits nw))
+                 (trans (cong valFr (trans (sym eq) eq'))
+                        (recombine-value qv' rv' bits nw'))
+      (vqeq , vreq) = euclid-unique (valFr qv) (valFr rv)
+                        (valFr qv') (valFr rv') (2 ^ bits)
+                        {{m^n≢0 2 bits}} fr fr' value-eq
+  in valFr-inj vqeq , valFr-inj vreq
+
+-- A satisfying `constraint-div-mod` value equation, with the range bound on
+-- the remainder and the `NoWrap` guard, pins (q, r) to the canonical
+-- (non-wrapping) bit-decomposition of `vv`.  This is the payload the
+-- div-mod backward step and the statement-soundness walk both read off
+-- the constraint.
+divmod-canon : ∀ {qv rv vv : Fr} {bits : ℕ}
+  → Fits-in rv bits
+  → NoWrap qv rv bits
+  → vv ≡ (qv *ᶠ pow2-fr bits) +ᶠ rv
+  → (qv ≡ from-le-bits (drop bits (to-le-bits vv)))
+  × (rv ≡ from-le-bits (take bits (to-le-bits vv)))
+divmod-canon {vv = vv} {bits = bits} frv nw veq =
+  div-mod-constraint-unique {bits = bits} frv
+                        (fits-from-le-bits-take (to-le-bits vv) bits)
+                        nw (divmod-canonical-noWrap vv bits)
+                        veq (bits-decomp-split vv bits)

--- a/formal/src/zkir-v2/FieldProperties.agda
+++ b/formal/src/zkir-v2/FieldProperties.agda
@@ -1,0 +1,361 @@
+{-# OPTIONS --safe #-}
+
+------------------------------------------------------------------------
+-- Field properties of the zkir-v2 formalization
+--
+-- Consequences of the `Assumptions` field operations:
+-- the boolean field-equality test and its reflection laws, `to-bool`,
+-- the `fits-in` / `bits-lt` bit predicates, `pow2-fr`, `lt-bits`, and the
+-- pure list/nat bit-value machinery (`bits-to-ℕ-split`, `msbval`, …).
+------------------------------------------------------------------------
+
+open import zkir-v2.Assumptions
+
+module zkir-v2.FieldProperties (⋯ : Assumptions) (open Assumptions ⋯) where
+
+open import Data.Bool  using (Bool; true; false; if_then_else_; T)
+open import Data.Empty using (⊥-elim)
+open import Data.Unit  using (tt)
+open import Data.List  using (List; []; _∷_; _++_; take; drop; reverse; length)
+open import Data.Maybe using (Maybe; nothing; just)
+open import Data.Nat   using (ℕ; zero; suc; _+_; _∸_; _%_; _⊔_; _⊓_; _≤_; _<_; _<?_; _*_; _^_)
+open import Data.Nat.Properties  using ( m+[n∸m]≡n; m≤m+n; m≤m⊔n; ≤-trans
+                                        ; ≤-<-trans; <-≤-trans; m≤n+m; m⊓n≤m
+                                        ; *-monoʳ-<; *-monoʳ-≤; ^-monoʳ-≤
+                                        ; *-cancelˡ-<; *-cancelʳ-<; *-identityˡ
+                                        ; <ᵇ⇒<
+                                        ; *-distribˡ-+; n<1⇒n≡0; 0<1+n
+                                        ; +-assoc; +-comm; +-identityʳ
+                                        ; *-assoc; *-comm; *-identityʳ; *-zeroʳ
+                                        ; ≤-reflexive; ∸-+-assoc; ^-distribˡ-+-*
+                                        ; +-monoˡ-<; +-monoʳ-<
+                                        ; +-cancelˡ-<; +-cancelˡ-≤; <-asym; <-irrefl; suc-injective )
+open import Data.List.Properties using (drop-drop; length-take; length-drop
+                                        ; length-reverse; reverse-involutive; unfold-reverse)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; cong₂; subst; module ≡-Reasoning)
+open import Relation.Nullary using (¬_; yes; no; Dec)
+open import Relation.Nullary.Decidable using (does; dec-true; dec-false)
+open ≡-Reasoning
+
+-- Boolean field-equality test, derived from decidable propositional
+-- equality.
+_≡ᶠ?_ : Fr → Fr → Bool
+x ≡ᶠ? y = does (x ≟ᶠ y)
+
+-- Reflection of boolean field-equality into propositional equality:
+-- theorems about `_≟ᶠ_`.
+≡ᶠ?-refl : ∀ {x} → (x ≡ᶠ? x) ≡ true
+≡ᶠ?-refl {x} = dec-true (x ≟ᶠ x) refl
+
+≡ᶠ?-false : ∀ {x y} → ¬ (x ≡ y) → (x ≡ᶠ? y) ≡ false
+≡ᶠ?-false {x} {y} = dec-false (x ≟ᶠ y)
+
+≡ᶠ?-true : ∀ {x y} → T (x ≡ᶠ? y) → x ≡ y
+≡ᶠ?-true {x} {y} t with x ≟ᶠ y
+... | yes p = p
+... | no  _ = ⊥-elim t
+
+-- Negation fixes zero: −0 = 0.  (0 = 0 + (−0) = −0.)
+-ᶠ-zero : (-ᶠ 0ᶠ) ≡ 0ᶠ
+-ᶠ-zero = trans (sym (+-zero-l (-ᶠ 0ᶠ))) (+-inv-r 0ᶠ)
+
+-- Right additive identity, from commutativity and the left law.
++-zero-r : ∀ x → x +ᶠ 0ᶠ ≡ x
++-zero-r x = trans (+ᶠ-comm x 0ᶠ) (+-zero-l x)
+
+-- Left additive inverse, and additive cancellation, derived from the
+-- field laws.  `+ᶠ-cancel` is the bridge that turns a polynomial gate
+-- `x − y = 0` into the equation `x = y` (see `zkir-v2.Circuit`).
++ᶠ-inv-l : ∀ x → (-ᶠ x) +ᶠ x ≡ 0ᶠ
++ᶠ-inv-l x = trans (+ᶠ-comm (-ᶠ x) x) (+-inv-r x)
+
++ᶠ-cancel : ∀ {x y} → x +ᶠ (-ᶠ y) ≡ 0ᶠ → x ≡ y
++ᶠ-cancel {x} {y} h = begin
+  x                  ≡⟨ sym (+-zero-r x) ⟩
+  x +ᶠ 0ᶠ            ≡⟨ cong (x +ᶠ_) (sym (+ᶠ-inv-l y)) ⟩
+  x +ᶠ ((-ᶠ y) +ᶠ y) ≡⟨ sym (+ᶠ-assoc x (-ᶠ y) y) ⟩
+  (x +ᶠ (-ᶠ y)) +ᶠ y ≡⟨ cong (_+ᶠ y) h ⟩
+  0ᶠ +ᶠ y            ≡⟨ +-zero-l y ⟩
+  y                  ∎
+
+-- Convert Fr to Bool; nothing if not in {0, 1} (UB in the IR)
+to-bool : Fr → Maybe Bool
+to-bool x with x ≟ᶠ 0ᶠ
+... | yes _ = just false
+... | no  _ with x ≟ᶠ 1ᶠ
+...   | yes _ = just true
+...   | no  _ = nothing
+
+-- `x` fits in `n` bits: its canonical value is below 2^n.
+-- A decidable predicate.
+Fits-in : Fr → ℕ → Set
+Fits-in x n = valFr x < 2 ^ n
+
+fits-in? : ∀ x n → Dec (Fits-in x n)
+fits-in? x n = valFr x <? 2 ^ n
+
+-- Non-wrapping recombination guard for `div_mod_power_of_two`: the
+-- integer recombination `q·2^bits + r` stays below the field order, so
+-- it does not wrap modulo |Fr|.  This is the in-circuit analogue of the
+-- `BitsInField` check `reconstitute-field` performs operationally; with
+-- it, the field equation `v = q·2^bits + r` forces the unique Euclidean
+-- decomposition of `valFr v` (see `Encoding.div-mod-constraint-unique`).
+NoWrap : Fr → Fr → ℕ → Set
+NoWrap q r bits = valFr q * 2 ^ bits + valFr r < FR-ORDER
+
+noWrap? : ∀ q r bits → Dec (NoWrap q r bits)
+noWrap? q r bits = (valFr q * 2 ^ bits + valFr r) <? FR-ORDER
+
+-- Bridges to/from the Bool decision `does (fits-in? x n)`, used by the
+-- operational/relational guards (which need a Bool) while the proofs
+-- carry the `Fits-in` predicate.
+fits-in?-true : ∀ x n → Fits-in x n → does (fits-in? x n) ≡ true
+fits-in?-true x n = dec-true (fits-in? x n)
+
+fits-in?-from-true : ∀ x n → T (does (fits-in? x n)) → Fits-in x n
+fits-in?-from-true x n = <ᵇ⇒< (valFr x) (2 ^ n)
+
+-- Same bridges for the `BitsInField` decision (used by the
+-- reconstitute-field guard in the operational/relational correspondence).
+bitsInField?-true : ∀ bs → BitsInField bs → does (bitsInField? bs) ≡ true
+bitsInField?-true bs = dec-true (bitsInField? bs)
+
+bitsInField?-from-true : ∀ bs → T (does (bitsInField? bs)) → BitsInField bs
+bitsInField?-from-true bs = <ᵇ⇒< (bits-to-ℕ bs) FR-ORDER
+
+-- MSB-first lexicographic comparison of two equal-length bit lists.
+bits-cmp : List Bool → List Bool → Bool
+bits-cmp []          _          = false
+bits-cmp _           []         = false
+bits-cmp (false ∷ _) (true ∷ _) = true
+bits-cmp (true ∷ _)  (false ∷ _) = false
+bits-cmp (_ ∷ as')   (_ ∷ bs')   = bits-cmp as' bs'
+
+-- bits-lt as bs: true iff the natural number represented by as (LE) is
+-- < that of bs.  Assumes both lists have the same length.
+bits-lt : List Bool → List Bool → Bool
+bits-lt as bs = bits-cmp (reverse as) (reverse bs)
+
+-- 2^n as a field element.
+pow2-fr : ℕ → Fr
+pow2-fr zero    = 1ᶠ
+pow2-fr (suc n) = pow2-fr n +ᶠ pow2-fr n
+
+-- Padded bit-count used by the range-check chip.
+lt-bits : ℕ → ℕ
+lt-bits n = (n + (n % 2)) ⊔ 4
+
+-- Monotonicity of `Fits-in`: if v fits in m bits, it fits in any larger
+-- bit-count.
+fits-in-mono : ∀ {v m n} → Fits-in v m → m ≤ n → Fits-in v n
+fits-in-mono p m≤n = <-≤-trans p (^-monoʳ-≤ 2 m≤n)
+
+-- `lt-bits n ≥ n`, so a value fitting in n bits also fits in
+-- `lt-bits n` bits.  A corollary of `fits-in-mono`: `lt-bits` only
+-- ever grows the bit-count (`n ≤ (n + n % 2) ⊔ 4`).
+fits-in-lt-bits : ∀ v n → Fits-in v n → Fits-in v (lt-bits n)
+fits-in-lt-bits v n p =
+  fits-in-mono p (≤-trans (m≤m+n n (n % 2)) (m≤m⊔n (n + (n % 2)) 4))
+
+----------------------------------------------------------------------
+-- Bounds on the integer value of a little-endian bit list.
+----------------------------------------------------------------------
+
+private
+  -- A bit list of length L represents a value < 2^L.
+  bits-to-ℕ-bound : ∀ bs → bits-to-ℕ bs < 2 ^ length bs
+  bits-to-ℕ-bound []           = 0<1+n
+  bits-to-ℕ-bound (false ∷ bs) = *-monoʳ-< 2 (bits-to-ℕ-bound bs)
+  bits-to-ℕ-bound (true  ∷ bs) =
+    subst (_≤ 2 * 2 ^ length bs) (*-distribˡ-+ 2 1 (bits-to-ℕ bs))
+          (*-monoʳ-≤ 2 (bits-to-ℕ-bound bs))
+
+-- `take n bs` represents a value < 2^n.
+take-bound : ∀ n bs → bits-to-ℕ (take n bs) < 2 ^ n
+take-bound n bs =
+  <-≤-trans
+    (subst (λ L → bits-to-ℕ (take n bs) < 2 ^ L) (length-take n bs)
+           (bits-to-ℕ-bound (take n bs)))
+    (^-monoʳ-≤ 2 (m⊓n≤m n (length bs)))
+
+-- `drop n bs` represents a value < 2^(length bs − n).
+drop-bound : ∀ n bs → bits-to-ℕ (drop n bs) < 2 ^ (length bs ∸ n)
+drop-bound n bs =
+  subst (λ L → bits-to-ℕ (drop n bs) < 2 ^ L) (length-drop n bs)
+        (bits-to-ℕ-bound (drop n bs))
+
+----------------------------------------------------------------------
+-- The LE split/concat identities for the canonical valuation.
+----------------------------------------------------------------------
+
+private
+  -- Ring rearrangements (proved by hand to avoid solver-API coupling).
+  2*[dp] : ∀ d p → 2 * (d * p) ≡ d * (2 * p)
+  2*[dp] d p = trans (sym (*-assoc 2 d p))
+                     (trans (cong (_* p) (*-comm 2 d)) (*-assoc d 2 p))
+
+  split-rearrange : ∀ i d t p → i + 2 * (d * p + t) ≡ d * (2 * p) + (i + 2 * t)
+  split-rearrange i d t p = begin
+    i + 2 * (d * p + t)            ≡⟨ cong (i +_) (*-distribˡ-+ 2 (d * p) t) ⟩
+    i + (2 * (d * p) + 2 * t)      ≡⟨ cong (λ z → i + (z + 2 * t)) (2*[dp] d p) ⟩
+    i + (d * (2 * p) + 2 * t)      ≡⟨ sym (+-assoc i (d * (2 * p)) (2 * t)) ⟩
+    (i + d * (2 * p)) + 2 * t      ≡⟨ cong (_+ 2 * t) (+-comm i (d * (2 * p))) ⟩
+    (d * (2 * p) + i) + 2 * t      ≡⟨ +-assoc (d * (2 * p)) i (2 * t) ⟩
+    d * (2 * p) + (i + 2 * t)      ∎
+
+  ++-rearrange : ∀ i x p y → i + 2 * (x + p * y) ≡ (i + 2 * x) + (2 * p) * y
+  ++-rearrange i x p y = begin
+    i + 2 * (x + p * y)            ≡⟨ cong (i +_) (*-distribˡ-+ 2 x (p * y)) ⟩
+    i + (2 * x + 2 * (p * y))      ≡⟨ cong (λ z → i + (2 * x + z)) (2*[dp] p y) ⟩
+    i + (2 * x + p * (2 * y))      ≡⟨ sym (+-assoc i (2 * x) (p * (2 * y))) ⟩
+    (i + 2 * x) + p * (2 * y)      ≡⟨ cong ((i + 2 * x) +_) (sym (2*[dp] p y)) ⟩
+    (i + 2 * x) + 2 * (p * y)      ≡⟨ cong (λ z → (i + 2 * x) + z) (sym (*-assoc 2 p y)) ⟩
+    (i + 2 * x) + (2 * p) * y      ∎
+
+-- LE split: dropping/​taking at position n recovers the value as
+-- high·2^n + low.  Holds for every n (drop/take saturate past the end).
+bits-to-ℕ-split : ∀ n bs
+  → bits-to-ℕ bs ≡ bits-to-ℕ (drop n bs) * 2 ^ n + bits-to-ℕ (take n bs)
+bits-to-ℕ-split zero    bs       =
+  sym (trans (+-identityʳ (bits-to-ℕ bs * 1)) (*-identityʳ (bits-to-ℕ bs)))
+bits-to-ℕ-split (suc k) []       = refl
+bits-to-ℕ-split (suc k) (b ∷ bs) =
+  trans (cong (λ z → (if b then 1 else 0) + 2 * z) (bits-to-ℕ-split k bs))
+        (split-rearrange (if b then 1 else 0)
+                         (bits-to-ℕ (drop k bs)) (bits-to-ℕ (take k bs)) (2 ^ k))
+
+-- LE concatenation: value of xs ++ ys = value xs + 2^|xs|·value ys.
+bits-to-ℕ-++ : ∀ xs ys
+  → bits-to-ℕ (xs ++ ys) ≡ bits-to-ℕ xs + 2 ^ length xs * bits-to-ℕ ys
+bits-to-ℕ-++ []       ys = sym (+-identityʳ (bits-to-ℕ ys))
+bits-to-ℕ-++ (b ∷ xs) ys =
+  trans (cong (λ z → (if b then 1 else 0) + 2 * z) (bits-to-ℕ-++ xs ys))
+        (++-rearrange (if b then 1 else 0)
+                      (bits-to-ℕ xs) (2 ^ length xs) (bits-to-ℕ ys))
+
+-- `fits-in x n` ⇒ the dropped high part has value 0, hence the low n
+-- bits already carry the full value.
+-- `Fits-in x n` ⇒ the dropped high part has value 0.  From the split
+-- `valFr x ≡ q·2^n + r`, the bound `valFr x < 2^n` forces `q ≡ 0`.
+fits→drop0 : ∀ x n → Fits-in x n → bits-to-ℕ (drop n (to-le-bits x)) ≡ 0
+fits→drop0 x n fit =
+  n<1⇒n≡0 (*-cancelʳ-< (2 ^ n) (bits-to-ℕ (drop n (to-le-bits x))) 1
+    (subst (bits-to-ℕ (drop n (to-le-bits x)) * 2 ^ n <_)
+           (sym (*-identityˡ (2 ^ n)))
+           (≤-<-trans
+             (subst (bits-to-ℕ (drop n (to-le-bits x)) * 2 ^ n ≤_)
+                    (sym (bits-to-ℕ-split n (to-le-bits x)))
+                    (m≤m+n (bits-to-ℕ (drop n (to-le-bits x)) * 2 ^ n)
+                           (bits-to-ℕ (take n (to-le-bits x)))))
+             fit)))
+
+fits→take-full : ∀ x n → Fits-in x n
+  → bits-to-ℕ (take n (to-le-bits x)) ≡ valFr x
+fits→take-full x n p =
+  sym (trans (bits-to-ℕ-split n (to-le-bits x))
+             (cong (λ z → z * 2 ^ n + bits-to-ℕ (take n (to-le-bits x)))
+                   (fits→drop0 x n p)))
+
+-- If a < 2^e and b < 2^d then a + 2^e·b < 2^(e+d).
+combine-bound : ∀ a b e d → a < 2 ^ e → b < 2 ^ d → a + 2 ^ e * b < 2 ^ (e + d)
+combine-bound a b e d a<2e b<2d =
+  <-≤-trans (+-monoˡ-< (2 ^ e * b) a<2e)
+    (≤-trans (≤-reflexive (sym eq1))
+    (≤-trans (*-monoʳ-≤ (2 ^ e) b<2d)
+             (≤-reflexive (sym (^-distribˡ-+-* 2 e d)))))
+  where eq1 : 2 ^ e * suc b ≡ 2 ^ e + 2 ^ e * b
+        eq1 = trans (*-distribˡ-+ (2 ^ e) 1 b) (cong (_+ 2 ^ e * b) (*-identityʳ (2 ^ e)))
+
+-- For n < FR_BITS: n + (FR_BITS − n − 1) = FR_BITS − 1.
+exp-sum : ∀ n → n < FR-BITS → n + (FR-BITS ∸ n ∸ 1) ≡ FR-BITS ∸ 1
+exp-sum n n<FB =
+  trans (cong (n +_)
+              (trans (∸-+-assoc FR-BITS n 1) (cong (FR-BITS ∸_) (+-comm n 1))))
+        (cong (_∸ 1) (m+[n∸m]≡n n<FB))
+
+----------------------------------------------------------------------
+-- `bits-lt` as a numeric comparison (used to discharge `bits-lt-pad`).
+--
+-- `msbval` is the MSB-first value; `bits-cmp` (MSB-first lexicographic)
+-- agrees with numeric `<` on equal-length lists.  `msbval ∘ reverse`
+-- recovers the LE value `bits-to-ℕ`, so `bits-lt` is numeric `<`.
+----------------------------------------------------------------------
+
+msbval : List Bool → ℕ
+msbval []       = 0
+msbval (b ∷ bs) = (if b then 2 ^ length bs else 0) + msbval bs
+
+msbval-bound : ∀ bs → msbval bs < 2 ^ length bs
+msbval-bound []           = 0<1+n
+msbval-bound (false ∷ bs) =
+  <-≤-trans (msbval-bound bs) (^-monoʳ-≤ 2 (m≤n+m (length bs) 1))
+msbval-bound (true ∷ bs)  =
+  <-≤-trans (+-monoʳ-< (2 ^ length bs) (msbval-bound bs))
+            (≤-reflexive (cong (2 ^ length bs +_) (sym (+-identityʳ (2 ^ length bs)))))
+
+-- `msbval (false ∷ xs) < msbval (true ∷ ys)` when the tails match length.
+private
+  msbval-f<t : ∀ xs ys → length xs ≡ length ys → msbval xs < 2 ^ length ys + msbval ys
+  msbval-f<t xs ys len =
+    <-≤-trans (subst (λ L → msbval xs < 2 ^ L) len (msbval-bound xs))
+              (m≤m+n (2 ^ length ys) (msbval ys))
+
+-- MSB-first comparison agrees with numeric `<` on equal-length lists.
+bits-cmp-true : ∀ xs ys → length xs ≡ length ys
+  → msbval xs < msbval ys → bits-cmp xs ys ≡ true
+bits-cmp-true []           []           _   ()
+bits-cmp-true []           (_ ∷ _)      ()  _
+bits-cmp-true (_ ∷ _)      []           ()  _
+bits-cmp-true (false ∷ _)  (true ∷ _)   _   _  = refl
+bits-cmp-true (true ∷ xs)  (false ∷ ys) len lt =
+  ⊥-elim (<-asym lt (msbval-f<t ys xs (sym (suc-injective len))))
+bits-cmp-true (false ∷ xs) (false ∷ ys) len lt = bits-cmp-true xs ys (suc-injective len) lt
+bits-cmp-true (true ∷ xs)  (true ∷ ys)  len lt =
+  bits-cmp-true xs ys (suc-injective len)
+    (+-cancelˡ-< (2 ^ length xs) (msbval xs) (msbval ys)
+       (subst (λ L → 2 ^ length xs + msbval xs < 2 ^ L + msbval ys)
+              (sym (suc-injective len)) lt))
+
+bits-cmp-false : ∀ xs ys → length xs ≡ length ys
+  → msbval ys ≤ msbval xs → bits-cmp xs ys ≡ false
+bits-cmp-false []           []           _   _  = refl
+bits-cmp-false []           (_ ∷ _)      ()  _
+bits-cmp-false (_ ∷ _)      []           ()  _
+bits-cmp-false (true ∷ _)   (false ∷ _)  _   _  = refl
+bits-cmp-false (false ∷ xs) (true ∷ ys)  len le =
+  ⊥-elim (<-irrefl refl (≤-<-trans le (msbval-f<t xs ys (suc-injective len))))
+bits-cmp-false (false ∷ xs) (false ∷ ys) len le = bits-cmp-false xs ys (suc-injective len) le
+bits-cmp-false (true ∷ xs)  (true ∷ ys)  len le =
+  bits-cmp-false xs ys (suc-injective len)
+    (+-cancelˡ-≤ (2 ^ length xs) (msbval ys) (msbval xs)
+       (subst (λ L → 2 ^ L + msbval ys ≤ 2 ^ length xs + msbval xs)
+              (sym (suc-injective len)) le))
+
+-- `msbval` of a list equals the LE value of its reverse.
+msbval-rev : ∀ xs → msbval xs ≡ bits-to-ℕ (reverse xs)
+msbval-rev []       = refl
+msbval-rev (b ∷ xs) = begin
+  (if b then 2 ^ length xs else 0) + msbval xs
+    ≡⟨ cong ((if b then 2 ^ length xs else 0) +_) (msbval-rev xs) ⟩
+  (if b then 2 ^ length xs else 0) + bits-to-ℕ (reverse xs)
+    ≡⟨ rearr b ⟩
+  bits-to-ℕ (reverse xs) + 2 ^ length xs * (if b then 1 else 0)
+    ≡⟨ cong₂ (λ E F → bits-to-ℕ (reverse xs) + E * F)
+             (cong (2 ^_) (sym (length-reverse xs)))
+             (sym (+-identityʳ (if b then 1 else 0))) ⟩
+  bits-to-ℕ (reverse xs) + 2 ^ length (reverse xs) * bits-to-ℕ (b ∷ [])
+    ≡⟨ sym (bits-to-ℕ-++ (reverse xs) (b ∷ [])) ⟩
+  bits-to-ℕ (reverse xs ++ (b ∷ []))
+    ≡⟨ cong bits-to-ℕ (sym (unfold-reverse b xs)) ⟩
+  bits-to-ℕ (reverse (b ∷ xs)) ∎
+  where
+    rearr : ∀ b → (if b then 2 ^ length xs else 0) + bits-to-ℕ (reverse xs)
+          ≡ bits-to-ℕ (reverse xs) + 2 ^ length xs * (if b then 1 else 0)
+    rearr true  = trans (+-comm (2 ^ length xs) (bits-to-ℕ (reverse xs)))
+                        (cong (bits-to-ℕ (reverse xs) +_) (sym (*-identityʳ (2 ^ length xs))))
+    rearr false = sym (trans (cong (bits-to-ℕ (reverse xs) +_) (*-zeroʳ (2 ^ length xs)))
+                             (+-identityʳ (bits-to-ℕ (reverse xs))))
+
+msbval-reverse : ∀ cs → msbval (reverse cs) ≡ bits-to-ℕ cs
+msbval-reverse cs = trans (msbval-rev (reverse cs)) (cong bits-to-ℕ (reverse-involutive cs))

--- a/formal/src/zkir-v2/Main.agda
+++ b/formal/src/zkir-v2/Main.agda
@@ -1,0 +1,30 @@
+-- Top-level module for the zkir-v2 formalization.
+--
+-- Importing this module type-checks the entire zkir-v2 development:
+-- the syntax and semantics of the IR, the constraint-system (circuit)
+-- model, the proof obligations, and the soundness / faithfulness results
+-- connecting them.
+--
+-- The development is abstract over the trust base: it takes an
+-- `Assumptions` value as a module parameter rather than postulating the
+-- field/curve/hash primitives and their axioms.  No concrete BLS12-381
+-- instantiation is provided yet, so the whole development typechecks
+-- under `--safe`.
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.Main (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v2.FieldProperties ⋯
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+open import zkir-v2.SemanticsLemmas ⋯
+open import zkir-v2.Properties ⋯
+open import zkir-v2.Circuit ⋯
+open import zkir-v2.CircuitFaithfulness ⋯
+open import zkir-v2.CircuitProof ⋯
+open import zkir-v2.Encoding ⋯
+open import zkir-v2.Obligations ⋯
+open import zkir-v2.ObligationsSoundness ⋯
+open import zkir-v2.StatementSoundness ⋯
+open import zkir-v2.StatementUniqueness ⋯

--- a/formal/src/zkir-v2/Obligations.agda
+++ b/formal/src/zkir-v2/Obligations.agda
@@ -1,0 +1,705 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.Obligations (⋯ : _) (open Assumptions ⋯) where
+
+------------------------------------------------------------------------
+-- Producer obligations  (spec §6.4)
+--
+-- Four checkable circuit well-formedness conditions — properties of a
+-- circuit that guarantee the preprocess and circuit semantics coincide
+-- (the backward direction of P5):
+--
+--   O0  Operand-index discipline    (every operand index refers to an
+--                                    already-allocated cell; `wire-disc`)
+--   O1  PiSkip discipline           (structural; coincides with WF3)
+--   O2  Boolean-UB freedom          (operands of `assert`, `not`, and
+--                                    the bit of `cond-select` lie in {0,1})
+--   O3  ReconstituteField           (no field-overflow; subsumes O4
+--                                    via the `less-than` constraint)
+--
+-- Each obligation is presented as a *checker function* `IrSource → Bool`
+-- that performs a single linear scan over the instruction list, mirror-
+-- ing the spec's algorithmic statement.  We keep the data structures
+-- deliberately concrete: lists of indices for the boolean-known set and
+-- lists of (index, ℕ) pairs for the bit-bound partial map.  No stdlib
+-- set/AVL abstractions.
+--
+-- `producer-safe` is the conjunction of all four checks.
+-- `ObligationsSoundness` threads `T (producer-safe src)` through the
+-- program-level induction, supplying the per-instruction obligation
+-- evidence the backward proofs require.
+------------------------------------------------------------------------
+
+-- `FR-BITS` comes from the `Assumptions` parameter.
+open import zkir-v2.FieldProperties ⋯
+open import zkir-v2.Syntax ⋯
+
+open import Data.Bool    using (Bool; true; false; _∧_; if_then_else_; T)
+open import Data.Bool.Properties using (T-∧)
+open import Data.List    using (List; []; _∷_)
+open import Data.Maybe   using (Maybe; nothing; just)
+open import Data.Nat     using (ℕ; suc; _+_; _∸_; _≟_; _<_; _<?_; _≤_; _≤?_; _≡ᵇ_)
+open import Data.Nat.Properties using (≡ᵇ⇒≡)
+open import Data.Product using (_×_; _,_)
+open import Data.Unit    using (⊤; tt)
+open import Data.Empty   using (⊥; ⊥-elim)
+open import Function.Bundles using (Equivalence)
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Nullary.Decidable using (_×-dec_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; subst)
+
+-- Idiomatic decidable membership on `IndexSet = List Index` (= `List ℕ`),
+-- from the standard library, instantiated at `ℕ`'s decidable equality.
+open import Data.List.Membership.DecPropositional (_≟_) using (_∈_; _∈?_)
+-- Decidable `All` for the list-operand wire-discipline predicate.
+open import Data.List.Relation.Unary.All using (All; all?)
+
+------------------------------------------------------------------------
+-- Index sets and partial maps (small concrete encodings).
+------------------------------------------------------------------------
+
+-- Index set: a list of indices.  Membership is the standard-library
+-- propositional `_∈_`, decided by `_∈?_` (see the import above).
+IndexSet : Set
+IndexSet = List Index
+
+insert : Index → IndexSet → IndexSet
+insert i js = i ∷ js     -- duplicates harmless; lookup is up to `_≡_`.
+
+-- Partial map ℕ → ℕ as an association list.  First match wins under
+-- `lookupᵐ`.  Inserts always shadow, keeping the invariant that older
+-- bindings are still in the list but never reachable.
+PartialMap : Set
+PartialMap = List (Index × ℕ)
+
+-- `lookupᵐ i ps` returns the most-recently-inserted value at `i`, or
+-- `nothing` if `i` is not in the map.  Used by the obligation checks
+-- below.
+lookupᵐ : Index → PartialMap → Maybe ℕ
+lookupᵐ _ []             = nothing
+lookupᵐ i ((j , n) ∷ ps) = if (i ≡ᵇ j) then just n else lookupᵐ i ps
+
+-- Insert (shadows any existing binding).  Used by every "record" step
+-- in the spec.
+insertᵐ : Index → ℕ → PartialMap → PartialMap
+insertᵐ i n ps = (i , n) ∷ ps
+
+------------------------------------------------------------------------
+-- Instruction bookkeeping shape.
+--
+-- Every instruction contributes a fixed amount of bookkeeping to the
+-- circuit-faithfulness development: how many memory cells it pushes
+-- (Δmem ∈ {0,1,2}), how many public-input entries it appends
+-- (Δpis ∈ {0,1}), and — for the four instructions that read a side
+-- channel — which channel.  `InstrShape` names those bookkeeping
+-- classes; `shapeView` is the single place that enumerates the
+-- instruction constructors and assigns each its shape.
+--
+-- Bookkeeping tables downstream dispatch on the view instead of
+-- re-enumerating the instructions.  The genuine per-instruction
+-- mathematics (the faithfulness lemmas, the emitted constraints, the
+-- obligation checks) stays keyed on the constructors directly — those
+-- are real content, not bookkeeping, and do not factor through a shape.
+--
+-- `sh-pure0/1/2` push {0,1,2} cells and touch no side channel;
+-- `sh-declare` appends one public input; `sh-output`, `sh-skip`,
+-- `sh-pub-in`, `sh-priv-in` are the four side-channel instructions.
+------------------------------------------------------------------------
+
+data InstrShape : Set where
+  sh-pure0 sh-pure1 sh-pure2 sh-declare : InstrShape
+  sh-output sh-skip sh-pub-in sh-priv-in : InstrShape
+
+shape-Δmem : InstrShape → ℕ
+shape-Δmem sh-pure0   = 0
+shape-Δmem sh-pure1   = 1
+shape-Δmem sh-pure2   = 2
+shape-Δmem sh-declare = 0
+shape-Δmem sh-output  = 0
+shape-Δmem sh-skip    = 0
+shape-Δmem sh-pub-in  = 1
+shape-Δmem sh-priv-in = 1
+
+shape-Δpis : InstrShape → ℕ
+shape-Δpis sh-declare = 1
+shape-Δpis _          = 0
+
+-- The view: for each instruction the shape it belongs to.  The pure
+-- constructors leave the instruction abstract (their bookkeeping does
+-- not read any operand); the side-channel constructors refine the
+-- instruction so a consumer can reach the operand the channel needs.
+data ShapeView : Instruction → Set where
+  sv-pure0   : ∀ {i}   → ShapeView i
+  sv-pure1   : ∀ {i}   → ShapeView i
+  sv-pure2   : ∀ {i}   → ShapeView i
+  sv-declare : ∀ {v}   → ShapeView (declare-pub-input v)
+  sv-output  : ∀ {v}   → ShapeView (output v)
+  sv-skip    : ∀ {g c} → ShapeView (pi-skip g c)
+  sv-pub-in  : ∀ {g}   → ShapeView (public-input g)
+  sv-priv-in : ∀ {g}   → ShapeView (private-input g)
+
+shape-of : ∀ {i} → ShapeView i → InstrShape
+shape-of sv-pure0   = sh-pure0
+shape-of sv-pure1   = sh-pure1
+shape-of sv-pure2   = sh-pure2
+shape-of sv-declare = sh-declare
+shape-of sv-output  = sh-output
+shape-of sv-skip    = sh-skip
+shape-of sv-pub-in  = sh-pub-in
+shape-of sv-priv-in = sh-priv-in
+
+-- The single 26-way enumeration of the instruction constructors.
+shapeView : (i : Instruction) → ShapeView i
+shapeView (assert _)                 = sv-pure0
+shapeView (constrain-bits _ _)       = sv-pure0
+shapeView (constrain-eq _ _)         = sv-pure0
+shapeView (constrain-to-boolean _)   = sv-pure0
+shapeView (add _ _)                  = sv-pure1
+shapeView (mul _ _)                  = sv-pure1
+shapeView (neg _)                    = sv-pure1
+shapeView (copy _)                   = sv-pure1
+shapeView (load-imm _)               = sv-pure1
+shapeView (test-eq _ _)              = sv-pure1
+shapeView (transient-hash _)         = sv-pure1
+shapeView (cond-select _ _ _)        = sv-pure1
+shapeView (not _)                    = sv-pure1
+shapeView (less-than _ _ _)          = sv-pure1
+shapeView (reconstitute-field _ _ _) = sv-pure1
+shapeView (ec-add _ _ _ _)           = sv-pure2
+shapeView (ec-mul _ _ _)             = sv-pure2
+shapeView (ec-mul-generator _)       = sv-pure2
+shapeView (hash-to-curve _)          = sv-pure2
+shapeView (persistent-hash _ _)      = sv-pure2
+shapeView (div-mod-power-of-two _ _) = sv-pure2
+shapeView (declare-pub-input _)      = sv-declare
+shapeView (output _)                 = sv-output
+shapeView (pi-skip _ _)              = sv-skip
+shapeView (public-input _)           = sv-pub-in
+shapeView (private-input _)          = sv-priv-in
+
+------------------------------------------------------------------------
+-- Δmem  (output arity per instruction; matches `circuit-instr`),
+-- derived from the shape so it reduces through `shapeView`.
+------------------------------------------------------------------------
+
+Δmem : Instruction → ℕ
+Δmem i = shape-Δmem (shape-of (shapeView i))
+
+------------------------------------------------------------------------
+-- O1  —  PiSkip discipline (WF3, full-bracketing)
+--
+-- Linear scan tracking `d`, the number of `declare-pub-input`s emitted
+-- *since the previous* `pi-skip` (or program start).  Each `pi-skip g n`
+-- must cover exactly that group (`n ≡ d`), then resets the counter; after
+-- the scan no declares may be left uncovered (`d ≡ 0`).  This is WF3 as
+-- stated in spec §3.3 ("no PiSkip may cover more than emitted since the
+-- previous one", with the counts summing to the declare total): the two
+-- conditions together force `n = d` at every skip and no trailing
+-- declares.  It is faithful to the Rust producer, which emits a `PiSkip`
+-- "covering" each preceding declare group "as an instruction"
+-- (`zkir/src/ir.rs`).  A running-pool scan (`n ≤ pool`, final
+-- `pool = 0`) would be strictly weaker — it admits sources whose
+-- declared public inputs cannot be reconciled with any verifier
+-- transcript (see `StatementSoundness`), so statement soundness fails
+-- for them; full bracketing is required.
+------------------------------------------------------------------------
+
+-- Instructions that neither declare a public input nor mark a skip
+-- group; the `O1-Trace` group counter `d` is unchanged across them.
+-- Purely syntactic, so it lives here beside `O1-Trace`.
+NotDeclSkip : Instruction → Set
+NotDeclSkip (declare-pub-input _) = ⊥
+NotDeclSkip (pi-skip _ _)         = ⊥
+NotDeclSkip _                     = ⊤
+
+-- A view classifying an instruction as a declare, a skip (exposing its
+-- covered count `n`), or "other" (carrying its `NotDeclSkip` witness).
+-- The single point where the instruction constructors are enumerated;
+-- both `O1-scan` and `o1-scan→trace` dispatch on it, so the bracketing
+-- scan and its witness reconstruction stay in lock-step.
+data DeclSkipView : Instruction → Set where
+  dsv-decl  : ∀ {v}   → DeclSkipView (declare-pub-input v)
+  dsv-skip  : ∀ {g n} → DeclSkipView (pi-skip g n)
+  dsv-other : ∀ {i}   → NotDeclSkip i → DeclSkipView i
+
+declSkipView : (i : Instruction) → DeclSkipView i
+declSkipView (declare-pub-input _)     = dsv-decl
+declSkipView (pi-skip _ _)             = dsv-skip
+declSkipView (assert _)                = dsv-other tt
+declSkipView (cond-select _ _ _)       = dsv-other tt
+declSkipView (constrain-bits _ _)      = dsv-other tt
+declSkipView (constrain-eq _ _)        = dsv-other tt
+declSkipView (constrain-to-boolean _)  = dsv-other tt
+declSkipView (copy _)                  = dsv-other tt
+declSkipView (ec-add _ _ _ _)          = dsv-other tt
+declSkipView (ec-mul _ _ _)            = dsv-other tt
+declSkipView (ec-mul-generator _)      = dsv-other tt
+declSkipView (hash-to-curve _)         = dsv-other tt
+declSkipView (load-imm _)              = dsv-other tt
+declSkipView (div-mod-power-of-two _ _)= dsv-other tt
+declSkipView (reconstitute-field _ _ _)= dsv-other tt
+declSkipView (output _)                = dsv-other tt
+declSkipView (transient-hash _)        = dsv-other tt
+declSkipView (persistent-hash _ _)     = dsv-other tt
+declSkipView (test-eq _ _)             = dsv-other tt
+declSkipView (add _ _)                 = dsv-other tt
+declSkipView (mul _ _)                 = dsv-other tt
+declSkipView (neg _)                   = dsv-other tt
+declSkipView (not _)                   = dsv-other tt
+declSkipView (less-than _ _ _)         = dsv-other tt
+declSkipView (public-input _)          = dsv-other tt
+declSkipView (private-input _)         = dsv-other tt
+
+O1-scan : ℕ → List Instruction → Bool
+O1-scan d [] = d ≡ᵇ 0
+O1-scan d (i ∷ is) with declSkipView i
+... | dsv-decl         = O1-scan (suc d) is
+... | dsv-skip {n = n} = (n ≡ᵇ d) ∧ O1-scan 0 is
+... | dsv-other _      = O1-scan d is
+
+O1 : IrSource → Bool
+O1 src = O1-scan 0 (IrSource.instructions src)
+
+-- Witness-bearing form of the scan (parallel to `Wire-Trace`), threaded
+-- by the statement-soundness builder.  `O1-Trace d is` certifies that
+-- `is` is well-bracketed starting from a group with `d` declares already
+-- emitted.
+data O1-Trace : ℕ → List Instruction → Set where
+  o1-nil   : O1-Trace 0 []
+  o1-decl  : ∀ {d v is} → O1-Trace (suc d) is
+           → O1-Trace d (declare-pub-input v ∷ is)
+  o1-skip  : ∀ {d g n is} → n ≡ d → O1-Trace 0 is
+           → O1-Trace d (pi-skip g n ∷ is)
+  o1-other : ∀ {d i is} → NotDeclSkip i → O1-Trace d is
+           → O1-Trace d (i ∷ is)
+
+-- The PiSkip discipline O1, reflected into its `O1-Trace` witness.
+o1-scan→trace : ∀ (is : List Instruction) (d : ℕ)
+  → T (O1-scan d is) → O1-Trace d is
+o1-scan→trace [] d ok =
+  subst (λ k → O1-Trace k []) (sym (≡ᵇ⇒≡ d 0 ok)) o1-nil
+o1-scan→trace (i ∷ is) d ok with declSkipView i
+... | dsv-decl         = o1-decl (o1-scan→trace is (suc d) ok)
+... | dsv-skip {n = n} =
+        let (n≡ , rest) = T-∧ .Equivalence.to ok
+        in o1-skip (≡ᵇ⇒≡ n d n≡) (o1-scan→trace is 0 rest)
+... | dsv-other nds    = o1-other nds (o1-scan→trace is d ok)
+
+-- Peel the residual `O1-Trace` past a non-declare/skip head; the group
+-- counter `d` is unchanged.  Consumers with a `NotDeclSkip` head (or a
+-- stronger purity predicate that reduces to `⊥` on declare/skip) reuse
+-- this single peeler.
+o1-tail : ∀ {d i is} → NotDeclSkip i → O1-Trace d (i ∷ is) → O1-Trace d is
+o1-tail _  (o1-other _ t) = t
+o1-tail nt (o1-decl _)    = ⊥-elim nt
+o1-tail nt (o1-skip _ _)  = ⊥-elim nt
+
+------------------------------------------------------------------------
+-- O2  —  Boolean-UB freedom
+--
+-- Linear scan with a `bool-known` set and a wire counter `i`.  Spec is
+-- "check obligation, then record": `O2-check` decides the obligation
+-- (`Maybe IndexSet`, `nothing` = violated), `O2-step` composes it with
+-- the record step and the wire-counter bump (`Maybe (ℕ × IndexSet)`).
+--
+-- Records (spec §6.4): boolean-producing instructions add `i` (the
+-- next wire index) to the set; `ConstrainToBoolean(v)` adds `v` (the
+-- *operand*) — a constraint pinning an existing wire's value to {0,1}.
+-- The spec's further `ConstrainBits(v, 1)` record case is deliberately
+-- dropped (see the comment on `O2-record` below).
+--
+-- Note (spec): `public-input` and `private-input` outputs are NOT added
+-- even when contextually boolean — the producer must `ConstrainToBoolean`.
+------------------------------------------------------------------------
+
+-- Is the constant `k` boolean?  Deliberately the constant `false` — a
+-- sound *under-approximation*: we may miss boolean-known wires but
+-- never falsely claim one is boolean.  (`_≟ᶠ_` is in scope, so the real
+-- test is implementable; this checker is the restriction the spec's
+-- §6.4 mechanisation caveat documents, under which `load-imm` results
+-- are never marked.  Producers mark boolean constants with
+-- `constrain-to-boolean` instead.)
+is-bool-imm? : Fr → Bool
+is-bool-imm? _ = false   -- conservative; see note above.
+
+-- Obligation-check for one instruction.  `i` is the next wire index
+-- (only used for "record" cases; the obligation cases only need `bk`).
+-- Returns `nothing` if the obligation is violated.
+-- Membership obligation: succeed (leaving `bk` unchanged) iff `c ∈ bk`,
+-- decided by `_∈?_`.  Factored out so the four obligation-bearing
+-- instructions (`assert`, `not`, `cond-select`, guarded `pi-skip`)
+-- share one reduct, hence one extraction lemma downstream.
+require-∈ : Index → IndexSet → Maybe IndexSet
+require-∈ c bk with c ∈? bk
+... | yes _ = just bk
+... | no  _ = nothing
+
+O2-check : Instruction → IndexSet → Maybe IndexSet
+O2-check (assert c)           bk = require-∈ c bk
+O2-check (not a)              bk = require-∈ a bk
+O2-check (cond-select b _ _)  bk = require-∈ b bk
+O2-check (pi-skip (just g) _) bk = require-∈ g bk
+O2-check _                    bk = just bk
+
+-- Record-step: extend `bk` based on the instruction's outputs.  `i` is
+-- the wire index of the first output.
+O2-record : Instruction → ℕ → IndexSet → IndexSet
+O2-record (test-eq _ _)        i bk = insert i bk
+O2-record (less-than _ _ _)    i bk = insert i bk
+O2-record (not _)              i bk = insert i bk
+O2-record (load-imm k)         i bk = if is-bool-imm? k then insert i bk else bk
+O2-record (copy v)             i bk with v ∈? bk
+... | yes _ = insert i bk
+... | no  _ = bk
+O2-record (cond-select _ a c)  i bk with a ∈? bk | c ∈? bk
+... | yes _ | yes _ = insert i bk
+... | _     | _     = bk
+O2-record (constrain-to-boolean v) _ bk = insert v bk
+-- `constrain-bits v 1` morally pins v to {0, 1}, but
+-- `Fits-in v 1 ↔ v ∈ {0, 1}` is not in the bit-arithmetic trust base,
+-- so `constrain-bits` never adds to bool-known (a sound under-
+-- approximation).  Producers must use `constrain-to-boolean` to mark
+-- a wire boolean.
+O2-record (constrain-bits _ _) _ bk = bk
+O2-record _ _ bk = bk
+
+-- One step of the scan.  `nothing` = obligation violated.
+O2-step : Instruction → ℕ × IndexSet → Maybe (ℕ × IndexSet)
+O2-step instr (i , bk) with O2-check instr bk
+... | nothing  = nothing
+... | just bk₁ = just (i + Δmem instr , O2-record instr i bk₁)
+
+-- Full scan.
+O2-scan : List Instruction → ℕ × IndexSet → Maybe (ℕ × IndexSet)
+O2-scan []       acc = just acc
+O2-scan (i ∷ is) acc with O2-step i acc
+... | nothing  = nothing
+... | just acc' = O2-scan is acc'
+
+O2 : IrSource → Bool
+O2 src with O2-scan (IrSource.instructions src) (IrSource.num-inputs src , [])
+... | just _  = true
+... | nothing = false
+
+------------------------------------------------------------------------
+-- O3  —  ReconstituteField no-overflow  (also covers O4)
+--
+-- Linear scan with a `bits-known` partial map and wire counter `i`.
+-- `ReconstituteField(d, m, n)` requires:
+--   d ∈ dom(bits-known)  ∧  bits-known[d] ≤ FR_BITS - n - 1
+--   m ∈ dom(bits-known)  ∧  bits-known[m] ≤ n
+-- `LessThan(a, b, n)` (O4 folded in):
+--   a, b ∈ dom(bits-known)  ∧  bits-known[a] ≤ n  ∧  bits-known[b] ≤ n
+--
+-- Records: `ConstrainBits`, `DivModPowerOfTwo`, and `Copy` — the sound
+-- restriction of the spec's §6.4 map that this checker implements (the
+-- spec's further `TestEq`/`LessThan`/`Not`, `LoadImm`, `CondSelect`,
+-- `ReconstituteField` record cases are dropped; see the comment on
+-- `O3-record` below and the spec's mechanisation caveat).
+------------------------------------------------------------------------
+
+-- The per-instruction O3 obligation as a decidable predicate: the
+-- operands' recorded bit-bounds (looked up in `bm`) are small enough
+-- to rule out field overflow.  `reconstitute-field`/`less-than` are the
+-- only constrained instructions; all others hold trivially.
+O3OK : Instruction → PartialMap → Set
+O3OK (reconstitute-field d m n) bm with lookupᵐ d bm | lookupᵐ m bm
+... | just kd | just km = (kd ≤ (FR-BITS ∸ n ∸ 1)) × (km ≤ n)
+... | _       | _       = ⊥
+O3OK (less-than a b n) bm with lookupᵐ a bm | lookupᵐ b bm
+... | just ka | just kb = (ka ≤ n) × (kb ≤ n)
+... | _       | _       = ⊥
+O3OK _ _ = ⊤
+
+o3OK? : ∀ instr bm → Dec (O3OK instr bm)
+o3OK? (reconstitute-field d m n) bm with lookupᵐ d bm | lookupᵐ m bm
+... | just kd | just km = (kd ≤? (FR-BITS ∸ n ∸ 1)) ×-dec (km ≤? n)
+... | just _  | nothing = no (λ ())
+... | nothing | _       = no (λ ())
+o3OK? (less-than a b n) bm with lookupᵐ a bm | lookupᵐ b bm
+... | just ka | just kb = (ka ≤? n) ×-dec (kb ≤? n)
+... | just _  | nothing = no (λ ())
+... | nothing | _       = no (λ ())
+o3OK? (assert _)               bm = yes tt
+o3OK? (cond-select _ _ _)      bm = yes tt
+o3OK? (constrain-bits _ _)     bm = yes tt
+o3OK? (constrain-eq _ _)       bm = yes tt
+o3OK? (constrain-to-boolean _) bm = yes tt
+o3OK? (copy _)                 bm = yes tt
+o3OK? (declare-pub-input _)    bm = yes tt
+o3OK? (pi-skip _ _)            bm = yes tt
+o3OK? (ec-add _ _ _ _)         bm = yes tt
+o3OK? (ec-mul _ _ _)           bm = yes tt
+o3OK? (ec-mul-generator _)     bm = yes tt
+o3OK? (hash-to-curve _)        bm = yes tt
+o3OK? (load-imm _)             bm = yes tt
+o3OK? (div-mod-power-of-two _ _) bm = yes tt
+o3OK? (output _)               bm = yes tt
+o3OK? (transient-hash _)       bm = yes tt
+o3OK? (persistent-hash _ _)    bm = yes tt
+o3OK? (test-eq _ _)            bm = yes tt
+o3OK? (add _ _)                bm = yes tt
+o3OK? (mul _ _)                bm = yes tt
+o3OK? (neg _)                  bm = yes tt
+o3OK? (not _)                  bm = yes tt
+o3OK? (public-input _)         bm = yes tt
+o3OK? (private-input _)        bm = yes tt
+
+-- Record-step.  `i` is the wire index of the first output.
+--
+-- Some "natural" record entries in the spec (from-bool of
+-- test-eq/less-than/not, a bit-length bound for
+-- load-imm/reconstitute-field, ka⊔kc for cond-select) would require
+-- `fits-in` facts outside the
+-- bit-arithmetic trust base, so `O3-record` records only the subset
+-- whose justification *is* in-base:
+--
+--   • `constrain-bits v n`       (premise `Fits-in v n`)
+--   • `div-mod-power-of-two _ n` (via `fits-from-le-bits-{take,drop}`)
+--   • `copy v`                   (inherits from v)
+--
+-- The other record cases are no-ops.  Backward soundness for
+-- `reconstitute-field` and `less-than` does not use the O3-recorded
+-- map — both `*-bwd` lemmas take their `fits-in` premises directly
+-- from satisfies-constraints data.  We record with plain `insertᵐ`, so the
+-- stored value is exactly `n`, justified by the `r-constrain-bits`
+-- premise.
+O3-record : Instruction → ℕ → PartialMap → PartialMap
+O3-record (constrain-bits v n) _ bm = insertᵐ v n bm
+O3-record (div-mod-power-of-two _ n) i bm =
+  insertᵐ (suc i) n (insertᵐ i (FR-BITS ∸ n) bm)
+O3-record (copy v)             i bm with lookupᵐ v bm
+... | just k  = insertᵐ i k bm
+... | nothing = bm
+O3-record _ _ bm = bm
+
+O3-step : Instruction → ℕ × PartialMap → Maybe (ℕ × PartialMap)
+O3-step instr (i , bm) with o3OK? instr bm
+... | yes _ = just (i + Δmem instr , O3-record instr i bm)
+... | no  _ = nothing
+
+O3-scan : List Instruction → ℕ × PartialMap → Maybe (ℕ × PartialMap)
+O3-scan []       acc = just acc
+O3-scan (i ∷ is) acc with O3-step i acc
+... | nothing  = nothing
+... | just acc' = O3-scan is acc'
+
+O3 : IrSource → Bool
+O3 src with O3-scan (IrSource.instructions src) (IrSource.num-inputs src , [])
+... | just _  = true
+... | nothing = false
+
+------------------------------------------------------------------------
+-- Wire-discipline (O0)  —  every operand index < nr-wires at emission.
+--
+-- The spec (§3.3) phrases this as a structural well-formedness invariant
+-- producers maintain: when an instruction emits, all index operands must
+-- be < the current wire count.  The backward (`satisfies → R-instr`)
+-- per-step dispatcher needs this to pull `mem-lookup mem a ≡ just av`
+-- back from `mem-lookup (mem ++ suf) a ≡ just av'`.
+--
+-- We encode it idiomatically as a decidable predicate `WireOK instr n`
+-- (each operand index `< n`), with `wireOK?` the decision procedure.  A
+-- linear scan tracks the current wire count `n`, requires `WireOK instr
+-- n` at each instruction, then bumps `n := n + Δmem instr`.
+------------------------------------------------------------------------
+
+-- Guard-operand discipline (Maybe Index).  `nothing` is always OK;
+-- `just g` requires `g < n`.
+GuardOK : Maybe Index → ℕ → Set
+GuardOK nothing  _ = ⊤
+GuardOK (just g) n = g < n
+
+guardOK? : ∀ g n → Dec (GuardOK g n)
+guardOK? nothing  _ = yes tt
+guardOK? (just g) n = g <? n
+
+-- Per-instruction operand-discipline predicate: every wire-index operand
+-- of `instr` is `< n` (the current wire count).
+WireOK : Instruction → ℕ → Set
+WireOK (assert c)                 n = c < n
+WireOK (cond-select b a c)        n = (b < n) × (a < n) × (c < n)
+WireOK (constrain-bits v _)       n = v < n
+WireOK (constrain-eq a b)         n = (a < n) × (b < n)
+WireOK (constrain-to-boolean v)   n = v < n
+WireOK (copy v)                   n = v < n
+WireOK (declare-pub-input v)      n = v < n
+WireOK (pi-skip g _)              n = GuardOK g n
+WireOK (ec-add ax ay bx by)       n = (ax < n) × (ay < n) × (bx < n) × (by < n)
+WireOK (ec-mul ax ay s)           n = (ax < n) × (ay < n) × (s < n)
+WireOK (ec-mul-generator s)       n = s < n
+WireOK (hash-to-curve is)         n = All (_< n) is
+WireOK (load-imm _)               _ = ⊤
+WireOK (div-mod-power-of-two v _) n = v < n
+WireOK (reconstitute-field d m _) n = (d < n) × (m < n)
+WireOK (output v)                 n = v < n
+WireOK (transient-hash is)        n = All (_< n) is
+WireOK (persistent-hash _ is)     n = All (_< n) is
+WireOK (test-eq a b)              n = (a < n) × (b < n)
+WireOK (add a b)                  n = (a < n) × (b < n)
+WireOK (mul a b)                  n = (a < n) × (b < n)
+WireOK (neg a)                    n = a < n
+WireOK (not a)                    n = a < n
+WireOK (less-than a b _)          n = (a < n) × (b < n)
+WireOK (public-input g)           n = GuardOK g n
+WireOK (private-input g)          n = GuardOK g n
+
+wireOK? : ∀ instr n → Dec (WireOK instr n)
+wireOK? (assert c)                 n = c <? n
+wireOK? (cond-select b a c)        n = (b <? n) ×-dec (a <? n) ×-dec (c <? n)
+wireOK? (constrain-bits v _)       n = v <? n
+wireOK? (constrain-eq a b)         n = (a <? n) ×-dec (b <? n)
+wireOK? (constrain-to-boolean v)   n = v <? n
+wireOK? (copy v)                   n = v <? n
+wireOK? (declare-pub-input v)      n = v <? n
+wireOK? (pi-skip g _)              n = guardOK? g n
+wireOK? (ec-add ax ay bx by)       n = (ax <? n) ×-dec (ay <? n) ×-dec (bx <? n) ×-dec (by <? n)
+wireOK? (ec-mul ax ay s)           n = (ax <? n) ×-dec (ay <? n) ×-dec (s <? n)
+wireOK? (ec-mul-generator s)       n = s <? n
+wireOK? (hash-to-curve is)         n = all? (_<? n) is
+wireOK? (load-imm _)               _ = yes tt
+wireOK? (div-mod-power-of-two v _) n = v <? n
+wireOK? (reconstitute-field d m _) n = (d <? n) ×-dec (m <? n)
+wireOK? (output v)                 n = v <? n
+wireOK? (transient-hash is)        n = all? (_<? n) is
+wireOK? (persistent-hash _ is)     n = all? (_<? n) is
+wireOK? (test-eq a b)              n = (a <? n) ×-dec (b <? n)
+wireOK? (add a b)                  n = (a <? n) ×-dec (b <? n)
+wireOK? (mul a b)                  n = (a <? n) ×-dec (b <? n)
+wireOK? (neg a)                    n = a <? n
+wireOK? (not a)                    n = a <? n
+wireOK? (less-than a b _)          n = (a <? n) ×-dec (b <? n)
+wireOK? (public-input g)           n = guardOK? g n
+wireOK? (private-input g)          n = guardOK? g n
+
+-- One step: `nothing` = obligation violated; otherwise bump count.
+wire-step : Instruction → ℕ → Maybe ℕ
+wire-step instr n with wireOK? instr n
+... | yes _ = just (n + Δmem instr)
+... | no  _ = nothing
+
+wire-scan : List Instruction → ℕ → Maybe ℕ
+wire-scan []       n = just n
+wire-scan (i ∷ is) n with wire-step i n
+... | nothing  = nothing
+... | just n'  = wire-scan is n'
+
+wire-disc : IrSource → Bool
+wire-disc src with wire-scan (IrSource.instructions src) (IrSource.num-inputs src)
+... | just _  = true
+... | nothing = false
+
+-- Witness-bearing trace, parallel to O2-Trace / O3-Trace.
+data Wire-Trace : List Instruction → ℕ → ℕ → Set where
+  wire-done : ∀ {n} → Wire-Trace [] n n
+  wire-cons : ∀ {i is n n' final}
+    → wire-step i n ≡ just n'
+    → Wire-Trace is n' final
+    → Wire-Trace (i ∷ is) n final
+
+------------------------------------------------------------------------
+-- Producer safety: all four obligations hold.
+------------------------------------------------------------------------
+
+producer-safe : IrSource → Bool
+producer-safe src = O1 src ∧ O2 src ∧ O3 src ∧ wire-disc src
+
+-- Producer safety reflects the PiSkip discipline into an `O1-Trace`
+-- over the whole instruction list.  `producer-safe` leads with `O1`, so
+-- its `T` splits off the O1 conjunct directly.
+o1-sound : ∀ (src : IrSource) → T (producer-safe src)
+  → O1-Trace 0 (IrSource.instructions src)
+o1-sound src ps =
+  let (o1 , _) = T-∧ .Equivalence.to ps
+  in o1-scan→trace (IrSource.instructions src) 0 o1
+
+------------------------------------------------------------------------
+-- Witness-bearing predicates (Set form)
+--
+-- Two ways to use these obligations downstream:
+--
+--   • As Bool checkers, via `O1`, `O2`, `O3` above (decidable by
+--     construction — they are functions to Bool).
+--
+--   • As witness-bearing predicates that record the trace of
+--     `bool-known` / `bits-known` along the scan, used to thread the
+--     invariant through the program-level induction.
+--
+-- The Set forms are inductive predicates that exactly mirror the
+-- scans.  Decidability for any specific `IrSource` follows from the
+-- corresponding Bool form: `T (O2 src) ↔ O2-Runs src`.  Only the
+-- Bool ⇒ Set direction is proved (`O2-bool→Runs` / `O3-bool→Runs`
+-- below); the reverse is not needed.
+------------------------------------------------------------------------
+
+-- O2 trace: at each step, the obligation check returned `just`.
+data O2-Trace : List Instruction → ℕ × IndexSet → ℕ × IndexSet → Set where
+  o2-done : ∀ {acc} → O2-Trace [] acc acc
+  o2-step : ∀ {i is acc acc' final}
+    → O2-step i acc ≡ just acc'
+    → O2-Trace is acc' final
+    → O2-Trace (i ∷ is) acc final
+
+-- Convenience: existence of a trace.
+record O2-Runs (src : IrSource) : Set where
+  constructor mk-o2-runs
+  field
+    final : ℕ × IndexSet
+    trace : O2-Trace (IrSource.instructions src)
+                     (IrSource.num-inputs src , []) final
+
+-- O3 trace, analogous.
+data O3-Trace : List Instruction → ℕ × PartialMap → ℕ × PartialMap → Set where
+  o3-done : ∀ {acc} → O3-Trace [] acc acc
+  o3-step : ∀ {i is acc acc' final}
+    → O3-step i acc ≡ just acc'
+    → O3-Trace is acc' final
+    → O3-Trace (i ∷ is) acc final
+
+record O3-Runs (src : IrSource) : Set where
+  constructor mk-o3-runs
+  field
+    final : ℕ × PartialMap
+    trace : O3-Trace (IrSource.instructions src)
+                     (IrSource.num-inputs src , []) final
+
+------------------------------------------------------------------------
+-- Bool ⇒ witness extractors: a successful scan reconstructs its trace.
+------------------------------------------------------------------------
+
+private
+  O2-scan→trace : ∀ is acc {final}
+    → O2-scan is acc ≡ just final
+    → O2-Trace is acc final
+  O2-scan→trace []       acc refl = o2-done
+  O2-scan→trace (i ∷ is) acc eq
+    with O2-step i acc in step-eq
+  ... | just acc' = o2-step step-eq (O2-scan→trace is acc' eq)
+
+  O3-scan→trace : ∀ is acc {final}
+    → O3-scan is acc ≡ just final
+    → O3-Trace is acc final
+  O3-scan→trace []       acc refl = o3-done
+  O3-scan→trace (i ∷ is) acc eq
+    with O3-step i acc in step-eq
+  ... | just acc' = o3-step step-eq (O3-scan→trace is acc' eq)
+
+O2-bool→Runs : ∀ {src} → T (O2 src) → O2-Runs src
+O2-bool→Runs {src} eq
+  with O2-scan (IrSource.instructions src) (IrSource.num-inputs src , [])
+       in scan-eq
+... | just final = mk-o2-runs final
+                     (O2-scan→trace (IrSource.instructions src)
+                                     (IrSource.num-inputs src , [])
+                                     scan-eq)
+
+O3-bool→Runs : ∀ {src} → T (O3 src) → O3-Runs src
+O3-bool→Runs {src} eq
+  with O3-scan (IrSource.instructions src) (IrSource.num-inputs src , [])
+       in scan-eq
+... | just final = mk-o3-runs final
+                     (O3-scan→trace (IrSource.instructions src)
+                                     (IrSource.num-inputs src , [])
+                                     scan-eq)

--- a/formal/src/zkir-v2/ObligationsSoundness.agda
+++ b/formal/src/zkir-v2/ObligationsSoundness.agda
@@ -1,0 +1,1283 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.ObligationsSoundness (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v2.FieldProperties ⋯
+open import zkir-v2.Encoding ⋯
+
+------------------------------------------------------------------------
+-- Soundness of producer obligations
+--
+-- For each obligation we have a static scan (in `Obligations.agda`) and
+-- a witness-bearing trace predicate (`O2-Trace`/`O3-Trace`).  This
+-- module proves the *connection* between those static facts and the
+-- dynamic relational semantics `R-instr`/`R-instrs`:
+--
+--   • O2-sound  — if the scan adds `i` to bool-known, then for every
+--                 reachable state with `mem-lookup mem i ≡ just v`, the
+--                 value `v` is in {0, 1} (`is-bit v`).
+--
+--   • O3-sound  — analogous for the known partial map: if the scan
+--                 has `lookupᵐ bm i ≡ just n`, then `Fits-in v n`.
+--
+--   • integration lemmas — `o2-known-is-bit` / `o3-known-fits` extract
+--                 an `is-bit` / `Fits-in` witness for a specific operand,
+--                 consumed by the per-instruction backward lemmas.
+--
+-- The proof is by induction along the `R-instrs` trace, threading an
+-- invariant `O2-Inv (i, bk) s` saying:
+--
+--   • `i ≡ length (Preprocessed.memory s)`     (index alignment)
+--   • every wire in `bk` is bound to an `is-bit` value in `mem s`.
+--
+-- The 29-constructor case analysis on `R-instr` (26 instructions, with
+-- `pi-skip`/`public-input`/`private-input` split by guard) mirrors the
+-- `O2-record` / `O3-record` discriminations.
+------------------------------------------------------------------------
+
+-- The `to-bool-*` and `fits-from-le-bits-*` facts are derived from the
+-- `Assumptions` laws in `FieldProperties`/`Encoding`, not assumed.
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+open import zkir-v2.SemanticsLemmas ⋯
+  using ( init-state-memory; init-state-num-inputs
+        ; consume-pub-out-mem; consume-priv-mem )
+open import zkir-v2.Circuit ⋯ using (is-bit)
+open import zkir-v2.Obligations ⋯
+
+open import Data.Bool      using (Bool; true; false; _∧_; if_then_else_; T)
+open import Data.Bool.Properties using (T-∧)
+import Data.Bool as Bool
+open import Data.List      using (List; []; _∷_; _++_; length; take; drop)
+open import Data.List.Properties using (++-assoc)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Maybe     using (Maybe; nothing; just; _>>=_)
+open import Data.Maybe.Properties using (just-injective)
+open import Data.Nat       using (ℕ; zero; suc; _+_; _∸_; _≟_; _≡ᵇ_; _<_; z<s; s<s)
+open import Data.List.Membership.DecPropositional (_≟_) using (_∈_; _∈?_)
+open import Data.Nat.Properties
+  using (+-identityʳ; +-comm; ≡ᵇ⇒≡; m<n⇒m<1+n; n<1+n; <-irrefl; <⇒≯)
+open import Function.Bundles using (Equivalence)
+open import Data.Product   using (_×_; _,_; ∃-syntax; proj₁; proj₂)
+open import Data.Sum       using (_⊎_; inj₁; inj₂)
+open import Data.Empty     using (⊥; ⊥-elim)
+open import Data.Unit      using (⊤; tt)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; subst)
+open import Relation.Nullary using (¬_; yes; no)
+
+------------------------------------------------------------------------
+-- Common helpers
+------------------------------------------------------------------------
+
+private
+
+  -- Length of an "appended ∷[]" memory.
+  length-++-one : ∀ {A : Set} (xs : List A) (y : A)
+    → length (xs ++ (y ∷ [])) ≡ suc (length xs)
+  length-++-one [] y = refl
+  length-++-one (x ∷ xs) y = cong suc (length-++-one xs y)
+
+  length-++-two : ∀ {A : Set} (xs : List A) (y z : A)
+    → length (xs ++ (y ∷ z ∷ [])) ≡ suc (suc (length xs))
+  length-++-two [] y z = refl
+  length-++-two (x ∷ xs) y z = cong suc (length-++-two xs y z)
+
+  -- Lookup at exactly `length mem` returns the appended value.
+  lookup-new : ∀ (mem : List Fr) v
+    → mem-lookup (mem ++ (v ∷ [])) (length mem) ≡ just v
+  lookup-new []       v = refl
+  lookup-new (x ∷ xs) v = lookup-new xs v
+
+  -- Two cells.
+  lookup-new-fst : ∀ (mem : List Fr) x y
+    → mem-lookup (mem ++ (x ∷ y ∷ [])) (length mem) ≡ just x
+  lookup-new-fst []       x y = refl
+  lookup-new-fst (z ∷ zs) x y = lookup-new-fst zs x y
+
+  lookup-new-snd : ∀ (mem : List Fr) x y
+    → mem-lookup (mem ++ (x ∷ y ∷ [])) (suc (length mem)) ≡ just y
+  lookup-new-snd []       x y = refl
+  lookup-new-snd (z ∷ zs) x y = lookup-new-snd zs x y
+
+  ------------------------------------------------------------------
+  -- Bool reasoning lemmas
+  ------------------------------------------------------------------
+
+  ∧-true : ∀ {a b : Bool} → T (a ∧ b) → T a × T b
+  ∧-true {a} {b} = Equivalence.to (T-∧ {a} {b})
+
+  ≡ᵇ-true : ∀ {m n : ℕ} → (m ≡ᵇ n) ≡ true → m ≡ n
+  ≡ᵇ-true {m} {n} eq = ≡ᵇ⇒≡ m n (subst T (sym eq) tt)
+
+------------------------------------------------------------------------
+-- Set membership is the standard-library propositional `_∈_` on
+-- `IndexSet = List Index`, decided by `_∈?_` (both from `Obligations`).
+------------------------------------------------------------------------
+
+------------------------------------------------------------------------
+-- O2 step invariant
+--
+-- `O2-Inv (i, bk) s` says:
+--   • `i ≡ length (memory s)`              — the scan's wire counter is
+--                                            in sync with the program
+--                                            memory length.
+--   • every `j ∈ bk` looks up to an
+--     `is-bit` value in `memory s`.
+------------------------------------------------------------------------
+
+-- An `n < i` follows from a successful mem-lookup at index n in a
+-- memory of length matching i.
+private
+  lookup-bound : ∀ (mem : List Fr) (j : Index) {val : Fr}
+    → mem-lookup mem j ≡ just val
+    → ∀ {i₀} → i₀ ≡ length mem
+    → j < i₀
+  lookup-bound (x ∷ xs) zero    eq   refl = z<s
+  lookup-bound (x ∷ xs) (suc j) eq   refl =
+    s<s (lookup-bound xs j eq refl)
+  lookup-bound []       _       ()   _
+
+-- Generic per-wire-property invariant shared by O2 and O3.  The
+-- known-structure `k : K` records, for some wires `j`, a payload `d : D`
+-- (`Mem k j d`); the invariant says every such wire's value satisfies
+-- the tracked property `P v d`, and every recorded index is `< i`.
+record KInv {K D : Set} (Mem : K → Index → D → Set) (P : Fr → D → Set)
+            (acc : ℕ × K) (s : Preprocessed) : Set where
+  constructor mk-kinv
+  field
+    idx-sync : proj₁ acc ≡ length (Preprocessed.memory s)
+    bound    : ∀ {j d} → Mem (proj₂ acc) j d → j < proj₁ acc
+    known    : ∀ {j d v}
+      → Mem (proj₂ acc) j d
+      → mem-lookup (Preprocessed.memory s) j ≡ just v
+      → P v d
+
+open KInv public
+
+-- O2 tracks a boolean-known set: payload is trivial, property is `is-bit`.
+O2-Inv : ℕ × IndexSet → Preprocessed → Set
+O2-Inv = KInv {IndexSet} {⊤} (λ bk j _ → j ∈ bk) (λ v _ → is-bit v)
+
+------------------------------------------------------------------------
+-- Base case: at the initial state with `acc = (num-inputs src, [])` the
+-- invariant holds vacuously.
+------------------------------------------------------------------------
+
+o2-inv-init : ∀ {src pre s₀}
+  → init-state src pre ≡ just s₀
+  → length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src
+  → O2-Inv (IrSource.num-inputs src , []) s₀
+o2-inv-init {src} {pre} {s₀} eq lenEq =
+  mk-kinv idx-eq empty-bound empty-bk-bits
+  where
+    mem-eq : Preprocessed.memory s₀ ≡ ProofPreimage.inputs pre
+    mem-eq = init-state-memory src pre s₀ eq
+
+    len-eq : length (Preprocessed.memory s₀) ≡ length (ProofPreimage.inputs pre)
+    len-eq = cong length mem-eq
+
+    idx-eq : IrSource.num-inputs src ≡ length (Preprocessed.memory s₀)
+    idx-eq = trans (sym lenEq) (sym len-eq)
+
+    empty-bound : ∀ {j} → j ∈ [] → j < IrSource.num-inputs src
+    empty-bound ()
+
+    empty-bk-bits : ∀ {j v}
+      → j ∈ []
+      → mem-lookup (Preprocessed.memory s₀) j ≡ just v
+      → is-bit v
+    empty-bk-bits ()
+
+------------------------------------------------------------------------
+-- Per-step preservation
+--
+-- The workhorse:  if `R-instr pre s instr s'` and `O2-step instr acc ≡
+-- just acc'` and the invariant held at `(acc, s)`, then it holds at
+-- `(acc', s')`.
+--
+-- We case-split on `instr`.  For each case we know the shape of `s'`
+-- (from the R-instr constructor) and the shape of `acc'` (from
+-- `O2-step`).  Memory-preserving cases inherit the invariant; memory-
+-- extending cases need a fresh witness for the new wire index when
+-- the scan adds it to `bk`.
+------------------------------------------------------------------------
+
+private
+
+  ------------------------------------------------------------------
+  -- Push-mem and lookup helpers
+  ------------------------------------------------------------------
+
+  -- Positional characterization of a lookup into an extended memory:
+  -- `mem-lookup (mem ++ (newv ∷ [])) j` returns:
+  --   • the original `mem-lookup mem j` if defined,
+  --   • else `just newv` at j = length mem,
+  --   • else nothing.
+  lookup-shrink-or-new : ∀ (mem : List Fr) newv j v
+    → mem-lookup (mem ++ (newv ∷ [])) j ≡ just v
+    → (mem-lookup mem j ≡ just v) ⊎ ((j ≡ length mem) × (v ≡ newv))
+  lookup-shrink-or-new []       newv zero    .newv refl = inj₂ (refl , refl)
+  lookup-shrink-or-new []       newv (suc j) v    ()
+  lookup-shrink-or-new (x ∷ xs) newv zero    .x   refl = inj₁ refl
+  lookup-shrink-or-new (x ∷ xs) newv (suc j) v    eq
+    with lookup-shrink-or-new xs newv j v eq
+  ... | inj₁ p        = inj₁ p
+  ... | inj₂ (q , vr) = inj₂ (cong suc q , vr)
+
+  -- Two-cell variant: lookup in mem ++ (x ∷ y ∷ []) decomposes into:
+  --   • lookup mem j (if j < length mem)
+  --   • j = length mem with value x
+  --   • j = suc (length mem) with value y
+  lookup-shrink-or-new-2 : ∀ (mem : List Fr) x y j v
+    → mem-lookup (mem ++ (x ∷ y ∷ [])) j ≡ just v
+    → (mem-lookup mem j ≡ just v)
+    ⊎ ((j ≡ length mem) × (v ≡ x))
+    ⊎ ((j ≡ suc (length mem)) × (v ≡ y))
+  lookup-shrink-or-new-2 []       x y zero          .x refl = inj₂ (inj₁ (refl , refl))
+  lookup-shrink-or-new-2 []       x y (suc zero)    .y refl = inj₂ (inj₂ (refl , refl))
+  lookup-shrink-or-new-2 []       x y (suc (suc j)) v  ()
+  lookup-shrink-or-new-2 (z ∷ zs) x y zero          .z refl = inj₁ refl
+  lookup-shrink-or-new-2 (z ∷ zs) x y (suc j)       v  eq
+    with lookup-shrink-or-new-2 zs x y j v eq
+  ... | inj₁ p              = inj₁ p
+  ... | inj₂ (inj₁ (q , vr)) = inj₂ (inj₁ (cong suc q , vr))
+  ... | inj₂ (inj₂ (q , vr)) = inj₂ (inj₂ (cong suc q , vr))
+
+------------------------------------------------------------------------
+-- O2 step preservation
+--
+-- Given the invariant at (i, bk) and a successful one-step transition
+-- `R-instr pre s instr s'` matched by `O2-step instr (i, bk) ≡ just
+-- acc'`, the invariant holds at (acc', s').
+--
+-- The proof is a 29-case dispatch on `R-instr`.  Most cases are
+-- trivial; the "boolean-producing" instructions (test-eq, less-than,
+-- not, cond-select with both branches in bk, copy of bk member) need
+-- the actual witness derivation.
+------------------------------------------------------------------------
+
+-- Witness lemma:  `from-bool b` is always is-bit.
+from-bool-is-bit : ∀ (b : Bool) → is-bit (from-bool b)
+from-bool-is-bit false = inj₁ refl
+from-bool-is-bit true  = inj₂ refl
+
+-- Witness lemma:  if `to-bool v ≡ just _`, then `is-bit v`.
+to-bool→is-bit : ∀ {v sel} → to-bool v ≡ just sel → is-bit v
+to-bool→is-bit {sel = true}  eq = inj₂ (to-bool-true  eq)
+to-bool→is-bit {sel = false} eq = inj₁ (to-bool-false eq)
+
+-- A `(mem-lookup mem a >>= to-bool) ≡ just sel` can be decomposed into
+-- the underlying field value plus a `to-bool` evidence on it.
+extract-to-bool : ∀ (mem : List Fr) (a : Index) {sel}
+  → (mem-lookup mem a >>= to-bool) ≡ just sel
+  → ∃-syntax λ av → mem-lookup mem a ≡ just av × to-bool av ≡ just sel
+extract-to-bool mem a {sel} eq = aux (mem-lookup mem a) refl eq
+  where
+    aux : ∀ (m : Maybe Fr)
+        → mem-lookup mem a ≡ m
+        → (m >>= to-bool) ≡ just sel
+        → ∃-syntax λ av → mem-lookup mem a ≡ just av × to-bool av ≡ just sel
+    aux nothing  _    ()
+    aux (just x) m-eq eq' = x , m-eq , eq'
+
+------------------------------------------------------------------------
+-- Step-preservation helpers (frame lemmas)
+--
+-- We package the three classes of memory transitions:
+--   • frame-no-grow         : memory unchanged.
+--   • frame-push-mem        : memory grows by one cell.
+--   • frame-push-mem-2      : memory grows by two cells.
+-- Each takes the (i, bk)-side accumulator update and produces the
+-- post-state O2-Inv.
+------------------------------------------------------------------------
+
+private
+
+  ------------------------------------------------------------------
+  -- Generic frames: memory transitions that leave the known-structure
+  -- untouched.  Shared by O2 and O3 (aliased below).
+  ------------------------------------------------------------------
+
+  -- Memory unchanged.
+  gen-frame-no-grow : ∀ {K D} {Mem : K → Index → D → Set} {P : Fr → D → Set}
+                        {i k s s'}
+    → Preprocessed.memory s' ≡ Preprocessed.memory s
+    → KInv Mem P (i , k) s
+    → KInv Mem P (i , k) s'
+  gen-frame-no-grow mem-eq inv =
+    mk-kinv
+      (trans (idx-sync inv) (sym (cong length mem-eq)))
+      (bound inv)
+      (λ m? lookup-eq →
+        known inv m?
+          (trans (cong (λ m → mem-lookup m _) (sym mem-eq)) lookup-eq))
+
+  -- Memory grows by one cell (push-mem).
+  gen-frame-push-mem : ∀ {K D} {Mem : K → Index → D → Set} {P : Fr → D → Set}
+                         {i k s newv}
+    → KInv Mem P (i , k) s
+    → KInv Mem P (suc i , k) (push-mem s newv)
+  gen-frame-push-mem {Mem = Mem} {P = P} {i = i} {k = k} {s = s} {newv = newv} inv =
+    mk-kinv idx-eq bnd bits
+    where
+      mem = Preprocessed.memory s
+      idx-eq : suc i ≡ length (Preprocessed.memory (push-mem s newv))
+      idx-eq = trans (cong suc (idx-sync inv)) (sym (length-++-one mem newv))
+      bnd : ∀ {j d} → Mem k j d → j < suc i
+      bnd p = m<n⇒m<1+n (bound inv p)
+      bits : ∀ {j d w} → Mem k j d
+                       → mem-lookup (Preprocessed.memory (push-mem s newv)) j ≡ just w
+                       → P w d
+      bits {j} {d} {w} m? lookup-eq
+        with lookup-shrink-or-new mem newv j w lookup-eq
+      ... | inj₁ p          = known inv m? p
+      ... | inj₂ (j≡L , _)  =
+        ⊥-elim (<-irrefl refl
+                  (subst (_< i) (trans j≡L (sym (idx-sync inv))) (bound inv m?)))
+
+  -- Memory grows by two cells (push-mem2).
+  gen-frame-push-mem-2 : ∀ {K D} {Mem : K → Index → D → Set} {P : Fr → D → Set}
+                           {i k s x y}
+    → KInv Mem P (i , k) s
+    → KInv Mem P (suc (suc i) , k) (push-mem2 s x y)
+  gen-frame-push-mem-2 {Mem = Mem} {P = P} {i = i} {k = k} {s = s} {x = x} {y = y} inv =
+    mk-kinv idx-eq bnd bits
+    where
+      mem = Preprocessed.memory s
+      idx-eq : suc (suc i) ≡ length (Preprocessed.memory (push-mem2 s x y))
+      idx-eq = trans (cong suc (cong suc (idx-sync inv))) (sym (length-++-two mem x y))
+      bnd : ∀ {j d} → Mem k j d → j < suc (suc i)
+      bnd p = m<n⇒m<1+n (m<n⇒m<1+n (bound inv p))
+      bits : ∀ {j d w} → Mem k j d
+                       → mem-lookup (Preprocessed.memory (push-mem2 s x y)) j ≡ just w
+                       → P w d
+      bits {j} {d} {w} m? lookup-eq
+        with lookup-shrink-or-new-2 mem x y j w lookup-eq
+      ... | inj₁ p                    = known inv m? p
+      ... | inj₂ (inj₁ (j≡L , _))     =
+        ⊥-elim (<-irrefl refl
+                  (subst (_< i) (trans j≡L (sym (idx-sync inv))) (bound inv m?)))
+      ... | inj₂ (inj₂ (j≡sucL , _))  =
+        ⊥-elim (<⇒≯ (n<1+n _)
+                  (subst (_< i)
+                         (trans j≡sucL (cong suc (sym (idx-sync inv))))
+                         (bound inv m?)))
+
+  ------------------------------------------------------------------
+  -- (a) Memory unchanged, bk extended by `v` (constrain-* cases).
+  --     Requires v < i (operand lookup-bound) and an is-bit witness
+  --     for the value at v.
+  ------------------------------------------------------------------
+  frame-no-grow-add-v : ∀ {i bk s s' v vv}
+    → Preprocessed.memory s' ≡ Preprocessed.memory s
+    → mem-lookup (Preprocessed.memory s) v ≡ just vv
+    → is-bit vv
+    → O2-Inv (i , bk) s
+    → O2-Inv (i , insert v bk) s'
+  frame-no-grow-add-v {i = i} {bk = bk} {s = s} {s' = s'} {v = v} {vv = vv}
+                       mem-eq lv vv-bit inv =
+    mk-kinv idx-eq bnd bits
+    where
+      idx-eq : i ≡ length (Preprocessed.memory s')
+      idx-eq = trans (idx-sync inv) (sym (cong length mem-eq))
+
+      v<i : v < i
+      v<i = lookup-bound (Preprocessed.memory s) v lv (idx-sync inv)
+
+      bnd : ∀ {j} → j ∈ (insert v bk) → j < i
+      bnd {j} (here eq) = subst (_< i) (sym eq) v<i
+      bnd (there p) = bound inv p
+
+      bits : ∀ {j w} → j ∈ (insert v bk)
+                     → mem-lookup (Preprocessed.memory s') j ≡ just w
+                     → is-bit w
+      bits {j} {w} (here j≡v) lookup-eq =
+        let 
+            lookup-at-v : mem-lookup (Preprocessed.memory s) v ≡ just w
+            lookup-at-v =
+              subst (λ k → mem-lookup (Preprocessed.memory s) k ≡ just w)
+                    j≡v
+                    (trans (cong (λ m → mem-lookup m j) (sym mem-eq)) lookup-eq)
+
+            vv≡w : vv ≡ w
+            vv≡w = just-injective (trans (sym lv) lookup-at-v)
+        in subst is-bit vv≡w vv-bit
+      bits (there p) lookup-eq =
+        known inv p (trans (cong (λ m → mem-lookup m _) (sym mem-eq)) lookup-eq)
+
+  ------------------------------------------------------------------
+  -- (b) Memory grows by one cell, bk records the new index.
+  --     Requires an is-bit witness for the appended value.
+  ------------------------------------------------------------------
+  frame-push-mem-record : ∀ {i bk s newv}
+    → is-bit newv
+    → O2-Inv (i , bk) s
+    → O2-Inv (suc i , insert i bk) (push-mem s newv)
+  frame-push-mem-record {i = i} {bk = bk} {s = s} {newv = newv}
+                         newv-bit inv =
+    mk-kinv idx-eq bnd bits
+    where
+      mem  = Preprocessed.memory s
+      mem' = mem ++ (newv ∷ [])
+
+      idx-eq : suc i ≡ length (Preprocessed.memory (push-mem s newv))
+      idx-eq = trans (cong suc (idx-sync inv)) (sym (length-++-one mem newv))
+
+      bnd : ∀ {j} → j ∈ (insert i bk) → j < suc i
+      bnd {j} (here eq) = subst (_< suc i) (sym eq) (n<1+n i)
+      bnd (there p) = m<n⇒m<1+n (bound inv p)
+
+      bits : ∀ {j w} → j ∈ (insert i bk)
+                     → mem-lookup (Preprocessed.memory (push-mem s newv)) j ≡ just w
+                     → is-bit w
+      bits {j} {w} (here j≡i) lookup-eq =
+        let lookup-at-i : mem-lookup (mem ++ (newv ∷ [])) i ≡ just w
+            lookup-at-i =
+              subst (λ k → mem-lookup (mem ++ (newv ∷ [])) k ≡ just w)
+                    j≡i lookup-eq
+
+            lookup-at-i-new : mem-lookup (mem ++ (newv ∷ [])) i ≡ just newv
+            lookup-at-i-new =
+              subst (λ k → mem-lookup (mem ++ (newv ∷ [])) k ≡ just newv)
+                    (sym (idx-sync inv))
+                    (lookup-new mem newv)
+
+            newv≡w : newv ≡ w
+            newv≡w = just-injective (trans (sym lookup-at-i-new) lookup-at-i)
+        in subst is-bit newv≡w newv-bit
+      bits {j} {w} (there p) lookup-eq
+        with lookup-shrink-or-new mem newv j w lookup-eq
+      ... | inj₁ q          = known inv p q
+      ... | inj₂ (j≡L , _)  =
+        ⊥-elim (<-irrefl refl (subst (_< i) (trans j≡L (sym (idx-sync inv))) (bound inv p)))
+
+------------------------------------------------------------------------
+-- Frame helpers for the O2 preservation theorem
+--
+-- Coercion-bundled frame steps producing the invariant at the index
+-- `O2-step` demands for each memory growth (Δmem = 0, 1, or 2).
+------------------------------------------------------------------------
+
+private
+  -- Memory grows by two cells via iterated push-mem, known-structure
+  -- untouched (div-mod-power-of-two's memory shape).  Shared by O2/O3.
+  gen-frame-push-mem-push-mem :
+    ∀ {K D} {Mem : K → Index → D → Set} {P : Fr → D → Set} {i k s x y}
+    → KInv Mem P (i , k) s
+    → KInv Mem P (suc (suc i) , k) (push-mem (push-mem s x) y)
+  gen-frame-push-mem-push-mem {i = i} {k = k} {s = s} {x = x} {y = y} inv =
+    let mem    = Preprocessed.memory s
+        mem-eq : Preprocessed.memory (push-mem (push-mem s x) y)
+               ≡ Preprocessed.memory (push-mem2 s x y)
+        mem-eq = ++-assoc mem (x ∷ []) (y ∷ [])
+        inv2   = gen-frame-push-mem-2 inv
+    in mk-kinv
+         (trans (idx-sync inv2) (sym (cong length mem-eq)))
+         (bound inv2)
+         (λ look lookup-eq →
+            known inv2 look
+              (trans (cong (λ m → mem-lookup m _) (sym mem-eq)) lookup-eq))
+
+private
+  -- Sugar:  i + 0 ≡ i  and  i + 1 ≡ suc i  and  i + 2 ≡ suc (suc i).
+  +-0-r : ∀ i → i + 0 ≡ i
+  +-0-r = +-identityʳ
+
+  +-1-r : ∀ i → i + 1 ≡ suc i
+  +-1-r i = +-comm i 1
+
+  +-2-r : ∀ i → i + 2 ≡ suc (suc i)
+  +-2-r i = +-comm i 2
+
+  -- Coerce a `KInv` along an idx-counter equality.  Shared by O2/O3;
+  -- the `refl` match avoids the underscore-laden `subst (λ k → KInv …)`
+  -- shape that confuses meta inference.
+  gen-inv-coerce-idx : ∀ {K D} {Mem : K → Index → D → Set} {P : Fr → D → Set}
+                         {i i' k s}
+    → i ≡ i'
+    → KInv Mem P (i , k) s
+    → KInv Mem P (i' , k) s
+  gen-inv-coerce-idx refl inv = inv
+
+  -- Coercion-bundled frame steps.  Each produces the invariant at the
+  -- `i + Δmem` index that `O2-step` / `O3-step` demands, hiding the
+  -- `+-Δ-r` index arithmetic that otherwise clutters every clause.
+  step-0 : ∀ {K D} {Mem : K → Index → D → Set} {P : Fr → D → Set} {i k s s'}
+    → Preprocessed.memory s' ≡ Preprocessed.memory s
+    → KInv Mem P (i , k) s → KInv Mem P (i + 0 , k) s'
+  step-0 {i = i} eq inv =
+    gen-inv-coerce-idx (sym (+-0-r i)) (gen-frame-no-grow eq inv)
+
+  step-1 : ∀ {K D} {Mem : K → Index → D → Set} {P : Fr → D → Set} {i k s newv}
+    → KInv Mem P (i , k) s → KInv Mem P (i + 1 , k) (push-mem s newv)
+  step-1 {i = i} inv =
+    gen-inv-coerce-idx (sym (+-1-r i)) (gen-frame-push-mem inv)
+
+  step-1-rec : ∀ {i bk s newv} → is-bit newv
+    → O2-Inv (i , bk) s → O2-Inv (i + 1 , insert i bk) (push-mem s newv)
+  step-1-rec {i = i} bit inv =
+    gen-inv-coerce-idx (sym (+-1-r i)) (frame-push-mem-record bit inv)
+
+  step-2 : ∀ {K D} {Mem : K → Index → D → Set} {P : Fr → D → Set} {i k s x y}
+    → KInv Mem P (i , k) s → KInv Mem P (i + 2 , k) (push-mem2 s x y)
+  step-2 {i = i} inv =
+    gen-inv-coerce-idx (sym (+-2-r i)) (gen-frame-push-mem-2 inv)
+
+------------------------------------------------------------------------
+-- Main per-step preservation theorem (O2)
+--
+-- The result `O2-step instr (i, bk) ≡ just acc'` constrains `acc'` to
+-- be `(i + Δmem instr , O2-record instr i bk₁)` where `bk₁` comes from
+-- `O2-check`.  By case analysis on the constructor of `R-instr`, we
+-- unfold `O2-step` and apply the matching frame helper.  Cases are
+-- grouped by memory growth: Δmem = 0, Δmem = 1, then Δmem = 2.
+------------------------------------------------------------------------
+
+o2-preserve : ∀ {pre s s' instr i bk acc'}
+  → O2-Inv (i , bk) s
+  → R-instr pre s instr s'
+  → O2-step instr (i , bk) ≡ just acc'
+  → O2-Inv acc' s'
+-- ============================================================
+-- Δmem = 0 instructions
+-- ============================================================
+
+-- assert: bk-check requires `c ∈ bk`; record is a no-op.
+o2-preserve {instr = assert c} {i = i} {bk = bk} inv
+            (r-assert lookup-c-bool) step-eq
+  with c ∈? bk | step-eq
+... | yes _ | refl = step-0 refl inv
+-- (the `c ∉ bk` case is excluded: O2-check returns nothing, so step-eq
+--  would be `nothing ≡ just acc'`.)
+
+-- constrain-eq: record is a no-op.
+o2-preserve {instr = constrain-eq a b} {i = i} inv
+            (r-constrain-eq _ _ _) refl =
+  step-0 refl inv
+
+-- constrain-bits: record is a no-op under the conservative under-
+-- approximation (see Obligations.agda; we don't add v to bool-known
+-- even when bits ≡ 1, because `Fits-in v 1 → is-bit v` is
+-- outside the bit-arithmetic trust base).
+o2-preserve {instr = constrain-bits v bits} {i = i} inv
+            (r-constrain-bits _ _ _) refl =
+  step-0 refl inv
+
+-- constrain-to-boolean v: record adds `v` to bk.
+o2-preserve {s = s} {instr = constrain-to-boolean v} {i = i} {bk = bk} inv
+            (r-constrain-to-boolean {b = b} lookup-bool) refl =
+  let av , lv , to-eq = extract-to-bool (Preprocessed.memory s) v lookup-bool
+  in gen-inv-coerce-idx (sym (+-0-r i))
+       (frame-no-grow-add-v refl lv (to-bool→is-bit to-eq) inv)
+
+-- declare-pub-input: memory unchanged (push-pi), record is a no-op.
+o2-preserve {instr = declare-pub-input v} {i = i} inv
+            (r-declare-pub-input _) refl =
+  step-0 refl inv
+
+-- pi-skip active / inactive: memory unchanged (push-skip; pi-skip
+-- inactive additionally modifies pub-in-idx, which doesn't touch
+-- memory), no record.  A guarded pi-skip's check requires `g ∈ bk`
+-- (the `g ∉ bk` case is excluded: `O2-check` returns nothing, so the
+-- step equation would be `nothing ≡ just acc'`).
+o2-preserve {instr = pi-skip nothing n} {i = i} inv
+            (r-pi-skip-active _ _) refl =
+  step-0 refl inv
+o2-preserve {instr = pi-skip nothing n} {i = i} inv
+            (r-pi-skip-inactive _) refl =
+  step-0 refl inv
+o2-preserve {instr = pi-skip (just g) n} {i = i} {bk = bk} inv
+            (r-pi-skip-active _ _) step-eq
+  with g ∈? bk | step-eq
+... | yes _ | refl = step-0 refl inv
+o2-preserve {instr = pi-skip (just g) n} {i = i} {bk = bk} inv
+            (r-pi-skip-inactive _) step-eq
+  with g ∈? bk | step-eq
+... | yes _ | refl = step-0 refl inv
+
+-- output: memory unchanged (push-output), record is a no-op.
+o2-preserve {instr = output v} {i = i} inv
+            (r-output _) refl =
+  step-0 refl inv
+
+-- ============================================================
+-- Δmem = 1 instructions
+-- ============================================================
+
+-- cond-select bit a b: check requires `bit ∈ bk`; record adds new
+-- index `i` to bk if BOTH `a ∈ bk` AND `b ∈ bk` (else no record).
+o2-preserve {instr = cond-select bit a b} {i = i} {bk = bk} inv
+            (r-cond-select {sel = sel} {av = av} {bv = bv}
+                           lookup-bit la lb) step-eq
+  with bit ∈? bk | step-eq
+... | yes _ | step-eq'
+  with a ∈? bk | b ∈? bk | step-eq'
+... | yes a∈ | yes b∈ | refl =
+  step-1-rec (if-sel-bit sel) inv
+  where
+    av-bit : is-bit av
+    av-bit = known inv a∈ la
+
+    bv-bit : is-bit bv
+    bv-bit = known inv b∈ lb
+
+    if-sel-bit : ∀ (s : Bool) → is-bit (if s then av else bv)
+    if-sel-bit true  = av-bit
+    if-sel-bit false = bv-bit
+... | yes _ | no _ | refl =
+  step-1 inv
+... | no  _ | _    | refl =
+  step-1 inv
+
+-- copy v: record adds new index `i` to bk if `v ∈ bk`.
+o2-preserve {instr = copy v} {i = i} {bk = bk} inv
+            (r-copy {v = vv} lv) refl
+  with v ∈? bk
+... | yes v∈ =
+  let vv-bit : is-bit vv
+      vv-bit = known inv v∈ lv
+  in step-1-rec vv-bit inv
+... | no  _ =
+  step-1 inv
+
+-- load-imm k: under our conservative `is-bool-imm? _ = false`,
+-- O2-record never adds for load-imm.  (See Obligations.agda.)
+o2-preserve {instr = load-imm k} {i = i} inv r-load-imm refl =
+  step-1 inv
+
+-- add / mul / neg: push-mem, never record.
+o2-preserve {instr = add a b} {i = i} inv (r-add _ _) refl =
+  step-1 inv
+o2-preserve {instr = mul a b} {i = i} inv (r-mul _ _) refl =
+  step-1 inv
+o2-preserve {instr = neg a} {i = i} inv (r-neg _) refl =
+  step-1 inv
+
+-- test-eq: push-mem (from-bool (av ≡ᶠ? bv)) — always records, value
+-- is from-bool of a Bool, hence is-bit.
+o2-preserve {instr = test-eq a b} {i = i} inv (r-test-eq {av = av} {bv = bv} _ _) refl =
+  step-1-rec (from-bool-is-bit (av ≡ᶠ? bv)) inv
+
+-- not: check requires `a ∈ bk`; always records (from-bool (Bool.not b)).
+o2-preserve {instr = not a} {i = i} {bk = bk} inv (r-not {b = b} _) step-eq
+  with a ∈? bk | step-eq
+... | yes _ | refl =
+  step-1-rec (from-bool-is-bit (Bool.not b)) inv
+
+-- less-than: push-mem (from-bool (bits-lt …)) — always records.
+o2-preserve {instr = less-than a b bits} {i = i} inv
+            (r-less-than {av = av} {bv = bv} _ _ _ _) refl =
+  step-1-rec
+    (from-bool-is-bit
+      (bits-lt (take bits (to-le-bits av)) (take bits (to-le-bits bv)))) inv
+
+-- reconstitute-field: push-mem of a single combined value; Δmem = 1.
+-- No record.
+o2-preserve {instr = reconstitute-field d m bits} {i = i} inv
+            (r-reconstitute-field _ _ _ _ _) refl =
+  step-1 inv
+
+-- public-input inactive: push-mem s 0ᶠ.  No record.
+o2-preserve {instr = public-input g} {i = i} inv
+            (r-public-input-inactive _) refl =
+  step-1 inv
+
+-- public-input active: push-mem s₁ v where s₁ has same memory as s.
+-- After push, memory grows by one.  No record.
+o2-preserve {s = s} {instr = public-input g} {i = i} inv
+            (r-public-input-active {s₁ = s₁} _ s₁-eq) refl =
+  let mem-s₁ : Preprocessed.memory s₁ ≡ Preprocessed.memory s
+      mem-s₁ = consume-pub-out-mem s s₁-eq
+      -- inv at s₁ (memory equal):
+      inv-s₁ : O2-Inv (i , _) s₁
+      inv-s₁ = gen-frame-no-grow mem-s₁ inv
+  in step-1 inv-s₁
+
+-- private-input inactive / active: same shape as public-input.
+o2-preserve {instr = private-input g} {i = i} inv
+            (r-private-input-inactive _) refl =
+  step-1 inv
+o2-preserve {s = s} {instr = private-input g} {i = i} inv
+            (r-private-input-active {s₁ = s₁} _ s₁-eq) refl =
+  let mem-s₁ : Preprocessed.memory s₁ ≡ Preprocessed.memory s
+      mem-s₁ = consume-priv-mem s s₁-eq
+      inv-s₁ : O2-Inv (i , _) s₁
+      inv-s₁ = gen-frame-no-grow mem-s₁ inv
+  in step-1 inv-s₁
+
+-- transient-hash: push-mem (transient-hash-fn vs).  No record.
+o2-preserve {instr = transient-hash xs} {i = i} inv
+            (r-transient-hash _) refl =
+  step-1 inv
+
+-- ============================================================
+-- Δmem = 2 instructions
+-- ============================================================
+
+-- ec-add, ec-mul, ec-mul-generator, hash-to-curve, persistent-hash:
+-- push-mem2 s x y.  No record.
+o2-preserve {instr = ec-add a_x a_y b_x b_y} {i = i} inv
+            (r-ec-add _ _ _ _ _) refl =
+  step-2 inv
+o2-preserve {instr = ec-mul a_x a_y scalar} {i = i} inv
+            (r-ec-mul _ _ _ _) refl =
+  step-2 inv
+o2-preserve {instr = ec-mul-generator scalar} {i = i} inv
+            (r-ec-mul-generator _ _) refl =
+  step-2 inv
+o2-preserve {instr = hash-to-curve xs} {i = i} inv
+            (r-hash-to-curve _ _) refl =
+  step-2 inv
+o2-preserve {instr = persistent-hash a xs} {i = i} inv
+            (r-persistent-hash _ _) refl =
+  step-2 inv
+
+-- div-mod-power-of-two: push-mem (push-mem s x) y — iterated.  No
+-- record.  Uses the special frame for iterated push-mem.
+o2-preserve {instr = div-mod-power-of-two v bits} {i = i} inv
+            (r-div-mod-power-of-two _ _) refl =
+  gen-inv-coerce-idx (sym (+-2-r i)) (gen-frame-push-mem-push-mem inv)
+
+------------------------------------------------------------------------
+-- Multi-step preservation, indexed by O2-Trace
+--
+-- Given the invariant at (acc, s) and a parallel run of R-instrs and
+-- O2-Trace, conclude the invariant at (final, s').
+------------------------------------------------------------------------
+
+o2-preserve* : ∀ {pre s s' acc final is}
+  → O2-Inv acc s
+  → R-instrs pre s is s'
+  → O2-Trace is acc final
+  → O2-Inv final s'
+o2-preserve* inv r-done o2-done = inv
+o2-preserve* inv (r-step r rs) (o2-step step-eq tr) =
+  o2-preserve* (o2-preserve inv r step-eq) rs tr
+
+------------------------------------------------------------------------
+-- Whole-program O2 soundness
+--
+-- Given:
+--   • `R src pre s` (the source is faithfully realised by state s),
+--     which packages an initial state s₀ and an `R-instrs pre s₀ … s`
+--     run;
+--   • `O2-Runs src` (the O2 scan completed with final = (i, bk));
+-- conclude: for every wire `j` in the final `bk`, looking up `j` in
+-- `mem s` yields an `is-bit` value.
+--
+-- The WF1 arity fact `o2-inv-init` needs is extracted from the run's
+-- own `init-state` equation (`init-state-num-inputs`).
+------------------------------------------------------------------------
+
+O2-sound : ∀ {src pre s}
+  → R src pre s
+  → (run : O2-Runs src)
+  → ∀ {j v}
+  → j ∈ (proj₂ (O2-Runs.final run))
+  → mem-lookup (Preprocessed.memory s) j ≡ just v
+  → is-bit v
+O2-sound {src} {pre} {s} (s₀ , init-eq , r-instrs , _ , _)
+         (mk-o2-runs final trace) =
+  let inv₀ : O2-Inv (IrSource.num-inputs src , []) s₀
+      inv₀ = o2-inv-init {src} {pre} {s₀} init-eq
+               (init-state-num-inputs src pre s₀ init-eq)
+
+      inv-final : O2-Inv final s
+      inv-final = o2-preserve* inv₀ r-instrs trace
+  in known inv-final
+
+------------------------------------------------------------------------
+-- Integration lemma: extracting `is-bit` evidence from the O2 scan
+--
+-- The program-level induction (`satisfies-constraints→R-instrs`) iterates
+-- over the instruction list, threading a synth state and a preprocess
+-- state.  At each obligation-bearing instruction (`assert`, `not`,
+-- `cond-select`'s bit operand), it needs an `is-bit` witness for the
+-- operand.  Given the invariant at `(i, bk)` paired with state `s` and
+-- that the operand is `c ∈ bk`, `o2-known-is-bit` produces the witness
+-- via `known inv`.
+------------------------------------------------------------------------
+
+-- Extract `is-bit v` for an operand `c` known to be in bool-known.
+o2-known-is-bit : ∀ {i bk s c v}
+  → O2-Inv (i , bk) s
+  → c ∈ bk
+  → mem-lookup (Preprocessed.memory s) c ≡ just v
+  → is-bit v
+o2-known-is-bit inv c∈ lookup-eq = known inv c∈ lookup-eq
+
+------------------------------------------------------------------------
+-- O3 soundness
+--
+-- O3 tracks a `known` partial map.  `O3-record` records only the
+-- cases whose `Fits-in` justification is in the bit-arithmetic trust
+-- base:
+--
+--   • `constrain-bits v n`            (premise `Fits-in v n`)
+--   • `div-mod-power-of-two _ n`     (via `fits-from-le-bits-{take,drop}`)
+--   • `copy v`                       (inherits from v)
+--
+-- The other record cases (test-eq, less-than, not, load-imm,
+-- cond-select, reconstitute-field) are no-ops, since the backward
+-- lemmas `reconstitute-field-bwd` / `less-than-bwd` take the relevant
+-- `fits-in` premises directly from the satisfies-constraints data.
+--
+-- The invariant is analogous to O2's:
+--   • i ≡ length mem
+--   • for each (j, n) in the map (via lookupᵐ), the lookup at j
+--     yields a value v with `Fits-in v n`.
+------------------------------------------------------------------------
+
+-- O3 step invariant: pairs (i, bm) where i = length mem, and for
+-- every (j, n) in bm (via lookupᵐ), the memory entry at j fits in n
+-- bits.  An instance of `KInv`: payload is the bit-bound `n`, recorded
+-- via `lookupᵐ`, property is `Fits-in`.
+O3-Inv : ℕ × PartialMap → Preprocessed → Set
+O3-Inv = KInv {PartialMap} {ℕ} (λ bm j n → lookupᵐ j bm ≡ just n)
+                                (λ v n → Fits-in v n)
+
+-- Initial state: empty map vacuously satisfies the invariant.
+o3-inv-init : ∀ {src pre s₀}
+  → init-state src pre ≡ just s₀
+  → length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src
+  → O3-Inv (IrSource.num-inputs src , []) s₀
+o3-inv-init {src} {pre} {s₀} eq lenEq =
+  mk-kinv idx-eq empty-bound empty
+  where
+    mem-eq : Preprocessed.memory s₀ ≡ ProofPreimage.inputs pre
+    mem-eq = init-state-memory src pre s₀ eq
+
+    idx-eq : IrSource.num-inputs src ≡ length (Preprocessed.memory s₀)
+    idx-eq = trans (sym lenEq) (sym (cong length mem-eq))
+
+    empty-bound : ∀ {j n} → lookupᵐ j [] ≡ just n → j < IrSource.num-inputs src
+    empty-bound ()
+
+    empty : ∀ {j n v}
+          → lookupᵐ j [] ≡ just n
+          → mem-lookup (Preprocessed.memory s₀) j ≡ just v
+          → Fits-in v n
+    empty ()
+
+------------------------------------------------------------------------
+-- O3 helpers for lookupᵐ / insertᵐ.
+------------------------------------------------------------------------
+
+private
+
+  ------------------------------------------------------------------
+  -- O3-record-supporting helpers
+  ------------------------------------------------------------------
+
+  -- After insertᵐ k n bm, a lookup at k returns n; at j ≠ k, it
+  -- falls through to lookupᵐ j bm.
+  -- Combined with the boolean condition, this gives a decomposition.
+  lookupᵐ-insertᵐ-cases : ∀ (j k : Index) n bm {m}
+    → lookupᵐ j (insertᵐ k n bm) ≡ just m
+    → ((j ≡ k) × (m ≡ n)) ⊎ (lookupᵐ j bm ≡ just m)
+  lookupᵐ-insertᵐ-cases j k n bm eq with j ≡ᵇ k in jk-eq
+  ... | true  = inj₁ (≡ᵇ-true jk-eq , sym (just-injective eq))
+  ... | false = inj₂ eq
+
+  -- Frame: memory unchanged, map extended with `(v, n)`.  Requires:
+  --   • v < i  (operand bound from a successful mem-lookup),
+  --   • Fits-in vv n  (witness from the R-instr premise),
+  --   • mem-lookup s v ≡ just vv.
+  o3-frame-no-grow-insert-v : ∀ {i bm s s' v n vv}
+    → Preprocessed.memory s' ≡ Preprocessed.memory s
+    → mem-lookup (Preprocessed.memory s) v ≡ just vv
+    → Fits-in vv n
+    → O3-Inv (i , bm) s
+    → O3-Inv (i , insertᵐ v n bm) s'
+  o3-frame-no-grow-insert-v {i = i} {bm = bm} {s = s} {s' = s'}
+                              {v = v} {n = n} {vv = vv}
+                              mem-eq lv fits-vv inv =
+    mk-kinv idx-eq bnd bits
+    where
+      idx-eq : i ≡ length (Preprocessed.memory s')
+      idx-eq = trans (idx-sync inv) (sym (cong length mem-eq))
+
+      v<i : v < i
+      v<i = lookup-bound (Preprocessed.memory s) v lv (idx-sync inv)
+
+      bnd : ∀ {j n'} → lookupᵐ j (insertᵐ v n bm) ≡ just n' → j < i
+      bnd {j} look with lookupᵐ-insertᵐ-cases j v n bm look
+      ... | inj₁ (j≡v , _)  = subst (_< i) (sym j≡v) v<i
+      ... | inj₂ fall       = bound inv fall
+
+      bits : ∀ {j n' v'} → lookupᵐ j (insertᵐ v n bm) ≡ just n'
+                         → mem-lookup (Preprocessed.memory s') j ≡ just v'
+                         → Fits-in v' n'
+      bits {j} {n'} {v'} look lookup-eq
+        with lookupᵐ-insertᵐ-cases j v n bm look
+      ... | inj₁ (j≡v , n'≡n) =
+        let lookup-at-v : mem-lookup (Preprocessed.memory s) v ≡ just v'
+            lookup-at-v =
+              subst (λ k → mem-lookup (Preprocessed.memory s) k ≡ just v')
+                    j≡v
+                    (trans (cong (λ m → mem-lookup m j) (sym mem-eq)) lookup-eq)
+            vv≡v' : vv ≡ v'
+            vv≡v' = just-injective (trans (sym lv) lookup-at-v)
+        in subst (λ z → Fits-in z n') vv≡v'
+                 (subst (λ z → Fits-in vv z) (sym n'≡n) fits-vv)
+      ... | inj₂ fall =
+        known inv fall
+          (trans (cong (λ m → mem-lookup m _) (sym mem-eq)) lookup-eq)
+
+  -- Frame for div-mod-power-of-two: memory grows by two cells (via
+  -- iterated push-mem), and the map gets two new entries.  Requires
+  -- `fits-in` witnesses for the two appended values.
+  o3-frame-push-mem-2-insert-2 : ∀ {i bm s x y nx ny}
+    → Fits-in x nx
+    → Fits-in y ny
+    → O3-Inv (i , bm) s
+    → O3-Inv (suc (suc i) , insertᵐ (suc i) ny (insertᵐ i nx bm))
+             (push-mem (push-mem s x) y)
+  o3-frame-push-mem-2-insert-2 {i = i} {bm = bm} {s = s}
+                                 {x = x} {y = y} {nx = nx} {ny = ny}
+                                 fx fy inv =
+    mk-kinv idx-eq bnd bits
+    where
+      mem    = Preprocessed.memory s
+      mem-eq : Preprocessed.memory (push-mem (push-mem s x) y)
+             ≡ mem ++ (x ∷ y ∷ [])
+      mem-eq = ++-assoc mem (x ∷ []) (y ∷ [])
+
+      idx-eq : suc (suc i)
+             ≡ length (Preprocessed.memory (push-mem (push-mem s x) y))
+      idx-eq = trans (cong suc (cong suc (idx-sync inv)))
+                     (trans (sym (length-++-two mem x y))
+                            (sym (cong length mem-eq)))
+
+      bnd : ∀ {j n'} → lookupᵐ j (insertᵐ (suc i) ny (insertᵐ i nx bm)) ≡ just n'
+                     → j < suc (suc i)
+      bnd {j} look with lookupᵐ-insertᵐ-cases j (suc i) ny (insertᵐ i nx bm) look
+      ... | inj₁ (j≡sucI , _) =
+        subst (_< suc (suc i)) (sym j≡sucI) (n<1+n (suc i))
+      ... | inj₂ fall1 with lookupᵐ-insertᵐ-cases j i nx bm fall1
+      ...   | inj₁ (j≡i , _) =
+        subst (_< suc (suc i)) (sym j≡i) (m<n⇒m<1+n (n<1+n i))
+      ...   | inj₂ fall2     = m<n⇒m<1+n (m<n⇒m<1+n (bound inv fall2))
+
+      bits : ∀ {j n' v'}
+           → lookupᵐ j (insertᵐ (suc i) ny (insertᵐ i nx bm)) ≡ just n'
+           → mem-lookup (Preprocessed.memory (push-mem (push-mem s x) y)) j
+              ≡ just v'
+           → Fits-in v' n'
+      bits {j} {n'} {v'} look lookup-eq =
+        let lookup-eq' : mem-lookup (mem ++ (x ∷ y ∷ [])) j ≡ just v'
+            lookup-eq' = trans (cong (λ m → mem-lookup m j) (sym mem-eq))
+                                lookup-eq
+        in aux look lookup-eq'
+        where
+          aux : lookupᵐ j (insertᵐ (suc i) ny (insertᵐ i nx bm)) ≡ just n'
+              → mem-lookup (mem ++ (x ∷ y ∷ [])) j ≡ just v'
+              → Fits-in v' n'
+          aux look' lookup-eq''
+            with lookupᵐ-insertᵐ-cases j (suc i) ny (insertᵐ i nx bm) look'
+          ... | inj₁ (j≡sucI , n'≡ny) =
+            let -- lookup at suc i ≡ just y in mem ++ (x ∷ y ∷ [])
+                lookup-at-sucI : mem-lookup (mem ++ (x ∷ y ∷ [])) (suc i) ≡ just y
+                lookup-at-sucI =
+                  subst (λ k → mem-lookup (mem ++ (x ∷ y ∷ [])) (suc k) ≡ just y)
+                        (sym (idx-sync inv))
+                        (lookup-new-snd mem x y)
+                v'≡y : v' ≡ y
+                v'≡y = just-injective
+                         (trans (sym
+                                  (subst (λ k → mem-lookup (mem ++ (x ∷ y ∷ [])) k
+                                                ≡ just v')
+                                          j≡sucI lookup-eq''))
+                                lookup-at-sucI)
+            in subst (λ z → Fits-in z n') (sym v'≡y)
+                     (subst (λ z → Fits-in y z) (sym n'≡ny) fy)
+          ... | inj₂ fall1 with lookupᵐ-insertᵐ-cases j i nx bm fall1
+          ...   | inj₁ (j≡i , n'≡nx) =
+            let lookup-at-i : mem-lookup (mem ++ (x ∷ y ∷ [])) i ≡ just x
+                lookup-at-i =
+                  subst (λ k → mem-lookup (mem ++ (x ∷ y ∷ [])) k ≡ just x)
+                        (sym (idx-sync inv))
+                        (lookup-new-fst mem x y)
+                v'≡x : v' ≡ x
+                v'≡x = just-injective
+                         (trans (sym
+                                  (subst (λ k → mem-lookup (mem ++ (x ∷ y ∷ [])) k
+                                                ≡ just v')
+                                          j≡i lookup-eq''))
+                                lookup-at-i)
+            in subst (λ z → Fits-in z n') (sym v'≡x)
+                     (subst (λ z → Fits-in x z) (sym n'≡nx) fx)
+          ...   | inj₂ fall2 with lookup-shrink-or-new-2 mem x y j v' lookup-eq''
+          ...     | inj₁ p              = known inv fall2 p
+          ...     | inj₂ (inj₁ (j≡L , _)) =
+            ⊥-elim (<-irrefl refl
+                     (subst (_< i) (trans j≡L (sym (idx-sync inv)))
+                            (bound inv fall2)))
+          ...     | inj₂ (inj₂ (j≡sL , _)) =
+            ⊥-elim (<⇒≯ (n<1+n _)
+                     (subst (_< i)
+                            (trans j≡sL (cong suc (sym (idx-sync inv))))
+                            (bound inv fall2)))
+
+  -- Frame for copy v when `v ∈ dom(bm)`: memory grows by one cell;
+  -- the appended value is `vv` (the value at v); the map gets a new
+  -- entry `(i, k)` where k is the previous bound on v.  The witness:
+  -- by IH, `fits-in vv k`.
+  o3-frame-push-mem-copy : ∀ {i bm s v vv k}
+    → lookupᵐ v bm ≡ just k
+    → mem-lookup (Preprocessed.memory s) v ≡ just vv
+    → O3-Inv (i , bm) s
+    → O3-Inv (suc i , insertᵐ i k bm) (push-mem s vv)
+  o3-frame-push-mem-copy {i = i} {bm = bm} {s = s} {v = v} {vv = vv} {k = k}
+                           look-v lv inv =
+    mk-kinv idx-eq bnd bits
+    where
+      mem  = Preprocessed.memory s
+      idx-eq : suc i ≡ length (Preprocessed.memory (push-mem s vv))
+      idx-eq = trans (cong suc (idx-sync inv)) (sym (length-++-one mem vv))
+
+      fits-vv-k : Fits-in vv k
+      fits-vv-k = known inv look-v lv
+
+      bnd : ∀ {j n'} → lookupᵐ j (insertᵐ i k bm) ≡ just n' → j < suc i
+      bnd {j} look with lookupᵐ-insertᵐ-cases j i k bm look
+      ... | inj₁ (j≡i , _) = subst (_< suc i) (sym j≡i) (n<1+n i)
+      ... | inj₂ fall      = m<n⇒m<1+n (bound inv fall)
+
+      bits : ∀ {j n' v'} → lookupᵐ j (insertᵐ i k bm) ≡ just n'
+                         → mem-lookup (Preprocessed.memory (push-mem s vv)) j ≡ just v'
+                         → Fits-in v' n'
+      bits {j} {n'} {v'} look lookup-eq
+        with lookupᵐ-insertᵐ-cases j i k bm look
+      ... | inj₁ (j≡i , n'≡k) =
+        let lookup-at-i : mem-lookup (mem ++ (vv ∷ [])) i ≡ just vv
+            lookup-at-i =
+              subst (λ z → mem-lookup (mem ++ (vv ∷ [])) z ≡ just vv)
+                    (sym (idx-sync inv)) (lookup-new mem vv)
+            v'≡vv : v' ≡ vv
+            v'≡vv = just-injective
+                      (trans (sym (subst (λ z → mem-lookup (mem ++ (vv ∷ [])) z
+                                                 ≡ just v')
+                                          j≡i lookup-eq))
+                             lookup-at-i)
+        in subst (λ z → Fits-in z n') (sym v'≡vv)
+                 (subst (λ z → Fits-in vv z) (sym n'≡k) fits-vv-k)
+      ... | inj₂ fall with lookup-shrink-or-new mem vv j v' lookup-eq
+      ...   | inj₁ p              = known inv fall p
+      ...   | inj₂ (j≡L , _)      =
+        ⊥-elim (<-irrefl refl (subst (_< i)
+                                       (trans j≡L (sym (idx-sync inv)))
+                                       (bound inv fall)))
+
+------------------------------------------------------------------------
+-- Main per-step preservation theorem (O3)
+--
+-- 29-case dispatch.  Memory-preserving cases use `step-0`; one-cell
+-- push-mem cases use `step-1`; two-cell cases use `step-2`.  The
+-- substantive record cases (constrain-bits, div-mod, copy) use the
+-- specialised insert frames.
+------------------------------------------------------------------------
+
+o3-preserve : ∀ {pre s s' instr i bm acc'}
+  → O3-Inv (i , bm) s
+  → R-instr pre s instr s'
+  → O3-step instr (i , bm) ≡ just acc'
+  → O3-Inv acc' s'
+-- Δmem = 0 cases (no record under our conservative O3-record)
+o3-preserve {instr = assert c} {i = i} inv (r-assert _) refl =
+  step-0 refl inv
+o3-preserve {instr = constrain-eq a b} {i = i} inv (r-constrain-eq _ _ _) refl =
+  step-0 refl inv
+o3-preserve {instr = constrain-to-boolean v} {i = i} inv
+            (r-constrain-to-boolean _) refl =
+  step-0 refl inv
+o3-preserve {instr = declare-pub-input v} {i = i} inv
+            (r-declare-pub-input _) refl =
+  step-0 refl inv
+o3-preserve {instr = pi-skip g n} {i = i} inv (r-pi-skip-active _ _) refl =
+  step-0 refl inv
+o3-preserve {instr = pi-skip g n} {i = i} inv (r-pi-skip-inactive _) refl =
+  step-0 refl inv
+o3-preserve {instr = output v} {i = i} inv (r-output _) refl =
+  step-0 refl inv
+
+-- constrain-bits v n: record inserts (v, n).  Justified by r-constrain-bits.
+o3-preserve {instr = constrain-bits v n} {i = i} inv
+            (r-constrain-bits {v = vv} lv _ fits-eq) refl =
+  gen-inv-coerce-idx (sym (+-0-r i))
+    (o3-frame-no-grow-insert-v refl lv fits-eq inv)
+
+-- Δmem = 1 cases (no record under conservative O3-record except copy)
+o3-preserve {instr = cond-select bit a b} {i = i} inv
+            (r-cond-select _ _ _) refl =
+  step-1 inv
+o3-preserve {instr = copy v} {i = i} {bm = bm} inv (r-copy {v = vv} lv) refl
+  with lookupᵐ v bm in vbm-eq
+... | just k  =
+  gen-inv-coerce-idx (sym (+-1-r i)) (o3-frame-push-mem-copy vbm-eq lv inv)
+... | nothing =
+  step-1 inv
+o3-preserve {instr = load-imm k} {i = i} inv r-load-imm refl =
+  step-1 inv
+o3-preserve {instr = add a b} {i = i} inv (r-add _ _) refl =
+  step-1 inv
+o3-preserve {instr = mul a b} {i = i} inv (r-mul _ _) refl =
+  step-1 inv
+o3-preserve {instr = neg a} {i = i} inv (r-neg _) refl =
+  step-1 inv
+o3-preserve {instr = test-eq a b} {i = i} inv (r-test-eq _ _) refl =
+  step-1 inv
+o3-preserve {instr = not a} {i = i} inv (r-not _) refl =
+  step-1 inv
+o3-preserve {instr = less-than a b bits} {i = i} {bm = bm} inv
+            (r-less-than _ _ _ _) step-eq
+  with o3OK? (less-than a b bits) bm | step-eq
+... | yes _ | refl =
+  step-1 inv
+... | no  _ | ()
+o3-preserve {instr = reconstitute-field d m bits} {i = i} {bm = bm} inv
+            (r-reconstitute-field _ _ _ _ _) step-eq
+  with o3OK? (reconstitute-field d m bits) bm | step-eq
+... | yes _ | refl =
+  step-1 inv
+... | no  _ | ()
+o3-preserve {instr = public-input g} {i = i} inv
+            (r-public-input-inactive _) refl =
+  step-1 inv
+o3-preserve {s = s} {instr = public-input g} {i = i} inv
+            (r-public-input-active {s₁ = s₁} _ s₁-eq) refl =
+  let mem-eq : Preprocessed.memory s₁ ≡ Preprocessed.memory s
+      mem-eq = consume-pub-out-mem s s₁-eq
+      inv-s₁ = gen-frame-no-grow mem-eq inv
+  in step-1 inv-s₁
+o3-preserve {instr = private-input g} {i = i} inv
+            (r-private-input-inactive _) refl =
+  step-1 inv
+o3-preserve {s = s} {instr = private-input g} {i = i} inv
+            (r-private-input-active {s₁ = s₁} _ s₁-eq) refl =
+  let mem-eq : Preprocessed.memory s₁ ≡ Preprocessed.memory s
+      mem-eq = consume-priv-mem s s₁-eq
+      inv-s₁ = gen-frame-no-grow mem-eq inv
+  in step-1 inv-s₁
+o3-preserve {instr = transient-hash xs} {i = i} inv (r-transient-hash _) refl =
+  step-1 inv
+
+-- Δmem = 2 cases.
+o3-preserve {instr = ec-add ax ay bx by} {i = i} inv (r-ec-add _ _ _ _ _) refl =
+  step-2 inv
+o3-preserve {instr = ec-mul ax ay sc} {i = i} inv (r-ec-mul _ _ _ _) refl =
+  step-2 inv
+o3-preserve {instr = ec-mul-generator sc} {i = i} inv (r-ec-mul-generator _ _) refl =
+  step-2 inv
+o3-preserve {instr = hash-to-curve xs} {i = i} inv (r-hash-to-curve _ _) refl =
+  step-2 inv
+o3-preserve {instr = persistent-hash a xs} {i = i} inv (r-persistent-hash _ _) refl =
+  step-2 inv
+
+-- div-mod-power-of-two v n: 2 records.  divisor at i (fits in FR-BITS ∸ n);
+-- modulus at suc i (fits in n).  Justified by the bit-arithmetic axioms.
+o3-preserve {instr = div-mod-power-of-two v n} {i = i} inv
+            (r-div-mod-power-of-two {v = vv} lv _) refl =
+  let divisor = from-le-bits (drop n (to-le-bits vv))
+      modulus = from-le-bits (take n (to-le-bits vv))
+      fits-div : Fits-in divisor (FR-BITS ∸ n)
+      fits-div = fits-from-le-bits-drop vv n
+      fits-mod : Fits-in modulus n
+      fits-mod = fits-from-le-bits-take (to-le-bits vv) n
+  in gen-inv-coerce-idx (sym (+-2-r i))
+       (o3-frame-push-mem-2-insert-2 {nx = FR-BITS ∸ n} {ny = n}
+                                      fits-div fits-mod inv)
+
+------------------------------------------------------------------------
+-- Multi-step preservation, indexed by O3-Trace
+--
+-- Given the invariant at (acc, s) and a parallel run of R-instrs and
+-- O3-Trace, conclude the invariant at (final, s').
+------------------------------------------------------------------------
+
+o3-preserve* : ∀ {pre s s' acc final is}
+  → O3-Inv acc s
+  → R-instrs pre s is s'
+  → O3-Trace is acc final
+  → O3-Inv final s'
+o3-preserve* inv r-done o3-done = inv
+o3-preserve* inv (r-step r rs) (o3-step step-eq tr) =
+  o3-preserve* (o3-preserve inv r step-eq) rs tr
+
+------------------------------------------------------------------------
+-- Whole-program O3 soundness
+--
+-- Given:
+--   • `R src pre s` (the source is faithfully realised by state s),
+--     which packages an initial state s₀ and an `R-instrs pre s₀ … s`
+--     run;
+--   • `O3-Runs src` (the O3 scan completed with final = (i, bm));
+--   • the WF1 hypothesis `length inputs ≡ num-inputs src`
+-- conclude: for every wire `j` with `lookupᵐ j (proj₂ final) ≡ just n`,
+-- the corresponding memory entry `v` satisfies `Fits-in v n`.
+------------------------------------------------------------------------
+
+O3-sound : ∀ {src pre s}
+  → R src pre s
+  → (run : O3-Runs src)
+  → ∀ {j n v}
+  → lookupᵐ j (proj₂ (O3-Runs.final run)) ≡ just n
+  → mem-lookup (Preprocessed.memory s) j ≡ just v
+  → Fits-in v n
+O3-sound {src} {pre} {s} (s₀ , init-eq , r-instrs , _ , _)
+         (mk-o3-runs final trace) =
+  let inv₀ : O3-Inv (IrSource.num-inputs src , []) s₀
+      inv₀ = o3-inv-init {src} {pre} {s₀} init-eq
+               (init-state-num-inputs src pre s₀ init-eq)
+
+      inv-final : O3-Inv final s
+      inv-final = o3-preserve* inv₀ r-instrs trace
+  in known inv-final
+
+------------------------------------------------------------------------
+-- Integration lemma: extracting `Fits-in` evidence from the O3 scan
+--
+-- `o3-known-fits`: at any intermediate (i, bm)/s pairing, if
+-- `lookupᵐ a bm ≡ just n` and `mem-lookup mem a ≡ just v`, then
+-- `Fits-in v n`.  This is the direct extractor used by
+-- `reconstitute-field-bwd` and `less-than-bwd`.
+------------------------------------------------------------------------
+
+-- Extract `Fits-in v n` for an operand `a` known in bm.
+o3-known-fits : ∀ {i bm s a n v}
+  → O3-Inv (i , bm) s
+  → lookupᵐ a bm ≡ just n
+  → mem-lookup (Preprocessed.memory s) a ≡ just v
+  → Fits-in v n
+o3-known-fits inv look-eq lookup-eq = known inv look-eq lookup-eq
+
+------------------------------------------------------------------------
+-- Bool ⇒ Witness extractors for the producer-safe conjunction.
+--
+-- These let a caller holding `T (producer-safe src)` recover the
+-- witness-bearing `O2-Runs` / `O3-Runs` needed to feed the soundness
+-- theorems above.
+--
+-- `producer-safe src = O1 src ∧ O2 src ∧ O3 src ∧ wire-disc src`
+-- decomposes via `∧-true` into the four conjunct checks.
+------------------------------------------------------------------------
+
+-- Project conjuncts of `producer-safe`.  Since `producer-safe =
+-- O1 ∧ O2 ∧ O3 ∧ wire-disc`, each conjunct's `T` check is peeled off
+-- the (right-nested) conjunction with `∧-true`.
+producer-safe-O1 : ∀ {src} → T (producer-safe src) → T (O1 src)
+producer-safe-O1 {src} eq = proj₁ (∧-true {O1 src} eq)
+
+producer-safe-O2 : ∀ {src} → T (producer-safe src) → T (O2 src)
+producer-safe-O2 {src} eq = proj₁ (∧-true {O2 src} (proj₂ (∧-true {O1 src} eq)))
+
+producer-safe-O3 : ∀ {src} → T (producer-safe src) → T (O3 src)
+producer-safe-O3 {src} eq =
+  proj₁ (∧-true {O3 src} (proj₂ (∧-true {O2 src} (proj₂ (∧-true {O1 src} eq)))))
+
+producer-safe-wire-disc : ∀ {src} → T (producer-safe src) → T (wire-disc src)
+producer-safe-wire-disc {src} eq =
+  proj₂ (∧-true {O3 src} (proj₂ (∧-true {O2 src} (proj₂ (∧-true {O1 src} eq)))))
+

--- a/formal/src/zkir-v2/Properties.agda
+++ b/formal/src/zkir-v2/Properties.agda
@@ -1,0 +1,807 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.Properties (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v2.FieldProperties ⋯
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+open import zkir-v2.SemanticsLemmas ⋯
+  using ( init-state-memory; init-state-num-inputs
+        ; init-state-pub-in-idx; init-state-outputs
+        ; consume-pub-out-mem; consume-priv-mem )
+
+open import Data.Bool    using (Bool; true; false; if_then_else_; _∧_; T)
+open import Data.Bool.Properties using (T-∧; T-≡)
+open import Function.Bundles using (Equivalence)
+open import Data.Unit    using (tt)
+open import Data.List    using (List; []; _∷_; _++_; length; take)
+open import Data.List.Properties using (length-++)
+open import Data.List.Relation.Unary.All using (All) renaming ([] to ⟨⟩; _∷_ to _◂_)
+open import Data.Maybe   using (Maybe; nothing; just; _>>=_)
+open import Data.Nat     using (ℕ; zero; suc; _≤_; _<_; _<?_; _≤?_; _+_; _∸_; _≡ᵇ_; z≤n; s≤s)
+open import Data.Nat.Properties
+  using (≤-refl; ≤-trans; ≤-reflexive; m∸n≤m; m≤m+n; +-comm; +-assoc; +-monoʳ-≤
+        ; +-identityʳ; ≡ᵇ⇒≡; <ᵇ⇒<; ≤ᵇ⇒≤)
+open import Data.Product using (_×_; _,_; ∃; proj₁; proj₂)
+open import Data.Maybe.Properties using (just-injective)
+open import Relation.Nullary.Decidable using (does; dec-true)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; subst)
+-- Re-exported (`public`): Properties is the façade through which spec-level
+-- consumers reach the P5 vocabulary and statement.
+open import zkir-v2.Circuit ⋯      using (circuit; satisfies) public
+open import zkir-v2.Obligations ⋯  using (producer-safe; Δmem) public
+open import zkir-v2.CircuitProof ⋯
+  using (witness-of; preprocess-shaped; circuit-faithful) public
+
+------------------------------------------------------------------------
+-- Local proof helpers
+------------------------------------------------------------------------
+
+private
+
+  >>=-just : ∀ {A B : Set} {f : A → Maybe B} {y : B}
+    → (m : Maybe A) → (m >>= f) ≡ just y
+    → ∃ λ x → m ≡ just x × f x ≡ just y
+  >>=-just (just x) p = x , refl , p
+  >>=-just nothing  ()
+
+  if-just : ∀ {A : Set} (b : Bool) {x y : A}
+    → (if b then just x else nothing) ≡ just y
+    → T b × x ≡ y
+  if-just true  refl = tt , refl
+  if-just false ()
+
+  -- Recover the `Fits-in`/`BitsInField` conjuncts of the reconstitute /
+  -- less-than operational guards (Bool) as the `Set` product premise.
+  lt-guard→ : ∀ av bv bits
+    → T (does (fits-in? av bits) ∧ does (fits-in? bv bits))
+    → Fits-in av bits × Fits-in bv bits
+  lt-guard→ av bv bits g =
+    let sa , sb = Equivalence.to T-∧ g
+    in fits-in?-from-true av bits sa , fits-in?-from-true bv bits sb
+
+  recon-guard→ : ∀ mv dv bits
+    → T (does (fits-in? mv bits) ∧ does (fits-in? dv (FR-BITS ∸ bits)) ∧
+       does (bitsInField? (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv))))
+    → Fits-in mv bits × Fits-in dv (FR-BITS ∸ bits) ×
+      BitsInField (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv))
+  recon-guard→ mv dv bits g =
+    let s1a , s1b = Equivalence.to T-∧ g
+        s2a , s2b = Equivalence.to T-∧ s1b
+    in fits-in?-from-true mv bits s1a
+     , fits-in?-from-true dv (FR-BITS ∸ bits) s2a
+     , bitsInField?-from-true
+         (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv)) s2b
+
+  from-just-R : ∀ {pre s i t s'} → R-instr pre s i t → just t ≡ just s' → R-instr pre s i s'
+  from-just-R r refl = r
+
+------------------------------------------------------------------------
+-- 1. Transcript consumption
+-- A successful preprocessing fully consumes all three transcript streams.
+------------------------------------------------------------------------
+
+preprocess-transcripts-consumed : ∀ src pre s
+  → preprocess src pre ≡ just s
+  → T (transcripts-consumed pre s)
+preprocess-transcripts-consumed src pre s eq
+  with >>=-just (init-state src pre) eq
+... | s₀ , _ , eq₁
+  with >>=-just (preprocess-instrs pre s₀ (IrSource.instructions src)) eq₁
+... | s' , _ , eq₂
+  with if-just _ eq₂
+... | b-true , s'-eq
+  = subst (λ x → T (transcripts-consumed pre x)) s'-eq
+      (proj₁ (Equivalence.to T-∧ b-true))
+
+------------------------------------------------------------------------
+-- 2. Exact memory accounting (the exact-Δmem form of P2)
+--
+-- A successful step grows the memory by exactly `Δmem i` cells, so a
+-- full run's memory length is `num-inputs` plus the per-instruction
+-- `Δmem` sum.  Matched against the synthesis-side wire count, this pins
+-- a run's memory length to the circuit's `nr-wires` — the witness-shape
+-- fact the statement-soundness characterization consumes.
+------------------------------------------------------------------------
+
+Δmem-sum : List Instruction → ℕ
+Δmem-sum []       = 0
+Δmem-sum (i ∷ is) = Δmem i + Δmem-sum is
+
+R-instr-Δmem : ∀ {pre s i s'} → R-instr pre s i s'
+  → length (Preprocessed.memory s') ≡ length (Preprocessed.memory s) + Δmem i
+R-instr-Δmem (r-assert _)                 = sym (+-identityʳ _)
+R-instr-Δmem (r-constrain-bits _ _ _)       = sym (+-identityʳ _)
+R-instr-Δmem (r-constrain-eq _ _ _)       = sym (+-identityʳ _)
+R-instr-Δmem (r-constrain-to-boolean _)   = sym (+-identityʳ _)
+R-instr-Δmem (r-declare-pub-input _)      = sym (+-identityʳ _)
+R-instr-Δmem (r-pi-skip-active _ _)       = sym (+-identityʳ _)
+R-instr-Δmem (r-pi-skip-inactive _)       = sym (+-identityʳ _)
+R-instr-Δmem (r-output _)                 = sym (+-identityʳ _)
+R-instr-Δmem {s = s} (r-cond-select _ _ _)        = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-copy _)                   = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} r-load-imm                   = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-reconstitute-field _ _ _ _ _) = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-transient-hash _)         = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-test-eq _ _)              = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-add _ _)                  = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-mul _ _)                  = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-neg _)                    = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-not _)                    = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-less-than _ _ _ _)          = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-public-input-inactive _)  = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-private-input-inactive _) = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-ec-add _ _ _ _ _)         = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-ec-mul _ _ _ _)           = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-ec-mul-generator _ _)     = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-hash-to-curve _ _)        = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-persistent-hash _ _)      = length-++ (Preprocessed.memory s)
+R-instr-Δmem {s = s} (r-div-mod-power-of-two _ _)   =
+  trans (length-++ (Preprocessed.memory s ++ _))
+        (trans (cong (_+ 1) (length-++ (Preprocessed.memory s)))
+               (+-assoc (length (Preprocessed.memory s)) 1 1))
+R-instr-Δmem {s = s} (r-public-input-active {v = v} {s₁ = s₁} _ cp) =
+  trans (length-++ (Preprocessed.memory s₁))
+        (cong (_+ 1) (cong length (consume-pub-out-mem s cp)))
+R-instr-Δmem {s = s} (r-private-input-active {v = v} {s₁ = s₁} _ cp) =
+  trans (length-++ (Preprocessed.memory s₁))
+        (cong (_+ 1) (cong length (consume-priv-mem s cp)))
+
+R-instrs-Δmem : ∀ {pre s is s'} → R-instrs pre s is s'
+  → length (Preprocessed.memory s')
+    ≡ length (Preprocessed.memory s) + Δmem-sum is
+R-instrs-Δmem r-done = sym (+-identityʳ _)
+R-instrs-Δmem {s = s} {is = i ∷ is} (r-step step rest) =
+  trans (R-instrs-Δmem rest)
+    (trans (cong (_+ Δmem-sum is) (R-instr-Δmem step))
+           (+-assoc (length (Preprocessed.memory s)) (Δmem i) (Δmem-sum is)))
+
+R-memory-length : ∀ src pre s → R src pre s
+  → length (Preprocessed.memory s)
+    ≡ IrSource.num-inputs src + Δmem-sum (IrSource.instructions src)
+R-memory-length src pre s (s₀ , init-eq , Rs , _ , _) =
+  trans (R-instrs-Δmem Rs)
+    (cong (_+ Δmem-sum (IrSource.instructions src))
+      (trans (cong length (init-state-memory src pre s₀ init-eq))
+             (init-state-num-inputs src pre s₀ init-eq)))
+
+------------------------------------------------------------------------
+-- 3. Faithfulness
+-- The computational and relational semantics agree.
+------------------------------------------------------------------------
+
+-- Per-instruction: computational → relational
+
+preprocess-instr→R-instr : ∀ pre s i s'
+  → preprocess-instr pre s i ≡ just s' → R-instr pre s i s'
+preprocess-instr→R-instr _ s (assert cond) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) cond >>= to-bool) eq
+... | b , lb , eq₁
+  with if-just b eq₁
+... | b-true , s-eq
+  = subst (R-instr _ s (assert cond)) s-eq
+      (r-assert (subst (λ x → _ ≡ just x) (Equivalence.to T-≡ b-true) lb))
+
+preprocess-instr→R-instr _ s (cond-select bit a b) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) bit >>= to-bool) eq
+... | sel , lsel , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) a) eq₁
+... | av , la , eq₂
+  with >>=-just (mem-lookup (Preprocessed.memory s) b) eq₂
+... | bv , lb , eq₃
+  = from-just-R (r-cond-select lsel la lb) eq₃
+
+preprocess-instr→R-instr _ s (constrain-bits var bits) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) var) eq
+... | v , lv , eq₁
+  with if-just (does (bits <? FR-BITS) ∧ does (fits-in? v bits)) eq₁
+... | guard , s-eq
+  = let bnd , ft = Equivalence.to T-∧ guard
+    in subst (R-instr _ s (constrain-bits var bits)) s-eq
+         (r-constrain-bits lv (<ᵇ⇒< bits FR-BITS bnd) (fits-in?-from-true v bits ft))
+
+preprocess-instr→R-instr _ s (constrain-eq a b) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a) eq
+... | av , la , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) b) eq₁
+... | bv , lb , eq₂
+  with if-just (av ≡ᶠ? bv) eq₂
+... | eq? , s-eq
+  = subst (R-instr _ s (constrain-eq a b)) s-eq (r-constrain-eq la lb (≡ᶠ?-true eq?))
+
+preprocess-instr→R-instr _ s (constrain-to-boolean var) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) var >>= to-bool) eq
+... | b , lb , eq₁
+  = subst (R-instr _ s (constrain-to-boolean var)) (just-injective eq₁) (r-constrain-to-boolean lb)
+
+preprocess-instr→R-instr _ s (copy var) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) var) eq
+... | v , lv , eq₁ = from-just-R (r-copy lv) eq₁
+
+preprocess-instr→R-instr _ s (declare-pub-input var) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) var) eq
+... | v , lv , eq₁ = from-just-R (r-declare-pub-input lv) eq₁
+
+preprocess-instr→R-instr pre s (pi-skip guard count) s' eq
+  with >>=-just (eval-guard (Preprocessed.memory s) guard) eq
+... | false , gf , eq₁ = from-just-R (r-pi-skip-inactive gf) eq₁
+... | true  , gt , eq₁
+  with if-just _ eq₁
+... | chk , s-eq
+  = subst (R-instr pre s (pi-skip guard count)) s-eq (r-pi-skip-active gt chk)
+
+preprocess-instr→R-instr _ s (ec-add a_x a_y b_x b_y) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a_x) eq
+... | ax , lax , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) a_y) eq₁
+... | ay , lay , eq₂
+  with >>=-just (mem-lookup (Preprocessed.memory s) b_x) eq₂
+... | bx , lbx , eq₃
+  with >>=-just (mem-lookup (Preprocessed.memory s) b_y) eq₃
+... | by , lby , eq₄
+  with >>=-just (ec-add-pts ax ay bx by) eq₄
+... | (cx , cy) , add-eq , eq₅ = from-just-R (r-ec-add lax lay lbx lby add-eq) eq₅
+
+preprocess-instr→R-instr _ s (ec-mul a_x a_y scalar) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a_x) eq
+... | ax , lax , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) a_y) eq₁
+... | ay , lay , eq₂
+  with >>=-just (mem-lookup (Preprocessed.memory s) scalar) eq₂
+... | sc , lsc , eq₃
+  with >>=-just (ec-mul-pt ax ay sc) eq₃
+... | (cx , cy) , mul-eq , eq₄ = from-just-R (r-ec-mul lax lay lsc mul-eq) eq₄
+
+preprocess-instr→R-instr _ s (ec-mul-generator scalar) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) scalar) eq
+... | sc , lsc , eq₁
+  = subst (R-instr _ s (ec-mul-generator scalar)) (just-injective eq₁) (r-ec-mul-generator lsc refl)
+
+preprocess-instr→R-instr _ s (hash-to-curve inputs) s' eq
+  with >>=-just (mem-lookups (Preprocessed.memory s) inputs) eq
+... | vs , lvs , eq₁
+  = subst (R-instr _ s (hash-to-curve inputs)) (just-injective eq₁) (r-hash-to-curve lvs refl)
+
+preprocess-instr→R-instr _ s (load-imm imm) s' eq = from-just-R r-load-imm eq
+
+preprocess-instr→R-instr _ s (div-mod-power-of-two var bits) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) var) eq
+... | v , lv , eq₁
+  with if-just (does (bits ≤? FR-STORED-BITS)) eq₁
+... | le , s-eq
+  = subst (R-instr _ s (div-mod-power-of-two var bits)) s-eq
+      (r-div-mod-power-of-two lv (≤ᵇ⇒≤ bits FR-STORED-BITS le))
+
+preprocess-instr→R-instr _ s (reconstitute-field divisor modulus bits) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) divisor) eq
+... | dv , ldv , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) modulus) eq₁
+... | mv , lmv , eq₂
+  with if-just (does (1 ≤? bits) ∧ does (bits ≤? FR-STORED-BITS) ∧
+                does (fits-in? mv bits) ∧ does (fits-in? dv (FR-BITS ∸ bits)) ∧
+                does (bitsInField? (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv)))) eq₂
+... | cond , s-eq
+  = let ge1b , r1 = Equivalence.to T-∧ cond
+        leb  , r2 = Equivalence.to T-∧ r1
+    in subst (R-instr _ s (reconstitute-field divisor modulus bits)) s-eq
+         (r-reconstitute-field ldv lmv (≤ᵇ⇒≤ 1 bits ge1b) (≤ᵇ⇒≤ bits FR-STORED-BITS leb)
+            (recon-guard→ mv dv bits r2))
+
+preprocess-instr→R-instr _ s (output var) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) var) eq
+... | v , lv , eq₁ = from-just-R (r-output lv) eq₁
+
+preprocess-instr→R-instr _ s (transient-hash inputs) s' eq
+  with >>=-just (mem-lookups (Preprocessed.memory s) inputs) eq
+... | vs , lvs , eq₁ = from-just-R (r-transient-hash lvs) eq₁
+
+preprocess-instr→R-instr _ s (persistent-hash alignment inputs) s' eq
+  with >>=-just (mem-lookups (Preprocessed.memory s) inputs) eq
+... | vs , lvs , eq₁
+  = subst (R-instr _ s (persistent-hash alignment inputs)) (just-injective eq₁) (r-persistent-hash lvs refl)
+
+preprocess-instr→R-instr _ s (test-eq a b) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a) eq
+... | av , la , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) b) eq₁
+... | bv , lb , eq₂ = from-just-R (r-test-eq la lb) eq₂
+
+preprocess-instr→R-instr _ s (add a b) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a) eq
+... | av , la , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) b) eq₁
+... | bv , lb , eq₂ = from-just-R (r-add la lb) eq₂
+
+preprocess-instr→R-instr _ s (mul a b) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a) eq
+... | av , la , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) b) eq₁
+... | bv , lb , eq₂ = from-just-R (r-mul la lb) eq₂
+
+preprocess-instr→R-instr _ s (neg a) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a) eq
+... | av , la , eq₁ = from-just-R (r-neg la) eq₁
+
+preprocess-instr→R-instr _ s (not a) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a >>= to-bool) eq
+... | b , lb , eq₁ = from-just-R (r-not lb) eq₁
+
+preprocess-instr→R-instr _ s (less-than a b bits) s' eq
+  with >>=-just (mem-lookup (Preprocessed.memory s) a) eq
+... | av , la , eq₁
+  with >>=-just (mem-lookup (Preprocessed.memory s) b) eq₁
+... | bv , lb , eq₂
+  with if-just (does (bits <? FR-BITS) ∧ does (fits-in? av bits) ∧ does (fits-in? bv bits)) eq₂
+... | guard , s-eq
+  = let bnd , fts = Equivalence.to T-∧ guard
+    in subst (R-instr _ s (less-than a b bits)) s-eq
+         (r-less-than la lb (<ᵇ⇒< bits FR-BITS bnd) (lt-guard→ av bv bits fts))
+
+preprocess-instr→R-instr _ s (public-input guard) s' eq
+  with >>=-just (eval-guard (Preprocessed.memory s) guard) eq
+... | false , gf , eq₁ = from-just-R (r-public-input-inactive gf) eq₁
+... | true  , gt , eq₁
+  with >>=-just (consume-pub-out s) eq₁
+... | (v , s₁) , cp , eq₂ = from-just-R (r-public-input-active gt cp) eq₂
+
+preprocess-instr→R-instr _ s (private-input guard) s' eq
+  with >>=-just (eval-guard (Preprocessed.memory s) guard) eq
+... | false , gf , eq₁ = from-just-R (r-private-input-inactive gf) eq₁
+... | true  , gt , eq₁
+  with >>=-just (consume-priv s) eq₁
+... | (v , s₁) , cp , eq₂ = from-just-R (r-private-input-active gt cp) eq₂
+
+
+-- Per-instruction: relational → computational
+
+R-instr→preprocess-instr : ∀ pre s i s'
+  → R-instr pre s i s' → preprocess-instr pre s i ≡ just s'
+R-instr→preprocess-instr _ s (assert cond) _ (r-assert la) rewrite la = refl
+R-instr→preprocess-instr _ s (cond-select bit a b) _ (r-cond-select lsel la lb) rewrite lsel | la | lb = refl
+R-instr→preprocess-instr _ s (constrain-bits var bits) _ (r-constrain-bits {v = v} lv bound fits)
+  rewrite lv | dec-true (bits <? FR-BITS) bound | fits-in?-true v bits fits = refl
+R-instr→preprocess-instr _ s (constrain-eq a b) _ (r-constrain-eq {av = av} {bv = bv} la lb eq)
+  rewrite la | lb | subst (λ z → (av ≡ᶠ? z) ≡ true) eq ≡ᶠ?-refl = refl
+R-instr→preprocess-instr _ s (constrain-to-boolean var) _ (r-constrain-to-boolean lb) rewrite lb = refl
+R-instr→preprocess-instr _ s (copy var) _ (r-copy lv) rewrite lv = refl
+R-instr→preprocess-instr _ s (declare-pub-input var) _ (r-declare-pub-input lv) rewrite lv = refl
+R-instr→preprocess-instr pre s (pi-skip guard count) _ (r-pi-skip-active gt chk)
+  rewrite gt | Equivalence.to T-≡ chk = refl
+R-instr→preprocess-instr pre s (pi-skip guard count) _ (r-pi-skip-inactive gf)   rewrite gf       = refl
+R-instr→preprocess-instr _ s (ec-add a_x a_y b_x b_y) _ (r-ec-add lax lay lbx lby add-eq)
+  rewrite lax | lay | lbx | lby | add-eq = refl
+R-instr→preprocess-instr _ s (ec-mul a_x a_y scalar) _ (r-ec-mul lax lay lsc mul-eq)
+  rewrite lax | lay | lsc | mul-eq = refl
+R-instr→preprocess-instr _ s (ec-mul-generator scalar) _ (r-ec-mul-generator lsc gen-eq)
+  rewrite lsc | gen-eq = refl
+R-instr→preprocess-instr _ s (hash-to-curve inputs) _ (r-hash-to-curve lvs htc-eq)
+  rewrite lvs | htc-eq = refl
+R-instr→preprocess-instr _ s (load-imm imm) _ r-load-imm = refl
+R-instr→preprocess-instr _ s (div-mod-power-of-two var bits) _ (r-div-mod-power-of-two lv le)
+  rewrite lv | dec-true (bits ≤? FR-STORED-BITS) le = refl
+R-instr→preprocess-instr _ s (reconstitute-field divisor modulus bits) _
+  (r-reconstitute-field {dv = dv} {mv = mv} ldv lmv ge1 le (fmv , fdv , inf))
+  rewrite ldv | lmv
+        | dec-true (1 ≤? bits) ge1
+        | dec-true (bits ≤? FR-STORED-BITS) le
+        | fits-in?-true mv bits fmv
+        | fits-in?-true dv (FR-BITS ∸ bits) fdv
+        | bitsInField?-true (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv)) inf = refl
+R-instr→preprocess-instr _ s (output var) _ (r-output lv) rewrite lv = refl
+R-instr→preprocess-instr _ s (transient-hash inputs) _ (r-transient-hash lvs) rewrite lvs = refl
+R-instr→preprocess-instr _ s (persistent-hash alignment inputs) _ (r-persistent-hash lvs ph-eq)
+  rewrite lvs | ph-eq = refl
+R-instr→preprocess-instr _ s (test-eq a b) _ (r-test-eq la lb) rewrite la | lb = refl
+R-instr→preprocess-instr _ s (add a b) _ (r-add la lb) rewrite la | lb = refl
+R-instr→preprocess-instr _ s (mul a b) _ (r-mul la lb) rewrite la | lb = refl
+R-instr→preprocess-instr _ s (neg a) _ (r-neg la) rewrite la = refl
+R-instr→preprocess-instr _ s (not a) _ (r-not lb) rewrite lb = refl
+R-instr→preprocess-instr _ s (less-than a b bits) _ (r-less-than {av = av} {bv = bv} la lb bound (fav , fbv))
+  rewrite la | lb | dec-true (bits <? FR-BITS) bound | fits-in?-true av bits fav | fits-in?-true bv bits fbv = refl
+R-instr→preprocess-instr _ s (public-input guard) _ (r-public-input-inactive gf) rewrite gf       = refl
+R-instr→preprocess-instr _ s (public-input guard) _ (r-public-input-active gt cp) rewrite gt | cp = refl
+R-instr→preprocess-instr _ s (private-input guard) _ (r-private-input-inactive gf) rewrite gf       = refl
+R-instr→preprocess-instr _ s (private-input guard) _ (r-private-input-active gt cp) rewrite gt | cp = refl
+
+
+-- Lift faithfulness from instructions to instruction sequences.
+
+preprocess-instrs→R-instrs : ∀ pre s is s'
+  → preprocess-instrs pre s is ≡ just s' → R-instrs pre s is s'
+preprocess-instrs→R-instrs _ s [] s' eq
+  = subst (R-instrs _ s []) (just-injective eq) r-done
+preprocess-instrs→R-instrs pre s (i ∷ is) s' eq
+  with >>=-just (preprocess-instr pre s i) eq
+... | s₁ , eq₁ , eq₂
+  = r-step (preprocess-instr→R-instr pre s i s₁ eq₁)
+           (preprocess-instrs→R-instrs pre s₁ is s' eq₂)
+
+R-instrs→preprocess-instrs : ∀ pre s is s'
+  → R-instrs pre s is s' → preprocess-instrs pre s is ≡ just s'
+R-instrs→preprocess-instrs _ _ [] _ r-done = refl
+R-instrs→preprocess-instrs pre s (i ∷ is) s' (r-step ri ris)
+  with R-instr→preprocess-instr pre s i _ ri
+... | eq₁ rewrite eq₁ = R-instrs→preprocess-instrs pre _ is s' ris
+
+-- Top-level faithfulness.
+
+preprocess→R : ∀ src pre s → preprocess src pre ≡ just s → R src pre s
+preprocess→R src pre s eq
+  with >>=-just (init-state src pre) eq
+... | s₀ , eq₀ , eq₁
+  with >>=-just (preprocess-instrs pre s₀ (IrSource.instructions src)) eq₁
+... | s' , eq₂ , eq₃
+  with if-just _ eq₃
+... | tc-co , s'-eq =
+  let tc , co = Equivalence.to T-∧ tc-co in
+    s₀ , eq₀ ,
+    subst (R-instrs pre s₀ (IrSource.instructions src)) s'-eq
+      (preprocess-instrs→R-instrs pre s₀ (IrSource.instructions src) s' eq₂) ,
+    subst (λ x → T (transcripts-consumed pre x)) s'-eq tc ,
+    subst (λ x → T (comm-ok src pre x)) s'-eq co
+
+R→preprocess : ∀ src pre s → R src pre s → preprocess src pre ≡ just s
+R→preprocess src pre s (s₀ , init-eq , ris , tc , co)
+  with R-instrs→preprocess-instrs pre s₀ (IrSource.instructions src) s ris
+... | instrs-eq
+  rewrite init-eq | instrs-eq | Equivalence.to T-≡ tc | Equivalence.to T-≡ co
+  = refl
+
+------------------------------------------------------------------------
+-- 4. Memory monotonicity (the `≤` form of P2)
+--
+-- A successful step, sequence, or run never shrinks the memory.  Each
+-- form follows from the exact `Δmem` accounting of section 2 (a step's
+-- post-length is its pre-length plus a nonnegative delta) composed with
+-- the faithfulness bridge of section 3.
+------------------------------------------------------------------------
+
+-- A successful step never shrinks the memory.
+preprocess-instr-mem-≤ : ∀ pre s i s'
+  → preprocess-instr pre s i ≡ just s'
+  → length (Preprocessed.memory s) ≤ length (Preprocessed.memory s')
+preprocess-instr-mem-≤ pre s i s' eq =
+  subst (length (Preprocessed.memory s) ≤_)
+    (sym (R-instr-Δmem (preprocess-instr→R-instr pre s i s' eq)))
+    (m≤m+n _ _)
+
+-- Executing a sequence of instructions does not shrink the memory.
+preprocess-instrs-mono : ∀ pre s is s'
+  → preprocess-instrs pre s is ≡ just s'
+  → length (Preprocessed.memory s) ≤ length (Preprocessed.memory s')
+preprocess-instrs-mono pre s is s' eq =
+  subst (length (Preprocessed.memory s) ≤_)
+    (sym (R-instrs-Δmem (preprocess-instrs→R-instrs pre s is s' eq)))
+    (m≤m+n _ _)
+
+-- A successful top-level preprocessing grows (or preserves) the memory.
+preprocess-memory-mono : ∀ src pre s
+  → preprocess src pre ≡ just s
+  → length (ProofPreimage.inputs pre) ≤ length (Preprocessed.memory s)
+preprocess-memory-mono src pre s eq =
+  let r = preprocess→R src pre s eq
+      (s₀ , init-eq , _) = r
+  in subst (_≤ length (Preprocessed.memory s))
+       (sym (init-state-num-inputs src pre s₀ init-eq))
+       (subst (IrSource.num-inputs src ≤_)
+         (sym (R-memory-length src pre s r))
+         (m≤m+n _ _))
+
+------------------------------------------------------------------------
+-- 5. Circuit correctness (Property P5, spec §6.2)
+--
+-- The Halo2 constraint-synthesis function `circuit` is faithful to the
+-- relational semantics `R`.
+--
+-- The faithful statement carries the following preconditions:
+--
+--   • producer-safety  `T (producer-safe src)`                  (§6.4)
+--   • input arity      `length (inputs pre) ≡ num-inputs src`    (§3.3, WF1)
+--   • bit bounds       `WF2 src`                                 (§3.3, WF2)
+--   • shape            `preprocess-shaped src pre s`             (§5.3)
+--
+-- and concludes the spec's biconditional as a logical equivalence
+-- (`_⇔_`):  `R src pre s ⇔ satisfies (circuit src) (witness-of s pre)`.
+--
+-- `circuit-faithful` is re-exported from `CircuitProof` (see the import
+-- list above); its full statement is:
+--
+--   circuit-faithful : ∀ src pre s
+--     → T (producer-safe src)
+--     → length (inputs pre) ≡ num-inputs src
+--     → WF2 src
+--     → preprocess-shaped src pre s
+--     → R src pre s ⇔ satisfies (circuit src) (witness-of s pre)
+------------------------------------------------------------------------
+
+------------------------------------------------------------------------
+-- 6. Well-formedness preservation (Property P4, spec §6.1)
+--
+-- The spec's P4 makes three claims about every reachable intermediate
+-- state of a preprocess run.  We mechanise all three over the relational
+-- trace `R-instrs` (equivalently `preprocess`, via section 3's bridge):
+--
+--   (a) in-bounds.    A successful step references only memory indices
+--                     `< |memory|` of its pre-state.  This is the
+--                     contrapositive of the spec's "… < |Σᵢ.M| — or the
+--                     transition fails": a step that does *not* fail
+--                     (i.e. `R-instr` relates it) has all its operand
+--                     indices in range.  (`R-instr→in-bounds`)
+--   (b) PI bound.     `pub-in-idx` never exceeds the number of
+--                     `declare-pub-input`s executed so far.
+--                     (`pub-idx-trace`; corollary `preprocess-pub-in-idx-bound`)
+--   (c) output count. `|outputs|` equals the number of `output`s executed
+--                     so far — the cardinality of the spec's bijection
+--                     between `Σ.ω` and the executed `Output`s.
+--                     (`out-trace`; corollary `preprocess-output-count`)
+--
+-- None of the three needs the §3.3 well-formedness hypotheses: they hold
+-- for every trace the semantics admits.  (Well-formedness is what makes
+-- such traces *exist* for honest producers; the invariants themselves are
+-- structural.)  The top-level corollaries specialise (b)/(c) to a full
+-- `preprocess` run, where the initial `pub-in-idx`/`outputs` are `0`/`[]`.
+------------------------------------------------------------------------
+
+-- A successful memory lookup proves its index is in range.
+mem-lookup-< : ∀ (mem : List Fr) idx {v}
+  → mem-lookup mem idx ≡ just v → idx < length mem
+mem-lookup-< (x ∷ _)  zero    _  = s≤s z≤n
+mem-lookup-< (_ ∷ xs) (suc n) eq = s≤s (mem-lookup-< xs n eq)
+mem-lookup-< []       _       ()
+
+-- Likewise for a lookup followed by a boolean coercion.
+lookup-bool-< : ∀ (mem : List Fr) idx {b}
+  → (mem-lookup mem idx >>= to-bool) ≡ just b → idx < length mem
+lookup-bool-< mem idx eq with >>=-just (mem-lookup mem idx) eq
+... | _ , lk , _ = mem-lookup-< mem idx lk
+
+-- A successful multi-lookup proves every index is in range.
+mem-lookups-all : ∀ (mem : List Fr) is {vs}
+  → mem-lookups mem is ≡ just vs → All (_< length mem) is
+mem-lookups-all _   []       _  = ⟨⟩
+mem-lookups-all mem (i ∷ is) eq with >>=-just (mem-lookup mem i) eq
+... | _ , lk , eq₁ with >>=-just (mem-lookups mem is) eq₁
+...   | _ , lks , _ = mem-lookup-< mem i lk ◂ mem-lookups-all mem is lks
+
+-- The memory indices a guard reads (empty guard reads nothing).
+idx-of : Maybe Index → List Index
+idx-of nothing  = []
+idx-of (just i) = i ∷ []
+
+eval-guard-all : ∀ (mem : List Fr) g {b}
+  → eval-guard mem g ≡ just b → All (_< length mem) (idx-of g)
+eval-guard-all _   nothing    _  = ⟨⟩
+eval-guard-all mem (just idx) eq = lookup-bool-< mem idx eq ◂ ⟨⟩
+
+-- The memory indices an instruction reads.
+refs : Instruction → List Index
+refs (assert cond)               = cond ∷ []
+refs (cond-select bit a b)       = bit ∷ a ∷ b ∷ []
+refs (constrain-bits var _)      = var ∷ []
+refs (constrain-eq a b)          = a ∷ b ∷ []
+refs (constrain-to-boolean var)  = var ∷ []
+refs (copy var)                  = var ∷ []
+refs (declare-pub-input var)     = var ∷ []
+refs (pi-skip guard _)           = idx-of guard
+refs (ec-add a_x a_y b_x b_y)    = a_x ∷ a_y ∷ b_x ∷ b_y ∷ []
+refs (ec-mul a_x a_y scalar)     = a_x ∷ a_y ∷ scalar ∷ []
+refs (ec-mul-generator scalar)   = scalar ∷ []
+refs (hash-to-curve inputs)      = inputs
+refs (load-imm _)                = []
+refs (div-mod-power-of-two var _) = var ∷ []
+refs (reconstitute-field d m _)  = d ∷ m ∷ []
+refs (output var)                = var ∷ []
+refs (transient-hash inputs)     = inputs
+refs (persistent-hash _ inputs)  = inputs
+refs (test-eq a b)               = a ∷ b ∷ []
+refs (add a b)                   = a ∷ b ∷ []
+refs (mul a b)                   = a ∷ b ∷ []
+refs (neg a)                     = a ∷ []
+refs (not a)                     = a ∷ []
+refs (less-than a b _)           = a ∷ b ∷ []
+refs (public-input guard)        = idx-of guard
+refs (private-input guard)       = idx-of guard
+
+-- P4(a): every index a non-failing step references is `< |memory|`.
+R-instr→in-bounds : ∀ {pre i s'} s → R-instr pre s i s'
+  → All (_< length (Preprocessed.memory s)) (refs i)
+R-instr→in-bounds s (r-assert p)                = lookup-bool-< M _ p ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-cond-select ps pa pb)    = lookup-bool-< M _ ps ◂ mem-lookup-< M _ pa ◂ mem-lookup-< M _ pb ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-constrain-bits lv _ _)   = mem-lookup-< M _ lv ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-constrain-eq la lb _)    = mem-lookup-< M _ la ◂ mem-lookup-< M _ lb ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-constrain-to-boolean lb) = lookup-bool-< M _ lb ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-copy lv)                 = mem-lookup-< M _ lv ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-declare-pub-input lv)    = mem-lookup-< M _ lv ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-pi-skip-active {guard = guard} g _) = eval-guard-all (Preprocessed.memory s) guard g
+R-instr→in-bounds s (r-pi-skip-inactive {guard = guard} g) = eval-guard-all (Preprocessed.memory s) guard g
+R-instr→in-bounds s (r-ec-add lax lay lbx lby _) = mem-lookup-< M _ lax ◂ mem-lookup-< M _ lay ◂ mem-lookup-< M _ lbx ◂ mem-lookup-< M _ lby ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-ec-mul lax lay lsc _)    = mem-lookup-< M _ lax ◂ mem-lookup-< M _ lay ◂ mem-lookup-< M _ lsc ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-ec-mul-generator lsc _)  = mem-lookup-< M _ lsc ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-hash-to-curve lvs _)     = mem-lookups-all (Preprocessed.memory s) _ lvs
+R-instr→in-bounds s r-load-imm                  = ⟨⟩
+R-instr→in-bounds s (r-div-mod-power-of-two lv _) = mem-lookup-< M _ lv ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-reconstitute-field ldv lmv _ _ _) = mem-lookup-< M _ ldv ◂ mem-lookup-< M _ lmv ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-output lv)               = mem-lookup-< M _ lv ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-transient-hash lvs)      = mem-lookups-all (Preprocessed.memory s) _ lvs
+R-instr→in-bounds s (r-persistent-hash lvs _)   = mem-lookups-all (Preprocessed.memory s) _ lvs
+R-instr→in-bounds s (r-test-eq la lb)           = mem-lookup-< M _ la ◂ mem-lookup-< M _ lb ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-add la lb)               = mem-lookup-< M _ la ◂ mem-lookup-< M _ lb ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-mul la lb)               = mem-lookup-< M _ la ◂ mem-lookup-< M _ lb ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-neg la)                  = mem-lookup-< M _ la ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-not lb)                  = lookup-bool-< M _ lb ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-less-than la lb _ _)     = mem-lookup-< M _ la ◂ mem-lookup-< M _ lb ◂ ⟨⟩  where M = Preprocessed.memory s
+R-instr→in-bounds s (r-public-input-inactive {guard = guard} g)  = eval-guard-all (Preprocessed.memory s) guard g
+R-instr→in-bounds s (r-public-input-active {guard = guard} g _)  = eval-guard-all (Preprocessed.memory s) guard g
+R-instr→in-bounds s (r-private-input-inactive {guard = guard} g) = eval-guard-all (Preprocessed.memory s) guard g
+R-instr→in-bounds s (r-private-input-active {guard = guard} g _) = eval-guard-all (Preprocessed.memory s) guard g
+
+------------------------------------------------------------------------
+-- P4(b): public-input-index bound.
+------------------------------------------------------------------------
+
+-- consume-pub-out / consume-priv preserve pub-in-idx and outputs.
+consume-pub-out-idx : ∀ s v s₁ → consume-pub-out s ≡ just (v , s₁)
+  → Preprocessed.pub-in-idx s₁ ≡ Preprocessed.pub-in-idx s
+consume-pub-out-idx s v s₁ eq with Preprocessed.pub-out-rem s | eq
+... | []    | ()
+... | _ ∷ _ | p = sym (cong Preprocessed.pub-in-idx (cong proj₂ (just-injective p)))
+
+consume-priv-idx : ∀ s v s₁ → consume-priv s ≡ just (v , s₁)
+  → Preprocessed.pub-in-idx s₁ ≡ Preprocessed.pub-in-idx s
+consume-priv-idx s v s₁ eq with Preprocessed.priv-rem s | eq
+... | []    | ()
+... | _ ∷ _ | p = sym (cong Preprocessed.pub-in-idx (cong proj₂ (just-injective p)))
+
+consume-pub-out-out : ∀ s v s₁ → consume-pub-out s ≡ just (v , s₁)
+  → Preprocessed.outputs s₁ ≡ Preprocessed.outputs s
+consume-pub-out-out s v s₁ eq with Preprocessed.pub-out-rem s | eq
+... | []    | ()
+... | _ ∷ _ | p = sym (cong Preprocessed.outputs (cong proj₂ (just-injective p)))
+
+consume-priv-out : ∀ s v s₁ → consume-priv s ≡ just (v , s₁)
+  → Preprocessed.outputs s₁ ≡ Preprocessed.outputs s
+consume-priv-out s v s₁ eq with Preprocessed.priv-rem s | eq
+... | []    | ()
+... | _ ∷ _ | p = sym (cong Preprocessed.outputs (cong proj₂ (just-injective p)))
+
+-- Rearrangement used by both trace folds: b + (a + c) ≡ (a + b) + c.
++-rearr : ∀ a b c → b + (a + c) ≡ (a + b) + c
++-rearr a b c = trans (sym (+-assoc b a c)) (cong (_+ c) (+-comm b a))
+
+-- How much each instruction can advance pub-in-idx (only DeclarePubInput).
+declare-count : Instruction → ℕ
+declare-count (declare-pub-input _) = 1
+declare-count _                     = 0
+
+count-declares : List Instruction → ℕ
+count-declares []       = 0
+count-declares (i ∷ is) = declare-count i + count-declares is
+
+-- Per step: pub-in-idx grows by at most `declare-count i` (PiSkip may
+-- shrink it; everything but DeclarePubInput leaves it untouched).
+pub-idx-step : ∀ {pre s i s'} → R-instr pre s i s'
+  → Preprocessed.pub-in-idx s' ≤ declare-count i + Preprocessed.pub-in-idx s
+pub-idx-step (r-assert _)                 = ≤-refl
+pub-idx-step (r-cond-select _ _ _)        = ≤-refl
+pub-idx-step (r-constrain-bits _ _ _)       = ≤-refl
+pub-idx-step (r-constrain-eq _ _ _)       = ≤-refl
+pub-idx-step (r-constrain-to-boolean _)   = ≤-refl
+pub-idx-step (r-copy _)                   = ≤-refl
+pub-idx-step (r-declare-pub-input _)      = ≤-refl
+pub-idx-step (r-pi-skip-active _ _)       = ≤-refl
+pub-idx-step (r-pi-skip-inactive {s = s} {count = count} _) = m∸n≤m (Preprocessed.pub-in-idx s) count
+pub-idx-step (r-ec-add _ _ _ _ _)         = ≤-refl
+pub-idx-step (r-ec-mul _ _ _ _)           = ≤-refl
+pub-idx-step (r-ec-mul-generator _ _)     = ≤-refl
+pub-idx-step (r-hash-to-curve _ _)        = ≤-refl
+pub-idx-step r-load-imm                   = ≤-refl
+pub-idx-step (r-div-mod-power-of-two _ _)   = ≤-refl
+pub-idx-step (r-reconstitute-field _ _ _ _ _) = ≤-refl
+pub-idx-step (r-output _)                 = ≤-refl
+pub-idx-step (r-transient-hash _)         = ≤-refl
+pub-idx-step (r-persistent-hash _ _)      = ≤-refl
+pub-idx-step (r-test-eq _ _)              = ≤-refl
+pub-idx-step (r-add _ _)                  = ≤-refl
+pub-idx-step (r-mul _ _)                  = ≤-refl
+pub-idx-step (r-neg _)                    = ≤-refl
+pub-idx-step (r-not _)                    = ≤-refl
+pub-idx-step (r-less-than _ _ _ _)          = ≤-refl
+pub-idx-step (r-public-input-inactive _)  = ≤-refl
+pub-idx-step (r-public-input-active _ cp) = ≤-reflexive (consume-pub-out-idx _ _ _ cp)
+pub-idx-step (r-private-input-inactive _) = ≤-refl
+pub-idx-step (r-private-input-active _ cp) = ≤-reflexive (consume-priv-idx _ _ _ cp)
+
+-- Over a whole trace: pub-in-idx ≤ #DeclarePubInputs executed (+ initial).
+pub-idx-trace : ∀ {pre s₀ is s} → R-instrs pre s₀ is s
+  → Preprocessed.pub-in-idx s ≤ count-declares is + Preprocessed.pub-in-idx s₀
+pub-idx-trace r-done = ≤-refl
+pub-idx-trace {s₀ = s₀} (r-step {s₁ = s₁} {i = i} {is = is} ri ris) =
+  ≤-trans (pub-idx-trace ris)
+    (≤-trans (+-monoʳ-≤ (count-declares is) (pub-idx-step ri))
+             (≤-reflexive (+-rearr (declare-count i) (count-declares is) (Preprocessed.pub-in-idx s₀))))
+
+------------------------------------------------------------------------
+-- P4(c): output count.
+------------------------------------------------------------------------
+
+output-count : Instruction → ℕ
+output-count (output _) = 1
+output-count _          = 0
+
+count-outputs : List Instruction → ℕ
+count-outputs []       = 0
+count-outputs (i ∷ is) = output-count i + count-outputs is
+
+-- Per step: |outputs| grows by exactly `output-count i`.
+out-step : ∀ {pre s i s'} → R-instr pre s i s'
+  → length (Preprocessed.outputs s') ≡ output-count i + length (Preprocessed.outputs s)
+out-step (r-assert _)                 = refl
+out-step (r-cond-select _ _ _)        = refl
+out-step (r-constrain-bits _ _ _)       = refl
+out-step (r-constrain-eq _ _ _)       = refl
+out-step (r-constrain-to-boolean _)   = refl
+out-step (r-copy _)                   = refl
+out-step (r-declare-pub-input _)      = refl
+out-step (r-pi-skip-active _ _)       = refl
+out-step (r-pi-skip-inactive _)       = refl
+out-step (r-ec-add _ _ _ _ _)         = refl
+out-step (r-ec-mul _ _ _ _)           = refl
+out-step (r-ec-mul-generator _ _)     = refl
+out-step (r-hash-to-curve _ _)        = refl
+out-step r-load-imm                   = refl
+out-step (r-div-mod-power-of-two _ _)   = refl
+out-step (r-reconstitute-field _ _ _ _ _) = refl
+out-step (r-output {s = s} _)         = trans (length-++ (Preprocessed.outputs s))
+                                              (+-comm (length (Preprocessed.outputs s)) 1)
+out-step (r-transient-hash _)         = refl
+out-step (r-persistent-hash _ _)      = refl
+out-step (r-test-eq _ _)              = refl
+out-step (r-add _ _)                  = refl
+out-step (r-mul _ _)                  = refl
+out-step (r-neg _)                    = refl
+out-step (r-not _)                    = refl
+out-step (r-less-than _ _ _ _)          = refl
+out-step (r-public-input-inactive _)  = refl
+out-step (r-public-input-active _ cp) = cong length (consume-pub-out-out _ _ _ cp)
+out-step (r-private-input-inactive _) = refl
+out-step (r-private-input-active _ cp) = cong length (consume-priv-out _ _ _ cp)
+
+-- Over a whole trace: |outputs| = #Outputs executed (+ initial).
+out-trace : ∀ {pre s₀ is s} → R-instrs pre s₀ is s
+  → length (Preprocessed.outputs s) ≡ count-outputs is + length (Preprocessed.outputs s₀)
+out-trace r-done = refl
+out-trace {s₀ = s₀} (r-step {s₁ = s₁} {i = i} {is = is} ri ris) =
+  trans (out-trace ris)
+    (trans (cong (count-outputs is +_) (out-step ri))
+           (+-rearr (output-count i) (count-outputs is) (length (Preprocessed.outputs s₀))))
+
+------------------------------------------------------------------------
+-- Top-level corollaries over a full `preprocess` run.
+------------------------------------------------------------------------
+
+-- P4(b): a successful preprocess has pub-in-idx ≤ #DeclarePubInputs.
+preprocess-pub-in-idx-bound : ∀ src pre s
+  → preprocess src pre ≡ just s
+  → Preprocessed.pub-in-idx s ≤ count-declares (IrSource.instructions src)
+preprocess-pub-in-idx-bound src pre s eq
+  with preprocess→R src pre s eq
+... | s₀ , init-eq , ris , _ , _ =
+  ≤-trans
+    (subst (λ n → Preprocessed.pub-in-idx s ≤ count-declares (IrSource.instructions src) + n)
+           (init-state-pub-in-idx src pre s₀ init-eq)
+           (pub-idx-trace ris))
+    (≤-reflexive (+-identityʳ (count-declares (IrSource.instructions src))))
+
+-- P4(c): a successful preprocess records exactly #Outputs values.
+preprocess-output-count : ∀ src pre s
+  → preprocess src pre ≡ just s
+  → length (Preprocessed.outputs s) ≡ count-outputs (IrSource.instructions src)
+preprocess-output-count src pre s eq
+  with preprocess→R src pre s eq
+... | s₀ , init-eq , ris , _ , _ =
+  trans (out-trace ris)
+    (trans (cong (count-outputs (IrSource.instructions src) +_)
+                 (cong length (init-state-outputs src pre s₀ init-eq)))
+           (+-identityʳ (count-outputs (IrSource.instructions src))))

--- a/formal/src/zkir-v2/README.md
+++ b/formal/src/zkir-v2/README.md
@@ -1,0 +1,131 @@
+# ZKIR v2 — Agda formalization
+
+This directory contains the Agda mechanization of **ZKIR major version 2**
+(minor version V1, the current default lowering). It formalizes the abstract
+syntax of the IR, its two semantics — the *preprocess* (witness-generation)
+semantics and the Halo2 PLONKish *circuit* semantics — and the central
+correctness theorem connecting them, together with the producer obligations
+(spec §6.4): checkable circuit well-formedness conditions that guarantee
+the two semantics coincide.
+
+The companion textual specification is [`docs/zkir-v2-spec.md`](../../docs/zkir-v2-spec.md);
+section references below (e.g. §5.2, §6.2) point into it. The ultimate
+source of truth is the Rust implementation referenced from that spec.
+
+## Headline result
+
+The development discharges **P5** (spec §6.2): *circuit faithfulness*. For a
+*producer-safe* (spec §6.4) source with the WF1/WF2 well-formedness bounds
+(spec §3.3), and for every *preprocess-shaped* state `s`, the operational
+relation `R src pre s` holds **iff** the synthesized circuit is satisfied by
+the canonical witness:
+
+```
+R src pre s  ⇔  satisfies (circuit src) (witness-of s pre)
+```
+
+The `preprocess-shaped` hypothesis restricts `s` to states with the arity
+shape of a run: `public_input`/`private_input` emit no constraint pinning
+their output wire (spec §5.2), so satisfaction alone cannot see transcript
+reads. It pins only suffix *arities*, never computed values, so `satisfies`
+remains load-bearing; all four hypotheses constrain only the backward
+direction and hold automatically for any state arising from `R`.
+
+This was previously a postulate in the spec; it is now fully mechanized
+(`circuit-faithful` in [`CircuitProof.agda`](CircuitProof.agda), re-exported
+from [`Properties.agda`](Properties.agda)). No axioms are introduced by the
+proof itself — it rests only on the cryptographic trust base collected in
+the [`Assumptions`](Assumptions.agda) record described below.
+
+On top of P5 the development proves **statement soundness**
+(`circuit-statement-sound` in
+[`StatementSoundness.agda`](StatementSoundness.agda)): P5 speaks only about
+the *canonical* witness of a given run, while statement soundness is the
+universal direction — for a producer-safe source, **every** satisfying
+witness of the synthesized circuit is the
+canonical witness of some genuine preprocess run:
+
+```
+satisfies (circuit src) w  →  Realizer src w
+```
+
+where `Realizer src w` is a record packaging a run `(pre , s)` together
+with the proofs `R src pre s` and `witness-of s pre ≡ w`.
+
+Two refinements complete the picture. `circuit-witness-characterization`
+(same module) combines this with P5's forward direction into an *iff*: the
+satisfying witnesses are **exactly** the
+canonical witnesses of preprocess runs. And **extraction uniqueness**
+(`circuit-statement-unique` in
+[`StatementUniqueness.agda`](StatementUniqueness.agda)) shows the realizing
+run is *unique* — for commitment-well-shaped preimages (`CommWF`; when the
+commitment flag is off, a vestigial `comm-commitment` is invisible to the
+semantics, so it must be excluded) — making the extractor a function of the
+witness (`circuit-statement-sound-unique`: exactly one `CommWFRealizer`,
+the `Realizer` record extended with the `CommWF` proof).
+
+The development contains **no `postulate`s**: the trust base is a structured
+record taken as a module parameter, so every module type-checks under Agda's
+`--safe` flag.
+
+## Modules
+
+Import [`Main.agda`](Main.agda) to type-check the entire development at once.
+Every module takes the [`Assumptions`](Assumptions.agda) record as a module
+parameter (`module M (⋯ : _) (open Assumptions ⋯) where`), so `Assumptions`
+sits at the root of the dependency layering:
+
+```
+Assumptions → FieldProperties → Syntax → { Semantics → Circuit, Obligations }
+FieldProperties → Encoding            (consumed by the proof modules)
+Semantics → SemanticsLemmas           (consumed by the proof modules)
+Circuit → CircuitFaithfulness → CircuitProof → { Properties, StatementSoundness }
+Obligations → ObligationsSoundness → { CircuitProof, StatementSoundness }
+{ Properties, StatementSoundness } → StatementUniqueness
+```
+
+| Module | Contents |
+| --- | --- |
+| [`Assumptions.agda`](Assumptions.agda) | The entire trust base as one record: carrier types (`Fr`, `Alignment`), field/curve/hash/commitment operations, derived helpers (`to-bool`, `fits-in`, `bits-lt`, `pow2-fr`, `lt-bits`), and the field's prime-order valuation laws + the LE encoding round-trip law (the higher-level bit-arithmetic identities are *derived* here, not assumed). Downstream modules take it as a parameter; nothing is `postulate`d. |
+| [`FieldProperties.agda`](FieldProperties.agda) | Derived field/bit helpers — the boolean equality test `_≡ᶠ?_` and its reflection laws, `to-bool`, the `Fits-in`/`NoWrap` predicates, `bits-lt`, `pow2-fr`, the padded bit-count `lt-bits`, and the pure LE bit-value machinery (`bits-to-ℕ` splits and bounds). Everything here is a consequence of the `Assumptions` operations. |
+| [`Encoding.agda`](Encoding.agda) | Consequences of the encoding/valuation axioms: the operational characterization of `to-bool`, the `fits-from-le-bits-*` truncation facts, and the bit-arithmetic identities (`bits-decomp-split`, `reconstitute-no-overflow`, `bits-lt-pad`, `div-mod-constraint-unique`, …) the faithfulness and soundness proofs consume. |
+| [`Syntax.agda`](Syntax.agda) | Abstract syntax (spec §3): the 26-variant `Instruction` datatype, `Index` operands, IR minor versions, and an `IrSource`. Mirrors the Rust `ir.rs` in source order. |
+| [`Semantics.agda`](Semantics.agda) | Preprocess / operational semantics (spec §4): the small-step relation over the witness-population state. The field, Jubjub-curve, hashing, and commitment operations come from the `Assumptions` parameter. |
+| [`SemanticsLemmas.agda`](SemanticsLemmas.agda) | Inversion and framing principles for the `Semantics` definitions: `mem-lookup` stability under memory extension, inversion of the transcript consumers (`consume-pub-out`/`consume-priv`), and the `init-state` inversion record (`InitInv`). The single home for this lemma layer; the proof modules import it rather than re-proving these facts privately. |
+| [`Properties.agda`](Properties.agda) | Top-level correctness properties (spec §6). Re-exports `circuit-faithful` (P5) and bundles the spec's stated guarantees. |
+| [`Circuit.agda`](Circuit.agda) | Halo2 PLONKish circuit semantics (spec §5). Defines `Constraint`/`Circuit`, the deterministic synthesis function `circuit` (§5.2 emission contracts), the `Witness` assignment model, and the `satisfies` relation. Chip behaviour is interpreted via the same canonical functions used by the preprocess semantics. |
+| [`CircuitFaithfulness.agda`](CircuitFaithfulness.agda) | Per-instruction faithfulness lemmas: forward and backward bridging between `R-instr` and the emitted constraints, instruction by instruction. |
+| [`CircuitProof.agda`](CircuitProof.agda) | Program-level induction that assembles the per-instruction lemmas into the full `circuit-faithful` equivalence. Contains no postulates. |
+| [`Obligations.agda`](Obligations.agda) | Producer obligations (spec §6.4) as linear-scan checker functions: O0 (operand-index discipline, `wire-disc`), O1 (PiSkip discipline), O2 (Boolean-UB freedom), O3 (ReconstituteField / no field overflow). `producer-safe` is their four-way conjunction. |
+| [`ObligationsSoundness.agda`](ObligationsSoundness.agda) | Soundness of the obligation checkers: connects the static scans (`O2`/`O3`) to the dynamic relational semantics, by induction along the `R-instrs` trace. Feeds the backward bridging proofs. |
+| [`StatementSoundness.agda`](StatementSoundness.agda) | Statement soundness (`circuit-statement-sound`): every satisfying witness of `circuit src` is *realizable* — it is the canonical witness `witness-of s pre` of a genuine preprocess run, for every producer-safe source. The universal property P5 lacks; builds the realizing run from the witness and closes via P5's backward direction. Also `circuit-witness-characterization`: with P5's forward direction, the satisfying witnesses are *exactly* the canonical run witnesses. |
+| [`StatementUniqueness.agda`](StatementUniqueness.agda) | Extraction uniqueness (`circuit-statement-unique`): two commitment-well-shaped (`CommWF`) preimage/state pairs realizing the same witness are equal — a parallel induction over the two `R-instrs` traces, anchored on the common final memory/pis, pins every preimage field (the verifier transcript via O1's full bracketing). `circuit-statement-sound-unique` packages existence + uniqueness: exactly one `CommWF` realizer per satisfying witness (with flag-respecting `comm-rand`). |
+| [`Main.agda`](Main.agda) | Aggregator that imports every module above; type-checking it verifies the whole development. |
+
+## Trust base (`Assumptions`)
+
+The mechanization is parametric in the underlying cryptography. Rather than
+`postulate`s, the trust base is a single structured record,
+[`Assumptions`](Assumptions.agda), threaded through every module as a
+parameter. It collects:
+
+- field types and arithmetic over the BLS12-381 scalar field `Fr`,
+- bit decomposition and in-field range predicates,
+- Jubjub elliptic-curve operations,
+- the Poseidon / persistent hash and commitment functions,
+- byte-`Alignment` descriptors,
+- the field's prime-order (ℤ/|Fr|) valuation laws and the canonical
+  little-endian encoding round-trip law (from which the higher-level
+  bit-arithmetic identities — reconstitution, range/`fits` monotonicity,
+  quotient/remainder splitting, padded comparison — are *derived*, not
+  assumed).
+
+No concrete instantiation of `Assumptions` is provided yet; the development
+is intentionally abstract over this interface. Because nothing is
+`postulate`d, the whole development type-checks under `--safe`. All other
+results — including P5 — are proved, not assumed.
+
+## Type-checking
+
+See [`../README.md`](../README.md) for the toolchain and commands; checking
+[`Main.agda`](Main.agda) verifies the entire `--safe` development.

--- a/formal/src/zkir-v2/Semantics.agda
+++ b/formal/src/zkir-v2/Semantics.agda
@@ -1,0 +1,624 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.Semantics (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v2.FieldProperties ⋯
+open import zkir-v2.Syntax ⋯
+
+open import Data.Bool    using (Bool; true; false; if_then_else_; _∧_; T)
+import Data.Bool as Bool
+open import Data.List    using (List; []; _∷_; _++_; length; drop; take)
+open import Data.Maybe   using (Maybe; nothing; just; _>>=_)
+open import Data.Product using (_×_; _,_; ∃)
+open import Data.Unit     using (⊤; tt)
+open import Data.List.Relation.Unary.All using (All)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+open import Relation.Nullary.Decidable using (does)
+open import Data.Nat        using (ℕ; zero; suc; _∸_; _≡ᵇ_; _+_; _*_;
+                                   _<_; _≤_; _<?_; _≤?_)
+open import Data.Nat.DivMod using (_/_)
+
+------------------------------------------------------------------------
+-- Field and curve operations come from the `Assumptions` parameter; the
+-- bit/boolean helpers (`to-bool`, `fits-in?`/`Fits-in`, `bits-lt`, …)
+-- are *derived* from them in `FieldProperties`, not assumed.
+------------------------------------------------------------------------
+
+------------------------------------------------------------------------
+-- Utilities
+------------------------------------------------------------------------
+
+-- `from-bool` is exported because `R-instr` constructor types
+-- (`r-test-eq`, `r-not`, `r-less-than`, …) refer to it; downstream
+-- modules need to refer to the *same* function in their proofs.
+from-bool : Bool → Fr
+from-bool false = 0ᶠ
+from-bool true  = 1ᶠ
+
+------------------------------------------------------------------------
+-- Bit-bound constants
+--
+-- The byte width of a canonically-stored field element, derived from
+-- `FR-BITS` exactly as in the Rust runtime (`transient_crypto::curve`):
+--   FR_BYTES        = ⌈FR_BITS / 8⌉            (= FR_BITS.div_ceil(8))
+--   FR_BYTES_STORED = FR_BYTES − 1
+-- `FR-STORED-BITS = FR_BYTES_STORED · 8` is the bit ceiling that
+-- `div-mod-power-of-two` and `reconstitute-field` must not exceed
+-- (248 bits for BLS12-381).  No new assumption is needed: the bound is
+-- a function of the existing `FR-BITS`.
+------------------------------------------------------------------------
+
+FR-BYTES : ℕ
+FR-BYTES = (FR-BITS + 7) / 8
+
+FR-BYTES-STORED : ℕ
+FR-BYTES-STORED = FR-BYTES ∸ 1
+
+FR-STORED-BITS : ℕ
+FR-STORED-BITS = FR-BYTES-STORED * 8
+
+private
+  is-empty : {A : Set} → List A → Bool
+  is-empty []      = true
+  is-empty (_ ∷ _) = false
+
+-- Element-wise Fr equality on lists.  Exposed (not private) because
+-- the backward dispatcher D1 for `pi-skip` references it inside the
+-- operational side-data ADT `op-side-data` (CircuitProof.agda), for
+-- the same reason `from-bool` above is exposed.
+_≡ᶠ-list?_ : List Fr → List Fr → Bool
+[]       ≡ᶠ-list? []       = true
+(x ∷ xs) ≡ᶠ-list? (y ∷ ys) = x ≡ᶠ? y ∧ xs ≡ᶠ-list? ys
+_        ≡ᶠ-list? _        = false
+
+mem-lookup : List Fr → Index → Maybe Fr
+mem-lookup []       _       = nothing
+mem-lookup (x ∷ _)  zero    = just x
+mem-lookup (_ ∷ xs) (suc n) = mem-lookup xs n
+
+mem-lookups : List Fr → List Index → Maybe (List Fr)
+mem-lookups _   []       = just []
+mem-lookups mem (i ∷ is) =
+  mem-lookup mem i  >>= λ v  →
+  mem-lookups mem is >>= λ vs →
+  just (v ∷ vs)
+
+------------------------------------------------------------------------
+-- Proof preimage
+-- Mirrors ProofPreimage in transient_crypto::proofs
+------------------------------------------------------------------------
+
+record ProofPreimage : Set where
+  constructor mk-preimage
+  field
+    inputs                 : List Fr
+    binding-input          : Fr
+    comm-commitment        : Maybe (Fr × Fr)  -- (commitment, randomness)
+    pub-transcript-inputs  : List Fr
+    pub-transcript-outputs : List Fr
+    priv-transcript        : List Fr
+
+------------------------------------------------------------------------
+-- Execution state
+------------------------------------------------------------------------
+
+record Preprocessed : Set where
+  constructor mk-state
+  field
+    memory      : List Fr
+    pis         : List Fr         -- public inputs: binding-input first, then
+                                  --   DeclarePubInput values
+    pi-skips    : List (Maybe ℕ)  -- nothing = active group, just n = skipped
+    pub-in-idx  : ℕ               -- count of DeclarePubInput processed
+    pub-out-rem : List Fr         -- remaining pub-transcript-outputs
+    priv-rem    : List Fr         -- remaining priv-transcript
+    outputs     : List Fr         -- values written by Output instructions
+
+------------------------------------------------------------------------
+-- Initial state from preimage
+-- Fails if do-communications-commitment is set but no commitment is provided.
+------------------------------------------------------------------------
+
+-- Spec §4.2:  fail if |inputs| ≠ num-inputs (WF1 enforcement)
+-- or if do-comm is set but the preimage carries no commitment.
+init-state : IrSource → ProofPreimage → Maybe Preprocessed
+init-state src pre
+  with length (ProofPreimage.inputs pre) ≡ᵇ IrSource.num-inputs src
+     | IrSource.do-communications-commitment src
+     | ProofPreimage.comm-commitment pre
+... | false | _     | _            = nothing
+... | true  | false | _            = just (mk-state
+      (ProofPreimage.inputs pre)
+      (ProofPreimage.binding-input pre ∷ [])
+      [] 0
+      (ProofPreimage.pub-transcript-outputs pre)
+      (ProofPreimage.priv-transcript pre)
+      [])
+... | true  | true  | just (c , _) = just (mk-state
+      (ProofPreimage.inputs pre)
+      (ProofPreimage.binding-input pre ∷ c ∷ [])
+      [] 0
+      (ProofPreimage.pub-transcript-outputs pre)
+      (ProofPreimage.priv-transcript pre)
+      [])
+... | true  | true  | nothing      = nothing
+
+------------------------------------------------------------------------
+-- State helpers
+------------------------------------------------------------------------
+
+push-mem : Preprocessed → Fr → Preprocessed
+push-mem s v = record s { memory = Preprocessed.memory s ++ (v ∷ []) }
+
+push-mem2 : Preprocessed → Fr → Fr → Preprocessed
+push-mem2 s v₁ v₂ = record s { memory = Preprocessed.memory s ++ (v₁ ∷ v₂ ∷ []) }
+
+consume-pub-out : Preprocessed → Maybe (Fr × Preprocessed)
+consume-pub-out s with Preprocessed.pub-out-rem s
+... | []       = nothing
+... | v ∷ rest = just (v , record s { pub-out-rem = rest })
+
+consume-priv : Preprocessed → Maybe (Fr × Preprocessed)
+consume-priv s with Preprocessed.priv-rem s
+... | []       = nothing
+... | v ∷ rest = just (v , record s { priv-rem = rest })
+
+private
+  push-pi : Preprocessed → Fr → Preprocessed
+  push-pi s v = record s
+    { pis        = Preprocessed.pis s ++ (v ∷ [])
+    ; pub-in-idx = suc (Preprocessed.pub-in-idx s) }
+
+  push-skip : Preprocessed → Maybe ℕ → Preprocessed
+  push-skip s sk = record s { pi-skips = Preprocessed.pi-skips s ++ (sk ∷ []) }
+
+  push-output : Preprocessed → Fr → Preprocessed
+  push-output s v = record s { outputs = Preprocessed.outputs s ++ (v ∷ []) }
+
+------------------------------------------------------------------------
+-- Guard evaluation
+-- nothing  → always active (true)
+-- just idx → evaluate memory[idx] as a boolean
+------------------------------------------------------------------------
+
+eval-guard : List Fr → Maybe Index → Maybe Bool
+eval-guard _   nothing    = just true
+eval-guard mem (just idx) = mem-lookup mem idx >>= to-bool
+
+------------------------------------------------------------------------
+-- PiSkip
+--
+-- Active guard (true): validate the last `count` declared pub inputs
+--   match the corresponding entries in the pub-transcript-inputs, then
+--   record nothing (group is live).
+-- Inactive guard (false): decrement pub-in-idx by count and record
+--   just count (group is skipped).
+------------------------------------------------------------------------
+
+private
+  preprocess-pi-skip : ProofPreimage → Preprocessed → Maybe Index → ℕ → Maybe Preprocessed
+  preprocess-pi-skip pre s guard count =
+    eval-guard (Preprocessed.memory s) guard >>= λ active →
+    if active then validate else skip
+    where
+      validate : Maybe Preprocessed
+      validate =
+        let
+          pis      = Preprocessed.pis s
+          recent   = drop (length pis ∸ count) pis
+          start    = Preprocessed.pub-in-idx s ∸ count
+          expected = take count (drop start (ProofPreimage.pub-transcript-inputs pre))
+        in
+        if recent ≡ᶠ-list? expected
+          then just (push-skip s nothing)
+          else nothing
+
+      skip : Maybe Preprocessed
+      skip = just (push-skip
+        (record s { pub-in-idx = Preprocessed.pub-in-idx s ∸ count })
+        (just count))
+
+------------------------------------------------------------------------
+-- Single-instruction preprocessing
+-- Returns nothing on out-of-bounds access, UB, or constraint failure.
+------------------------------------------------------------------------
+
+preprocess-instr : ProofPreimage → Preprocessed → Instruction → Maybe Preprocessed
+
+preprocess-instr _ s (assert cond) =
+  mem-lookup (Preprocessed.memory s) cond >>= to-bool >>= λ b →
+  if b then just s else nothing
+
+preprocess-instr _ s (cond-select bit a b) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem bit >>= to-bool >>= λ bv →
+  mem-lookup mem a   >>= λ av   →
+  mem-lookup mem b   >>= λ bv'  →
+  just (push-mem s (if bv then av else bv'))
+
+preprocess-instr _ s (constrain-bits var bits) =
+  mem-lookup (Preprocessed.memory s) var >>= λ v →
+  if does (bits <? FR-BITS) ∧ does (fits-in? v bits) then just s else nothing
+
+preprocess-instr _ s (constrain-eq a b) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem a >>= λ av →
+  mem-lookup mem b >>= λ bv →
+  if av ≡ᶠ? bv then just s else nothing
+
+preprocess-instr _ s (constrain-to-boolean var) =
+  mem-lookup (Preprocessed.memory s) var >>= to-bool >>= λ _ →
+  just s
+
+preprocess-instr _ s (copy var) =
+  mem-lookup (Preprocessed.memory s) var >>= λ v →
+  just (push-mem s v)
+
+preprocess-instr _ s (declare-pub-input var) =
+  mem-lookup (Preprocessed.memory s) var >>= λ v →
+  just (push-pi s v)
+
+preprocess-instr pre s (pi-skip guard count) =
+  preprocess-pi-skip pre s guard count
+
+preprocess-instr _ s (ec-add a_x a_y b_x b_y) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem a_x >>= λ ax →
+  mem-lookup mem a_y >>= λ ay →
+  mem-lookup mem b_x >>= λ bx →
+  mem-lookup mem b_y >>= λ by →
+  ec-add-pts ax ay bx by >>= λ { (cx , cy) →
+  just (push-mem2 s cx cy) }
+
+preprocess-instr _ s (ec-mul a_x a_y scalar) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem a_x    >>= λ ax →
+  mem-lookup mem a_y    >>= λ ay →
+  mem-lookup mem scalar >>= λ sc →
+  ec-mul-pt ax ay sc >>= λ { (cx , cy) →
+  just (push-mem2 s cx cy) }
+
+preprocess-instr _ s (ec-mul-generator scalar) =
+  mem-lookup (Preprocessed.memory s) scalar >>= λ sc →
+  let (cx , cy) = ec-mul-gen sc in
+  just (push-mem2 s cx cy)
+
+preprocess-instr _ s (hash-to-curve inputs) =
+  mem-lookups (Preprocessed.memory s) inputs >>= λ vs →
+  let (cx , cy) = hash-to-curve-fn vs in
+  just (push-mem2 s cx cy)
+
+preprocess-instr _ s (load-imm imm) =
+  just (push-mem s imm)
+
+preprocess-instr _ s (div-mod-power-of-two var bits) =
+  mem-lookup (Preprocessed.memory s) var >>= λ v →
+  let
+    all-bits = to-le-bits v
+    divisor  = from-le-bits (drop bits all-bits)
+    modulus  = from-le-bits (take bits all-bits)
+  in
+  if does (bits ≤? FR-STORED-BITS)
+    then just (push-mem (push-mem s divisor) modulus)
+    else nothing
+
+preprocess-instr _ s (persistent-hash alignment inputs) =
+  mem-lookups (Preprocessed.memory s) inputs >>= λ vs →
+  let (h₁ , h₂) = persistent-hash-fn alignment vs in
+  just (push-mem2 s h₁ h₂)
+
+preprocess-instr _ s (reconstitute-field divisor modulus bits) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem divisor >>= λ dv →
+  mem-lookup mem modulus >>= λ mv →
+  let
+    mv-bits  = take bits             (to-le-bits mv)
+    dv-bits  = take (FR-BITS ∸ bits) (to-le-bits dv)
+    all-bits = mv-bits ++ dv-bits
+  in
+  if does (1 ≤? bits) ∧ does (bits ≤? FR-STORED-BITS) ∧
+     does (fits-in? mv bits) ∧ does (fits-in? dv (FR-BITS ∸ bits)) ∧ does (bitsInField? all-bits)
+    then just (push-mem s (from-le-bits all-bits))
+    else nothing
+
+preprocess-instr _ s (output var) =
+  mem-lookup (Preprocessed.memory s) var >>= λ v →
+  just (push-output s v)
+
+preprocess-instr _ s (transient-hash inputs) =
+  mem-lookups (Preprocessed.memory s) inputs >>= λ vs →
+  just (push-mem s (transient-hash-fn vs))
+
+preprocess-instr _ s (test-eq a b) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem a >>= λ av →
+  mem-lookup mem b >>= λ bv →
+  just (push-mem s (from-bool (av ≡ᶠ? bv)))
+
+preprocess-instr _ s (add a b) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem a >>= λ av →
+  mem-lookup mem b >>= λ bv →
+  just (push-mem s (av +ᶠ bv))
+
+preprocess-instr _ s (mul a b) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem a >>= λ av →
+  mem-lookup mem b >>= λ bv →
+  just (push-mem s (av *ᶠ bv))
+
+preprocess-instr _ s (neg a) =
+  mem-lookup (Preprocessed.memory s) a >>= λ av →
+  just (push-mem s (-ᶠ av))
+
+preprocess-instr _ s (not a) =
+  mem-lookup (Preprocessed.memory s) a >>= to-bool >>= λ b →
+  just (push-mem s (from-bool (Bool.not b)))
+
+preprocess-instr _ s (less-than a b bits) =
+  let mem = Preprocessed.memory s in
+  mem-lookup mem a >>= λ av →
+  mem-lookup mem b >>= λ bv →
+  if does (bits <? FR-BITS) ∧ does (fits-in? av bits) ∧ does (fits-in? bv bits)
+    then just (push-mem s (from-bool
+           (bits-lt (take bits (to-le-bits av))
+                    (take bits (to-le-bits bv)))))
+    else nothing
+
+preprocess-instr pre s (public-input guard) =
+  eval-guard (Preprocessed.memory s) guard >>= λ active →
+  if Bool.not active
+    then just (push-mem s 0ᶠ)
+    else consume-pub-out s >>= λ { (v , s') → just (push-mem s' v) }
+
+preprocess-instr pre s (private-input guard) =
+  eval-guard (Preprocessed.memory s) guard >>= λ active →
+  if Bool.not active
+    then just (push-mem s 0ᶠ)
+    else consume-priv s >>= λ { (v , s') → just (push-mem s' v) }
+
+------------------------------------------------------------------------
+-- Circuit preprocessing: fold preprocess-instr over the instruction list
+------------------------------------------------------------------------
+
+preprocess-instrs : ProofPreimage → Preprocessed → List Instruction → Maybe Preprocessed
+preprocess-instrs _   s []       = just s
+preprocess-instrs pre s (i ∷ is) =
+  preprocess-instr pre s i >>= λ s' →
+  preprocess-instrs pre s' is
+
+------------------------------------------------------------------------
+-- Post-preprocessing validation
+------------------------------------------------------------------------
+
+-- All three transcripts must be fully consumed.
+transcripts-consumed : ProofPreimage → Preprocessed → Bool
+transcripts-consumed pre s =
+  (length (ProofPreimage.pub-transcript-inputs pre) ≡ᵇ Preprocessed.pub-in-idx s)
+  ∧ is-empty (Preprocessed.pub-out-rem s)
+  ∧ is-empty (Preprocessed.priv-rem s)
+
+-- If do-communications-commitment is set, verify the commitment.
+comm-ok : IrSource → ProofPreimage → Preprocessed → Bool
+comm-ok src pre s
+  with IrSource.do-communications-commitment src
+     | ProofPreimage.comm-commitment pre
+... | false | _            = true
+... | true  | nothing      = false
+... | true  | just (c , r) =
+  c ≡ᶠ? transient-commit (ProofPreimage.inputs pre ++ Preprocessed.outputs s) r
+
+------------------------------------------------------------------------
+-- Top-level: preprocess the circuit and validate
+------------------------------------------------------------------------
+
+preprocess : IrSource → ProofPreimage → Maybe Preprocessed
+preprocess src pre =
+  init-state src pre                           >>= λ s  →
+  preprocess-instrs pre s (IrSource.instructions src) >>= λ s' →
+  if transcripts-consumed pre s' ∧ comm-ok src pre s'
+    then just s'
+    else nothing
+
+------------------------------------------------------------------------
+-- Relational semantics
+--
+-- R-instr pre s i s' holds when instruction i can validly transition
+-- from state s to state s', given preimage pre.  Defined independently
+-- of preprocess-instr; faithfulness connects the two.
+------------------------------------------------------------------------
+
+data R-instr (pre : ProofPreimage)
+    : Preprocessed → Instruction → Preprocessed → Set where
+
+  r-assert : ∀ {s cond}
+    → (mem-lookup (Preprocessed.memory s) cond >>= to-bool) ≡ just true
+    → R-instr pre s (assert cond) s
+
+  r-cond-select : ∀ {s bit a b sel av bv}
+    → (mem-lookup (Preprocessed.memory s) bit >>= to-bool) ≡ just sel
+    → mem-lookup (Preprocessed.memory s) a ≡ just av
+    → mem-lookup (Preprocessed.memory s) b ≡ just bv
+    → R-instr pre s (cond-select bit a b) (push-mem s (if sel then av else bv))
+
+  r-constrain-bits : ∀ {s var bits v}
+    → mem-lookup (Preprocessed.memory s) var ≡ just v
+    → bits < FR-BITS
+    → Fits-in v bits
+    → R-instr pre s (constrain-bits var bits) s
+
+  r-constrain-eq : ∀ {s a b av bv}
+    → mem-lookup (Preprocessed.memory s) a ≡ just av
+    → mem-lookup (Preprocessed.memory s) b ≡ just bv
+    → av ≡ bv
+    → R-instr pre s (constrain-eq a b) s
+
+  r-constrain-to-boolean : ∀ {s var b}
+    → (mem-lookup (Preprocessed.memory s) var >>= to-bool) ≡ just b
+    → R-instr pre s (constrain-to-boolean var) s
+
+  r-copy : ∀ {s var v}
+    → mem-lookup (Preprocessed.memory s) var ≡ just v
+    → R-instr pre s (copy var) (push-mem s v)
+
+  r-declare-pub-input : ∀ {s var v}
+    → mem-lookup (Preprocessed.memory s) var ≡ just v
+    → R-instr pre s (declare-pub-input var) (push-pi s v)
+
+  r-pi-skip-active : ∀ {s guard count}
+    → eval-guard (Preprocessed.memory s) guard ≡ just true
+    → T (drop (length (Preprocessed.pis s) ∸ count) (Preprocessed.pis s)
+         ≡ᶠ-list? take count (drop (Preprocessed.pub-in-idx s ∸ count)
+                                    (ProofPreimage.pub-transcript-inputs pre)))
+    → R-instr pre s (pi-skip guard count) (push-skip s nothing)
+
+  r-pi-skip-inactive : ∀ {s guard count}
+    → eval-guard (Preprocessed.memory s) guard ≡ just false
+    → R-instr pre s (pi-skip guard count)
+        (push-skip (record s { pub-in-idx = Preprocessed.pub-in-idx s ∸ count }) (just count))
+
+  r-ec-add : ∀ {s a_x a_y b_x b_y ax ay bx by cx cy}
+    → mem-lookup (Preprocessed.memory s) a_x ≡ just ax
+    → mem-lookup (Preprocessed.memory s) a_y ≡ just ay
+    → mem-lookup (Preprocessed.memory s) b_x ≡ just bx
+    → mem-lookup (Preprocessed.memory s) b_y ≡ just by
+    → ec-add-pts ax ay bx by ≡ just (cx , cy)
+    → R-instr pre s (ec-add a_x a_y b_x b_y) (push-mem2 s cx cy)
+
+  r-ec-mul : ∀ {s a_x a_y scalar ax ay sc cx cy}
+    → mem-lookup (Preprocessed.memory s) a_x ≡ just ax
+    → mem-lookup (Preprocessed.memory s) a_y ≡ just ay
+    → mem-lookup (Preprocessed.memory s) scalar ≡ just sc
+    → ec-mul-pt ax ay sc ≡ just (cx , cy)
+    → R-instr pre s (ec-mul a_x a_y scalar) (push-mem2 s cx cy)
+
+  r-ec-mul-generator : ∀ {s scalar sc cx cy}
+    → mem-lookup (Preprocessed.memory s) scalar ≡ just sc
+    → ec-mul-gen sc ≡ (cx , cy)
+    → R-instr pre s (ec-mul-generator scalar) (push-mem2 s cx cy)
+
+  r-hash-to-curve : ∀ {s inputs vs cx cy}
+    → mem-lookups (Preprocessed.memory s) inputs ≡ just vs
+    → hash-to-curve-fn vs ≡ (cx , cy)
+    → R-instr pre s (hash-to-curve inputs) (push-mem2 s cx cy)
+
+  r-load-imm : ∀ {s imm}
+    → R-instr pre s (load-imm imm) (push-mem s imm)
+
+  r-div-mod-power-of-two : ∀ {s var bits v}
+    → mem-lookup (Preprocessed.memory s) var ≡ just v
+    → bits ≤ FR-STORED-BITS
+    → R-instr pre s (div-mod-power-of-two var bits)
+        (push-mem (push-mem s (from-le-bits (drop bits (to-le-bits v))))
+                  (from-le-bits (take bits (to-le-bits v))))
+
+  r-reconstitute-field : ∀ {s divisor modulus bits dv mv}
+    → mem-lookup (Preprocessed.memory s) divisor ≡ just dv
+    → mem-lookup (Preprocessed.memory s) modulus ≡ just mv
+    → 1 ≤ bits
+    → bits ≤ FR-STORED-BITS
+    → (Fits-in mv bits × Fits-in dv (FR-BITS ∸ bits) ×
+       BitsInField (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv)))
+    → R-instr pre s (reconstitute-field divisor modulus bits)
+        (push-mem s (from-le-bits (take bits (to-le-bits mv) ++ take (FR-BITS ∸ bits) (to-le-bits dv))))
+
+  r-output : ∀ {s var v}
+    → mem-lookup (Preprocessed.memory s) var ≡ just v
+    → R-instr pre s (output var) (push-output s v)
+
+  r-transient-hash : ∀ {s inputs vs}
+    → mem-lookups (Preprocessed.memory s) inputs ≡ just vs
+    → R-instr pre s (transient-hash inputs) (push-mem s (transient-hash-fn vs))
+
+  r-persistent-hash : ∀ {s alignment inputs vs h₁ h₂}
+    → mem-lookups (Preprocessed.memory s) inputs ≡ just vs
+    → persistent-hash-fn alignment vs ≡ (h₁ , h₂)
+    → R-instr pre s (persistent-hash alignment inputs) (push-mem2 s h₁ h₂)
+
+  r-test-eq : ∀ {s a b av bv}
+    → mem-lookup (Preprocessed.memory s) a ≡ just av
+    → mem-lookup (Preprocessed.memory s) b ≡ just bv
+    → R-instr pre s (test-eq a b) (push-mem s (from-bool (av ≡ᶠ? bv)))
+
+  r-add : ∀ {s a b av bv}
+    → mem-lookup (Preprocessed.memory s) a ≡ just av
+    → mem-lookup (Preprocessed.memory s) b ≡ just bv
+    → R-instr pre s (add a b) (push-mem s (av +ᶠ bv))
+
+  r-mul : ∀ {s a b av bv}
+    → mem-lookup (Preprocessed.memory s) a ≡ just av
+    → mem-lookup (Preprocessed.memory s) b ≡ just bv
+    → R-instr pre s (mul a b) (push-mem s (av *ᶠ bv))
+
+  r-neg : ∀ {s a av}
+    → mem-lookup (Preprocessed.memory s) a ≡ just av
+    → R-instr pre s (neg a) (push-mem s (-ᶠ av))
+
+  r-not : ∀ {s a b}
+    → (mem-lookup (Preprocessed.memory s) a >>= to-bool) ≡ just b
+    → R-instr pre s (not a) (push-mem s (from-bool (Bool.not b)))
+
+  r-less-than : ∀ {s a b bits av bv}
+    → mem-lookup (Preprocessed.memory s) a ≡ just av
+    → mem-lookup (Preprocessed.memory s) b ≡ just bv
+    → bits < FR-BITS
+    → (Fits-in av bits × Fits-in bv bits)
+    → R-instr pre s (less-than a b bits)
+        (push-mem s (from-bool (bits-lt (take bits (to-le-bits av))
+                                        (take bits (to-le-bits bv)))))
+
+  r-public-input-inactive : ∀ {s guard}
+    → eval-guard (Preprocessed.memory s) guard ≡ just false
+    → R-instr pre s (public-input guard) (push-mem s 0ᶠ)
+
+  r-public-input-active : ∀ {s guard v s₁}
+    → eval-guard (Preprocessed.memory s) guard ≡ just true
+    → consume-pub-out s ≡ just (v , s₁)
+    → R-instr pre s (public-input guard) (push-mem s₁ v)
+
+  r-private-input-inactive : ∀ {s guard}
+    → eval-guard (Preprocessed.memory s) guard ≡ just false
+    → R-instr pre s (private-input guard) (push-mem s 0ᶠ)
+
+  r-private-input-active : ∀ {s guard v s₁}
+    → eval-guard (Preprocessed.memory s) guard ≡ just true
+    → consume-priv s ≡ just (v , s₁)
+    → R-instr pre s (private-input guard) (push-mem s₁ v)
+
+-- Relational semantics for a sequence of instructions.
+data R-instrs (pre : ProofPreimage)
+    : Preprocessed → List Instruction → Preprocessed → Set where
+  r-done : ∀ {s} → R-instrs pre s [] s
+  r-step : ∀ {s s₁ s' i is}
+    → R-instr  pre s  i  s₁
+    → R-instrs pre s₁ is s'
+    → R-instrs pre s (i ∷ is) s'
+
+------------------------------------------------------------------------
+-- Bit-bound well-formedness (WF2, §3.3)
+--
+-- The per-instruction bit-count bounds the Rust runtime enforces.  Both
+-- the functional `preprocess-instr` and the relational `R-instr` reject
+-- a bit count outside these bounds, so WF2 is the residual hypothesis
+-- under which `circuit-faithful` recovers `R` from circuit satisfaction.
+------------------------------------------------------------------------
+
+WF2-instr : Instruction → Set
+WF2-instr (constrain-bits _ bits)       = bits < FR-BITS
+WF2-instr (less-than _ _ bits)          = bits < FR-BITS
+WF2-instr (div-mod-power-of-two _ bits) = bits ≤ FR-STORED-BITS
+WF2-instr (reconstitute-field _ _ bits) = (1 ≤ bits) × (bits ≤ FR-STORED-BITS)
+WF2-instr _                             = ⊤
+
+WF2 : IrSource → Set
+WF2 src = All WF2-instr (IrSource.instructions src)
+
+-- Top-level relational semantics: pre and s satisfy circuit src.
+R : IrSource → ProofPreimage → Preprocessed → Set
+R src pre s =
+  ∃ λ s₀ →
+    init-state src pre ≡ just s₀ ×
+    R-instrs pre s₀ (IrSource.instructions src) s ×
+    T (transcripts-consumed pre s) ×
+    T (comm-ok src pre s)

--- a/formal/src/zkir-v2/SemanticsLemmas.agda
+++ b/formal/src/zkir-v2/SemanticsLemmas.agda
@@ -1,0 +1,403 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+------------------------------------------------------------------------
+-- Inversion and framing principles for the `Semantics` definitions.
+--
+-- This module is the single home for the lemma layer directly above
+-- `Semantics`: lookup stability under memory extension, inversion of
+-- the transcript consumers (`consume-pub-out` / `consume-priv`), and
+-- inversion of `init-state`.  Scope discipline: only facts *about
+-- definitions of `Semantics`* belong here — nothing about circuits,
+-- obligations, or the proof modules.
+--
+-- `Semantics` itself stays a definition-only, spec-mirroring artifact
+-- (spec §4); consumers import this module instead of re-proving these
+-- facts privately.
+------------------------------------------------------------------------
+
+module zkir-v2.SemanticsLemmas (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+
+open import Data.Bool using (Bool; true; false; T)
+open import Data.List using (List; []; _∷_; _++_; length)
+open import Data.List.Properties using (++-assoc)
+open import Data.Maybe using (Maybe; nothing; just; _>>=_)
+open import Data.Maybe.Properties using (just-injective)
+open import Data.Nat using (ℕ; zero; suc; _≡ᵇ_)
+open import Data.Nat.Properties using (≡ᵇ⇒≡)
+open import Data.Product using (_×_; _,_; ∃; ∃₂; proj₁; proj₂)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Data.Unit using (tt)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; subst)
+
+------------------------------------------------------------------------
+-- 1. `mem-lookup` under memory extension
+--
+-- Memory only ever grows by appending (spec P2), so a successful
+-- lookup is stable under any suffix, and the freshly-pushed cell(s)
+-- are found at the old length.  The `mem` argument is explicit to
+-- make implicit-argument inference robust at use sites.
+------------------------------------------------------------------------
+
+lookup-extends : ∀ (mem suffix : List Fr) i {v}
+  → mem-lookup mem i ≡ just v
+  → mem-lookup (mem ++ suffix) i ≡ just v
+lookup-extends []       _ _       ()
+lookup-extends (x ∷ xs) _ zero    eq = eq
+lookup-extends (x ∷ xs) s (suc i) eq = lookup-extends xs s i eq
+
+lookup-new : ∀ (mem : List Fr) v
+  → mem-lookup (mem ++ (v ∷ [])) (length mem) ≡ just v
+lookup-new []       v = refl
+lookup-new (x ∷ xs) v = lookup-new xs v
+
+-- Two-cell variants for instructions with Δmem = 2.  The post-state's
+-- memory is `(mem ++ (x ∷ [])) ++ (y ∷ [])` — the shape produced by
+-- `push-mem (push-mem s x) y`.
+lookup-new-fst : ∀ (mem : List Fr) x y
+  → mem-lookup ((mem ++ (x ∷ [])) ++ (y ∷ [])) (length mem) ≡ just x
+lookup-new-fst mem x y =
+  lookup-extends (mem ++ (x ∷ [])) (y ∷ []) (length mem) (lookup-new mem x)
+
+lookup-new-snd : ∀ (mem : List Fr) x y
+  → mem-lookup ((mem ++ (x ∷ [])) ++ (y ∷ [])) (suc (length mem)) ≡ just y
+lookup-new-snd []       x y = refl
+lookup-new-snd (z ∷ zs) x y = lookup-new-snd zs x y
+
+-- Extend a pre-state lookup across both pushed cells of a Δmem = 2
+-- instruction (the iterated `(mem ++ x ∷ []) ++ y ∷ []` shape).
+lookup-extend2 : ∀ (mem : List Fr) x y i {v}
+  → mem-lookup mem i ≡ just v
+  → mem-lookup ((mem ++ (x ∷ [])) ++ (y ∷ [])) i ≡ just v
+lookup-extend2 mem x y i e =
+  lookup-extends (mem ++ (x ∷ [])) (y ∷ []) i
+    (lookup-extends mem (x ∷ []) i e)
+
+lookup-uniq : ∀ (mem : List Fr) (i : Index) {v w}
+  → mem-lookup mem i ≡ just v
+  → mem-lookup mem i ≡ just w
+  → v ≡ w
+lookup-uniq _ _ p q = just-injective (trans (sym p) q)
+
+-- A pre-state lookup, extended to the post-state memory, matched
+-- against a second lookup at the same index: identifies the
+-- operational operand value `v` with the witnessed value `w`.
+extend-uniq : ∀ (mem suffix : List Fr) (i : Index) {v w}
+  → mem-lookup mem i ≡ just v
+  → mem-lookup (mem ++ suffix) i ≡ just w
+  → v ≡ w
+extend-uniq mem suffix i la la' =
+  lookup-uniq (mem ++ suffix) i (lookup-extends mem suffix i la) la'
+
+-- The freshly-pushed cell, matched against a lookup at the new index
+-- `length mem`: identifies the pushed value `v` with the witnessed
+-- output value `w`.
+new-uniq : ∀ (mem : List Fr) v {w}
+  → mem-lookup (mem ++ (v ∷ [])) (length mem) ≡ just w
+  → v ≡ w
+new-uniq mem v lout =
+  lookup-uniq (mem ++ (v ∷ [])) (length mem) (lookup-new mem v) lout
+
+-- Two-cell analogues of `new-uniq`.
+new2-uniq-fst : ∀ (mem : List Fr) x y {w}
+  → mem-lookup ((mem ++ (x ∷ [])) ++ (y ∷ [])) (length mem) ≡ just w
+  → x ≡ w
+new2-uniq-fst mem x y l =
+  lookup-uniq ((mem ++ (x ∷ [])) ++ (y ∷ [])) (length mem)
+    (lookup-new-fst mem x y) l
+
+new2-uniq-snd : ∀ (mem : List Fr) x y {w}
+  → mem-lookup ((mem ++ (x ∷ [])) ++ (y ∷ [])) (suc (length mem)) ≡ just w
+  → y ≡ w
+new2-uniq-snd mem x y l =
+  lookup-uniq ((mem ++ (x ∷ [])) ++ (y ∷ [])) (suc (length mem))
+    (lookup-new-snd mem x y) l
+
+-- Multi-index analogue of `lookup-extends`, for instructions whose
+-- premises look up an index list via `mem-lookups`.
+mem-lookups-extends : ∀ (mem suffix : List Fr) (is : List Index) {vs}
+  → mem-lookups mem is ≡ just vs
+  → mem-lookups (mem ++ suffix) is ≡ just vs
+mem-lookups-extends mem suffix []       refl = refl
+mem-lookups-extends mem suffix (i ∷ is) eq   =
+  aux (mem-lookup mem i)      refl
+      (mem-lookups mem is)    refl
+      eq
+  where
+    aux : ∀ (m : Maybe Fr) → mem-lookup mem i ≡ m
+        → (ms : Maybe (List Fr)) → mem-lookups mem is ≡ ms
+        → ∀ {vs}
+        → (m >>= λ v → ms >>= λ vs' → just (v ∷ vs')) ≡ just vs
+        → mem-lookups (mem ++ suffix) (i ∷ is) ≡ just vs
+    aux nothing   _    _          _     ()
+    aux (just _)  _    nothing    _     ()
+    aux (just v)  m-eq (just vs') ms-eq refl
+      rewrite lookup-extends mem suffix i {v} m-eq
+            | mem-lookups-extends mem suffix is {vs'} ms-eq
+      = refl
+
+-- `push-mem2 s x y`'s memory unfolds to `mem ++ (x ∷ y ∷ [])`; the
+-- iterated `push-mem` form is `(mem ++ x ∷ []) ++ y ∷ []`.  The two
+-- shapes are propositionally equal by `++`-associativity.
+push-mem2-assoc : ∀ (mem : List Fr) x y
+  → mem ++ (x ∷ y ∷ []) ≡ (mem ++ (x ∷ [])) ++ (y ∷ [])
+push-mem2-assoc mem x y = sym (++-assoc mem (x ∷ []) (y ∷ []))
+
+------------------------------------------------------------------------
+-- 2. Inversion of the transcript consumers
+--
+-- `consume-pub-out` / `consume-priv` touch exactly one field: they
+-- pop the head of their transcript stream and leave every other
+-- state component unchanged.  `consume-*-inv` is the full
+-- characterization; the named corollaries below project the facts
+-- the proof modules consume.
+------------------------------------------------------------------------
+
+consume-pub-out-inv : ∀ s {v s′}
+  → consume-pub-out s ≡ just (v , s′)
+  → ∃ λ rest
+      → (Preprocessed.pub-out-rem s ≡ v ∷ rest)
+      × (s′ ≡ record s { pub-out-rem = rest })
+consume-pub-out-inv s eq with Preprocessed.pub-out-rem s | eq
+... | []       | ()
+... | w ∷ rest | p =
+  rest
+  , cong (_∷ rest) (cong proj₁ (just-injective p))
+  , sym (cong proj₂ (just-injective p))
+
+consume-priv-inv : ∀ s {v s′}
+  → consume-priv s ≡ just (v , s′)
+  → ∃ λ rest
+      → (Preprocessed.priv-rem s ≡ v ∷ rest)
+      × (s′ ≡ record s { priv-rem = rest })
+consume-priv-inv s eq with Preprocessed.priv-rem s | eq
+... | []       | ()
+... | w ∷ rest | p =
+  rest
+  , cong (_∷ rest) (cong proj₁ (just-injective p))
+  , sym (cong proj₂ (just-injective p))
+
+-- Forward direction: a non-empty stream makes the consumer succeed
+-- with exactly the head/tail split.
+consume-pub-out-eq : ∀ s {v rest}
+  → Preprocessed.pub-out-rem s ≡ v ∷ rest
+  → consume-pub-out s ≡ just (v , record s { pub-out-rem = rest })
+consume-pub-out-eq s eq with Preprocessed.pub-out-rem s | eq
+... | _ ∷ _ | refl = refl
+
+consume-priv-eq : ∀ s {v rest}
+  → Preprocessed.priv-rem s ≡ v ∷ rest
+  → consume-priv s ≡ just (v , record s { priv-rem = rest })
+consume-priv-eq s eq with Preprocessed.priv-rem s | eq
+... | _ ∷ _ | refl = refl
+
+-- Projections: the fields a consumer leaves unchanged, and the
+-- one-step stream relation on the field it pops.
+
+consume-pub-out-mem : ∀ s {v s′}
+  → consume-pub-out s ≡ just (v , s′)
+  → Preprocessed.memory s′ ≡ Preprocessed.memory s
+consume-pub-out-mem s eq =
+  let (_ , _ , s′≡) = consume-pub-out-inv s eq
+  in cong Preprocessed.memory s′≡
+
+consume-pub-out-pis : ∀ s {v s′}
+  → consume-pub-out s ≡ just (v , s′)
+  → Preprocessed.pis s′ ≡ Preprocessed.pis s
+consume-pub-out-pis s eq =
+  let (_ , _ , s′≡) = consume-pub-out-inv s eq
+  in cong Preprocessed.pis s′≡
+
+consume-pub-out-skips : ∀ s {v s′}
+  → consume-pub-out s ≡ just (v , s′)
+  → Preprocessed.pi-skips s′ ≡ Preprocessed.pi-skips s
+consume-pub-out-skips s eq =
+  let (_ , _ , s′≡) = consume-pub-out-inv s eq
+  in cong Preprocessed.pi-skips s′≡
+
+consume-pub-out-idx : ∀ s {v s′}
+  → consume-pub-out s ≡ just (v , s′)
+  → Preprocessed.pub-in-idx s′ ≡ Preprocessed.pub-in-idx s
+consume-pub-out-idx s eq =
+  let (_ , _ , s′≡) = consume-pub-out-inv s eq
+  in cong Preprocessed.pub-in-idx s′≡
+
+consume-pub-out-outputs : ∀ s {v s′}
+  → consume-pub-out s ≡ just (v , s′)
+  → Preprocessed.outputs s′ ≡ Preprocessed.outputs s
+consume-pub-out-outputs s eq =
+  let (_ , _ , s′≡) = consume-pub-out-inv s eq
+  in cong Preprocessed.outputs s′≡
+
+consume-pub-out-priv : ∀ s {v s′}
+  → consume-pub-out s ≡ just (v , s′)
+  → Preprocessed.priv-rem s′ ≡ Preprocessed.priv-rem s
+consume-pub-out-priv s eq =
+  let (_ , _ , s′≡) = consume-pub-out-inv s eq
+  in cong Preprocessed.priv-rem s′≡
+
+consume-pub-out-rem : ∀ s {v s′}
+  → consume-pub-out s ≡ just (v , s′)
+  → Preprocessed.pub-out-rem s ≡ v ∷ Preprocessed.pub-out-rem s′
+consume-pub-out-rem s {v} eq =
+  let (rest , step , s′≡) = consume-pub-out-inv s eq
+  in trans step (cong (v ∷_) (sym (cong Preprocessed.pub-out-rem s′≡)))
+
+consume-priv-mem : ∀ s {v s′}
+  → consume-priv s ≡ just (v , s′)
+  → Preprocessed.memory s′ ≡ Preprocessed.memory s
+consume-priv-mem s eq =
+  let (_ , _ , s′≡) = consume-priv-inv s eq
+  in cong Preprocessed.memory s′≡
+
+consume-priv-pis : ∀ s {v s′}
+  → consume-priv s ≡ just (v , s′)
+  → Preprocessed.pis s′ ≡ Preprocessed.pis s
+consume-priv-pis s eq =
+  let (_ , _ , s′≡) = consume-priv-inv s eq
+  in cong Preprocessed.pis s′≡
+
+consume-priv-skips : ∀ s {v s′}
+  → consume-priv s ≡ just (v , s′)
+  → Preprocessed.pi-skips s′ ≡ Preprocessed.pi-skips s
+consume-priv-skips s eq =
+  let (_ , _ , s′≡) = consume-priv-inv s eq
+  in cong Preprocessed.pi-skips s′≡
+
+consume-priv-idx : ∀ s {v s′}
+  → consume-priv s ≡ just (v , s′)
+  → Preprocessed.pub-in-idx s′ ≡ Preprocessed.pub-in-idx s
+consume-priv-idx s eq =
+  let (_ , _ , s′≡) = consume-priv-inv s eq
+  in cong Preprocessed.pub-in-idx s′≡
+
+consume-priv-outputs : ∀ s {v s′}
+  → consume-priv s ≡ just (v , s′)
+  → Preprocessed.outputs s′ ≡ Preprocessed.outputs s
+consume-priv-outputs s eq =
+  let (_ , _ , s′≡) = consume-priv-inv s eq
+  in cong Preprocessed.outputs s′≡
+
+consume-priv-pub : ∀ s {v s′}
+  → consume-priv s ≡ just (v , s′)
+  → Preprocessed.pub-out-rem s′ ≡ Preprocessed.pub-out-rem s
+consume-priv-pub s eq =
+  let (_ , _ , s′≡) = consume-priv-inv s eq
+  in cong Preprocessed.pub-out-rem s′≡
+
+consume-priv-rem : ∀ s {v s′}
+  → consume-priv s ≡ just (v , s′)
+  → Preprocessed.priv-rem s ≡ v ∷ Preprocessed.priv-rem s′
+consume-priv-rem s {v} eq =
+  let (rest , step , s′≡) = consume-priv-inv s eq
+  in trans step (cong (v ∷_) (sym (cong Preprocessed.priv-rem s′≡)))
+
+------------------------------------------------------------------------
+-- 3. Inversion of `init-state`
+--
+-- A successful `init-state src pre ≡ just s₀` pins every field of
+-- `s₀` and enforces WF1 (input arity).  The `pis` preamble depends on
+-- the communications-commitment flag, so `pis-shape` is a sum.
+------------------------------------------------------------------------
+
+record InitInv (src : IrSource) (pre : ProofPreimage)
+               (s₀ : Preprocessed) : Set where
+  constructor mk-init-inv
+  field
+    mem≡      : Preprocessed.memory s₀ ≡ ProofPreimage.inputs pre
+    arity≡    : length (ProofPreimage.inputs pre)
+                  ≡ IrSource.num-inputs src
+    idx≡      : Preprocessed.pub-in-idx s₀ ≡ 0
+    skips≡    : Preprocessed.pi-skips s₀ ≡ []
+    outputs≡  : Preprocessed.outputs s₀ ≡ []
+    pub-rem≡  : Preprocessed.pub-out-rem s₀
+                  ≡ ProofPreimage.pub-transcript-outputs pre
+    priv-rem≡ : Preprocessed.priv-rem s₀
+                  ≡ ProofPreimage.priv-transcript pre
+    pis-shape : (IrSource.do-communications-commitment src ≡ false
+                  × Preprocessed.pis s₀
+                    ≡ ProofPreimage.binding-input pre ∷ [])
+              ⊎ ∃₂ λ c r
+                  → (IrSource.do-communications-commitment src ≡ true)
+                  × (ProofPreimage.comm-commitment pre ≡ just (c , r))
+                  × (Preprocessed.pis s₀
+                      ≡ ProofPreimage.binding-input pre ∷ c ∷ [])
+
+init-state-inv : ∀ src pre {s₀}
+  → init-state src pre ≡ just s₀
+  → InitInv src pre s₀
+init-state-inv src pre eq
+  with length (ProofPreimage.inputs pre) ≡ᵇ IrSource.num-inputs src in ar
+     | IrSource.do-communications-commitment src in hc
+     | ProofPreimage.comm-commitment pre in cc
+     | eq
+... | false | _     | _            | ()
+... | true  | true  | nothing      | ()
+... | true  | false | _            | eq′ =
+  let st≡ = just-injective eq′ in mk-init-inv
+    (sym (cong Preprocessed.memory      st≡))
+    (≡ᵇ⇒≡ _ _ (subst T (sym ar) tt))
+    (sym (cong Preprocessed.pub-in-idx  st≡))
+    (sym (cong Preprocessed.pi-skips    st≡))
+    (sym (cong Preprocessed.outputs     st≡))
+    (sym (cong Preprocessed.pub-out-rem st≡))
+    (sym (cong Preprocessed.priv-rem    st≡))
+    (inj₁ (hc , sym (cong Preprocessed.pis st≡)))
+... | true  | true  | just (c , r) | eq′ =
+  let st≡ = just-injective eq′ in mk-init-inv
+    (sym (cong Preprocessed.memory      st≡))
+    (≡ᵇ⇒≡ _ _ (subst T (sym ar) tt))
+    (sym (cong Preprocessed.pub-in-idx  st≡))
+    (sym (cong Preprocessed.pi-skips    st≡))
+    (sym (cong Preprocessed.outputs     st≡))
+    (sym (cong Preprocessed.pub-out-rem st≡))
+    (sym (cong Preprocessed.priv-rem    st≡))
+    (inj₂ (c , r , hc , cc , sym (cong Preprocessed.pis st≡)))
+
+-- Named corollaries in the signatures the proof modules use.
+
+init-state-memory : ∀ src pre s₀
+  → init-state src pre ≡ just s₀
+  → Preprocessed.memory s₀ ≡ ProofPreimage.inputs pre
+init-state-memory src pre s₀ eq = InitInv.mem≡ (init-state-inv src pre eq)
+
+init-state-num-inputs : ∀ src pre s₀
+  → init-state src pre ≡ just s₀
+  → length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src
+init-state-num-inputs src pre s₀ eq =
+  InitInv.arity≡ (init-state-inv src pre eq)
+
+init-state-pub-in-idx : ∀ src pre s₀
+  → init-state src pre ≡ just s₀
+  → Preprocessed.pub-in-idx s₀ ≡ 0
+init-state-pub-in-idx src pre s₀ eq =
+  InitInv.idx≡ (init-state-inv src pre eq)
+
+init-state-pi-skips : ∀ src pre s₀
+  → init-state src pre ≡ just s₀
+  → Preprocessed.pi-skips s₀ ≡ []
+init-state-pi-skips src pre s₀ eq =
+  InitInv.skips≡ (init-state-inv src pre eq)
+
+init-state-outputs : ∀ src pre s₀
+  → init-state src pre ≡ just s₀
+  → Preprocessed.outputs s₀ ≡ []
+init-state-outputs src pre s₀ eq =
+  InitInv.outputs≡ (init-state-inv src pre eq)
+
+init-state-pub-rem : ∀ src pre s₀
+  → init-state src pre ≡ just s₀
+  → Preprocessed.pub-out-rem s₀
+      ≡ ProofPreimage.pub-transcript-outputs pre
+init-state-pub-rem src pre s₀ eq =
+  InitInv.pub-rem≡ (init-state-inv src pre eq)
+
+init-state-priv-rem : ∀ src pre s₀
+  → init-state src pre ≡ just s₀
+  → Preprocessed.priv-rem s₀ ≡ ProofPreimage.priv-transcript pre
+init-state-priv-rem src pre s₀ eq =
+  InitInv.priv-rem≡ (init-state-inv src pre eq)

--- a/formal/src/zkir-v2/StatementSoundness.agda
+++ b/formal/src/zkir-v2/StatementSoundness.agda
@@ -1,0 +1,2338 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.StatementSoundness (⋯ : _) (open Assumptions ⋯) where
+
+------------------------------------------------------------------------
+-- Statement soundness for ZKIR v2.
+--
+--   circuit-statement-sound
+--     : ∀ src w → T (producer-safe src)
+--     → WF2 src
+--     → satisfies (circuit src) w
+--     → Realizer src w
+--
+-- where a `Realizer src w` (a record, defined before the theorem)
+-- packages a preprocess run together with proofs that it is genuine
+-- (`R src pre s`) and that its canonical witness is exactly `w`.
+--
+-- P5 (`circuit-faithful`, CircuitProof.agda) is an iff for the SINGLE
+-- canonical witness `witness-of s pre`; it does not rule out *other*
+-- satisfying witnesses.  Statement soundness is the universal property
+-- P5 lacks: EVERY satisfying witness `w` of the synthesized circuit
+-- (with the allocated memory length — see the note at the end of this
+-- file) is *realizable*, i.e. the canonical witness of a genuine
+-- preprocess run with the same public inputs.  Combined with P5's
+-- forward direction this yields the exact characterization
+-- `circuit-witness-characterization` (end of file): the satisfying
+-- witnesses of the allocated length are EXACTLY the canonical witnesses
+-- of preprocess runs.
+--
+-- Strategy.  Exhibit a preimage / state pair `(pre , s)` with
+-- `witness-of s pre ≡ w` and `preprocess-shaped src pre s`; P5's
+-- backward direction (`circuit-faithful-bwd`, packaged as
+-- `sstmt-from-realize`) then turns `satisfies (circuit src) w` into
+-- `R src pre s`.  The work is building the `Tr-shaped` shape walk from
+-- `w`: two pre-passes read off `w` the transcripts `pre` must carry
+-- (`make-trfacts` for the guarded `public-input` / `private-input`
+-- reads, `make-pti` for the `pi-skip` verifier transcript), and `build`
+-- walks the instruction stream, tiling the memory and pis suffixes of
+-- `w` cell-by-cell and consuming those transcripts.  The construction
+-- is assembled, generically in the communications-commitment flag, by
+-- `realize` at the end of the file.
+------------------------------------------------------------------------
+
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+  using ( ProofPreimage; Preprocessed; mk-state; init-state
+        ; transcripts-consumed; R; push-mem; push-mem2; mem-lookup
+        ; eval-guard; consume-pub-out; consume-priv; from-bool
+        ; _≡ᶠ-list?_; WF2 )
+open import zkir-v2.SemanticsLemmas ⋯
+  using ( consume-pub-out-eq; consume-priv-eq )
+open import zkir-v2.Circuit ⋯
+  using ( Witness; satisfies; circuit; Circuit
+        ; SynthState; mk-synth; circuit-instr; circuit-instrs
+        ; is-bit; holds; satisfies-constraints; Constraint; guard-disj
+        ; test-eq; less-than; is-zero; select
+        ; boolean; Maybe-shape; wire; _≑_
+        ; ≑wire-inv
+        ; _at_↦_ )
+open import zkir-v2.FieldProperties ⋯
+  using ( to-bool; _≡ᶠ?_; bits-lt; lt-bits; ≡ᶠ?-refl; -ᶠ-zero
+        ; +-zero-r )
+open import zkir-v2.Encoding ⋯
+  using ( to-bool-of-0ᶠ; to-bool-of-1ᶠ )
+open import zkir-v2.Obligations ⋯
+  using ( producer-safe; Δmem
+        ; Wire-Trace; wire-done; wire-cons; wire-step; wire-scan
+        ; WireOK; wireOK?; wire-disc
+        ; O1-scan
+        ; O1-Trace; o1-nil; o1-decl; o1-skip; o1-other
+        ; NotDeclSkip; o1-tail
+        ; IndexSet; insert; require-∈; O2-check; O2-record
+        ; O2-Trace; o2-step; O2-Runs
+        ; o1-sound; O2-bool→Runs )
+open import zkir-v2.ObligationsSoundness ⋯
+  using ( producer-safe-wire-disc; producer-safe-O1
+        ; producer-safe-O2
+        ; from-bool-is-bit )
+open import zkir-v2.CircuitProof ⋯
+  using ( witness-of; comm-rand-of; preprocess-shaped; mk-shaped
+        ; mk-shape-walk; circuit-faithful-bwd
+        ; circuit-faithful-fwd; Tr-shaped; tr-cons; tr-nil
+        ; tr-step; tr-next )
+open import zkir-v2.Properties ⋯
+  using ( Δmem-sum; R-memory-length )
+
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.List.Relation.Unary.All using (All)
+  renaming ([] to []ᴬ; _∷_ to _∷ᴬ_; head to headᴬ)
+open import Data.List.Relation.Unary.All.Properties using (++⁻)
+import Data.Nat as ℕ
+open import Data.List.Membership.DecPropositional (ℕ._≟_) using (_∈_; _∈?_)
+
+open import Data.Bool    using (Bool; true; false; T; if_then_else_)
+open import Data.Sum     using (_⊎_; inj₁; inj₂)
+open import Data.List    using (List; []; _∷_; _++_; length; take; drop)
+open import Data.List.Properties
+  using ( ++-assoc; ++-identityʳ; take++drop≡id; length-take; length-drop
+        ; length-++ )
+open import Data.Maybe   using (Maybe; just; nothing; fromMaybe)
+open import Data.Maybe.Properties using (just-injective)
+open import Data.Nat     using (ℕ; zero; suc; _+_; _∸_; _≤_; _<_; s≤s; _≡ᵇ_)
+open import Data.Nat.Properties
+  using (≡⇒≡ᵇ; ≡ᵇ⇒≡; +-identityʳ; +-suc; +-comm; +-assoc; suc-injective
+        ; m+n∸m≡n; m+n∸n≡m; m≤n⇒m⊓n≡m; m≤m+n)
+open import Data.Bool.Properties using (T-≡; T-∧)
+open import Data.Empty   using (⊥; ⊥-elim)
+open import Data.Unit    using (⊤; tt)
+open import Relation.Nullary using (yes; no)
+open import Function.Bundles     using (Equivalence; _⇔_; mk⇔)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; Σ)
+open import Relation.Binary.PropositionalEquality
+  using ( _≡_; refl; sym; trans; cong; cong₂; subst; subst₂
+        ; module ≡-Reasoning )
+
+------------------------------------------------------------------------
+-- Wire accounting.  Synthesis allocates exactly `Δmem i` fresh wires per
+-- instruction, so the circuit's wire count is `num-inputs` plus the
+-- per-instruction `Δmem` sum (`Δmem-sum`, from `Properties`).  This
+-- fixes the length of the memory suffix the builder must tile from
+-- `Witness.mem w`.
+------------------------------------------------------------------------
+
+-- Declared-PI delta: `declare-pub-input` appends one pis cell (and bumps
+-- `pub-in-idx`); every other instruction appends none.
+Δpis : Instruction → ℕ
+Δpis (declare-pub-input _) = 1
+Δpis _                     = 0
+
+Δpis-sum : List Instruction → ℕ
+Δpis-sum []       = 0
+Δpis-sum (i ∷ is) = Δpis i + Δpis-sum is
+
+private
+  nr-wires-step : ∀ (hc : Bool) (i : Instruction) (st : SynthState)
+    → SynthState.nr-wires (circuit-instr hc i st)
+      ≡ SynthState.nr-wires st + Δmem i
+  nr-wires-step hc (assert _)               st = sym (+-identityʳ _)
+  nr-wires-step hc (constrain-bits _ _)     st = sym (+-identityʳ _)
+  nr-wires-step hc (constrain-eq _ _)       st = sym (+-identityʳ _)
+  nr-wires-step hc (constrain-to-boolean _) st = sym (+-identityʳ _)
+  nr-wires-step hc (declare-pub-input _)    st = sym (+-identityʳ _)
+  nr-wires-step hc (pi-skip _ _)            st = sym (+-identityʳ _)
+  nr-wires-step hc (output _)               st = sym (+-identityʳ _)
+  nr-wires-step hc (cond-select _ _ _)      st = refl
+  nr-wires-step hc (copy _)                 st = refl
+  nr-wires-step hc (load-imm _)             st = refl
+  nr-wires-step hc (reconstitute-field _ _ _) st = refl
+  nr-wires-step hc (transient-hash _)       st = refl
+  nr-wires-step hc (test-eq _ _)            st = refl
+  nr-wires-step hc (add _ _)                st = refl
+  nr-wires-step hc (mul _ _)                st = refl
+  nr-wires-step hc (neg _)                  st = refl
+  nr-wires-step hc (not _)                  st = refl
+  nr-wires-step hc (less-than _ _ _)        st = refl
+  nr-wires-step hc (public-input nothing)   st = refl
+  nr-wires-step hc (public-input (just _))  st = refl
+  nr-wires-step hc (private-input nothing)  st = refl
+  nr-wires-step hc (private-input (just _)) st = refl
+  nr-wires-step hc (ec-add _ _ _ _)         st = refl
+  nr-wires-step hc (ec-mul _ _ _)           st = refl
+  nr-wires-step hc (ec-mul-generator _)     st = refl
+  nr-wires-step hc (hash-to-curve _)        st = refl
+  nr-wires-step hc (div-mod-power-of-two _ _) st = refl
+  nr-wires-step hc (persistent-hash _ _)    st = refl
+
+nr-wires-acc : ∀ (hc : Bool) (is : List Instruction) (st : SynthState)
+  → SynthState.nr-wires (circuit-instrs hc is st)
+    ≡ SynthState.nr-wires st + Δmem-sum is
+nr-wires-acc hc []       st = sym (+-identityʳ _)
+nr-wires-acc hc (i ∷ is) st =
+  let open ≡-Reasoning in
+  begin
+    SynthState.nr-wires (circuit-instrs hc is (circuit-instr hc i st))
+  ≡⟨ nr-wires-acc hc is (circuit-instr hc i st) ⟩
+    SynthState.nr-wires (circuit-instr hc i st) + Δmem-sum is
+  ≡⟨ cong (_+ Δmem-sum is) (nr-wires-step hc i st) ⟩
+    (SynthState.nr-wires st + Δmem i) + Δmem-sum is
+  ≡⟨ +-assoc (SynthState.nr-wires st) (Δmem i) (Δmem-sum is) ⟩
+    SynthState.nr-wires st + (Δmem i + Δmem-sum is)
+  ∎
+
+-- P2's exact-Δmem form (`R-memory-length`) matched against the
+-- synthesis-side wire count: a run's memory length is pinned to the
+-- circuit's `nr-wires` — the witness-shape fact `Witness.mem` must
+-- respect (the `mem-length` conjunct of `satisfies`).
+--
+-- Stated for the spec (§6.1, P2): the proofs below use
+-- `satisfies.mem-length` + `nr-wires-acc` directly rather than this
+-- packaging.
+R-mem-nr-wires : ∀ src pre s → R src pre s
+  → length (Preprocessed.memory s) ≡ Circuit.nr-wires (circuit src)
+R-mem-nr-wires src pre s r =
+  trans (R-memory-length src pre s r)
+        (sym (nr-wires-acc (IrSource.do-communications-commitment src)
+               (IrSource.instructions src)
+               (mk-synth (IrSource.num-inputs src) [] 0 [])))
+
+private
+  -- `declare-pub-input` is the only instruction that allocates a declared
+  -- PI; synthesis bumps `nr-declared-pi` by `Δpis i` per instruction.
+  nr-decl-step : ∀ (hc : Bool) (i : Instruction) (st : SynthState)
+    → SynthState.nr-declared-pi (circuit-instr hc i st)
+      ≡ SynthState.nr-declared-pi st + Δpis i
+  nr-decl-step hc (declare-pub-input _)    st = sym (+-comm (SynthState.nr-declared-pi st) 1)
+  nr-decl-step hc (assert _)               st = sym (+-identityʳ _)
+  nr-decl-step hc (constrain-bits _ _)     st = sym (+-identityʳ _)
+  nr-decl-step hc (constrain-eq _ _)       st = sym (+-identityʳ _)
+  nr-decl-step hc (constrain-to-boolean _) st = sym (+-identityʳ _)
+  nr-decl-step hc (copy _)                 st = sym (+-identityʳ _)
+  nr-decl-step hc (load-imm _)             st = sym (+-identityʳ _)
+  nr-decl-step hc (transient-hash _)       st = sym (+-identityʳ _)
+  nr-decl-step hc (cond-select _ _ _)      st = sym (+-identityʳ _)
+  nr-decl-step hc (not _)                  st = sym (+-identityʳ _)
+  nr-decl-step hc (less-than _ _ _)        st = sym (+-identityʳ _)
+  nr-decl-step hc (neg _)                  st = sym (+-identityʳ _)
+  nr-decl-step hc (reconstitute-field _ _ _) st = sym (+-identityʳ _)
+  nr-decl-step hc (test-eq _ _)            st = sym (+-identityʳ _)
+  nr-decl-step hc (add _ _)                st = sym (+-identityʳ _)
+  nr-decl-step hc (mul _ _)                st = sym (+-identityʳ _)
+  nr-decl-step hc (ec-add _ _ _ _)         st = sym (+-identityʳ _)
+  nr-decl-step hc (ec-mul _ _ _)           st = sym (+-identityʳ _)
+  nr-decl-step hc (ec-mul-generator _)     st = sym (+-identityʳ _)
+  nr-decl-step hc (hash-to-curve _)        st = sym (+-identityʳ _)
+  nr-decl-step hc (persistent-hash _ _)    st = sym (+-identityʳ _)
+  nr-decl-step hc (div-mod-power-of-two _ _) st = sym (+-identityʳ _)
+  nr-decl-step hc (output _)               st = sym (+-identityʳ _)
+  nr-decl-step hc (public-input nothing)   st = sym (+-identityʳ _)
+  nr-decl-step hc (public-input (just _))  st = sym (+-identityʳ _)
+  nr-decl-step hc (private-input nothing)  st = sym (+-identityʳ _)
+  nr-decl-step hc (private-input (just _)) st = sym (+-identityʳ _)
+  nr-decl-step hc (pi-skip _ _)            st = sym (+-identityʳ _)
+
+  nr-decl-acc : ∀ (hc : Bool) (is : List Instruction) (st : SynthState)
+    → SynthState.nr-declared-pi (circuit-instrs hc is st)
+      ≡ SynthState.nr-declared-pi st + Δpis-sum is
+  nr-decl-acc hc []       st = sym (+-identityʳ _)
+  nr-decl-acc hc (i ∷ is) st =
+    let open ≡-Reasoning in
+    begin
+      SynthState.nr-declared-pi (circuit-instrs hc is (circuit-instr hc i st))
+    ≡⟨ nr-decl-acc hc is (circuit-instr hc i st) ⟩
+      SynthState.nr-declared-pi (circuit-instr hc i st) + Δpis-sum is
+    ≡⟨ cong (_+ Δpis-sum is) (nr-decl-step hc i st) ⟩
+      (SynthState.nr-declared-pi st + Δpis i) + Δpis-sum is
+    ≡⟨ +-assoc (SynthState.nr-declared-pi st) (Δpis i) (Δpis-sum is) ⟩
+      SynthState.nr-declared-pi st + (Δpis i + Δpis-sum is)
+    ∎
+
+------------------------------------------------------------------------
+-- The walk builder.
+--
+-- `build` walks the instruction stream, consuming the memory suffix
+-- `mem-rest` and pis suffix `pis-rest` of `Witness.mem w` /
+-- `Witness.pis w` cell-by-cell (one `tr-cons` per instruction), and
+-- returns the endpoint state with its memory and pis equal to `w`'s, its
+-- `pub-in-idx` landing on the committed transcript length, and its
+-- public-output / private transcripts fully consumed.  It handles every
+-- instruction, threading four certificates:
+--   • a `Wire-Trace` (the `wire-disc` bound, indexed by the wire count
+--     `length (memory s)`) — so `output` / guarded inputs / skip guards
+--     can look their operands up in the prefix built so far;
+--   • a `TrFacts` (from `make-trfacts`) — the per-transcript-instruction
+--     guard decision and consumed value, and the skip-guard booleanity;
+--   • `pub-out-rem ≡ po` / `priv-rem ≡ pv` invariants, consumed to `[]`
+--     by the active public/private-input steps; and
+--   • a `PiInv` — the pi-skip transcript bookkeeping (O1's bracketing
+--     trace, the committed/current-group split of `pub-in-idx`, and the
+--     `make-pti` shape of `pre`'s verifier transcript).
+------------------------------------------------------------------------
+
+private
+  split1 : ∀ {n} (xs : List Fr) → length xs ≡ suc n
+    → Σ Fr (λ c → Σ (List Fr) (λ xs′ →
+         (xs ≡ c ∷ xs′) × (length xs′ ≡ n)))
+  split1 (c ∷ xs′) eq = c , xs′ , refl , suc-injective eq
+
+  split2 : ∀ {n} (xs : List Fr) → length xs ≡ suc (suc n)
+    → Σ Fr (λ a → Σ Fr (λ b → Σ (List Fr) (λ xs′ →
+         (xs ≡ a ∷ b ∷ xs′) × (length xs′ ≡ n))))
+  split2 (a ∷ b ∷ xs′) eq =
+    a , b , xs′ , refl , suc-injective (suc-injective eq)
+
+  -- A `mem-lookup` below the memory length always succeeds.
+  mem-lookup-exists : ∀ (xs : List Fr) (i : ℕ) → i < length xs
+    → Σ Fr (λ v → mem-lookup xs i ≡ just v)
+  mem-lookup-exists (x ∷ _)  zero    _           = x , refl
+  mem-lookup-exists (_ ∷ xs) (suc i) (s≤s i<len) =
+    mem-lookup-exists xs i i<len
+
+  -- The producer's `wire-disc` obligation, reflected into a `Wire-Trace`
+  -- (the witness-bearing form of the linear wire scan).  The bound
+  -- `WireOK i n` it threads at each step is exactly `i`'s operands
+  -- bounded by the wire count `n` allocated before `i`.
+  wire-scan→trace : ∀ is n {final} → wire-scan is n ≡ just final
+    → Wire-Trace is n final
+  wire-scan→trace []       n refl = wire-done
+  wire-scan→trace (i ∷ is) n eq with wire-step i n in step-eq
+  ... | just n′ = wire-cons step-eq (wire-scan→trace is n′ eq)
+
+  wire-bool→trace : ∀ {src} → T (wire-disc src)
+    → Σ ℕ (λ final →
+        Wire-Trace (IrSource.instructions src) (IrSource.num-inputs src) final)
+  wire-bool→trace {src} eq
+    with wire-scan (IrSource.instructions src) (IrSource.num-inputs src)
+         in scan-eq
+  ... | just final =
+        final , wire-scan→trace (IrSource.instructions src)
+                                (IrSource.num-inputs src) scan-eq
+
+  wire-disc-sound : ∀ {src} → T (producer-safe src)
+    → Σ ℕ (λ final →
+        Wire-Trace (IrSource.instructions src) (IrSource.num-inputs src) final)
+  wire-disc-sound {src} ps = wire-bool→trace {src} (producer-safe-wire-disc {src} ps)
+
+  -- Peel the head step's `WireOK` premise and the residual trace at the
+  -- bumped counter from a `Wire-Trace` over `i ∷ is`.
+  wire-trace-head-ok : ∀ {i is n final}
+    → Wire-Trace (i ∷ is) n final → WireOK i n
+  wire-trace-head-ok {i} {n = n} (wire-cons step-eq _)
+    with wireOK? i n | step-eq
+  ... | yes ok | refl = ok
+
+  wire-trace-tail : ∀ {i is n final}
+    → Wire-Trace (i ∷ is) n final → Wire-Trace is (n + Δmem i) final
+  wire-trace-tail {i} {n = n} (wire-cons step-eq tail)
+    with wireOK? i n | step-eq
+  ... | yes _ | refl = tail
+
+  -- Retag the residual trace to index the *next* state's memory length.
+  -- `wt-stay` covers a `Δmem i ≡ 0` step (memory unchanged); `wt-grow`
+  -- covers a step that appends `cells` (with `length cells ≡ Δmem i`),
+  -- so the next memory is `memory s ++ cells`.
+  wt-stay : ∀ {i is final} (s : Preprocessed) → Δmem i ≡ 0
+    → Wire-Trace (i ∷ is) (length (Preprocessed.memory s)) final
+    → Wire-Trace is (length (Preprocessed.memory s)) final
+  wt-stay s eq wt =
+    subst (λ k → Wire-Trace _ k _)
+      (trans (cong (length (Preprocessed.memory s) +_) eq) (+-identityʳ _))
+      (wire-trace-tail wt)
+
+  wt-grow : ∀ {i is final} (s : Preprocessed) (cells : List Fr)
+    → length cells ≡ Δmem i
+    → Wire-Trace (i ∷ is) (length (Preprocessed.memory s)) final
+    → Wire-Trace is (length (Preprocessed.memory s ++ cells)) final
+  wt-grow s cells eq wt =
+    subst (λ k → Wire-Trace _ k _)
+      (sym (trans (length-++ (Preprocessed.memory s) {cells})
+                  (cong (length (Preprocessed.memory s) +_) eq)))
+      (wire-trace-tail wt)
+
+  ------------------------------------------------------------------------
+  -- Transcript facts.  The transcript-reading instructions append a
+  -- memory cell whose value is constrained relative to the verifier
+  -- transcripts: an *active* `public-input` consumes the next
+  -- `pub-transcript-outputs` entry (= the cell `w` carries there), and an
+  -- *inactive* one is forced to `0ᶠ` by its guard-disj constraint.  `TrFacts`
+  -- bundles, per transcript instruction, the guard decision and the
+  -- consumed value, so the public-output / private supplies `po` / `pv`
+  -- that `pre` must carry are read off as the walk's *index*.  Built by
+  -- `make-trfacts` from `satisfies` (the guard-disj constraints) and consumed
+  -- by `build`.
+  ------------------------------------------------------------------------
+
+  GuardActive : Witness → Maybe Index → Set
+  GuardActive _ nothing   = ⊤
+  GuardActive w (just g) =
+    Σ Fr (λ iv → (Witness.mem w at g ↦ iv) × (iv ≡ 1ᶠ))
+
+  GuardInactive : Witness → Maybe Index → Set
+  GuardInactive _ nothing   = ⊥
+  GuardInactive w (just g) =
+    Σ Fr (λ iv → (Witness.mem w at g ↦ iv) × (iv ≡ 0ᶠ))
+
+  -- `NotTranscript i` marks the instructions `build` already tiles from
+  -- `mem-rest` (everything but the two transcript reads and `pi-skip`).
+  NotTranscript : Instruction → Set
+  NotTranscript (public-input _)  = ⊥
+  NotTranscript (private-input _) = ⊥
+  NotTranscript (pi-skip _ _)     = ⊥
+  NotTranscript _                 = ⊤
+
+  -- A guard wire's booleanity (trivial when unguarded).  The witness-level
+  -- O2 machinery below (`BoolKnown` / `bk-step` / the `O2-Trace` peelers)
+  -- produces this for a guarded `pi-skip`'s guard wire — the skip emits no
+  -- constraint, so its `is-bit` cannot be read off `satisfies`; it comes from
+  -- O2's `bool-known` set instead.
+  IsBitGuard : Witness → Maybe Index → Set
+  IsBitGuard _ nothing  = ⊤
+  IsBitGuard w (just g) =
+    Σ Fr (λ v → (Witness.mem w at g ↦ v) × is-bit v)
+
+  data TrFacts (w : Witness)
+       : List Instruction → ℕ → List Fr → List Fr → Set where
+    tf-nil  : ∀ {n} → TrFacts w [] n [] []
+    tf-other : ∀ {i is n po pv} → NotTranscript i
+      → TrFacts w is (n + Δmem i) po pv → TrFacts w (i ∷ is) n po pv
+    tf-pub-act : ∀ {g is n c po pv}
+      → GuardActive w g → (Witness.mem w at n ↦ c)
+      → TrFacts w is (suc n) po pv
+      → TrFacts w (public-input g ∷ is) n (c ∷ po) pv
+    tf-pub-inact : ∀ {g is n po pv}
+      → GuardInactive w g → (Witness.mem w at n ↦ 0ᶠ)
+      → TrFacts w is (suc n) po pv
+      → TrFacts w (public-input g ∷ is) n po pv
+    tf-priv-act : ∀ {g is n c po pv}
+      → GuardActive w g → (Witness.mem w at n ↦ c)
+      → TrFacts w is (suc n) po pv
+      → TrFacts w (private-input g ∷ is) n po (c ∷ pv)
+    tf-priv-inact : ∀ {g is n po pv}
+      → GuardInactive w g → (Witness.mem w at n ↦ 0ᶠ)
+      → TrFacts w is (suc n) po pv
+      → TrFacts w (private-input g ∷ is) n po pv
+    -- `pi-skip` appends no cell and consumes no transcript, but its guard
+    -- (if present) must be `is-bit` for the operational guard evaluation
+    -- to succeed (`to-bool` is `nothing` off {0,1}); the skip emits no
+    -- constraint, so this comes from O2's `bool-known` set, not `satisfies`.
+    tf-skip : ∀ {g count is n po pv}
+      → IsBitGuard w g
+      → TrFacts w is n po pv
+      → TrFacts w (pi-skip g count ∷ is) n po pv
+
+  -- The transcript supplies the preimage must carry, read off `w`: the
+  -- public-output / private supplies together with the `TrFacts` walk
+  -- they index.
+  record TrSupply (w : Witness) (is : List Instruction) (n : ℕ) : Set where
+    constructor mk-tr-supply
+    field
+      pub-out : List Fr
+      priv    : List Fr
+      facts   : TrFacts w is n pub-out priv
+
+  -- Peel a satisfies-constraints over an appended list.
+  sat-split : ∀ {w} (xs ys : List Constraint)
+    → satisfies-constraints (xs ++ ys) w
+    → satisfies-constraints xs w × satisfies-constraints ys w
+  sat-split xs _ = ++⁻ xs
+
+  -- One synthesis step appends a (possibly empty) constraint list.
+  constraint-extend : ∀ {hc} (i : Instruction) (st : SynthState)
+    → Σ (List Constraint) (λ new →
+        SynthState.constraints (circuit-instr hc i st)
+          ≡ SynthState.constraints st ++ new)
+  constraint-extend (assert _)               st = _ , refl
+  constraint-extend (cond-select _ _ _)      st = _ , refl
+  constraint-extend (constrain-bits _ _)     st = _ , refl
+  constraint-extend (constrain-eq _ _)       st = _ , refl
+  constraint-extend (constrain-to-boolean _) st = _ , refl
+  constraint-extend (copy _)                 st = _ , refl
+  constraint-extend (declare-pub-input _)    st = _ , refl
+  constraint-extend (pi-skip _ _)            st = _ , sym (++-identityʳ _)
+  constraint-extend (ec-add _ _ _ _)         st = _ , refl
+  constraint-extend (ec-mul _ _ _)           st = _ , refl
+  constraint-extend (ec-mul-generator _)     st = _ , refl
+  constraint-extend (hash-to-curve _)        st = _ , refl
+  constraint-extend (load-imm _)             st = _ , refl
+  constraint-extend (div-mod-power-of-two _ _) st = _ , refl
+  constraint-extend (reconstitute-field _ _ _) st = _ , refl
+  constraint-extend (output _)               st = _ , sym (++-identityʳ _)
+  constraint-extend (transient-hash _)       st = _ , refl
+  constraint-extend (persistent-hash _ _)    st = _ , refl
+  constraint-extend (test-eq _ _)            st = _ , refl
+  constraint-extend (add _ _)                st = _ , refl
+  constraint-extend (mul _ _)                st = _ , refl
+  constraint-extend (neg _)                  st = _ , refl
+  constraint-extend (not _)                  st = _ , refl
+  constraint-extend (less-than _ _ _)        st = _ , refl
+  constraint-extend (public-input nothing)   st = _ , sym (++-identityʳ _)
+  constraint-extend (public-input (just _))  st = _ , refl
+  constraint-extend (private-input nothing)  st = _ , sym (++-identityʳ _)
+  constraint-extend (private-input (just _)) st = _ , refl
+
+  -- Iterated: the whole instruction stream appends a tail.
+  constraints-extend-list : ∀ {hc} (is : List Instruction) (st : SynthState)
+    → Σ (List Constraint) (λ tail →
+        SynthState.constraints (circuit-instrs hc is st)
+          ≡ SynthState.constraints st ++ tail)
+  constraints-extend-list []       st = [] , sym (++-identityʳ _)
+  constraints-extend-list {hc} (i ∷ is) st =
+    let (new  , eq)  = constraint-extend {hc} i st
+        (tail , teq) = constraints-extend-list {hc} is (circuit-instr hc i st)
+    in new ++ tail
+     , trans teq (trans (cong (_++ tail) eq)
+                        (++-assoc (SynthState.constraints st) new tail))
+
+  -- The guard decision for a transcript instruction at wire `n`: either
+  -- active (consuming the cell `c` it carries there) or inactive (its
+  -- cell forced to `0ᶠ`).
+  GuardOutcome : Witness → Maybe Index → ℕ → Set
+  GuardOutcome w g n =
+      (Σ Fr (λ c → GuardActive w g × (Witness.mem w at n ↦ c)))
+    ⊎ (GuardInactive w g × (Witness.mem w at n ↦ 0ᶠ))
+
+  -- A guarded transcript instruction's guard-disj constraint decides the
+  -- outcome: a `1`-guard is active; a `0`-guard is inactive and the
+  -- disjunction `ov≡0 ∨ iv≡1` then forces the cell to `0ᶠ` (the `iv≡1`
+  -- alternative would make `1ᶠ ≡ 0ᶠ`).
+  classify-bit : ∀ (w : Witness) (gw n : Index) {ov iv : Fr}
+    → (Witness.mem w at gw ↦ iv) → (Witness.mem w at n ↦ ov)
+    → is-bit iv → (ov ≡ 0ᶠ) ⊎ (iv ≡ 1ᶠ)
+    → GuardOutcome w (just gw) n
+  classify-bit w gw n {ov} at-gw at-n (inj₂ iv≡1) _ =
+    inj₁ (ov , (_ , at-gw , iv≡1) , at-n)
+  classify-bit w gw n at-gw at-n (inj₁ iv≡0) (inj₁ ov≡0) =
+    inj₂ ((_ , at-gw , iv≡0)
+         , subst (λ z → Witness.mem w at n ↦ z) ov≡0 at-n)
+  classify-bit w gw n at-gw at-n (inj₁ iv≡0) (inj₂ iv≡1) =
+    ⊥-elim (1ᶠ≢0ᶠ (trans (sym iv≡1) iv≡0))
+
+  -- Peel the head instruction's appended constraint list from `satisfies`:
+  -- the `circuit-instr` constraints, dropping the tail.
+  head-constraints-sat : ∀ {hc} (w : Witness) (i : Instruction)
+      (is : List Instruction) (st : SynthState)
+    → satisfies-constraints
+        (SynthState.constraints (circuit-instrs hc (i ∷ is) st)) w
+    → satisfies-constraints (SynthState.constraints (circuit-instr hc i st)) w
+  head-constraints-sat {hc} w i is st sat =
+    let st₁          = circuit-instr hc i st
+        (tail , ceq) = constraints-extend-list {hc} is st₁
+    in proj₁ (sat-split (SynthState.constraints st₁) tail
+               (subst (λ cs → satisfies-constraints cs w) ceq sat))
+
+  -- Extract a guarded transcript instruction's guard-disj constraint from
+  -- `satisfies` and classify it.  `public-input (just gw)` and
+  -- `private-input (just gw)` synthesise the *same* constraint, so this
+  -- serves both.
+  gd-outcome : ∀ {hc} (w : Witness) (gw : Index)
+      (is : List Instruction) (st : SynthState) (n : ℕ)
+    → n ≡ SynthState.nr-wires st
+    → satisfies-constraints
+        (SynthState.constraints (circuit-instrs hc (public-input (just gw) ∷ is) st)) w
+    → GuardOutcome w (just gw) n
+  gd-outcome {hc} w gw is st n n≡ sat =
+    let sat-st₁ =
+          head-constraints-sat {hc} w (public-input (just gw)) is st sat
+        sat-gd  = proj₂ (sat-split (SynthState.constraints st)
+                   (guard-disj (SynthState.nr-wires st) gw ∷ []) sat-st₁)
+        (ov , iv , at-out , at-gw , bit , disj) = headᴬ sat-gd
+    in classify-bit w gw n at-gw
+         (subst (λ k → Witness.mem w at k ↦ ov) (sym n≡) at-out) bit disj
+
+  -- `public-input g` head: decide the outcome and emit the matching
+  -- `tf-pub-*`, given the tail facts.
+  pub-decide : ∀ {hc} (w : Witness) (g : Maybe Index)
+      (is : List Instruction) (st : SynthState) (n : ℕ)
+    → n ≡ SynthState.nr-wires st
+    → length (Witness.mem w) ≡ n + Δmem-sum (public-input g ∷ is)
+    → satisfies-constraints
+        (SynthState.constraints (circuit-instrs hc (public-input g ∷ is) st)) w
+    → TrSupply w is (suc n)
+    → TrSupply w (public-input g ∷ is) n
+  pub-decide w nothing is st n n≡ l sat (mk-tr-supply po pv tf-tail) =
+    let n<len : n < length (Witness.mem w)
+        n<len = subst (n <_) (sym l)
+                  (subst (n <_) (sym (+-suc n (Δmem-sum is)))
+                    (s≤s (m≤m+n n (Δmem-sum is))))
+        (c , at-c) = mem-lookup-exists (Witness.mem w) n n<len
+    in mk-tr-supply (c ∷ po) pv (tf-pub-act tt at-c tf-tail)
+  pub-decide {hc} w (just gw) is st n n≡ l sat (mk-tr-supply po pv tf-tail)
+    with gd-outcome {hc} w gw is st n n≡ sat
+  ... | inj₁ (c , ga , at-c) =
+        mk-tr-supply (c ∷ po) pv (tf-pub-act ga at-c tf-tail)
+  ... | inj₂ (gi , at-0)     =
+        mk-tr-supply po pv (tf-pub-inact gi at-0 tf-tail)
+
+  priv-decide : ∀ {hc} (w : Witness) (g : Maybe Index)
+      (is : List Instruction) (st : SynthState) (n : ℕ)
+    → n ≡ SynthState.nr-wires st
+    → length (Witness.mem w) ≡ n + Δmem-sum (private-input g ∷ is)
+    → satisfies-constraints
+        (SynthState.constraints (circuit-instrs hc (private-input g ∷ is) st)) w
+    → TrSupply w is (suc n)
+    → TrSupply w (private-input g ∷ is) n
+  priv-decide w nothing is st n n≡ l sat (mk-tr-supply po pv tf-tail) =
+    let n<len : n < length (Witness.mem w)
+        n<len = subst (n <_) (sym l)
+                  (subst (n <_) (sym (+-suc n (Δmem-sum is)))
+                    (s≤s (m≤m+n n (Δmem-sum is))))
+        (c , at-c) = mem-lookup-exists (Witness.mem w) n n<len
+    in mk-tr-supply po (c ∷ pv) (tf-priv-act tt at-c tf-tail)
+  priv-decide {hc} w (just gw) is st n n≡ l sat (mk-tr-supply po pv tf-tail)
+    with gd-outcome {hc} w gw is st n n≡ sat
+  ... | inj₁ (c , ga , at-c) =
+        mk-tr-supply po (c ∷ pv) (tf-priv-act ga at-c tf-tail)
+  ... | inj₂ (gi , at-0)     =
+        mk-tr-supply po pv (tf-priv-inact gi at-0 tf-tail)
+
+  ------------------------------------------------------------------------
+  -- Witness-level boolean-known invariant.  `pi-skip` emits no constraint, so
+  -- the `is-bit` of a guarded skip's guard wire cannot be read off
+  -- `satisfies` directly — it follows from O2, which requires the guard
+  -- in its `bool-known` set, and that set's members are all `is-bit` in
+  -- `w`.  `BoolKnown w bk` is the witness-level analogue of `O2-Inv`: it
+  -- keys the bit-property to `Witness.mem w` (the full memory) rather than
+  -- a growing operational state, so its preservation across `insert`
+  -- needs no positional reasoning — a membership in `i ∷ bk` is either the
+  -- fresh head (its `is-bit` supplied by the establishing constraint) or an
+  -- old member (its `is-bit` inherited).
+  ------------------------------------------------------------------------
+
+  BoolKnown : Witness → IndexSet → Set
+  BoolKnown w bk =
+    ∀ {j} → j ∈ bk
+    → Σ Fr (λ v → (Witness.mem w at j ↦ v) × is-bit v)
+
+  bk-empty : ∀ {w} → BoolKnown w []
+  bk-empty ()
+
+  -- Extend by a fresh wire whose value is `is-bit`.
+  bk-insert : ∀ {bk i v} (w : Witness) → (Witness.mem w at i ↦ v) → is-bit v
+    → BoolKnown w bk → BoolKnown w (insert i bk)
+  bk-insert w at-i bit bk (here refl)  = _ , at-i , bit
+  bk-insert w at-i bit bk (there j∈)   = bk j∈
+
+  -- Peel the single new constraint of a one-constraint instruction at wire `n`.
+  -- Used for `test-eq` / `less-than` / `not` / `cond-select` (output wire
+  -- `n`) and `constrain-to-boolean` / `copy` (operand wire).
+  single-constraint-holds : ∀ {hc} (w : Witness) (i : Instruction)
+      (is : List Instruction) (st : SynthState) (cl : Constraint)
+    → SynthState.constraints (circuit-instr hc i st)
+        ≡ SynthState.constraints st ++ (cl ∷ [])
+    → satisfies-constraints
+        (SynthState.constraints (circuit-instrs hc (i ∷ is) st)) w
+    → holds w cl
+  single-constraint-holds {hc} w i is st cl ceq sat =
+    headᴬ (proj₂ (sat-split (SynthState.constraints st) (cl ∷ [])
+            (subst (λ cs → satisfies-constraints cs w)
+                   ceq (head-constraints-sat {hc} w i is st sat))))
+
+  -- A wire equal to `from-bool b` is `is-bit`.  The Bool `b` is supplied
+  -- explicitly because `from-bool` is opaque to unification.
+  from-bool-eq-is-bit : ∀ {ov : Fr} (b : Bool) → ov ≡ from-bool b → is-bit ov
+  from-bool-eq-is-bit b eq = subst is-bit (sym eq) (from-bool-is-bit b)
+
+  -- The `cond-select` constraint output `(bv·av)+(1+(-bv))·cv` is `is-bit`
+  -- when the bit `bv` and both branches `av`, `cv` are.  When `bv ≡ 0ᶠ`
+  -- the expression reduces (by the field laws) to `cv`; when `bv ≡ 1ᶠ`,
+  -- to `av`.
+  mux-is-bit : ∀ {bv av cv ov : Fr} → is-bit bv → is-bit av → is-bit cv
+    → ov ≡ (bv *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ bv)) *ᶠ cv) → is-bit ov
+  mux-is-bit {bv} {av} {cv} (inj₁ bv≡0) _ cv-bit ov≡ =
+    subst is-bit (sym (trans ov≡ reduce)) cv-bit
+    where
+      reduce : (bv *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ bv)) *ᶠ cv) ≡ cv
+      reduce rewrite bv≡0 | -ᶠ-zero =
+        trans (cong₂ _+ᶠ_ (*-zero-l av)
+                  (trans (cong (_*ᶠ cv) (+-zero-r 1ᶠ)) (*-one-l cv)))
+              (+-zero-l cv)
+  mux-is-bit {bv} {av} {cv} (inj₂ bv≡1) av-bit _ ov≡ =
+    subst is-bit (sym (trans ov≡ reduce)) av-bit
+    where
+      reduce : (bv *ᶠ av) +ᶠ ((1ᶠ +ᶠ (-ᶠ bv)) *ᶠ cv) ≡ av
+      reduce rewrite bv≡1 =
+        trans (cong₂ _+ᶠ_ (*-one-l av)
+                  (trans (cong (_*ᶠ cv) (+-inv-r 1ᶠ)) (*-zero-l cv)))
+              (+-zero-r av)
+
+  -- `O2-record i n bk` preserves `BoolKnown`: each instruction that
+  -- extends the set adds a wire whose `is-bit` is read off the head
+  -- constraint from `satisfies` (`test-eq` / `less-than` / `not` /
+  -- `cond-select` outputs are `from-bool` / mux; `constrain-to-boolean`
+  -- pins the operand; `copy` inherits).  The boolean producers write to
+  -- `n ≡ nr-wires st`; the membership-conditioned cases (`copy`,
+  -- `cond-select`) branch on `_∈?_` exactly as `O2-record` does, so the
+  -- two stay in lockstep definitionally.
+  bk-step : ∀ {hc} (w : Witness) (i : Instruction) (bk : IndexSet)
+      (is : List Instruction) (st : SynthState) (n : ℕ)
+    → n ≡ SynthState.nr-wires st
+    → satisfies-constraints
+        (SynthState.constraints (circuit-instrs hc (i ∷ is) st)) w
+    → BoolKnown w bk → BoolKnown w (O2-record i n bk)
+  bk-step {hc} w (test-eq a b) bk is st n n≡ sat bkw =
+    let (av , bv , ov , _ , _ , at-out , ov≡) =
+          single-constraint-holds {hc} w (test-eq a b) is st
+            (test-eq n a b)
+            (cong (λ k → SynthState.constraints st ++ (test-eq k a b ∷ []))
+                  (sym n≡))
+            sat
+    in bk-insert w at-out (from-bool-eq-is-bit (av ≡ᶠ? bv) ov≡) bkw
+  bk-step {hc} w (less-than a b bits) bk is st n n≡ sat bkw =
+    let (av , bv , ov , _ , _ , at-out , _ , _ , ov≡) =
+          single-constraint-holds {hc} w (less-than a b bits) is st
+            (less-than n a b bits)
+            (cong (λ k → SynthState.constraints st
+                          ++ (less-than k a b bits ∷ [])) (sym n≡))
+            sat
+    in bk-insert w at-out
+         (from-bool-eq-is-bit
+            (bits-lt (take (lt-bits bits) (to-le-bits av))
+                     (take (lt-bits bits) (to-le-bits bv))) ov≡) bkw
+  bk-step {hc} w (not a) bk is st n n≡ sat bkw =
+    let (av , ov , _ , at-out , ov≡) =
+          single-constraint-holds {hc} w (not a) is st
+            (is-zero n a)
+            (cong (λ k → SynthState.constraints st ++ (is-zero k a ∷ []))
+                  (sym n≡))
+            sat
+    in bk-insert w at-out (from-bool-eq-is-bit (av ≡ᶠ? 0ᶠ) ov≡) bkw
+  bk-step {hc} w (constrain-to-boolean v) bk is st n n≡ sat bkw =
+    let (vv , at-v , vv-bit) =
+          single-constraint-holds {hc} w (constrain-to-boolean v) is st
+            (boolean v) refl sat
+    in bk-insert w at-v vv-bit bkw
+  bk-step {hc} w (copy v) bk is st n n≡ sat bkw with v ∈? bk
+  ... | no  _ = bkw
+  ... | yes v∈ =
+    let gate-h =
+          single-constraint-holds {hc} w (copy v) is st
+            (wire n ≑ wire v)
+            (cong (λ k → SynthState.constraints st
+                          ++ ((wire k ≑ wire v) ∷ []))
+                  (sym n≡))
+            sat
+        (vv , ov , at-v , at-out , ov≡) =
+          ≑wire-inv (Witness.mem w) {n} {v} gate-h
+        (_ , at-v′ , vv-bit) = bkw v∈
+        vv≡ = just-injective (trans (sym at-v′) at-v)
+    in bk-insert w at-out
+         (subst is-bit (trans vv≡ (sym ov≡)) vv-bit) bkw
+  bk-step {hc} w (cond-select b a c) bk is st n n≡ sat bkw
+    with a ∈? bk | c ∈? bk
+  ... | no  _ | _     = bkw
+  ... | yes _ | no  _ = bkw
+  ... | yes a∈ | yes c∈ =
+    let (bv , av , cv , ov , _ , at-a , at-c , at-out , bv-bit , ov≡) =
+          single-constraint-holds {hc} w (cond-select b a c) is st
+            (select n b a c)
+            (cong (λ k → SynthState.constraints st
+                          ++ (select k b a c ∷ [])) (sym n≡))
+            sat
+        (_ , at-a′ , av-bit) = bkw a∈
+        (_ , at-c′ , cv-bit) = bkw c∈
+        av-bit′ = subst is-bit (just-injective (trans (sym at-a′) at-a)) av-bit
+        cv-bit′ = subst is-bit (just-injective (trans (sym at-c′) at-c)) cv-bit
+    in bk-insert w at-out (mux-is-bit bv-bit av-bit′ cv-bit′ ov≡) bkw
+  -- Non-extending instructions: `O2-record _ _ bk = bk`.
+  bk-step w (assert _)               bk is st n _ _ bkw = bkw
+  bk-step w (constrain-bits _ _)     bk is st n _ _ bkw = bkw
+  bk-step w (constrain-eq _ _)       bk is st n _ _ bkw = bkw
+  bk-step w (declare-pub-input _)    bk is st n _ _ bkw = bkw
+  bk-step w (pi-skip _ _)            bk is st n _ _ bkw = bkw
+  bk-step w (ec-add _ _ _ _)         bk is st n _ _ bkw = bkw
+  bk-step w (ec-mul _ _ _)           bk is st n _ _ bkw = bkw
+  bk-step w (ec-mul-generator _)     bk is st n _ _ bkw = bkw
+  bk-step w (hash-to-curve _)        bk is st n _ _ bkw = bkw
+  bk-step w (load-imm _)             bk is st n _ _ bkw = bkw
+  bk-step w (div-mod-power-of-two _ _) bk is st n _ _ bkw = bkw
+  bk-step w (reconstitute-field _ _ _) bk is st n _ _ bkw = bkw
+  bk-step w (output _)               bk is st n _ _ bkw = bkw
+  bk-step w (transient-hash _)       bk is st n _ _ bkw = bkw
+  bk-step w (persistent-hash _ _)    bk is st n _ _ bkw = bkw
+  bk-step w (add _ _)                bk is st n _ _ bkw = bkw
+  bk-step w (mul _ _)                bk is st n _ _ bkw = bkw
+  bk-step w (neg _)                  bk is st n _ _ bkw = bkw
+  bk-step w (public-input _)         bk is st n _ _ bkw = bkw
+  bk-step w (private-input _)        bk is st n _ _ bkw = bkw
+
+  -- O2's `require-∈` succeeding (read off the threaded `O2-Trace`) gives
+  -- the guard's set membership, which `BoolKnown` turns into `is-bit`.
+  require-∈-∈ : ∀ (g : Index) (bk bk′ : IndexSet)
+    → require-∈ g bk ≡ just bk′ → g ∈ bk
+  require-∈-∈ g bk bk′ eq with g ∈? bk
+  ... | yes g∈ = g∈
+
+  require-∈-stable : ∀ (g : Index) (bk bk′ : IndexSet)
+    → require-∈ g bk ≡ just bk′ → bk′ ≡ bk
+  require-∈-stable g bk bk′ eq with g ∈? bk
+  ... | yes _ = sym (just-injective eq)
+
+  -- `O2-check` never grows its set (every branch returns the input `bk`,
+  -- via `require-∈`'s success or the trivial `just bk`).
+  o2-check-stable : ∀ (i : Instruction) (bk bk′ : IndexSet)
+    → O2-check i bk ≡ just bk′ → bk′ ≡ bk
+  o2-check-stable (assert c)          bk bk′ eq = require-∈-stable c bk bk′ eq
+  o2-check-stable (not a)             bk bk′ eq = require-∈-stable a bk bk′ eq
+  o2-check-stable (cond-select b _ _) bk bk′ eq = require-∈-stable b bk bk′ eq
+  o2-check-stable (pi-skip (just g) _) bk bk′ eq = require-∈-stable g bk bk′ eq
+  o2-check-stable (pi-skip nothing _) bk bk′ refl = refl
+  o2-check-stable (constrain-bits _ _) bk bk′ refl = refl
+  o2-check-stable (constrain-eq _ _)   bk bk′ refl = refl
+  o2-check-stable (constrain-to-boolean _) bk bk′ refl = refl
+  o2-check-stable (copy _)             bk bk′ refl = refl
+  o2-check-stable (declare-pub-input _) bk bk′ refl = refl
+  o2-check-stable (ec-add _ _ _ _)     bk bk′ refl = refl
+  o2-check-stable (ec-mul _ _ _)       bk bk′ refl = refl
+  o2-check-stable (ec-mul-generator _) bk bk′ refl = refl
+  o2-check-stable (hash-to-curve _)    bk bk′ refl = refl
+  o2-check-stable (load-imm _)         bk bk′ refl = refl
+  o2-check-stable (div-mod-power-of-two _ _) bk bk′ refl = refl
+  o2-check-stable (reconstitute-field _ _ _) bk bk′ refl = refl
+  o2-check-stable (output _)           bk bk′ refl = refl
+  o2-check-stable (transient-hash _)   bk bk′ refl = refl
+  o2-check-stable (persistent-hash _ _) bk bk′ refl = refl
+  o2-check-stable (test-eq _ _)        bk bk′ refl = refl
+  o2-check-stable (add _ _)            bk bk′ refl = refl
+  o2-check-stable (mul _ _)            bk bk′ refl = refl
+  o2-check-stable (neg _)              bk bk′ refl = refl
+  o2-check-stable (less-than _ _ _)    bk bk′ refl = refl
+  o2-check-stable (public-input _)     bk bk′ refl = refl
+  o2-check-stable (private-input _)    bk bk′ refl = refl
+
+  -- Peel one `O2-Trace` step: a successful `O2-step i (n, bk)` advances
+  -- the counter to `n + Δmem i` and leaves `bk` to `O2-record i n bk`
+  -- (the check never changes `bk`), so retag the tail.
+  o2-trace-tail : ∀ {i is n bk final}
+    → O2-Trace (i ∷ is) (n , bk) final
+    → O2-Trace is (n + Δmem i , O2-record i n bk) final
+  o2-trace-tail {i} {n = n} {bk} (o2-step {acc' = acc'} step-eq tail)
+    with O2-check i bk in chk
+  ... | just bk₁ =
+    subst (λ b → O2-Trace _ (n + Δmem i , O2-record i n b) _)
+          (o2-check-stable i bk bk₁ chk)
+          (subst (λ a → O2-Trace _ a _) (just-injective (sym step-eq)) tail)
+
+  -- A guarded `pi-skip` reaching this point has its guard in `bk`.
+  o2-trace-skip-∈ : ∀ {g count is n bk final}
+    → O2-Trace (pi-skip (just g) count ∷ is) (n , bk) final → g ∈ bk
+  o2-trace-skip-∈ {g} {n = n} {bk} (o2-step step-eq _)
+    with require-∈ g bk in chk
+  ... | just _ = require-∈-∈ g bk _ chk
+
+  -- A `pi-skip`'s guard wire is `is-bit` in `w`: O2 placed it in the
+  -- bool-known set, and `BoolKnown` carries that set's bit facts.
+  skip-guard-bit : ∀ {w bk n count is final} (g : Maybe Index)
+    → BoolKnown w bk
+    → O2-Trace (pi-skip g count ∷ is) (n , bk) final
+    → IsBitGuard w g
+  skip-guard-bit nothing   _   _   = tt
+  skip-guard-bit (just gw) bkw o2t = bkw (o2-trace-skip-∈ o2t)
+
+  ------------------------------------------------------------------------
+  -- The PI-transcript pre-pass.  `pi-skip` is non-monotone on
+  -- `pub-in-idx`: an *active* skip leaves it; an *inactive* one subtracts
+  -- the group size.  So the `pub-transcript-inputs` (`pti`) `pre` must
+  -- carry is the in-order concatenation of the *active* declare-groups,
+  -- and `pre`'s `pti` must be fixed *before* the walk (the active-skip
+  -- prefix-match reads it).  `make-pti` computes it from `w` alone: it
+  -- walks the instructions with the declared-value stream `decls` (the
+  -- pis tail of `w`) and the current group buffer `grp`, deciding each
+  -- skip's activity by `to-bool (mem w at guard)`.  An active skip
+  -- commits its group; an inactive one and the trailing (uncommitted)
+  -- group are dropped.
+  --
+  -- O1's full-bracketing (each skip's `count` equals the declares since
+  -- the previous skip, threaded as the `O1-Trace` in `PiInv`) is what
+  -- makes this transcript canonical: the active windows are exactly the
+  -- groups, in order.  Under the weaker pool-based O1, two active skips
+  -- can pin the same transcript position to different declared values,
+  -- and statement soundness FAILS for `pi-skip` (see the O1 header in
+  -- Obligations.agda).
+  ------------------------------------------------------------------------
+
+  -- Take / drop at a list's own length: the structural prefix lemmas the
+  -- active-skip window-match reduces to.
+  take-len-++ : ∀ (xs ys : List Fr) → take (length xs) (xs ++ ys) ≡ xs
+  take-len-++ []       ys = refl
+  take-len-++ (x ∷ xs) ys = cong (x ∷_) (take-len-++ xs ys)
+
+  drop-len-++ : ∀ (xs ys : List Fr) → drop (length xs) (xs ++ ys) ≡ ys
+  drop-len-++ []       ys = refl
+  drop-len-++ (x ∷ xs) ys = drop-len-++ xs ys
+
+  -- `≡ᶠ-list?` is reflexive (so an active skip whose `recent ≡ expected`
+  -- propositionally passes the boolean prefix-match).
+  ≡ᶠ-list?-refl : ∀ (xs : List Fr) → T (xs ≡ᶠ-list? xs)
+  ≡ᶠ-list?-refl []       = tt
+  ≡ᶠ-list?-refl (x ∷ xs) =
+    T-∧ .Equivalence.from
+      (subst T (sym (≡ᶠ?-refl {x})) tt , ≡ᶠ-list?-refl xs)
+
+  -- The guard's truth value, as a boolean (`true` iff active): the guard
+  -- evaluates to `just true`, everything else (`just false` / `nothing`)
+  -- to `false`.
+  pti-active : List Fr → Maybe Index → Bool
+  pti-active mem g = fromMaybe false (eval-guard mem g)
+
+  -- The active-group transcript.  `decls` is the declared-PI value stream
+  -- (the pis tail of `w`); `grp` the current uncommitted group.
+  make-pti : List Fr → List Instruction → (grp decls : List Fr) → List Fr
+  make-pti mem [] grp decls = []
+  make-pti mem (declare-pub-input _ ∷ is) grp (d ∷ ds) =
+    make-pti mem is (grp ++ (d ∷ [])) ds
+  make-pti mem (declare-pub-input _ ∷ is) grp [] = []
+  make-pti mem (pi-skip g _ ∷ is) grp decls =
+    if pti-active mem g
+      then grp ++ make-pti mem is [] decls
+      else make-pti mem is [] decls
+  make-pti mem (assert _ ∷ is)               grp decls = make-pti mem is grp decls
+  make-pti mem (cond-select _ _ _ ∷ is)      grp decls = make-pti mem is grp decls
+  make-pti mem (constrain-bits _ _ ∷ is)     grp decls = make-pti mem is grp decls
+  make-pti mem (constrain-eq _ _ ∷ is)       grp decls = make-pti mem is grp decls
+  make-pti mem (constrain-to-boolean _ ∷ is) grp decls = make-pti mem is grp decls
+  make-pti mem (copy _ ∷ is)                 grp decls = make-pti mem is grp decls
+  make-pti mem (ec-add _ _ _ _ ∷ is)         grp decls = make-pti mem is grp decls
+  make-pti mem (ec-mul _ _ _ ∷ is)           grp decls = make-pti mem is grp decls
+  make-pti mem (ec-mul-generator _ ∷ is)     grp decls = make-pti mem is grp decls
+  make-pti mem (hash-to-curve _ ∷ is)        grp decls = make-pti mem is grp decls
+  make-pti mem (load-imm _ ∷ is)             grp decls = make-pti mem is grp decls
+  make-pti mem (div-mod-power-of-two _ _ ∷ is) grp decls = make-pti mem is grp decls
+  make-pti mem (reconstitute-field _ _ _ ∷ is) grp decls = make-pti mem is grp decls
+  make-pti mem (output _ ∷ is)               grp decls = make-pti mem is grp decls
+  make-pti mem (transient-hash _ ∷ is)       grp decls = make-pti mem is grp decls
+  make-pti mem (persistent-hash _ _ ∷ is)    grp decls = make-pti mem is grp decls
+  make-pti mem (test-eq _ _ ∷ is)            grp decls = make-pti mem is grp decls
+  make-pti mem (add _ _ ∷ is)                grp decls = make-pti mem is grp decls
+  make-pti mem (mul _ _ ∷ is)                grp decls = make-pti mem is grp decls
+  make-pti mem (neg _ ∷ is)                  grp decls = make-pti mem is grp decls
+  make-pti mem (not _ ∷ is)                  grp decls = make-pti mem is grp decls
+  make-pti mem (less-than _ _ _ ∷ is)        grp decls = make-pti mem is grp decls
+  make-pti mem (public-input _ ∷ is)         grp decls = make-pti mem is grp decls
+  make-pti mem (private-input _ ∷ is)        grp decls = make-pti mem is grp decls
+
+  -- The pre-pass: from `satisfies` (the guard-disj constraints) read off, for
+  -- every transcript instruction, its guard decision and consumed value,
+  -- and hence the public-output / private supplies `pre` must carry.
+  -- `n` is the running wire count (= `nr-wires st`); the length premise
+  -- `length (mem w) ≡ n + Δmem-sum is` bounds nothing-guard lookups.
+  -- Alongside, it threads the witness-level O2 state: `bk` (with its
+  -- `BoolKnown` facts) and the producer's `O2-Trace`, which together
+  -- supply the `IsBitGuard` a `pi-skip` head's `tf-skip` needs.
+  mutual
+    make-trfacts : ∀ {hc} (w : Witness) (is : List Instruction)
+        (st : SynthState) (n : ℕ) (bk : IndexSet) {o2f : ℕ × IndexSet}
+      → n ≡ SynthState.nr-wires st
+      → length (Witness.mem w) ≡ n + Δmem-sum is
+      → BoolKnown w bk
+      → O2-Trace is (n , bk) o2f
+      → satisfies-constraints (SynthState.constraints (circuit-instrs hc is st)) w
+      → TrSupply w is n
+    make-trfacts w [] st n _ _ _ _ _ _ = mk-tr-supply [] [] tf-nil
+    make-trfacts w (assert c ∷ is) st n bk e l bkw o2t sat =
+      step-other w (assert c) is st n bk e l bkw o2t sat tt
+    make-trfacts w (cond-select b a c ∷ is) st n bk e l bkw o2t sat =
+      step-other w (cond-select b a c) is st n bk e l bkw o2t sat tt
+    make-trfacts w (constrain-bits v bits ∷ is) st n bk e l bkw o2t sat =
+      step-other w (constrain-bits v bits) is st n bk e l bkw o2t sat tt
+    make-trfacts w (constrain-eq a b ∷ is) st n bk e l bkw o2t sat =
+      step-other w (constrain-eq a b) is st n bk e l bkw o2t sat tt
+    make-trfacts w (constrain-to-boolean v ∷ is) st n bk e l bkw o2t sat =
+      step-other w (constrain-to-boolean v) is st n bk e l bkw o2t sat tt
+    make-trfacts w (copy v ∷ is) st n bk e l bkw o2t sat =
+      step-other w (copy v) is st n bk e l bkw o2t sat tt
+    make-trfacts w (declare-pub-input v ∷ is) st n bk e l bkw o2t sat =
+      step-other w (declare-pub-input v) is st n bk e l bkw o2t sat tt
+    make-trfacts w (ec-add ax ay bx by ∷ is) st n bk e l bkw o2t sat =
+      step-other w (ec-add ax ay bx by) is st n bk e l bkw o2t sat tt
+    make-trfacts w (ec-mul ax ay sc ∷ is) st n bk e l bkw o2t sat =
+      step-other w (ec-mul ax ay sc) is st n bk e l bkw o2t sat tt
+    make-trfacts w (ec-mul-generator sc ∷ is) st n bk e l bkw o2t sat =
+      step-other w (ec-mul-generator sc) is st n bk e l bkw o2t sat tt
+    make-trfacts w (hash-to-curve ins ∷ is) st n bk e l bkw o2t sat =
+      step-other w (hash-to-curve ins) is st n bk e l bkw o2t sat tt
+    make-trfacts w (load-imm imm ∷ is) st n bk e l bkw o2t sat =
+      step-other w (load-imm imm) is st n bk e l bkw o2t sat tt
+    make-trfacts w (div-mod-power-of-two v bits ∷ is) st n bk e l bkw o2t sat =
+      step-other w (div-mod-power-of-two v bits) is st n bk e l bkw o2t sat tt
+    make-trfacts w (reconstitute-field d m bits ∷ is) st n bk e l bkw o2t sat =
+      step-other w (reconstitute-field d m bits) is st n bk e l bkw o2t sat tt
+    make-trfacts w (output v ∷ is) st n bk e l bkw o2t sat =
+      step-other w (output v) is st n bk e l bkw o2t sat tt
+    make-trfacts w (transient-hash ins ∷ is) st n bk e l bkw o2t sat =
+      step-other w (transient-hash ins) is st n bk e l bkw o2t sat tt
+    make-trfacts w (persistent-hash α ins ∷ is) st n bk e l bkw o2t sat =
+      step-other w (persistent-hash α ins) is st n bk e l bkw o2t sat tt
+    make-trfacts w (test-eq a b ∷ is) st n bk e l bkw o2t sat =
+      step-other w (test-eq a b) is st n bk e l bkw o2t sat tt
+    make-trfacts w (add a b ∷ is) st n bk e l bkw o2t sat =
+      step-other w (add a b) is st n bk e l bkw o2t sat tt
+    make-trfacts w (mul a b ∷ is) st n bk e l bkw o2t sat =
+      step-other w (mul a b) is st n bk e l bkw o2t sat tt
+    make-trfacts w (neg a ∷ is) st n bk e l bkw o2t sat =
+      step-other w (neg a) is st n bk e l bkw o2t sat tt
+    make-trfacts w (not a ∷ is) st n bk e l bkw o2t sat =
+      step-other w (not a) is st n bk e l bkw o2t sat tt
+    make-trfacts w (less-than a b bits ∷ is) st n bk e l bkw o2t sat =
+      step-other w (less-than a b bits) is st n bk e l bkw o2t sat tt
+    -- `pi-skip` synthesises nothing (`circuit-instr` is the identity and
+    -- `Δmem` is 0), so everything passes through; the head's `tf-skip`
+    -- carries the guard booleanity read off `bk` / the `O2-Trace`.
+    make-trfacts {hc} w (pi-skip g count ∷ is) st n bk {o2f} n≡ l bkw o2t sat =
+      let o2t₁ : O2-Trace is (n , bk) o2f
+          o2t₁ = subst (λ k → O2-Trace is (k , bk) o2f) (+-identityʳ n)
+                       (o2-trace-tail o2t)
+          (mk-tr-supply po pv tf) =
+            make-trfacts {hc} w is st n bk n≡ l bkw o2t₁ sat
+      in mk-tr-supply po pv (tf-skip (skip-guard-bit g bkw o2t) tf)
+    make-trfacts {hc} w (public-input g ∷ is) st n bk n≡ l bkw o2t sat =
+      pub-decision {hc} w g is st n bk n≡ l bkw o2t sat
+    make-trfacts {hc} w (private-input g ∷ is) st n bk n≡ l bkw o2t sat =
+      priv-decision {hc} w g is st n bk n≡ l bkw o2t sat
+
+    -- Non-transcript head: tile via `tf-other`, recurse on the tail,
+    -- advancing the boolean-known set by `bk-step` and peeling the
+    -- `O2-Trace`.
+    step-other : ∀ {hc} (w : Witness) (i : Instruction)
+        (is : List Instruction) (st : SynthState) (n : ℕ) (bk : IndexSet)
+        {o2f : ℕ × IndexSet}
+      → n ≡ SynthState.nr-wires st
+      → length (Witness.mem w) ≡ n + Δmem-sum (i ∷ is)
+      → BoolKnown w bk
+      → O2-Trace (i ∷ is) (n , bk) o2f
+      → satisfies-constraints (SynthState.constraints (circuit-instrs hc (i ∷ is) st)) w
+      → NotTranscript i
+      → TrSupply w (i ∷ is) n
+    step-other {hc} w i is st n bk n≡ l bkw o2t sat nt =
+      let n≡′ : n + Δmem i ≡ SynthState.nr-wires (circuit-instr hc i st)
+          n≡′ = trans (cong (_+ Δmem i) n≡) (sym (nr-wires-step hc i st))
+          l′ : length (Witness.mem w) ≡ (n + Δmem i) + Δmem-sum is
+          l′ = trans l (sym (+-assoc n (Δmem i) (Δmem-sum is)))
+          (mk-tr-supply po pv tf) =
+            make-trfacts {hc} w is (circuit-instr hc i st) (n + Δmem i)
+              (O2-record i n bk) n≡′ l′
+              (bk-step {hc} w i bk is st n n≡ sat bkw)
+              (o2-trace-tail o2t) sat
+      in mk-tr-supply po pv (tf-other nt tf)
+
+    -- `public-input g`: decode the guard-disj constraint (if guarded), decide
+    -- active/inactive, recurse on the tail at cursor `suc n`.
+    pub-decision : ∀ {hc} (w : Witness) (g : Maybe Index)
+        (is : List Instruction) (st : SynthState) (n : ℕ) (bk : IndexSet)
+        {o2f : ℕ × IndexSet}
+      → n ≡ SynthState.nr-wires st
+      → length (Witness.mem w) ≡ n + Δmem-sum (public-input g ∷ is)
+      → BoolKnown w bk
+      → O2-Trace (public-input g ∷ is) (n , bk) o2f
+      → satisfies-constraints
+          (SynthState.constraints (circuit-instrs hc (public-input g ∷ is) st)) w
+      → TrSupply w (public-input g ∷ is) n
+    pub-decision {hc} w g is st n bk {o2f} n≡ l bkw o2t sat =
+      let st₁  = circuit-instr hc (public-input g) st
+          n≡₁ : suc n ≡ SynthState.nr-wires st₁
+          n≡₁ = trans (cong suc n≡)
+                 (trans (sym (+-comm (SynthState.nr-wires st) 1))
+                        (sym (nr-wires-step hc (public-input g) st)))
+          l₁ : length (Witness.mem w) ≡ suc n + Δmem-sum is
+          l₁ = trans l (+-suc n (Δmem-sum is))
+          o2t₁ : O2-Trace is (suc n , bk) o2f
+          o2t₁ = subst (λ k → O2-Trace is (k , bk) o2f) (+-comm n 1)
+                       (o2-trace-tail o2t)
+      in pub-decide {hc} w g is st n n≡ l sat
+           (make-trfacts {hc} w is st₁ (suc n) bk n≡₁ l₁ bkw o2t₁ sat)
+
+    priv-decision : ∀ {hc} (w : Witness) (g : Maybe Index)
+        (is : List Instruction) (st : SynthState) (n : ℕ) (bk : IndexSet)
+        {o2f : ℕ × IndexSet}
+      → n ≡ SynthState.nr-wires st
+      → length (Witness.mem w) ≡ n + Δmem-sum (private-input g ∷ is)
+      → BoolKnown w bk
+      → O2-Trace (private-input g ∷ is) (n , bk) o2f
+      → satisfies-constraints
+          (SynthState.constraints (circuit-instrs hc (private-input g ∷ is) st)) w
+      → TrSupply w (private-input g ∷ is) n
+    priv-decision {hc} w g is st n bk {o2f} n≡ l bkw o2t sat =
+      let st₁  = circuit-instr hc (private-input g) st
+          n≡₁ : suc n ≡ SynthState.nr-wires st₁
+          n≡₁ = trans (cong suc n≡)
+                 (trans (sym (+-comm (SynthState.nr-wires st) 1))
+                        (sym (nr-wires-step hc (private-input g) st)))
+          l₁ : length (Witness.mem w) ≡ suc n + Δmem-sum is
+          l₁ = trans l (+-suc n (Δmem-sum is))
+          o2t₁ : O2-Trace is (suc n , bk) o2f
+          o2t₁ = subst (λ k → O2-Trace is (k , bk) o2f) (+-comm n 1)
+                       (o2-trace-tail o2t)
+      in priv-decide {hc} w g is st n n≡ l sat
+           (make-trfacts {hc} w is st₁ (suc n) bk n≡₁ l₁ bkw o2t₁ sat)
+
+  -- Lookup at the boundary of a tiling: the cell just past `xs`.
+  lookup-bound : ∀ (xs : List Fr) (y : Fr) (ys : List Fr)
+    → mem-lookup (xs ++ (y ∷ ys)) (length xs) ≡ just y
+  lookup-bound []       y ys = refl
+  lookup-bound (x ∷ xs) y ys = lookup-bound xs y ys
+
+  -- Lookup below the prefix length is unaffected by an appended suffix.
+  lookup-prefix : ∀ (xs ys : List Fr) (i : ℕ) → i < length xs
+    → mem-lookup (xs ++ ys) i ≡ mem-lookup xs i
+  lookup-prefix (x ∷ xs) ys zero    _         = refl
+  lookup-prefix (x ∷ xs) ys (suc i) (s≤s lt) = lookup-prefix xs ys i lt
+
+  -- A guard's evaluation, given the guard wire's value.
+  eval-guard-eq : ∀ (mem : List Fr) (gw : Index) {v : Fr}
+    → mem-lookup mem gw ≡ just v → eval-guard mem (just gw) ≡ to-bool v
+  eval-guard-eq mem gw eq rewrite eq = refl
+
+  -- Retag a `TrFacts` tail (peeled from `tf-other`) to the next state's
+  -- memory length.  The tail is indexed at `length (memory s) + Δmem i`,
+  -- which for a concrete `i` reduces to `+ 0` / `+ 1` / `+ 2`; the three
+  -- helpers handle those, avoiding an uninferable `Δmem i`.
+  tf-stay : ∀ {w is po pv} (s : Preprocessed)
+    → TrFacts w is (length (Preprocessed.memory s) + 0) po pv
+    → TrFacts w is (length (Preprocessed.memory s)) po pv
+  tf-stay s tl = subst (λ k → TrFacts _ _ k _ _) (+-identityʳ _) tl
+
+  tf-grow1 : ∀ {w is po pv} (s : Preprocessed) (c : Fr)
+    → TrFacts w is (length (Preprocessed.memory s) + 1) po pv
+    → TrFacts w is (length (Preprocessed.memory s ++ (c ∷ []))) po pv
+  tf-grow1 s c tl =
+    subst (λ k → TrFacts _ _ k _ _)
+      (sym (length-++ (Preprocessed.memory s) {c ∷ []})) tl
+
+  tf-grow2 : ∀ {w is po pv} (s : Preprocessed) (a b : Fr)
+    → TrFacts w is (length (Preprocessed.memory s) + 2) po pv
+    → TrFacts w is (length (Preprocessed.memory s ++ (a ∷ b ∷ []))) po pv
+  tf-grow2 s a b tl =
+    subst (λ k → TrFacts _ _ k _ _)
+      (sym (length-++ (Preprocessed.memory s) {a ∷ b ∷ []})) tl
+
+  -- A transcript step appends one cell; its `TrFacts` tail is indexed at
+  -- `suc n` (not `n + Δmem`), so retag it to the next memory length.
+  tf-suc : ∀ {w is po pv} (s : Preprocessed) (cell : Fr)
+    → TrFacts w is (suc (length (Preprocessed.memory s))) po pv
+    → TrFacts w is (length (Preprocessed.memory s ++ (cell ∷ []))) po pv
+  tf-suc s cell tl =
+    subst (λ k → TrFacts _ _ k _ _)
+      (trans (sym (+-comm (length (Preprocessed.memory s)) 1))
+             (sym (length-++ (Preprocessed.memory s) {cell ∷ []}))) tl
+
+  -- Invert the `O1-Trace` constructors the walk's pi-skip / declare /
+  -- nil cases consume.
+  o1-nil-zero : ∀ {d} → O1-Trace d [] → d ≡ 0
+  o1-nil-zero o1-nil = refl
+
+  o1-decl-inv : ∀ {d v is} → O1-Trace d (declare-pub-input v ∷ is)
+    → O1-Trace (suc d) is
+  o1-decl-inv (o1-decl t) = t
+
+  o1-skip-inv : ∀ {d g n is} → O1-Trace d (pi-skip g n ∷ is)
+    → (n ≡ d) × O1-Trace 0 is
+  o1-skip-inv (o1-skip n≡d t) = n≡d , t
+
+  -- The pi-skip / public-input transcript invariants threaded by `build`:
+  -- the bracketing trace; that `pub-in-idx` is the committed-plus-current
+  -- group size; that the current group `grp` is a suffix of `pis`; and
+  -- that the verifier transcript `pre` carries is the committed groups
+  -- followed by the active groups still to come (`make-pti`).
+  record PiInv (pre : ProofPreimage) (w : Witness) (is : List Instruction)
+               (s : Preprocessed) (committed grp pis-rest : List Fr) : Set where
+    constructor mk-piinv
+    field
+      o1pii  : O1-Trace (length grp) is
+      pidx   : Preprocessed.pub-in-idx s ≡ length committed + length grp
+      pis-sf : Σ (List Fr) (λ ph → Preprocessed.pis s ≡ ph ++ grp)
+      pti-eq : ProofPreimage.pub-transcript-inputs pre
+             ≡ committed ++ make-pti (Witness.mem w) is grp pis-rest
+
+  -- Thread `PiInv` past a non-declare/skip head `i` to the next state
+  -- `s'` (which preserves `pub-in-idx`/`pis`); `make-pti` ignores such an
+  -- `i`, so the transcript invariant is unchanged.
+  pi-pass : ∀ {pre w i is committed grp pis-rest} (s s′ : Preprocessed)
+    → NotDeclSkip i
+    → Preprocessed.pub-in-idx s′ ≡ Preprocessed.pub-in-idx s
+    → Preprocessed.pis        s′ ≡ Preprocessed.pis        s
+    → make-pti (Witness.mem w) (i ∷ is) grp pis-rest
+        ≡ make-pti (Witness.mem w) is grp pis-rest
+    → PiInv pre w (i ∷ is) s  committed grp pis-rest
+    → PiInv pre w is        s′ committed grp pis-rest
+  pi-pass s s′ nt pidx≡ pis≡ mk≡ pii =
+    let (ph , pe) = PiInv.pis-sf pii in
+    mk-piinv (o1-tail nt (PiInv.o1pii pii))
+             (trans pidx≡ (PiInv.pidx pii))
+             (ph , trans pis≡ pe)
+             (trans (PiInv.pti-eq pii) (cong (_ ++_) mk≡))
+
+  -- The prefix-match an ACTIVE `pi-skip` must exhibit.  The last `count =
+  -- length grp` pis cells are the current group `grp` (the pis suffix
+  -- `pe`), and the verifier transcript reads `committed ++ (grp ++ mkrest)`
+  -- with the matching window landing on `grp` (from `pidx` and `pti≡`), so
+  -- both windows are `grp` and the check is reflexivity.
+  skip-match : ∀ (pre : ProofPreimage) (s : Preprocessed)
+      (committed grp mkrest ph : List Fr) {count : ℕ}
+    → count ≡ length grp
+    → Preprocessed.pis s ≡ ph ++ grp
+    → Preprocessed.pub-in-idx s ≡ length committed + length grp
+    → ProofPreimage.pub-transcript-inputs pre ≡ committed ++ (grp ++ mkrest)
+    → T (drop (length (Preprocessed.pis s) ∸ count) (Preprocessed.pis s)
+          ≡ᶠ-list?
+         take count (drop (Preprocessed.pub-in-idx s ∸ count)
+                          (ProofPreimage.pub-transcript-inputs pre)))
+  skip-match pre s committed grp mkrest ph {count} count≡ pe pidx pti≡ =
+    let recent≡ : drop (length (Preprocessed.pis s) ∸ count)
+                       (Preprocessed.pis s) ≡ grp
+        recent≡ =
+          trans (cong₂ drop
+                  (trans (cong₂ _∸_ (trans (cong length pe) (length-++ ph))
+                                    count≡)
+                         (m+n∸n≡m (length ph) (length grp)))
+                  pe)
+                (drop-len-++ ph grp)
+        expected≡ : take count
+                      (drop (Preprocessed.pub-in-idx s ∸ count)
+                            (ProofPreimage.pub-transcript-inputs pre)) ≡ grp
+        expected≡ =
+          trans (cong₂ (λ a xs → take count (drop a xs))
+                  (trans (cong₂ _∸_ pidx count≡)
+                         (m+n∸n≡m (length committed) (length grp)))
+                  pti≡)
+            (trans (cong (take count) (drop-len-++ committed (grp ++ mkrest)))
+              (trans (cong (λ k → take k (grp ++ mkrest)) count≡)
+                     (take-len-++ grp mkrest)))
+    in subst₂ (λ a b → T (a ≡ᶠ-list? b))
+              (sym recent≡) (sym expected≡) (≡ᶠ-list?-refl grp)
+
+  -- The end state `wstate` of the walk over `is`, packaged with proofs
+  -- that it tiles the memory / pis suffixes of `w`, has consumed all its
+  -- public-output / private transcripts, and validated exactly
+  -- `length committed + length (make-pti …)` public inputs.  A record (not
+  -- a nested Σ/×) so the fields are named at every use site.
+  record WalkResult (pre : ProofPreimage) (w : Witness)
+                    (is : List Instruction) (s : Preprocessed)
+                    (committed grp mem-rest pis-rest : List Fr) : Set where
+    constructor mk-walk
+    field
+      wstate : Preprocessed
+      wtr    : Tr-shaped pre s is wstate mem-rest pis-rest
+      wmem   : Preprocessed.memory     wstate ≡ Witness.mem w
+      wpis   : Preprocessed.pis        wstate ≡ Witness.pis w
+      widx   : Preprocessed.pub-in-idx wstate
+                 ≡ length committed
+                 + length (make-pti (Witness.mem w) is grp pis-rest)
+      wpout  : Preprocessed.pub-out-rem wstate ≡ []
+      wpriv  : Preprocessed.priv-rem    wstate ≡ []
+
+  build : ∀ (pre : ProofPreimage) (w : Witness) (is : List Instruction)
+            (s : Preprocessed) (mem-rest pis-rest : List Fr)
+            {final : ℕ} {po pv : List Fr}
+        → TrFacts w is (length (Preprocessed.memory s)) po pv
+        → Wire-Trace is (length (Preprocessed.memory s)) final
+        → Preprocessed.pub-out-rem s ≡ po
+        → Preprocessed.priv-rem    s ≡ pv
+        → Preprocessed.memory s ++ mem-rest ≡ Witness.mem w
+        → Preprocessed.pis    s ++ pis-rest ≡ Witness.pis w
+        → length mem-rest ≡ Δmem-sum is
+        → length pis-rest ≡ Δpis-sum is
+        → (committed grp : List Fr)
+        → PiInv pre w is s committed grp pis-rest
+        → WalkResult pre w is s committed grp mem-rest pis-rest
+
+  -- The three per-shape walk steps, one per non-transcript instruction
+  -- Δmem class (0 / 1 / 2 cells appended).  Each peels its head's
+  -- `Tr-shaped` `tr-step` payload `sd` (built at the call site, where the
+  -- instruction is concrete so `op-side-data` / `next-state-from-osd`
+  -- compute), recurses over the tail, and prepends `tr-cons sd`.  Being
+  -- generic in the head `i` — with `tr-next … sd ≡ <next state>`,
+  -- `Δmem i ≡ k`, `NotDeclSkip i`, and the `make-pti` identity passed in —
+  -- collapses the otherwise-identical per-instruction clauses to a
+  -- one-line dispatch.
+  step0 : ∀ (pre : ProofPreimage) (w : Witness) {i : Instruction}
+            (is : List Instruction) (s : Preprocessed)
+            (mem-rest pis-rest committed grp : List Fr)
+            {final : ℕ} {po pv : List Fr}
+        → (sd : tr-step i pre s [] [])
+        → tr-next i pre s [] [] sd ≡ s
+        → Δmem i ≡ 0
+        → NotDeclSkip i
+        → make-pti (Witness.mem w) (i ∷ is) grp pis-rest
+            ≡ make-pti (Witness.mem w) is grp pis-rest
+        → TrFacts w is (length (Preprocessed.memory s) + 0) po pv
+        → Wire-Trace (i ∷ is) (length (Preprocessed.memory s)) final
+        → Preprocessed.pub-out-rem s ≡ po
+        → Preprocessed.priv-rem    s ≡ pv
+        → Preprocessed.memory s ++ mem-rest ≡ Witness.mem w
+        → Preprocessed.pis    s ++ pis-rest ≡ Witness.pis w
+        → length mem-rest ≡ Δmem-sum is
+        → length pis-rest ≡ Δpis-sum is
+        → PiInv pre w (i ∷ is) s committed grp pis-rest
+        → WalkResult pre w (i ∷ is) s committed grp mem-rest pis-rest
+
+  step1 : ∀ (pre : ProofPreimage) (w : Witness) {i : Instruction}
+            (is : List Instruction) (s : Preprocessed) (c : Fr)
+            (rest′ pis-rest committed grp : List Fr)
+            {final : ℕ} {po pv : List Fr}
+        → (sd : tr-step i pre s (c ∷ []) [])
+        → tr-next i pre s (c ∷ []) [] sd ≡ push-mem s c
+        → Δmem i ≡ 1
+        → NotDeclSkip i
+        → make-pti (Witness.mem w) (i ∷ is) grp pis-rest
+            ≡ make-pti (Witness.mem w) is grp pis-rest
+        → TrFacts w is (length (Preprocessed.memory s) + 1) po pv
+        → Wire-Trace (i ∷ is) (length (Preprocessed.memory s)) final
+        → Preprocessed.pub-out-rem s ≡ po
+        → Preprocessed.priv-rem    s ≡ pv
+        → Preprocessed.memory s ++ (c ∷ rest′) ≡ Witness.mem w
+        → Preprocessed.pis    s ++ pis-rest ≡ Witness.pis w
+        → length rest′ ≡ Δmem-sum is
+        → length pis-rest ≡ Δpis-sum is
+        → PiInv pre w (i ∷ is) s committed grp pis-rest
+        → WalkResult pre w (i ∷ is) s committed grp (c ∷ rest′) pis-rest
+
+  step2 : ∀ (pre : ProofPreimage) (w : Witness) {i : Instruction}
+            (is : List Instruction) (s : Preprocessed) (a b : Fr)
+            (rest′ pis-rest committed grp : List Fr)
+            {final : ℕ} {po pv : List Fr}
+        → (sd : tr-step i pre s (a ∷ b ∷ []) [])
+        → tr-next i pre s (a ∷ b ∷ []) [] sd ≡ push-mem2 s a b
+        → Δmem i ≡ 2
+        → NotDeclSkip i
+        → make-pti (Witness.mem w) (i ∷ is) grp pis-rest
+            ≡ make-pti (Witness.mem w) is grp pis-rest
+        → TrFacts w is (length (Preprocessed.memory s) + 2) po pv
+        → Wire-Trace (i ∷ is) (length (Preprocessed.memory s)) final
+        → Preprocessed.pub-out-rem s ≡ po
+        → Preprocessed.priv-rem    s ≡ pv
+        → Preprocessed.memory s ++ (a ∷ b ∷ rest′) ≡ Witness.mem w
+        → Preprocessed.pis    s ++ pis-rest ≡ Witness.pis w
+        → length rest′ ≡ Δmem-sum is
+        → length pis-rest ≡ Δpis-sum is
+        → PiInv pre w (i ∷ is) s committed grp pis-rest
+        → WalkResult pre w (i ∷ is) s committed grp
+            (a ∷ b ∷ rest′) pis-rest
+
+  build pre w [] s []       []      tf-nil _ poeq pveq memeq piseq lmem lpis
+        committed grp pii =
+    mk-walk s tr-nil
+      (trans (sym (++-identityʳ _)) memeq)
+      (trans (sym (++-identityʳ _)) piseq)
+      (trans (PiInv.pidx pii)
+             (cong (length committed +_) (o1-nil-zero (PiInv.o1pii pii))))
+      poeq pveq
+  build pre w [] s (_ ∷ _) _        tf-nil _ _ _ memeq piseq () lpis _ _ _
+  build pre w [] s []      (_ ∷ _)  tf-nil _ _ _ memeq piseq lmem () _ _ _
+  build pre w (assert _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii =
+    step0 pre w is s mem-rest pis-rest committed grp
+          (refl , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lenp lpis pii
+  build pre w (constrain-bits _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii =
+    step0 pre w is s mem-rest pis-rest committed grp
+          (refl , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lenp lpis pii
+  build pre w (constrain-eq _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii =
+    step0 pre w is s mem-rest pis-rest committed grp
+          (refl , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lenp lpis pii
+  build pre w (constrain-to-boolean _ ∷ is)
+        s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii =
+    step0 pre w is s mem-rest pis-rest committed grp
+          (refl , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lenp lpis pii
+  build pre w (copy _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (load-imm _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (transient-hash _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (cond-select _ _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (not _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (less-than _ _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (neg _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (reconstitute-field _ _ _ ∷ is)
+        s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (test-eq _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (add _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (mul _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lenp lpis committed grp pii
+    with split1 mem-rest lenp
+  ... | c , rest′ , refl , lreq =
+    step1 pre w is s c rest′ pis-rest committed grp
+          ((c , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lreq lpis pii
+  build pre w (ec-add _ _ _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split2 mem-rest lmem
+  ... | a , b , rest′ , refl , lmem′ =
+    step2 pre w is s a b rest′ pis-rest committed grp
+          ((a , b , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lmem′ lpis pii
+  build pre w (ec-mul _ _ _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split2 mem-rest lmem
+  ... | a , b , rest′ , refl , lmem′ =
+    step2 pre w is s a b rest′ pis-rest committed grp
+          ((a , b , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lmem′ lpis pii
+  build pre w (ec-mul-generator _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split2 mem-rest lmem
+  ... | a , b , rest′ , refl , lmem′ =
+    step2 pre w is s a b rest′ pis-rest committed grp
+          ((a , b , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lmem′ lpis pii
+  build pre w (hash-to-curve _ ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split2 mem-rest lmem
+  ... | a , b , rest′ , refl , lmem′ =
+    step2 pre w is s a b rest′ pis-rest committed grp
+          ((a , b , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lmem′ lpis pii
+  build pre w (persistent-hash _ _ ∷ is)
+        s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split2 mem-rest lmem
+  ... | a , b , rest′ , refl , lmem′ =
+    step2 pre w is s a b rest′ pis-rest committed grp
+          ((a , b , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lmem′ lpis pii
+  build pre w (div-mod-power-of-two _ _ ∷ is)
+        s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split2 mem-rest lmem
+  ... | a , b , rest′ , refl , lmem′ =
+    step2 pre w is s a b rest′ pis-rest committed grp
+          ((a , b , refl) , refl) refl refl tt refl
+          tf wt poeq pveq memeq piseq lmem′ lpis pii
+  build pre w (output v ∷ is) s mem-rest pis-rest (tf-other _ tf) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with mem-lookup-exists (Preprocessed.memory s) v (wire-trace-head-ok wt)
+  ... | val , lk =
+    let (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is
+            (record s { outputs = Preprocessed.outputs s ++ (val ∷ []) })
+            mem-rest pis-rest (tf-stay s tf)
+            (wt-stay s refl wt) poeq pveq memeq piseq lmem lpis
+            committed grp (pi-pass s _ tt refl refl refl pii)
+    in mk-walk s′ (tr-cons ((val , lk) , refl , refl) tr) m≡ p≡ i≡ o≡ v≡
+  build pre w (declare-pub-input v ∷ is)
+        s mem-rest pis-rest (tf-other _ tf) wt poeq pveq
+        memeq piseq lmem lpis committed grp pii
+    with split1 pis-rest lpis
+  ... | wv , prest′ , refl , lpis′ =
+    let (ph , pe) = PiInv.pis-sf pii
+        -- The declared cell joins the current group: `grp ++ (wv ∷ [])`,
+        -- whose length is `suc (length grp)`.
+        lg≡ : length (grp ++ (wv ∷ [])) ≡ suc (length grp)
+        lg≡ = trans (length-++ grp) (+-comm (length grp) 1)
+        pii′ : PiInv pre w is
+                 (record s { pis = Preprocessed.pis s ++ (wv ∷ [])
+                           ; pub-in-idx = suc (Preprocessed.pub-in-idx s) })
+                 committed (grp ++ (wv ∷ [])) prest′
+        pii′ = mk-piinv
+                 (subst (λ k → O1-Trace k is) (sym lg≡)
+                        (o1-decl-inv (PiInv.o1pii pii)))
+                 (trans (cong suc (PiInv.pidx pii))
+                        (trans (sym (+-suc (length committed) (length grp)))
+                               (cong (length committed +_) (sym lg≡))))
+                 (ph , trans (cong (_++ (wv ∷ [])) pe)
+                             (++-assoc ph grp (wv ∷ [])))
+                 (PiInv.pti-eq pii)
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is
+            (record s { pis = Preprocessed.pis s ++ (wv ∷ [])
+                      ; pub-in-idx = suc (Preprocessed.pub-in-idx s) })
+            mem-rest prest′ (tf-stay s tf)
+            (wt-stay s refl wt) poeq pveq memeq
+            (trans (++-assoc (Preprocessed.pis s) (wv ∷ []) prest′) piseq)
+            lmem lpis′ committed (grp ++ (wv ∷ [])) pii′
+    in mk-walk s′ (tr-cons (refl , wv , refl) tr) m≡ p≡ i≡ o≡ v≡
+  -- ── pi-skip ───────────────────────────────────────────────────────
+  -- An ACTIVE skip checks the last `count` pis cells against the
+  -- transcript window at `pub-in-idx ∸ count` and commits the group:
+  -- `PiInv` pins both sides to exactly the current group `grp` (`count ≡
+  -- length grp` by O1's full-bracketing; `grp` is the pis suffix by
+  -- `pis-sf`; the window is the next active group of `make-pti` by
+  -- `pidx` + `pti-eq`), so the prefix-match is reflexivity.  An INACTIVE
+  -- skip rolls `pub-in-idx` back by `count`, discarding the group.  The
+  -- guard's truth value comes off the `tf-skip` bit fact: `is-bit`
+  -- splits it into the 1ᶠ (active) and 0ᶠ (inactive) cases.
+  build pre w (pi-skip nothing count ∷ is) s mem-rest pis-rest
+        (tf-skip _ tf-tl) wt poeq pveq memeq piseq lmem lpis
+        committed grp pii =
+    let (count≡ , o1tl) = o1-skip-inv (PiInv.o1pii pii)
+        (ph , pe)       = PiInv.pis-sf pii
+        mkrest          = make-pti (Witness.mem w) is [] pis-rest
+        match = skip-match pre s committed grp mkrest ph count≡ pe
+                           (PiInv.pidx pii) (PiInv.pti-eq pii)
+        s₁ = record s { pi-skips = Preprocessed.pi-skips s ++ (nothing ∷ []) }
+        pii′ : PiInv pre w is s₁ (committed ++ grp) [] pis-rest
+        pii′ = mk-piinv o1tl
+                 (trans (PiInv.pidx pii)
+                        (sym (trans (+-identityʳ _) (length-++ committed))))
+                 (Preprocessed.pis s , sym (++-identityʳ _))
+                 (trans (PiInv.pti-eq pii)
+                        (sym (++-assoc committed grp mkrest)))
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is s₁ mem-rest pis-rest tf-tl (wt-stay s refl wt)
+            poeq pveq memeq piseq lmem lpis (committed ++ grp) [] pii′
+    in mk-walk s′ (tr-cons (refl , refl , true , refl , match) tr) m≡ p≡
+      (trans i≡
+          (trans (cong (_+ length mkrest) (length-++ committed))
+            (trans (+-assoc (length committed) (length grp) (length mkrest))
+                   (cong (length committed +_) (sym (length-++ grp))))))
+      o≡ v≡
+  build pre w (pi-skip (just gw) count ∷ is) s mem-rest pis-rest
+        (tf-skip (gv , at-gw , inj₂ gv≡1) tf-tl) wt poeq pveq memeq piseq
+        lmem lpis committed grp pii =
+    let (count≡ , o1tl) = o1-skip-inv (PiInv.o1pii pii)
+        (ph , pe)       = PiInv.pis-sf pii
+        mkrest          = make-pti (Witness.mem w) is [] pis-rest
+        gw<len = wire-trace-head-ok wt
+        look-s-gw : mem-lookup (Preprocessed.memory s) gw ≡ just gv
+        look-s-gw =
+          trans (sym (lookup-prefix (Preprocessed.memory s) mem-rest gw gw<len))
+                (trans (cong (λ m → mem-lookup m gw) memeq) at-gw)
+        eval-s≡ : eval-guard (Preprocessed.memory s) (just gw) ≡ just true
+        eval-s≡ = trans (eval-guard-eq (Preprocessed.memory s) gw look-s-gw)
+                        (trans (cong to-bool gv≡1) to-bool-of-1ᶠ)
+        eval-w≡ : eval-guard (Witness.mem w) (just gw) ≡ just true
+        eval-w≡ = trans (eval-guard-eq (Witness.mem w) gw at-gw)
+                        (trans (cong to-bool gv≡1) to-bool-of-1ᶠ)
+        mk≡ : make-pti (Witness.mem w) (pi-skip (just gw) count ∷ is)
+                grp pis-rest
+            ≡ grp ++ mkrest
+        mk≡ = cong (λ b → if b then grp ++ mkrest else mkrest)
+                   (cong (fromMaybe false) eval-w≡)
+        pti≡ : ProofPreimage.pub-transcript-inputs pre
+             ≡ committed ++ (grp ++ mkrest)
+        pti≡ = trans (PiInv.pti-eq pii) (cong (committed ++_) mk≡)
+        match = skip-match pre s committed grp mkrest ph count≡ pe
+                           (PiInv.pidx pii) pti≡
+        s₁ = record s { pi-skips = Preprocessed.pi-skips s ++ (nothing ∷ []) }
+        pii′ : PiInv pre w is s₁ (committed ++ grp) [] pis-rest
+        pii′ = mk-piinv o1tl
+                 (trans (PiInv.pidx pii)
+                        (sym (trans (+-identityʳ _) (length-++ committed))))
+                 (Preprocessed.pis s , sym (++-identityʳ _))
+                 (trans pti≡ (sym (++-assoc committed grp mkrest)))
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is s₁ mem-rest pis-rest tf-tl (wt-stay s refl wt)
+            poeq pveq memeq piseq lmem lpis (committed ++ grp) [] pii′
+    in mk-walk s′ (tr-cons (refl , refl , true , eval-s≡ , match) tr) m≡ p≡
+      (trans i≡
+          (trans (cong (_+ length mkrest) (length-++ committed))
+            (trans (+-assoc (length committed) (length grp) (length mkrest))
+              (trans (cong (length committed +_) (sym (length-++ grp)))
+                     (cong (λ z → length committed + length z) (sym mk≡))))))
+      o≡ v≡
+  build pre w (pi-skip (just gw) count ∷ is) s mem-rest pis-rest
+        (tf-skip (gv , at-gw , inj₁ gv≡0) tf-tl) wt poeq pveq memeq piseq
+        lmem lpis committed grp pii =
+    let (count≡ , o1tl) = o1-skip-inv (PiInv.o1pii pii)
+        mkrest = make-pti (Witness.mem w) is [] pis-rest
+        gw<len = wire-trace-head-ok wt
+        look-s-gw : mem-lookup (Preprocessed.memory s) gw ≡ just gv
+        look-s-gw =
+          trans (sym (lookup-prefix (Preprocessed.memory s) mem-rest gw gw<len))
+                (trans (cong (λ m → mem-lookup m gw) memeq) at-gw)
+        eval-s≡ : eval-guard (Preprocessed.memory s) (just gw) ≡ just false
+        eval-s≡ = trans (eval-guard-eq (Preprocessed.memory s) gw look-s-gw)
+                        (trans (cong to-bool gv≡0) to-bool-of-0ᶠ)
+        eval-w≡ : eval-guard (Witness.mem w) (just gw) ≡ just false
+        eval-w≡ = trans (eval-guard-eq (Witness.mem w) gw at-gw)
+                        (trans (cong to-bool gv≡0) to-bool-of-0ᶠ)
+        mk≡ : make-pti (Witness.mem w) (pi-skip (just gw) count ∷ is)
+                grp pis-rest
+            ≡ mkrest
+        mk≡ = cong (λ b → if b then grp ++ mkrest else mkrest)
+                   (cong (fromMaybe false) eval-w≡)
+        s₁ = record s
+               { pi-skips   = Preprocessed.pi-skips s ++ (just count ∷ [])
+               ; pub-in-idx = Preprocessed.pub-in-idx s ∸ count }
+        pii′ : PiInv pre w is s₁ committed [] pis-rest
+        pii′ = mk-piinv o1tl
+                 (trans (cong₂ _∸_ (PiInv.pidx pii) count≡)
+                        (trans (m+n∸n≡m (length committed) (length grp))
+                               (sym (+-identityʳ _))))
+                 (Preprocessed.pis s , sym (++-identityʳ _))
+                 (trans (PiInv.pti-eq pii) (cong (committed ++_) mk≡))
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is s₁ mem-rest pis-rest tf-tl (wt-stay s refl wt)
+            poeq pveq memeq piseq lmem lpis committed [] pii′
+    in mk-walk s′ (tr-cons (refl , refl , false , eval-s≡ , tt) tr) m≡ p≡
+      (trans i≡ (cong (λ z → length committed + length z) (sym mk≡)))
+      o≡ v≡
+  -- ── public-input ──────────────────────────────────────────────────
+  build pre w (public-input nothing ∷ is) s mem-rest pis-rest
+        (tf-pub-act _ at-c tf-tl) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split1 mem-rest lmem
+  ... | cell , rest′ , refl , lreq =
+    let cell≡c =
+          just-injective
+            (trans (sym (trans (sym (cong (λ m → mem-lookup m _) memeq))
+                               (lookup-bound (Preprocessed.memory s) cell rest′)))
+                   at-c)
+        s₁ = record s { pub-out-rem = _ }
+        consume-eq = consume-pub-out-eq s
+                       (subst (λ z → Preprocessed.pub-out-rem s ≡ z ∷ _)
+                              (sym cell≡c) poeq)
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is
+            (record s { pub-out-rem = _
+                      ; memory = Preprocessed.memory s ++ (cell ∷ []) })
+            rest′ pis-rest (tf-suc s cell tf-tl)
+            (wt-grow s (cell ∷ []) refl wt) refl pveq
+            (trans (++-assoc (Preprocessed.memory s) (cell ∷ []) rest′) memeq)
+            piseq lreq lpis committed grp
+            (pi-pass s _ tt refl refl refl pii)
+    in mk-walk s′
+         (tr-cons (cell , refl , refl , true , refl , (s₁ , consume-eq)) tr)
+         m≡ p≡ i≡ o≡ v≡
+  build pre w (public-input nothing ∷ is) s mem-rest pis-rest
+        (tf-pub-inact () _ _) wt poeq pveq memeq piseq lmem lpis
+  build pre w (public-input (just gw) ∷ is) s mem-rest pis-rest
+        (tf-pub-act (iv , at-gw , iv≡1) at-c tf-tl) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split1 mem-rest lmem
+  ... | cell , rest′ , refl , lreq =
+    let gw<len = wire-trace-head-ok wt
+        cell≡c =
+          just-injective
+            (trans (sym (trans (sym (cong (λ m → mem-lookup m _) memeq))
+                               (lookup-bound (Preprocessed.memory s) cell rest′)))
+                   at-c)
+        look-s-gw : mem-lookup (Preprocessed.memory s) gw ≡ just iv
+        look-s-gw = trans (sym (lookup-prefix (Preprocessed.memory s) (cell ∷ rest′) gw gw<len))
+                          (trans (cong (λ m → mem-lookup m gw) memeq) at-gw)
+        eval-eq = trans (eval-guard-eq (Preprocessed.memory s) gw look-s-gw)
+                        (trans (cong to-bool iv≡1) to-bool-of-1ᶠ)
+        s₁ = record s { pub-out-rem = _ }
+        consume-eq = consume-pub-out-eq s
+                       (subst (λ z → Preprocessed.pub-out-rem s ≡ z ∷ _)
+                              (sym cell≡c) poeq)
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is
+            (record s { pub-out-rem = _
+                      ; memory = Preprocessed.memory s ++ (cell ∷ []) })
+            rest′ pis-rest (tf-suc s cell tf-tl)
+            (wt-grow s (cell ∷ []) refl wt) refl pveq
+            (trans (++-assoc (Preprocessed.memory s) (cell ∷ []) rest′) memeq)
+            piseq lreq lpis committed grp
+            (pi-pass s _ tt refl refl refl pii)
+    in mk-walk s′
+         (tr-cons (cell , refl , refl , true , eval-eq , (s₁ , consume-eq)) tr)
+         m≡ p≡ i≡ o≡ v≡
+  build pre w (public-input (just gw) ∷ is) s mem-rest pis-rest
+        (tf-pub-inact (iv , at-gw , iv≡0) at-0 tf-tl) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split1 mem-rest lmem
+  ... | cell , rest′ , refl , lreq =
+    let gw<len = wire-trace-head-ok wt
+        cell≡0 =
+          just-injective
+            (trans (sym (trans (sym (cong (λ m → mem-lookup m _) memeq))
+                               (lookup-bound (Preprocessed.memory s) cell rest′)))
+                   at-0)
+        look-s-gw : mem-lookup (Preprocessed.memory s) gw ≡ just iv
+        look-s-gw = trans (sym (lookup-prefix (Preprocessed.memory s) (cell ∷ rest′) gw gw<len))
+                          (trans (cong (λ m → mem-lookup m gw) memeq) at-gw)
+        eval-eq = trans (eval-guard-eq (Preprocessed.memory s) gw look-s-gw)
+                        (trans (cong to-bool iv≡0) to-bool-of-0ᶠ)
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is
+            (record s { memory = Preprocessed.memory s ++ (cell ∷ []) })
+            rest′ pis-rest (tf-suc s cell tf-tl)
+            (wt-grow s (cell ∷ []) refl wt) poeq pveq
+            (trans (++-assoc (Preprocessed.memory s) (cell ∷ []) rest′) memeq)
+            piseq lreq lpis committed grp
+            (pi-pass s _ tt refl refl refl pii)
+    in mk-walk s′
+         (tr-cons (cell , refl , refl , false , eval-eq , cell≡0) tr)
+         m≡ p≡ i≡ o≡ v≡
+  -- ── private-input ─────────────────────────────────────────────────
+  build pre w (private-input nothing ∷ is) s mem-rest pis-rest
+        (tf-priv-act _ at-c tf-tl) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split1 mem-rest lmem
+  ... | cell , rest′ , refl , lreq =
+    let cell≡c =
+          just-injective
+            (trans (sym (trans (sym (cong (λ m → mem-lookup m _) memeq))
+                               (lookup-bound (Preprocessed.memory s) cell rest′)))
+                   at-c)
+        s₁ = record s { priv-rem = _ }
+        consume-eq = consume-priv-eq s
+                       (subst (λ z → Preprocessed.priv-rem s ≡ z ∷ _)
+                              (sym cell≡c) pveq)
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is
+            (record s { priv-rem = _
+                      ; memory = Preprocessed.memory s ++ (cell ∷ []) })
+            rest′ pis-rest (tf-suc s cell tf-tl)
+            (wt-grow s (cell ∷ []) refl wt) poeq refl
+            (trans (++-assoc (Preprocessed.memory s) (cell ∷ []) rest′) memeq)
+            piseq lreq lpis committed grp
+            (pi-pass s _ tt refl refl refl pii)
+    in mk-walk s′
+         (tr-cons (cell , refl , refl , true , refl , (s₁ , consume-eq)) tr)
+         m≡ p≡ i≡ o≡ v≡
+  build pre w (private-input nothing ∷ is) s mem-rest pis-rest
+        (tf-priv-inact () _ _) wt poeq pveq memeq piseq lmem lpis
+  build pre w (private-input (just gw) ∷ is) s mem-rest pis-rest
+        (tf-priv-act (iv , at-gw , iv≡1) at-c tf-tl) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split1 mem-rest lmem
+  ... | cell , rest′ , refl , lreq =
+    let gw<len = wire-trace-head-ok wt
+        cell≡c =
+          just-injective
+            (trans (sym (trans (sym (cong (λ m → mem-lookup m _) memeq))
+                               (lookup-bound (Preprocessed.memory s) cell rest′)))
+                   at-c)
+        look-s-gw : mem-lookup (Preprocessed.memory s) gw ≡ just iv
+        look-s-gw = trans (sym (lookup-prefix (Preprocessed.memory s) (cell ∷ rest′) gw gw<len))
+                          (trans (cong (λ m → mem-lookup m gw) memeq) at-gw)
+        eval-eq = trans (eval-guard-eq (Preprocessed.memory s) gw look-s-gw)
+                        (trans (cong to-bool iv≡1) to-bool-of-1ᶠ)
+        s₁ = record s { priv-rem = _ }
+        consume-eq = consume-priv-eq s
+                       (subst (λ z → Preprocessed.priv-rem s ≡ z ∷ _)
+                              (sym cell≡c) pveq)
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is
+            (record s { priv-rem = _
+                      ; memory = Preprocessed.memory s ++ (cell ∷ []) })
+            rest′ pis-rest (tf-suc s cell tf-tl)
+            (wt-grow s (cell ∷ []) refl wt) poeq refl
+            (trans (++-assoc (Preprocessed.memory s) (cell ∷ []) rest′) memeq)
+            piseq lreq lpis committed grp
+            (pi-pass s _ tt refl refl refl pii)
+    in mk-walk s′
+         (tr-cons (cell , refl , refl , true , eval-eq , (s₁ , consume-eq)) tr)
+         m≡ p≡ i≡ o≡ v≡
+  build pre w (private-input (just gw) ∷ is) s mem-rest pis-rest
+        (tf-priv-inact (iv , at-gw , iv≡0) at-0 tf-tl) wt
+        poeq pveq memeq piseq lmem lpis committed grp pii
+    with split1 mem-rest lmem
+  ... | cell , rest′ , refl , lreq =
+    let gw<len = wire-trace-head-ok wt
+        cell≡0 =
+          just-injective
+            (trans (sym (trans (sym (cong (λ m → mem-lookup m _) memeq))
+                               (lookup-bound (Preprocessed.memory s) cell rest′)))
+                   at-0)
+        look-s-gw : mem-lookup (Preprocessed.memory s) gw ≡ just iv
+        look-s-gw = trans (sym (lookup-prefix (Preprocessed.memory s) (cell ∷ rest′) gw gw<len))
+                          (trans (cong (λ m → mem-lookup m gw) memeq) at-gw)
+        eval-eq = trans (eval-guard-eq (Preprocessed.memory s) gw look-s-gw)
+                        (trans (cong to-bool iv≡0) to-bool-of-0ᶠ)
+        (mk-walk s′ tr m≡ p≡ i≡ o≡ v≡) =
+          build pre w is
+            (record s { memory = Preprocessed.memory s ++ (cell ∷ []) })
+            rest′ pis-rest (tf-suc s cell tf-tl)
+            (wt-grow s (cell ∷ []) refl wt) poeq pveq
+            (trans (++-assoc (Preprocessed.memory s) (cell ∷ []) rest′) memeq)
+            piseq lreq lpis committed grp
+            (pi-pass s _ tt refl refl refl pii)
+    in mk-walk s′
+         (tr-cons (cell , refl , refl , false , eval-eq , cell≡0) tr)
+         m≡ p≡ i≡ o≡ v≡
+
+  step0 pre w is s mem-rest pis-rest committed grp sd tne Δ0 nds mkeq
+        tf wt poeq pveq memeq piseq lenp lpis pii =
+    let rec = build pre w is s mem-rest pis-rest (tf-stay s tf)
+                (wt-stay s Δ0 wt) poeq pveq memeq piseq lenp lpis
+                committed grp (pi-pass s s nds refl refl mkeq pii)
+    in mk-walk (WalkResult.wstate rec)
+         (tr-cons sd
+           (subst (λ st → Tr-shaped pre st is (WalkResult.wstate rec)
+                            mem-rest pis-rest)
+                  (sym tne) (WalkResult.wtr rec)))
+         (WalkResult.wmem rec) (WalkResult.wpis rec)
+         (trans (WalkResult.widx rec)
+                (cong (λ z → length committed + length z) (sym mkeq)))
+         (WalkResult.wpout rec) (WalkResult.wpriv rec)
+
+  step1 pre w is s c rest′ pis-rest committed grp sd tne Δ1 nds mkeq
+        tf wt poeq pveq memeq piseq lreq lpis pii =
+    let rec = build pre w is (push-mem s c) rest′ pis-rest
+                (tf-grow1 s c tf) (wt-grow s (c ∷ []) (sym Δ1) wt) poeq pveq
+                (trans (++-assoc (Preprocessed.memory s) (c ∷ []) rest′)
+                       memeq)
+                piseq lreq lpis committed grp
+                (pi-pass s (push-mem s c) nds refl refl mkeq pii)
+    in mk-walk (WalkResult.wstate rec)
+         (tr-cons sd
+           (subst (λ st → Tr-shaped pre st is (WalkResult.wstate rec)
+                            rest′ pis-rest)
+                  (sym tne) (WalkResult.wtr rec)))
+         (WalkResult.wmem rec) (WalkResult.wpis rec)
+         (trans (WalkResult.widx rec)
+                (cong (λ z → length committed + length z) (sym mkeq)))
+         (WalkResult.wpout rec) (WalkResult.wpriv rec)
+
+  step2 pre w is s a b rest′ pis-rest committed grp sd tne Δ2 nds mkeq
+        tf wt poeq pveq memeq piseq lreq lpis pii =
+    let rec = build pre w is (push-mem2 s a b) rest′ pis-rest
+                (tf-grow2 s a b tf) (wt-grow s (a ∷ b ∷ []) (sym Δ2) wt)
+                poeq pveq
+                (trans (++-assoc (Preprocessed.memory s) (a ∷ b ∷ []) rest′)
+                       memeq)
+                piseq lreq lpis committed grp
+                (pi-pass s (push-mem2 s a b) nds refl refl mkeq pii)
+    in mk-walk (WalkResult.wstate rec)
+         (tr-cons sd
+           (subst (λ st → Tr-shaped pre st is (WalkResult.wstate rec)
+                            rest′ pis-rest)
+                  (sym tne) (WalkResult.wtr rec)))
+         (WalkResult.wmem rec) (WalkResult.wpis rec)
+         (trans (WalkResult.widx rec)
+                (cong (λ z → length committed + length z) (sym mkeq)))
+         (WalkResult.wpout rec) (WalkResult.wpriv rec)
+
+------------------------------------------------------------------------
+-- The realization data.
+--
+-- `Realizes src w pre s` says the pair `(pre , s)` *realizes* the
+-- witness `w`: the canonical operational witness of `s` under `pre`
+-- equals `w`, and `s` is reachable by a (shape-faithful) preprocess run
+-- of `src` on `pre`.  These are exactly the two facts
+-- `circuit-faithful-bwd` consumes once `satisfies` is in hand.
+------------------------------------------------------------------------
+
+Realizes : IrSource → Witness → ProofPreimage → Preprocessed → Set
+Realizes src w pre s =
+  (witness-of s pre ≡ w) × preprocess-shaped src pre s
+
+------------------------------------------------------------------------
+-- The reduction step.  Given a *concrete* realization of `w` — a pair
+-- `(pre , s)` with the WF1 arity fact and a `Realizes` proof — S-stmt for
+-- `w` is immediate from P5's backward direction.  `realize` (below)
+-- discharges the realization and applies this.
+------------------------------------------------------------------------
+
+sstmt-from-realize
+  : ∀ (src : IrSource) (w : Witness)
+      (pre : ProofPreimage) (s : Preprocessed)
+  → T (producer-safe src)
+  → length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src
+  → WF2 src
+  → Realizes src w pre s
+  → satisfies (circuit src) w
+  → R src pre s × (witness-of s pre ≡ w)
+sstmt-from-realize src w pre s ps-safe wf1 wf2 (weq , pps) sat =
+  let sat' : satisfies (circuit src) (witness-of s pre)
+      sat' = subst (satisfies (circuit src)) (sym weq) sat
+      Rsrc : R src pre s
+      Rsrc = circuit-faithful-bwd src pre s ps-safe wf1 wf2 pps sat'
+  in Rsrc , weq
+
+------------------------------------------------------------------------
+-- Explicit init state.  Recovers the concrete `mk-state` (and hence all
+-- its projections) that `init-state` returns when the input arity
+-- matches and the commitment payload has the shape the `has-comm` flag
+-- demands: present when the flag is set (its commitment value `c` joins
+-- the pis preamble), arbitrary otherwise.
+------------------------------------------------------------------------
+
+-- The randomness component of a commitment payload (cf. `comm-rand-of`,
+-- which projects it out of a whole preimage).
+cm-rand : Maybe (Fr × Fr) → Maybe Fr
+cm-rand (just (_ , r)) = just r
+cm-rand nothing        = nothing
+
+comm-rand-of-cm : ∀ (pre : ProofPreimage)
+  → comm-rand-of pre ≡ cm-rand (ProofPreimage.comm-commitment pre)
+comm-rand-of-cm pre with ProofPreimage.comm-commitment pre
+... | just (_ , _) = refl
+... | nothing      = refl
+
+-- A commitment payload acceptable to `init-state`: required when the
+-- flag is set, unconstrained otherwise.
+CommShape : Bool → Maybe (Fr × Fr) → Set
+CommShape false _        = ⊤
+CommShape true  (just _) = ⊤
+CommShape true  nothing  = ⊥
+
+-- The pis preamble `init-state` seeds: the binding input, plus the
+-- commitment value when the flag is set.  (The `true`/`nothing` branch
+-- is arbitrary — `CommShape` rules it out.)
+init-pis : Bool → Fr → Maybe (Fr × Fr) → List Fr
+init-pis false b _              = b ∷ []
+init-pis true  b (just (c , _)) = b ∷ c ∷ []
+init-pis true  b nothing        = b ∷ []
+
+init-explicit : ∀ (src : IrSource) (pre : ProofPreimage)
+  → CommShape (IrSource.do-communications-commitment src)
+              (ProofPreimage.comm-commitment pre)
+  → length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src
+  → init-state src pre
+    ≡ just (mk-state (ProofPreimage.inputs pre)
+                     (init-pis (IrSource.do-communications-commitment src)
+                               (ProofPreimage.binding-input pre)
+                               (ProofPreimage.comm-commitment pre))
+                     [] 0
+                     (ProofPreimage.pub-transcript-outputs pre)
+                     (ProofPreimage.priv-transcript pre)
+                     [])
+init-explicit src pre cs wf1
+  with length (ProofPreimage.inputs pre) ≡ᵇ IrSource.num-inputs src
+     | T-≡ .Equivalence.to (≡⇒≡ᵇ _ _ wf1)
+     | IrSource.do-communications-commitment src
+     | ProofPreimage.comm-commitment pre
+     | cs
+... | .true | refl | false | _            | _  = refl
+... | .true | refl | true  | just (_ , _) | _  = refl
+... | .true | refl | true  | nothing      | ()
+
+------------------------------------------------------------------------
+-- The realization core, generic in the communications-commitment flag.
+--
+-- For a producer-safe source, every satisfying witness `w` (of the
+-- allocated memory length) is the canonical witness of a genuine
+-- preprocess run with the same public inputs.  The candidate preimage
+-- takes its inputs from the first `num-inputs` cells of `w`, its
+-- `pub-transcript-inputs` from `make-pti` (the active skip groups read
+-- off `w`), and its public-output / private transcripts (`po` / `pv`)
+-- from `make-trfacts` — the values the active `public-input` /
+-- `private-input` instructions read off `w`.  The walk (`build`) tiles
+-- the memory / pis suffixes and consumes those transcripts.
+--
+-- The hc-dependent data is supplied by the caller (the per-flag cases
+-- of `circuit-statement-sound` below): the pis preamble split of
+-- `Witness.pis w`, the commitment payload `cm` the preimage carries
+-- (with `cm-rand cm` matching `w`'s comm-rand, so `witness-of` agrees),
+-- and the satisfaction of the *synthesized* constraint list (for `hc = true`
+-- the caller peels the trailing comm-commitment constraint; it is consumed
+-- only by `circuit-faithful-bwd`, which recovers `comm-ok` from it).
+------------------------------------------------------------------------
+
+private
+  realize
+    : ∀ (src : IrSource) (w : Witness)
+        (bind : Fr) (prest : List Fr) (cm : Maybe (Fr × Fr))
+    → T (producer-safe src)
+    → WF2 src
+    → length (Witness.mem w) ≡ Circuit.nr-wires (circuit src)
+    → satisfies (circuit src) w
+    → satisfies-constraints
+        (SynthState.constraints
+          (circuit-instrs (IrSource.do-communications-commitment src)
+            (IrSource.instructions src)
+            (mk-synth (IrSource.num-inputs src) [] 0 []))) w
+    → CommShape (IrSource.do-communications-commitment src) cm
+    → cm-rand cm ≡ Witness.comm-rand w
+    → Witness.pis w
+      ≡ init-pis (IrSource.do-communications-commitment src) bind cm
+        ++ prest
+    → length prest ≡ Δpis-sum (IrSource.instructions src)
+    → Σ ProofPreimage (λ pre → Σ Preprocessed (λ s →
+          R src pre s × (witness-of s pre ≡ w)))
+  realize src w bind prest cm ps wf2 mlen sat sat-cls cshape creq pis-shape
+          lprest =
+    pre , s′ , Rsrc , weq
+    where
+      hc = IrSource.do-communications-commitment src
+
+      n : ℕ
+      n = IrSource.num-inputs src
+
+      instrs = IrSource.instructions src
+
+      preamble = init-pis hc bind cm
+
+      -- The circuit's wire count is `n + Δmem-sum instrs`.
+      nrw≡ : Circuit.nr-wires (circuit src) ≡ n + Δmem-sum instrs
+      nrw≡ = nr-wires-acc hc instrs (mk-synth n [] 0 [])
+
+      len≡ : length (Witness.mem w) ≡ n + Δmem-sum instrs
+      len≡ = trans mlen nrw≡
+
+      n≤len : n ≤ length (Witness.mem w)
+      n≤len = subst (n ≤_) (sym len≡) (m≤m+n n (Δmem-sum instrs))
+
+      -- The producer's O2 run; its trace supplies the guard booleanity
+      -- the `pi-skip` transcript facts need.
+      o2run = O2-bool→Runs {src} (producer-safe-O2 {src} ps)
+
+      -- The transcript supplies `pre` must carry, read off `w` via the
+      -- guard-disj constraints.
+      trf = make-trfacts {hc} w instrs (mk-synth n [] 0 []) n [] refl len≡
+              (bk-empty {w}) (O2-Runs.trace o2run) sat-cls
+      po  = TrSupply.pub-out trf
+      pv  = TrSupply.priv trf
+      tf  : TrFacts w instrs n po pv
+      tf  = TrSupply.facts trf
+
+      -- The verifier transcript: the in-order concatenation of the
+      -- active skip groups, computed from `w` alone.
+      pti : List Fr
+      pti = make-pti (Witness.mem w) instrs [] prest
+
+      pre : ProofPreimage
+      pre = record { inputs = take n (Witness.mem w)
+                   ; binding-input = bind ; comm-commitment = cm
+                   ; pub-transcript-inputs = pti
+                   ; pub-transcript-outputs = po
+                   ; priv-transcript = pv }
+
+      wf1 : length (ProofPreimage.inputs pre) ≡ n
+      wf1 = trans (length-take n (Witness.mem w)) (m≤n⇒m⊓n≡m n≤len)
+
+      s₀ : Preprocessed
+      s₀ = mk-state (take n (Witness.mem w)) preamble [] 0 po pv []
+
+      init≡ : init-state src pre ≡ just s₀
+      init≡ = init-explicit src pre cshape wf1
+
+      memeq : take n (Witness.mem w) ++ drop n (Witness.mem w)
+            ≡ Witness.mem w
+      memeq = take++drop≡id n (Witness.mem w)
+
+      piseq : Preprocessed.pis s₀ ++ prest ≡ Witness.pis w
+      piseq = sym pis-shape
+
+      lenp : length (drop n (Witness.mem w)) ≡ Δmem-sum instrs
+      lenp = trans (length-drop n (Witness.mem w))
+               (trans (cong (_∸ n) len≡) (m+n∸m≡n n (Δmem-sum instrs)))
+
+      -- The producer's wire discipline, as a `Wire-Trace` indexed by the
+      -- starting wire count `n` = `num-inputs` = `length (memory s₀)`.
+      wt-final : ℕ
+      wt-final = proj₁ (wire-disc-sound {src} ps)
+      wt-init : Wire-Trace instrs (length (Preprocessed.memory s₀)) wt-final
+      wt-init = subst (λ k → Wire-Trace instrs k wt-final) (sym wf1)
+                      (proj₂ (wire-disc-sound {src} ps))
+
+      tf-init : TrFacts w instrs (length (Preprocessed.memory s₀)) po pv
+      tf-init = subst (λ k → TrFacts w instrs k po pv) (sym wf1) tf
+
+      -- The initial transcript invariant: nothing committed, empty
+      -- group, O1's full-bracketing trace, and `pre`'s transcript is
+      -- `make-pti` in full.
+      pii₀ : PiInv pre w instrs s₀ [] [] prest
+      pii₀ = mk-piinv (o1-sound src ps) refl
+                      (preamble , sym (++-identityʳ _)) refl
+
+      walk = build pre w instrs s₀ (drop n (Witness.mem w)) prest
+                   tf-init wt-init refl refl memeq piseq lenp lprest
+                   [] [] pii₀
+      s′       = WalkResult.wstate walk
+      tr       = WalkResult.wtr    walk
+      mem≡     = WalkResult.wmem   walk
+      pis≡     = WalkResult.wpis   walk
+      pidx≡    = WalkResult.widx   walk
+      pout≡    = WalkResult.wpout  walk
+      priv≡    = WalkResult.wpriv  walk
+
+      tc : T (transcripts-consumed pre s′)
+      tc rewrite pout≡ | priv≡ =
+        T-∧ .Equivalence.from
+          ( ≡⇒≡ᵇ (length pti) (Preprocessed.pub-in-idx s′) (sym pidx≡)
+          , T-∧ .Equivalence.from (tt , tt) )
+
+      weq : witness-of s′ pre ≡ w
+      weq rewrite mem≡ | pis≡ =
+        cong (λ m → record { mem = Witness.mem w ; pis = Witness.pis w
+                           ; comm-rand = m })
+             (trans (comm-rand-of-cm pre) creq)
+
+      pps : preprocess-shaped src pre s′
+      pps = mk-shaped s₀ init≡
+              (mk-shape-walk (drop n (Witness.mem w)) prest tr) tc
+
+      Rsrc : R src pre s′
+      Rsrc = proj₁ (sstmt-from-realize src w pre s′ ps wf1 wf2 (weq , pps) sat)
+
+  -- A `Maybe-shape true` forces the comm-rand to be present.
+  rand-just : ∀ {mr : Maybe Fr} → Maybe-shape true mr
+    → Σ Fr (λ r → mr ≡ just r)
+  rand-just {just r}  _ = r , refl
+  rand-just {nothing} ()
+
+  -- The commitment payload for an hc = false preimage: `init-state`
+  -- ignores it, so it only has to reproduce `w`'s comm-rand (which the
+  -- circuit leaves unconstrained — the commitment value is arbitrary).
+  mk-cm-f : Maybe Fr → Maybe (Fr × Fr)
+  mk-cm-f (just r) = just (0ᶠ , r)
+  mk-cm-f nothing  = nothing
+
+  cm-rand-mk-f : ∀ (mr : Maybe Fr) → cm-rand (mk-cm-f mr) ≡ mr
+  cm-rand-mk-f (just _) = refl
+  cm-rand-mk-f nothing  = refl
+
+  -- hc = false: pis = binding ∷ declared tail; the synthesized constraints
+  -- are the whole constraint list.
+  sound-no-comm
+    : ∀ (src : IrSource) (w : Witness)
+    → IrSource.do-communications-commitment src ≡ false
+    → T (producer-safe src)
+    → WF2 src
+    → length (Witness.mem w) ≡ Circuit.nr-wires (circuit src)
+    → satisfies (circuit src) w
+    → Σ ProofPreimage (λ pre → Σ Preprocessed (λ s →
+          R src pre s × (witness-of s pre ≡ w)))
+  sound-no-comm src w hc≡f ps wf2 mlen sat =
+    realize src w bind prest (mk-cm-f (Witness.comm-rand w))
+      ps wf2 mlen sat sat-cls cshape (cm-rand-mk-f (Witness.comm-rand w))
+      pis-shape lprest
+    where
+      n : ℕ
+      n = IrSource.num-inputs src
+
+      instrs = IrSource.instructions src
+
+      -- pi-len is the preamble (`1`) plus the declared-PI count.
+      pilen≡ : Circuit.pi-len (circuit src) ≡ suc (Δpis-sum instrs)
+      pilen≡ rewrite hc≡f =
+        cong (1 +_) (nr-decl-acc false instrs (mk-synth n [] 0 []))
+
+      pislen : length (Witness.pis w) ≡ suc (Δpis-sum instrs)
+      pislen = trans (satisfies.pi-length sat) pilen≡
+
+      spl = split1 (Witness.pis w) pislen
+      bind   = proj₁ spl
+      prest  = proj₁ (proj₂ spl)
+      pisw≡ : Witness.pis w ≡ bind ∷ prest
+      pisw≡  = proj₁ (proj₂ (proj₂ spl))
+      lprest = proj₂ (proj₂ (proj₂ spl))
+
+      pis-shape : Witness.pis w
+        ≡ init-pis (IrSource.do-communications-commitment src) bind
+                   (mk-cm-f (Witness.comm-rand w)) ++ prest
+      pis-shape =
+        subst (λ b → Witness.pis w
+                   ≡ init-pis b bind (mk-cm-f (Witness.comm-rand w))
+                     ++ prest)
+              (sym hc≡f) pisw≡
+
+      cshape : CommShape (IrSource.do-communications-commitment src)
+                         (mk-cm-f (Witness.comm-rand w))
+      cshape = subst (λ b → CommShape b (mk-cm-f (Witness.comm-rand w)))
+                     (sym hc≡f) tt
+
+      -- No comm constraint is appended, so the circuit's constraints ARE the
+      -- synthesized ones.
+      sat-cls : satisfies-constraints
+                  (SynthState.constraints
+                    (circuit-instrs
+                      (IrSource.do-communications-commitment src)
+                      instrs (mk-synth n [] 0 []))) w
+      sat-cls = subst (λ cs → satisfies-constraints cs w) cls-eq
+                      (satisfies.constraint-ok sat)
+        where
+          cls-eq : Circuit.constraints (circuit src)
+                 ≡ SynthState.constraints
+                     (circuit-instrs
+                       (IrSource.do-communications-commitment src)
+                       instrs (mk-synth n [] 0 []))
+          cls-eq rewrite hc≡f = refl
+
+  -- hc = true: pis = binding ∷ commitment ∷ declared tail; the witness
+  -- carries the randomness (`rand-shape`); the trailing comm-commitment
+  -- constraint is peeled off before the walk (it constrains no walked wire —
+  -- `circuit-faithful-bwd` consumes it to recover `comm-ok`).
+  sound-comm
+    : ∀ (src : IrSource) (w : Witness)
+    → IrSource.do-communications-commitment src ≡ true
+    → T (producer-safe src)
+    → WF2 src
+    → length (Witness.mem w) ≡ Circuit.nr-wires (circuit src)
+    → satisfies (circuit src) w
+    → Σ ProofPreimage (λ pre → Σ Preprocessed (λ s →
+          R src pre s × (witness-of s pre ≡ w)))
+  sound-comm src w hc≡t ps wf2 mlen sat =
+    realize src w bind prest (just (c , rv))
+      ps wf2 mlen sat sat-cls cshape (sym rv≡) pis-shape lprest
+    where
+      n : ℕ
+      n = IrSource.num-inputs src
+
+      instrs = IrSource.instructions src
+
+      -- pi-len is the preamble (`2`) plus the declared-PI count.
+      pilen≡ : Circuit.pi-len (circuit src) ≡ suc (suc (Δpis-sum instrs))
+      pilen≡ rewrite hc≡t =
+        cong (2 +_) (nr-decl-acc true instrs (mk-synth n [] 0 []))
+
+      pislen : length (Witness.pis w) ≡ suc (suc (Δpis-sum instrs))
+      pislen = trans (satisfies.pi-length sat) pilen≡
+
+      spl = split2 (Witness.pis w) pislen
+      bind   = proj₁ spl
+      c      = proj₁ (proj₂ spl)
+      prest  = proj₁ (proj₂ (proj₂ spl))
+      pisw≡ : Witness.pis w ≡ bind ∷ c ∷ prest
+      pisw≡  = proj₁ (proj₂ (proj₂ (proj₂ spl)))
+      lprest = proj₂ (proj₂ (proj₂ (proj₂ spl)))
+
+      -- The witness carries the commitment randomness.
+      rv-just = rand-just
+        (subst (λ b → Maybe-shape b (Witness.comm-rand w)) hc≡t
+               (satisfies.rand-shape sat))
+      rv  = proj₁ rv-just
+      rv≡ : Witness.comm-rand w ≡ just rv
+      rv≡ = proj₂ rv-just
+
+      pis-shape : Witness.pis w
+        ≡ init-pis (IrSource.do-communications-commitment src) bind
+                   (just (c , rv)) ++ prest
+      pis-shape =
+        subst (λ b → Witness.pis w
+                   ≡ init-pis b bind (just (c , rv)) ++ prest)
+              (sym hc≡t) pisw≡
+
+      cshape : CommShape (IrSource.do-communications-commitment src)
+                         (just (c , rv))
+      cshape = subst (λ b → CommShape b (just (c , rv))) (sym hc≡t) tt
+
+      -- The circuit appends the comm-commitment constraint after the
+      -- synthesized ones; peel it.
+      sat-cls : satisfies-constraints
+                  (SynthState.constraints
+                    (circuit-instrs
+                      (IrSource.do-communications-commitment src)
+                      instrs (mk-synth n [] 0 []))) w
+      sat-cls =
+        let (extra , ceq) = cls-split in
+        proj₁ (sat-split
+                (SynthState.constraints
+                  (circuit-instrs
+                    (IrSource.do-communications-commitment src)
+                    instrs (mk-synth n [] 0 [])))
+                extra
+                (subst (λ cs → satisfies-constraints cs w) ceq
+                       (satisfies.constraint-ok sat)))
+        where
+          cls-split : Σ (List Constraint) (λ extra →
+              Circuit.constraints (circuit src)
+              ≡ SynthState.constraints
+                  (circuit-instrs
+                    (IrSource.do-communications-commitment src)
+                    instrs (mk-synth n [] 0 []))
+                ++ extra)
+          cls-split rewrite hc≡t = _ , refl
+
+------------------------------------------------------------------------
+-- A realizer of a witness: a preprocess run whose canonical witness is
+-- exactly `w`.  Statement soundness produces one; extraction uniqueness
+-- (`StatementUniqueness.agda`) shows the well-shaped one is unique.
+------------------------------------------------------------------------
+
+record Realizer (src : IrSource) (w : Witness) : Set where
+  constructor mk-realizer
+  field
+    preimage : ProofPreimage
+    run      : Preprocessed
+    R-run    : R src preimage run
+    extracts : witness-of run preimage ≡ w
+
+------------------------------------------------------------------------
+-- Statement soundness.  Dispatch on the communications-commitment flag.
+------------------------------------------------------------------------
+
+circuit-statement-sound
+  : ∀ (src : IrSource) (w : Witness)
+  → T (producer-safe src)
+  → WF2 src
+  → satisfies (circuit src) w
+  → Realizer src w
+circuit-statement-sound src w ps wf2 sat =
+  go (IrSource.do-communications-commitment src) refl
+  where
+    mlen = satisfies.mem-length sat
+    go : ∀ b → IrSource.do-communications-commitment src ≡ b
+       → Realizer src w
+    go false hc≡f = let (pre , s , Rs , wo≡) =
+                          sound-no-comm src w hc≡f ps wf2 mlen sat
+                    in mk-realizer pre s Rs wo≡
+    go true  hc≡t = let (pre , s , Rs , wo≡) =
+                          sound-comm src w hc≡t ps wf2 mlen sat
+                    in mk-realizer pre s Rs wo≡
+
+------------------------------------------------------------------------
+-- The memory-shape condition `length (Witness.mem w) ≡ nr-wires` is the
+-- `mem-length` field of `satisfies`: a satisfying assignment to a circuit
+-- over `nr-wires` wires is a memory vector of exactly that length.
+-- Without it `satisfies-constraints` alone would admit witnesses carrying
+-- trailing junk cells beyond the allocated wires, which equal no
+-- `witness-of s pre` (whose memory has exactly `nr-wires` cells along an
+-- honest walk) and so would not be realizable.
+------------------------------------------------------------------------
+
+------------------------------------------------------------------------
+-- Witness characterization.  `circuit-statement-sound` combined with
+-- P5's forward direction (`circuit-faithful-fwd`): for a producer-safe
+-- WF2 source, the satisfying witnesses are EXACTLY the canonical
+-- witnesses of preprocess runs.
+------------------------------------------------------------------------
+
+circuit-witness-characterization
+  : ∀ (src : IrSource) (w : Witness)
+  → T (producer-safe src)
+  → WF2 src
+  → satisfies (circuit src) w ⇔ Realizer src w
+circuit-witness-characterization src w ps wf2 = mk⇔
+  (circuit-statement-sound src w ps wf2)
+  (λ (mk-realizer pre s Rs wo≡) →
+      subst (satisfies (circuit src)) wo≡
+            (circuit-faithful-fwd src pre s Rs))

--- a/formal/src/zkir-v2/StatementUniqueness.agda
+++ b/formal/src/zkir-v2/StatementUniqueness.agda
@@ -1,0 +1,1224 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.StatementUniqueness (⋯ : _) (open Assumptions ⋯) where
+
+------------------------------------------------------------------------
+-- Extraction uniqueness for ZKIR v2.
+--
+--   circuit-statement-unique
+--     : ∀ src {pre s pre′ s′} → T (producer-safe src)
+--     → CommWF (do-comm src) (comm-commitment pre)
+--     → CommWF (do-comm src) (comm-commitment pre′)
+--     → R src pre s → R src pre′ s′
+--     → witness-of s pre ≡ witness-of s′ pre′
+--     → (pre ≡ pre′) × (s ≡ s′)
+--
+-- The realizing run of a witness is unique.  Combined with
+-- `circuit-statement-sound` (existence) this pins, for every satisfying
+-- witness of a WF2 source whose `comm-rand` respects the commitment
+-- flag (`RandWF`), EXACTLY ONE commitment-well-shaped realizer — a
+-- `CommWFRealizer`, the `Realizer` record of `StatementSoundness`
+-- extended with `CommWF` (`circuit-statement-sound-unique`; its full
+-- hypotheses are documented at its definition).
+--
+-- The witness `witness-of s pre` carries `(memory s , pis s , comm-rand
+-- of pre)`, so witness equality hands us, by `cong`,
+--   (E1) memory s ≡ memory s′,  (E2) pis s ≡ pis s′,
+--   (E3) comm-rand-of pre ≡ comm-rand-of pre′.
+-- The two runs execute the SAME instruction list from initial states
+-- with equal memory/pis lengths, ending with equal memory (E1) and pis
+-- (E2).  Memory and pis only grow by appends, so two intermediate states
+-- that are prefixes of the SAME final list and have the SAME length are
+-- equal — the anchor.  A single parallel induction over the instruction
+-- list, carrying both `R-instrs` traces and the anchoring suffix
+-- evidence, forces the two runs to agree at every step (`StateEq` of the
+-- post-states), which assembles to `s ≡ s′` and, reading off the
+-- preimage fields seeded into `s₀` / consumed along the walk, to
+-- `pre ≡ pre′`.
+------------------------------------------------------------------------
+
+open import zkir-v2.Syntax ⋯
+open import zkir-v2.Semantics ⋯
+  using ( ProofPreimage; mk-preimage; Preprocessed; mk-state; init-state
+        ; transcripts-consumed; comm-ok; R; push-mem; push-mem2
+        ; mem-lookup; eval-guard; consume-pub-out; consume-priv; from-bool
+        ; _≡ᶠ-list?_; WF2
+        ; R-instr; R-instrs; r-done; r-step
+        ; r-assert; r-cond-select; r-constrain-bits; r-constrain-eq
+        ; r-constrain-to-boolean; r-copy; r-declare-pub-input
+        ; r-pi-skip-active; r-pi-skip-inactive; r-ec-add; r-ec-mul
+        ; r-ec-mul-generator; r-hash-to-curve; r-load-imm
+        ; r-div-mod-power-of-two; r-reconstitute-field; r-output
+        ; r-transient-hash; r-persistent-hash; r-test-eq; r-add; r-mul
+        ; r-neg; r-not; r-less-than; r-public-input-inactive
+        ; r-public-input-active; r-private-input-inactive
+        ; r-private-input-active )
+open import zkir-v2.SemanticsLemmas ⋯
+  using ( consume-pub-out-mem; consume-pub-out-pis; consume-pub-out-idx
+        ; consume-pub-out-outputs; consume-pub-out-skips
+        ; consume-pub-out-priv; consume-pub-out-rem
+        ; consume-priv-mem; consume-priv-pis; consume-priv-idx
+        ; consume-priv-outputs; consume-priv-skips
+        ; consume-priv-pub; consume-priv-rem )
+open import zkir-v2.Circuit ⋯
+  using ( Witness; mk-witness; Circuit; circuit; satisfies )
+open import zkir-v2.FieldProperties ⋯
+  using ( to-bool; _≡ᶠ?_; ≡ᶠ?-true )
+open import zkir-v2.Obligations ⋯
+  using ( producer-safe; Δmem; O1-scan
+        ; O1-Trace; o1-nil; o1-decl; o1-skip; o1-other
+        ; o1-sound )
+open import zkir-v2.CircuitProof ⋯
+  using ( witness-of; comm-rand-of )
+open import zkir-v2.Properties ⋯
+  using ( R-instr-Δmem; Δmem-sum )
+open import zkir-v2.StatementSoundness ⋯
+  using ( circuit-statement-sound; Realizer; mk-realizer )
+
+open import Data.Bool    using (Bool; true; false; T; if_then_else_)
+import Data.Bool as Bool
+open import Function
+open import Data.Bool.Properties using (T-∧)
+open import Data.List    using (List; []; _∷_; _++_; length; take; drop)
+open import Data.List.Properties
+  using ( ++-identityʳ; ++-assoc; ++-cancelˡ
+        ; take-all; take-[]; ∷-injectiveˡ; ∷-injectiveʳ )
+open import Data.Maybe   using (Maybe; just; nothing)
+open import Data.Maybe.Properties using (just-injective)
+open import Data.Nat     using (ℕ; zero; suc; _+_; _∸_; _≤_; _<_; s≤s; _≡ᵇ_)
+open import Data.Nat.Properties
+  using ( ≡ᵇ⇒≡; +-identityʳ; +-suc; +-assoc
+        ; m+n∸n≡m; ≤-reflexive )
+open import Data.Empty   using (⊥; ⊥-elim)
+open import Data.Unit    using (⊤; tt)
+open import Data.Product using (_×_; _,_; Σ; proj₁; proj₂)
+open import Function.Bundles using (Equivalence)
+open import Relation.Binary.PropositionalEquality
+  using ( _≡_; refl; sym; trans; cong; cong₂; subst )
+
+------------------------------------------------------------------------
+-- Commitment well-shapedness.  A preimage may carry a commitment pair
+-- only when the source's flag is set.  When the flag is off, `init-state`
+-- and `comm-ok` ignore `comm-commitment` entirely, so a vestigial
+-- `just (c , r)` is invisible to `R` and to `witness-of` except through
+-- `r` — two preimages differing only in that `c` realize the same
+-- witness.  `CommWF` removes this slack.
+------------------------------------------------------------------------
+
+CommWF : Bool → Maybe (Fr × Fr) → Set
+CommWF false (just _) = ⊥
+CommWF false nothing  = ⊤
+CommWF true  _        = ⊤
+
+-- A commitment-well-shaped realizer: a `Realizer` (StatementSoundness)
+-- whose preimage is `CommWF`.  The `Realizer` fields (`preimage`,
+-- `run`, `R-run`, `extracts`) are re-exported as projections.
+record CommWFRealizer (src : IrSource) (w : Witness) : Set where
+  constructor mk-commwf-realizer
+  field
+    realizer : Realizer src w
+  open Realizer realizer public
+  field
+    comm-wf : CommWF (IrSource.do-communications-commitment src)
+                     (ProofPreimage.comm-commitment preimage)
+
+------------------------------------------------------------------------
+-- Reflection and anchoring helpers.
+------------------------------------------------------------------------
+
+private
+  -- `≡ᶠ-list?` reflected back to propositional list equality (the
+  -- two-run analogue of `≡ᶠ?-true`, lifted element-wise).
+  ≡ᶠ-list?-true : ∀ (xs ys : List Fr) → T (xs ≡ᶠ-list? ys) → xs ≡ ys
+  ≡ᶠ-list?-true []       []       _ = refl
+  ≡ᶠ-list?-true (x ∷ xs) (y ∷ ys) t =
+    let (hx , ht) = T-∧ .Equivalence.to t
+    in cong₂ _∷_ (≡ᶠ?-true {x} {y} hx) (≡ᶠ-list?-true xs ys ht)
+
+  -- Two appends with equal left lengths that produce the same list have
+  -- equal left parts and equal right parts: the anchor.  Proved by
+  -- splitting each side as `take + drop` at the common left length.
+  split-eq : ∀ (ys zs ysr zsr : List Fr)
+    → ys ++ ysr ≡ zs ++ zsr → length ys ≡ length zs
+    → (ys ≡ zs) × (ysr ≡ zsr)
+  split-eq ys zs ysr zsr eq ly≡lz = ys≡zs , ysr≡zsr
+    where
+      take-eq : take (length ys) (ys ++ ysr) ≡ take (length zs) (zs ++ zsr)
+      take-eq = cong₂ take ly≡lz eq
+
+      ys≡zs : ys ≡ zs
+      ys≡zs = trans (sym (take-len ys ysr))
+                    (trans take-eq (take-len zs zsr))
+        where
+          take-len : ∀ (xs xr : List Fr) → take (length xs) (xs ++ xr) ≡ xs
+          take-len []       xr = refl
+          take-len (x ∷ xs) xr = cong (x ∷_) (take-len xs xr)
+
+      ysr≡zsr : ysr ≡ zsr
+      ysr≡zsr = ++-cancelˡ ys ysr zsr
+                  (subst (λ z → ys ++ ysr ≡ z ++ zsr) (sym ys≡zs) eq)
+
+  -- `take (m + n) xs ≡ take m xs ++ take n (drop m xs)`.
+  take-split : ∀ (m n : ℕ) (xs : List Fr)
+    → take (m + n) xs ≡ take m xs ++ take n (drop m xs)
+  take-split zero    n xs       = refl
+  take-split (suc m) n []       = sym (cong (take (suc m) [] ++_) (take-[] n))
+  take-split (suc m) n (x ∷ xs) = cong (x ∷_) (take-split m n xs)
+
+------------------------------------------------------------------------
+-- The two-run parallel induction.
+--
+-- `StateEq s s′` records the five forward-determined fields agreeing
+-- between the two runs (memory and pis grow by appends, the rest by
+-- record updates); the transcript cursors `pub-out-rem` / `priv-rem`
+-- are settled backward from the final emptiness.
+------------------------------------------------------------------------
+
+private
+  -- A record (not a product) so that `StateEq s s′` keeps `s` / `s′` as
+  -- recoverable parameters — the accessors below then infer their state
+  -- arguments without leaving metas (a bare `_×_` of projections does
+  -- not pin `s` / `s′` under unification).
+  record StateEq (s s′ : Preprocessed) : Set where
+    constructor mk-stateq
+    field
+      eq-mem  : Preprocessed.memory     s ≡ Preprocessed.memory     s′
+      eq-pis  : Preprocessed.pis        s ≡ Preprocessed.pis        s′
+      eq-idx  : Preprocessed.pub-in-idx s ≡ Preprocessed.pub-in-idx s′
+      eq-out  : Preprocessed.outputs    s ≡ Preprocessed.outputs    s′
+      eq-skip : Preprocessed.pi-skips   s ≡ Preprocessed.pi-skips   s′
+
+  -- The result the parallel walk hands back.  A record (rather than a
+  -- nested product) so its components carry names at use sites.  `we-af`
+  -- (the final validated prefix length) is `pub-in-idx sf`, and the
+  -- transcript is pinned to agree up to it.
+  record WalkEq (pre pre′ : ProofPreimage)
+                (s s′ sf sf′ : Preprocessed) : Set where
+    constructor mk-walkeq
+    field
+      we-state : StateEq sf sf′
+      we-pout  : Preprocessed.pub-out-rem s ≡ Preprocessed.pub-out-rem s′
+      we-priv  : Preprocessed.priv-rem    s ≡ Preprocessed.priv-rem    s′
+      we-af    : ℕ
+      we-idx   : Preprocessed.pub-in-idx sf ≡ we-af
+      we-tpin  : take we-af (ProofPreimage.pub-transcript-inputs pre)
+               ≡ take we-af (ProofPreimage.pub-transcript-inputs pre′)
+
+  -- A `mem-lookup` agrees across the two runs when their memories agree.
+  lookup-cong : ∀ {m m′ : List Fr} (i : Index) → m ≡ m′
+    → mem-lookup m i ≡ mem-lookup m′ i
+  lookup-cong i meq = cong (λ m → mem-lookup m i) meq
+
+  -- An unguarded transcript instruction is always active (`eval-guard m
+  -- nothing = just true`, irrespective of `m`), so the inactive arm's
+  -- premise reduces to `just true ≡ just false`.  The memory is pinned to
+  -- `[]` — any choice reduces identically, but a fixed one avoids an
+  -- uninferable implicit.
+  unguarded-not-inactive : eval-guard [] nothing ≡ just false → ⊥
+  unguarded-not-inactive eq = case just-injective eq of λ where ()
+
+  -- A guarded instruction cannot be active on one run and inactive on the
+  -- other when the two memories agree (the guard reads the SAME wire).
+  guard-mismatch : ∀ {m m′ : List Fr} (gw : Index) → m ≡ m′
+    → eval-guard m (just gw) ≡ just true
+    → eval-guard m′ (just gw) ≡ just false → ⊥
+  guard-mismatch gw meq gt gf = 
+    case just-injective (trans (sym gt) 
+                        (trans (cong (λ m → eval-guard m (just gw)) meq) 
+                        gf)) 
+      of λ where ()
+
+  -- StateEq components, named for readability at use sites.
+  open StateEq renaming ( eq-mem to se-mem; eq-pis to se-pis; eq-idx to se-idx
+                        ; eq-out to se-out; eq-skip to se-skip )
+
+  -- Memory only grows by appends, so the start memory is a prefix of the
+  -- end memory along any `R-instr` / `R-instrs` trace.
+  mem-step-prefix : ∀ {pre s i s′} → R-instr pre s i s′
+    → Σ (List Fr) (λ ext →
+         Preprocessed.memory s′ ≡ Preprocessed.memory s ++ ext)
+  mem-step-prefix (r-assert _)               = [] , sym (++-identityʳ _)
+  mem-step-prefix (r-constrain-bits _ _ _)     = [] , sym (++-identityʳ _)
+  mem-step-prefix (r-constrain-eq _ _ _)     = [] , sym (++-identityʳ _)
+  mem-step-prefix (r-constrain-to-boolean _) = [] , sym (++-identityʳ _)
+  mem-step-prefix (r-declare-pub-input _)    = [] , sym (++-identityʳ _)
+  mem-step-prefix (r-pi-skip-active _ _)     = [] , sym (++-identityʳ _)
+  mem-step-prefix (r-pi-skip-inactive _)     = [] , sym (++-identityʳ _)
+  mem-step-prefix (r-output _)               = [] , sym (++-identityʳ _)
+  mem-step-prefix (r-cond-select {sel = sel} {av = av} {bv = bv} _ _ _) =
+    (if sel then av else bv) ∷ [] , refl
+  mem-step-prefix (r-copy {v = v} _)         = v ∷ [] , refl
+  mem-step-prefix (r-load-imm {imm = imm})   = imm ∷ [] , refl
+  mem-step-prefix (r-reconstitute-field _ _ _ _ _) = _ ∷ [] , refl
+  mem-step-prefix (r-transient-hash {vs = vs} _) =
+    transient-hash-fn vs ∷ [] , refl
+  mem-step-prefix (r-test-eq {av = av} {bv} _ _) =
+    from-bool (av ≡ᶠ? bv) ∷ [] , refl
+  mem-step-prefix (r-add {av = av} {bv} _ _) = (av +ᶠ bv) ∷ [] , refl
+  mem-step-prefix (r-mul {av = av} {bv} _ _) = (av *ᶠ bv) ∷ [] , refl
+  mem-step-prefix (r-neg {av = av} _)        = (-ᶠ av) ∷ [] , refl
+  mem-step-prefix (r-not {b = b} _)          =
+    from-bool (Bool.not b) ∷ [] , refl
+  mem-step-prefix (r-less-than _ _ _ _)        = _ ∷ [] , refl
+  mem-step-prefix (r-ec-add {cx = cx} {cy} _ _ _ _ _) = cx ∷ cy ∷ [] , refl
+  mem-step-prefix (r-ec-mul {cx = cx} {cy} _ _ _ _)   = cx ∷ cy ∷ [] , refl
+  mem-step-prefix (r-ec-mul-generator {cx = cx} {cy} _ _) = cx ∷ cy ∷ [] , refl
+  mem-step-prefix (r-hash-to-curve {cx = cx} {cy} _ _)    = cx ∷ cy ∷ [] , refl
+  mem-step-prefix (r-persistent-hash {h₁ = h₁} {h₂} _ _)  = h₁ ∷ h₂ ∷ [] , refl
+  mem-step-prefix {s = s} (r-div-mod-power-of-two {bits = bits} {v = v} _ _) =
+    let dvc = from-le-bits (drop bits (to-le-bits v))
+        mvc = from-le-bits (take bits (to-le-bits v))
+    in dvc ∷ mvc ∷ []
+     , ++-assoc (Preprocessed.memory s) (dvc ∷ []) (mvc ∷ [])
+  mem-step-prefix {s = s} (r-public-input-inactive _) = 0ᶠ ∷ [] , refl
+  mem-step-prefix {s = s} (r-public-input-active {v = v} {s₁} _ cp) =
+    v ∷ [] , cong (_++ (v ∷ [])) (consume-pub-out-mem _ cp)
+  mem-step-prefix {s = s} (r-private-input-inactive _) = 0ᶠ ∷ [] , refl
+  mem-step-prefix {s = s} (r-private-input-active {v = v} {s₁} _ cp) =
+    v ∷ [] , cong (_++ (v ∷ [])) (consume-priv-mem _ cp)
+
+  mem-prefix : ∀ {pre s is sf} → R-instrs pre s is sf
+    → Σ (List Fr) (λ ext →
+         Preprocessed.memory sf ≡ Preprocessed.memory s ++ ext)
+  mem-prefix r-done = [] , sym (++-identityʳ _)
+  mem-prefix {s = s} (r-step {s₁ = s₁} step rest) =
+    let (e1 , p1) = mem-step-prefix step
+        (e2 , p2) = mem-prefix rest
+    in e1 ++ e2
+     , trans p2 (trans (cong (_++ e2) p1)
+                       (++-assoc (Preprocessed.memory s) e1 e2))
+
+  -- The analogue for pis: only `declare-pub-input` appends a pis cell.
+  pis-step-prefix : ∀ {pre s i s′} → R-instr pre s i s′
+    → Σ (List Fr) (λ ext →
+         Preprocessed.pis s′ ≡ Preprocessed.pis s ++ ext)
+  pis-step-prefix (r-declare-pub-input {v = v} _) = v ∷ [] , refl
+  pis-step-prefix (r-assert _)               = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-cond-select _ _ _)      = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-constrain-bits _ _ _)     = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-constrain-eq _ _ _)     = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-constrain-to-boolean _) = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-copy _)                 = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-pi-skip-active _ _)     = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-pi-skip-inactive _)     = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-ec-add _ _ _ _ _)       = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-ec-mul _ _ _ _)         = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-ec-mul-generator _ _)   = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-hash-to-curve _ _)      = [] , sym (++-identityʳ _)
+  pis-step-prefix r-load-imm                 = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-div-mod-power-of-two _ _) = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-reconstitute-field _ _ _ _ _) = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-output _)               = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-transient-hash _)       = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-persistent-hash _ _)    = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-test-eq _ _)            = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-add _ _)                = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-mul _ _)                = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-neg _)                  = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-not _)                  = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-less-than _ _ _ _)        = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-public-input-inactive _)  = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-public-input-active _ cp) =
+    [] , trans (consume-pub-out-pis _ cp) (sym (++-identityʳ _))
+  pis-step-prefix (r-private-input-inactive _) = [] , sym (++-identityʳ _)
+  pis-step-prefix (r-private-input-active _ cp) =
+    [] , trans (consume-priv-pis _ cp) (sym (++-identityʳ _))
+
+  pis-prefix : ∀ {pre s is sf} → R-instrs pre s is sf
+    → Σ (List Fr) (λ ext →
+         Preprocessed.pis sf ≡ Preprocessed.pis s ++ ext)
+  pis-prefix r-done = [] , sym (++-identityʳ _)
+  pis-prefix {s = s} (r-step {s₁ = s₁} step rest) =
+    let (e1 , p1) = pis-step-prefix step
+        (e2 , p2) = pis-prefix rest
+    in e1 ++ e2
+     , trans p2 (trans (cong (_++ e2) p1)
+                       (++-assoc (Preprocessed.pis s) e1 e2))
+
+  -- The cell a step appends, read off the common final memory.  Given
+  -- `memory sf ≡ (memory s ++ (v ∷ [])) ++ extTail` for both runs, the
+  -- common final memory and the equal start memories force `v ≡ v′`.
+  next-cell-eq : ∀ {ms ms′ : List Fr} {v v′ : Fr} {et et′ mf mf′ : List Fr}
+    → ms ≡ ms′ → mf ≡ mf′
+    → mf  ≡ (ms  ++ (v  ∷ [])) ++ et
+    → mf′ ≡ (ms′ ++ (v′ ∷ [])) ++ et′
+    → v ≡ v′
+  next-cell-eq {ms} {ms′} {v} {v′} {et} {et′} meq mfeq pf pf′ =
+    let joined : ms ++ ((v ∷ []) ++ et) ≡ ms′ ++ ((v′ ∷ []) ++ et′)
+        joined = trans (sym (++-assoc ms (v ∷ []) et))
+                   (trans (sym pf)
+                     (trans mfeq (trans pf′ (++-assoc ms′ (v′ ∷ []) et′))))
+        (_ , tails) = split-eq ms ms′ ((v ∷ []) ++ et) ((v′ ∷ []) ++ et′)
+                        joined (cong length meq)
+    in ∷-injectiveˡ tails
+
+  -- Memory equality is preserved across a step of the SAME instruction:
+  -- both post-states are equal-length prefixes of the common final
+  -- memory.  The post-states' ext lengths agree (`R-instr-Δmem`), and
+  -- their tails reach the same `mf`.
+  step-mem-eq : ∀ {pre pre′ i} {s s′ s₁ s₁′ : Preprocessed}
+                  {mf mf′ et et′ : List Fr}
+    → R-instr pre  s  i s₁
+    → R-instr pre′ s′ i s₁′
+    → Preprocessed.memory s ≡ Preprocessed.memory s′
+    → mf ≡ mf′
+    → mf  ≡ Preprocessed.memory s₁  ++ et
+    → mf′ ≡ Preprocessed.memory s₁′ ++ et′
+    → Preprocessed.memory s₁ ≡ Preprocessed.memory s₁′
+  step-mem-eq {i = i} {s} {s′} {s₁} {s₁′} {mf} {mf′} {et} {et′}
+              step step′ meq mfeq pf pf′ =
+    proj₁ (split-eq (Preprocessed.memory s₁) (Preprocessed.memory s₁′) et et′
+             (trans (sym pf) (trans mfeq pf′)) len-eq)
+    where
+      len-eq : length (Preprocessed.memory s₁) ≡ length (Preprocessed.memory s₁′)
+      len-eq =
+        trans (R-instr-Δmem step)
+          (trans (cong (_+ Δmem i) (cong length meq))
+                 (sym (R-instr-Δmem step′)))
+
+  ------------------------------------------------------------------------
+  -- The two-run parallel induction proper.  Both runs execute the SAME
+  -- instruction list `is`; `o1` is the shared O1-Trace; `mf` is the
+  -- common final memory (`memory sf ≡ memory sf′`, anchored by `ma`/`ma′`
+  -- against the two intermediate memories).  `a` and `d` are the
+  -- validated-prefix length and the declares-since-last-skip counter; the
+  -- transcript prefix is pinned to agree up to `a` (`tpin`), and
+  -- `pub-in-idx s ≡ a + d` (`idx≡`).
+  -- Instructions whose `R-instr` touches only memory: pis / pub-in-idx /
+  -- outputs / pi-skips / both rems pass through.  `declare-pub-input`,
+  -- `pi-skip`, `output`, and active `public-input` / `private-input` are
+  -- excluded (they update one of those fields).
+  PureMem : Instruction → Set
+  PureMem (declare-pub-input _) = ⊥
+  PureMem (pi-skip _ _)         = ⊥
+  PureMem (output _)            = ⊥
+  PureMem (public-input _)      = ⊥
+  PureMem (private-input _)     = ⊥
+  PureMem _                     = ⊤
+
+  -- For a pure-memory step, the five non-memory state components are
+  -- unchanged, alongside the two transcript cursors.
+  -- (`public-input`/`private-input` are excluded by `PureMem` precisely
+  -- because their *active* arm pops a transcript.)
+  record PureMemFrame (s s′ : Preprocessed) : Set where
+    constructor mk-pmf
+    field
+      pmf-pis     : Preprocessed.pis s′ ≡ Preprocessed.pis s
+      pmf-idx     : Preprocessed.pub-in-idx s′ ≡ Preprocessed.pub-in-idx s
+      pmf-out     : Preprocessed.outputs s′ ≡ Preprocessed.outputs s
+      pmf-skip    : Preprocessed.pi-skips s′ ≡ Preprocessed.pi-skips s
+      pmf-pubrem  : Preprocessed.pub-out-rem s′ ≡ Preprocessed.pub-out-rem s
+      pmf-privrem : Preprocessed.priv-rem s′ ≡ Preprocessed.priv-rem s
+
+  pm-frame : ∀ {pre s i s′} → R-instr pre s i s′ → PureMem i
+    → PureMemFrame s s′
+  pm-frame (r-assert _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-cond-select _ _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-constrain-bits _ _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-constrain-eq _ _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-constrain-to-boolean _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-copy _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-ec-add _ _ _ _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-ec-mul _ _ _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-ec-mul-generator _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-hash-to-curve _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame r-load-imm _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-div-mod-power-of-two _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-reconstitute-field _ _ _ _ _) _ =
+    mk-pmf refl refl refl refl refl refl
+  pm-frame (r-transient-hash _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-persistent-hash _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-test-eq _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-add _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-mul _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-neg _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-not _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-less-than _ _ _ _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-public-input-inactive _) _ = mk-pmf refl refl refl refl refl refl
+  pm-frame (r-private-input-inactive _) _ =
+    mk-pmf refl refl refl refl refl refl
+
+  pm-pis : ∀ {pre s i s′} → R-instr pre s i s′ → PureMem i
+    → Preprocessed.pis s′ ≡ Preprocessed.pis s
+  pm-pis step pm = PureMemFrame.pmf-pis (pm-frame step pm)
+
+  pm-idx : ∀ {pre s i s′} → R-instr pre s i s′ → PureMem i
+    → Preprocessed.pub-in-idx s′ ≡ Preprocessed.pub-in-idx s
+  pm-idx step pm = PureMemFrame.pmf-idx (pm-frame step pm)
+
+  pm-out : ∀ {pre s i s′} → R-instr pre s i s′ → PureMem i
+    → Preprocessed.outputs s′ ≡ Preprocessed.outputs s
+  pm-out step pm = PureMemFrame.pmf-out (pm-frame step pm)
+
+  pm-skip : ∀ {pre s i s′} → R-instr pre s i s′ → PureMem i
+    → Preprocessed.pi-skips s′ ≡ Preprocessed.pi-skips s
+  pm-skip step pm = PureMemFrame.pmf-skip (pm-frame step pm)
+
+  pm-pubrem : ∀ {pre s i s′} → R-instr pre s i s′ → PureMem i
+    → Preprocessed.pub-out-rem s′ ≡ Preprocessed.pub-out-rem s
+  pm-pubrem step pm = PureMemFrame.pmf-pubrem (pm-frame step pm)
+
+  pm-privrem : ∀ {pre s i s′} → R-instr pre s i s′ → PureMem i
+    → Preprocessed.priv-rem s′ ≡ Preprocessed.priv-rem s
+  pm-privrem step pm = PureMemFrame.pmf-privrem (pm-frame step pm)
+
+  -- Peel the O1-Trace head past a pure-memory instruction (the counter
+  -- `d` is unchanged: `PureMem` excludes `declare-pub-input` / `pi-skip`).
+  o1-pure : ∀ {d i is} → PureMem i → O1-Trace d (i ∷ is) → O1-Trace d is
+  o1-pure _  (o1-other _ t) = t
+  o1-pure pm (o1-decl _)    = ⊥-elim pm
+  o1-pure pm (o1-skip _ _)  = ⊥-elim pm
+
+  ------------------------------------------------------------------------
+  walk-eq
+    : ∀ (pre pre′ : ProofPreimage) (is : List Instruction)
+        {s s′ sf sf′ : Preprocessed} {a d : ℕ}
+    → R-instrs pre  s  is sf
+    → R-instrs pre′ s′ is sf′
+    → O1-Trace d is
+    → StateEq s s′
+    → Preprocessed.memory sf ≡ Preprocessed.memory sf′
+    → Preprocessed.pub-out-rem sf  ≡ []
+    → Preprocessed.pub-out-rem sf′ ≡ []
+    → Preprocessed.priv-rem    sf  ≡ []
+    → Preprocessed.priv-rem    sf′ ≡ []
+    → Preprocessed.pub-in-idx s ≡ a + d
+    → take a (ProofPreimage.pub-transcript-inputs pre)
+      ≡ take a (ProofPreimage.pub-transcript-inputs pre′)
+    → WalkEq pre pre′ s s′ sf sf′
+
+  -- A pure-memory head: peel `o1`, build the post-state `StateEq` from
+  -- the inherited components, and recurse.  The backward rems pass
+  -- through unchanged, so the recursion's bundle transports directly.
+  pure-step
+    : ∀ (pre pre′ : ProofPreimage) {i is}
+        {s s′ s₁ s₁′ sf sf′ : Preprocessed} {a d : ℕ}
+    → PureMem i
+    → R-instr  pre  s  i s₁ → R-instr  pre′ s′ i s₁′
+    → R-instrs pre  s₁ is sf → R-instrs pre′ s₁′ is sf′
+    → O1-Trace d (i ∷ is)
+    → StateEq s s′
+    → Preprocessed.memory sf ≡ Preprocessed.memory sf′
+    → Preprocessed.pub-out-rem sf  ≡ []
+    → Preprocessed.pub-out-rem sf′ ≡ []
+    → Preprocessed.priv-rem    sf  ≡ []
+    → Preprocessed.priv-rem    sf′ ≡ []
+    → Preprocessed.pub-in-idx s ≡ a + d
+    → take a (ProofPreimage.pub-transcript-inputs pre)
+      ≡ take a (ProofPreimage.pub-transcript-inputs pre′)
+    → WalkEq pre pre′ s s′ sf sf′
+
+  -- The empty trace: both final states are the start states themselves;
+  -- the backward rem-equalities come from the supplied final emptiness,
+  -- and `O1-Trace d []` forces `d ≡ 0` so `pub-in-idx ≡ a`.
+  walk-eq pre pre′ [] {s} {s′} {a = a} {d} r-done r-done o1-nil se mfeq
+          poe poe′ pve pve′ idx≡ tpin =
+    mk-walkeq se (trans poe (sym poe′)) (trans pve (sym pve′))
+              a (trans idx≡ (+-identityʳ a)) tpin
+
+  -- Every pure-memory instruction delegates to `pure-step`.
+  walk-eq pre pre′ (assert _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (cond-select _ _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (constrain-bits _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (constrain-eq _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (constrain-to-boolean _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (copy _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (ec-add _ _ _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (ec-mul _ _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (ec-mul-generator _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (hash-to-curve _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (load-imm _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (div-mod-power-of-two _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (reconstitute-field _ _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (transient-hash _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (persistent-hash _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (test-eq _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (add _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (mul _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (neg _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (not _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+  walk-eq pre pre′ (less-than _ _ _ ∷ _) (r-step step rest) (r-step step′ rest′) =
+    pure-step pre pre′ tt step step′ rest rest′
+
+  -- `output`: the appended output cell is a memory lookup, equal across
+  -- runs; memory / pis / pub-in-idx / pi-skips / rems pass through.
+  walk-eq pre pre′ (output var ∷ is) {s} {s′} {a = a} {d}
+          (r-step (r-output {v = v} lk) rest)
+          (r-step (r-output {v = v′} lk′) rest′)
+          (o1-other _ o1t) se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let v≡ : v ≡ v′
+        v≡ = just-injective
+               (trans (sym lk) (trans (lookup-cong var (se-mem se)) lk′))
+        se₁ : StateEq (record s { outputs = Preprocessed.outputs s ++ (v ∷ []) })
+                      (record s′ { outputs = Preprocessed.outputs s′ ++ (v′ ∷ []) })
+        se₁ = mk-stateq (se-mem se) (se-pis se) (se-idx se)
+                (cong₂ _++_ (se-out se) (cong (_∷ []) v≡)) (se-skip se)
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a} {d = d} rest rest′ o1t se₁ mfeq
+                  poe poe′ pve pve′ idx≡ tpin
+    in mk-walkeq seq po≡ pv≡ af idx tpn
+
+  -- `declare-pub-input`: the appended pis cell is a memory lookup, equal
+  -- across runs; `pub-in-idx` bumps by one in both, and the O1 counter
+  -- `d` bumps to `suc d` while `a` is unchanged, so `pub-in-idx ≡ a +
+  -- suc d` is restored.
+  walk-eq pre pre′ (declare-pub-input var ∷ is) {s} {s′} {a = a} {d}
+          (r-step (r-declare-pub-input {v = v} lk) rest)
+          (r-step (r-declare-pub-input {v = v′} lk′) rest′)
+          (o1-decl o1t) se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let v≡ : v ≡ v′
+        v≡ = just-injective
+               (trans (sym lk) (trans (lookup-cong var (se-mem se)) lk′))
+        se₁ : StateEq
+                (record s { pis = Preprocessed.pis s ++ (v ∷ [])
+                          ; pub-in-idx = suc (Preprocessed.pub-in-idx s) })
+                (record s′ { pis = Preprocessed.pis s′ ++ (v′ ∷ [])
+                           ; pub-in-idx = suc (Preprocessed.pub-in-idx s′) })
+        se₁ = mk-stateq (se-mem se)
+                (cong₂ _++_ (se-pis se) (cong (_∷ []) v≡))
+                (cong suc (se-idx se)) (se-out se) (se-skip se)
+        idx₁ : suc (Preprocessed.pub-in-idx s) ≡ a + suc d
+        idx₁ = trans (cong suc idx≡) (sym (+-suc a d))
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a} {d = suc d} rest rest′ o1t se₁ mfeq
+                  poe poe′ pve pve′ idx₁ tpin
+    in mk-walkeq seq po≡ pv≡ af idx tpn
+
+  -- `pi-skip` ── ACTIVE / ACTIVE.  The validation premise pins the last
+  -- `count = d` declared cells against the transcript window at
+  -- `pub-in-idx ∸ d ≡ a`; the cells (`pis`) agree across runs, so the two
+  -- windows agree, extending the pinned prefix from `a` to `a + d`.  The
+  -- counter resets (`d := 0`, `a := a + d`); `pub-in-idx` is unchanged.
+  walk-eq pre pre′ (pi-skip g count ∷ is) {s} {s′} {a = a} {d}
+          (r-step (r-pi-skip-active _ chk) rest)
+          (r-step (r-pi-skip-active _ chk′) rest′)
+          (o1-skip n≡d o1t) se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let se₁ : StateEq
+                (record s  { pi-skips = Preprocessed.pi-skips s  ++ (nothing ∷ []) })
+                (record s′ { pi-skips = Preprocessed.pi-skips s′ ++ (nothing ∷ []) })
+        se₁ = mk-stateq (se-mem se) (se-pis se) (se-idx se) (se-out se)
+                (cong₂ _++_ (se-skip se) refl)
+        pti  = ProofPreimage.pub-transcript-inputs pre
+        pti′ = ProofPreimage.pub-transcript-inputs pre′
+        -- The validated window, with `count` rewritten to `d` and
+        -- `pub-in-idx ∸ d` to `a`.
+        win-s : Preprocessed.pub-in-idx s ∸ count ≡ a
+        win-s = trans (cong (_∸ count) idx≡)
+                      (trans (cong (λ k → (a + d) ∸ k) n≡d) (m+n∸n≡m a d))
+        win-s′ : Preprocessed.pub-in-idx s′ ∸ count ≡ a
+        win-s′ = trans (cong (_∸ count) (trans (sym (se-idx se)) idx≡))
+                       (trans (cong (λ k → (a + d) ∸ k) n≡d) (m+n∸n≡m a d))
+        rec-eq : drop (length (Preprocessed.pis s) ∸ count) (Preprocessed.pis s)
+               ≡ drop (length (Preprocessed.pis s′) ∸ count) (Preprocessed.pis s′)
+        rec-eq = cong₂ (λ l xs → drop (l ∸ count) xs)
+                       (cong length (se-pis se)) (se-pis se)
+        exp-s  : take count (drop (Preprocessed.pub-in-idx s ∸ count) pti)
+               ≡ take d (drop a pti)
+        exp-s  = cong₂ (λ k st → take k (drop st pti)) n≡d win-s
+        exp-s′ : take count (drop (Preprocessed.pub-in-idx s′ ∸ count) pti′)
+               ≡ take d (drop a pti′)
+        exp-s′ = cong₂ (λ k st → take k (drop st pti′)) n≡d win-s′
+        win-eq : take d (drop a pti) ≡ take d (drop a pti′)
+        win-eq = trans (sym exp-s)
+                   (trans (sym (≡ᶠ-list?-true _ _ chk))
+                     (trans rec-eq (trans (≡ᶠ-list?-true _ _ chk′) exp-s′)))
+        tpin₁ : take (a + d) pti ≡ take (a + d) pti′
+        tpin₁ = trans (take-split a d pti)
+                  (trans (cong₂ _++_ tpin win-eq)
+                         (sym (take-split a d pti′)))
+        idx₁ : Preprocessed.pub-in-idx s ≡ (a + d) + 0
+        idx₁ = trans idx≡ (sym (+-identityʳ (a + d)))
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a + d} {d = 0} rest rest′ o1t se₁ mfeq
+                  poe poe′ pve pve′ idx₁ tpin₁
+    in mk-walkeq seq po≡ pv≡ af idx tpn
+
+  -- Mixed guard outcomes are impossible: a guard reads the same wire of
+  -- equal memories.  An unguarded skip is always active.
+  walk-eq pre pre′ (pi-skip nothing count ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-pi-skip-active _ _) _)
+          (r-step (r-pi-skip-inactive gf′) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (unguarded-not-inactive gf′)
+  walk-eq pre pre′ (pi-skip nothing count ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-pi-skip-inactive gf) _)
+          (r-step (r-pi-skip-active _ _) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (unguarded-not-inactive gf)
+  walk-eq pre pre′ (pi-skip (just gw) count ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-pi-skip-active gt _) _)
+          (r-step (r-pi-skip-inactive gf′) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (guard-mismatch gw (se-mem se) gt gf′)
+  walk-eq pre pre′ (pi-skip (just gw) count ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-pi-skip-inactive gf) _)
+          (r-step (r-pi-skip-active gt′ _) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (guard-mismatch gw (sym (se-mem se)) gt′ gf)
+
+  -- `pi-skip` ── INACTIVE / INACTIVE.  Both roll `pub-in-idx` back by
+  -- `count = d` (discarding the current group), so `pub-in-idx ∸ d ≡ a`
+  -- and the counter resets (`d := 0`, `a` unchanged).
+  walk-eq pre pre′ (pi-skip g count ∷ is) {s} {s′} {a = a} {d}
+          (r-step (r-pi-skip-inactive _) rest)
+          (r-step (r-pi-skip-inactive _) rest′)
+          (o1-skip n≡d o1t) se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let se₁ : StateEq
+                (record s  { pi-skips   = Preprocessed.pi-skips s  ++ (just count ∷ [])
+                           ; pub-in-idx = Preprocessed.pub-in-idx s  ∸ count })
+                (record s′ { pi-skips   = Preprocessed.pi-skips s′ ++ (just count ∷ [])
+                           ; pub-in-idx = Preprocessed.pub-in-idx s′ ∸ count })
+        se₁ = mk-stateq (se-mem se) (se-pis se)
+                (cong (_∸ count) (se-idx se)) (se-out se)
+                (cong₂ _++_ (se-skip se) refl)
+        idx₁ : Preprocessed.pub-in-idx s ∸ count ≡ a + 0
+        idx₁ = trans (cong (_∸ count) idx≡)
+                 (trans (cong (λ k → (a + d) ∸ k) n≡d)
+                        (trans (m+n∸n≡m a d) (sym (+-identityʳ a))))
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a} {d = 0} rest rest′ o1t se₁ mfeq
+                  poe poe′ pve pve′ idx₁ tpin
+    in mk-walkeq seq po≡ pv≡ af idx tpn
+
+  -- `public-input` ── INACTIVE / INACTIVE: pushes `0ᶠ`; pure memory.
+  walk-eq pre pre′ (public-input g ∷ is) {s} {s′} {a = a} {d}
+          (r-step step@(r-public-input-inactive gf) rest)
+          (r-step step′@(r-public-input-inactive gf′) rest′)
+          (o1-other _ o1t) se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let se₁ : StateEq (push-mem s 0ᶠ) (push-mem s′ 0ᶠ)
+        se₁ = mk-stateq
+                (step-mem-eq step step′ (se-mem se) mfeq
+                  (proj₂ (mem-prefix rest)) (proj₂ (mem-prefix rest′)))
+                (se-pis se) (se-idx se) (se-out se) (se-skip se)
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a} {d = d} rest rest′ o1t se₁ mfeq
+                  poe poe′ pve pve′ idx≡ tpin
+    in mk-walkeq seq po≡ pv≡ af idx tpn
+
+  -- `public-input` ── ACTIVE / ACTIVE: consumes the next public-output
+  -- cell.  Its value is the appended memory cell — equal across runs by
+  -- the anchor — so the consumed-cursor cons reassembles the backward
+  -- `pub-out-rem` equality.
+  walk-eq pre pre′ (public-input g ∷ is) {s} {s′} {sf = sf} {sf′ = sf′} {a = a} {d}
+          (r-step (r-public-input-active {v = v} {s₁ = c1} _ cp) rest)
+          (r-step (r-public-input-active {v = v′} {s₁ = c1′} _ cp′) rest′)
+          (o1-other _ o1t) se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let pf  : Preprocessed.memory sf
+            ≡ (Preprocessed.memory s ++ (v ∷ [])) ++ proj₁ (mem-prefix rest)
+        pf  = trans (proj₂ (mem-prefix rest))
+                    (cong (λ m → (m ++ (v ∷ [])) ++ proj₁ (mem-prefix rest))
+                          (consume-pub-out-mem _ cp))
+        pf′ : Preprocessed.memory sf′
+            ≡ (Preprocessed.memory s′ ++ (v′ ∷ [])) ++ proj₁ (mem-prefix rest′)
+        pf′ = trans (proj₂ (mem-prefix rest′))
+                    (cong (λ m → (m ++ (v′ ∷ [])) ++ proj₁ (mem-prefix rest′))
+                          (consume-pub-out-mem _ cp′))
+        v≡ : v ≡ v′
+        v≡ = next-cell-eq (se-mem se) mfeq pf pf′
+        memc : Preprocessed.memory (push-mem c1 v)
+             ≡ Preprocessed.memory (push-mem c1′ v′)
+        memc = cong₂ _++_ (trans (consume-pub-out-mem _ cp)
+                            (trans (se-mem se) (sym (consume-pub-out-mem _ cp′))))
+                          (cong (_∷ []) v≡)
+        se₁ : StateEq (push-mem c1 v) (push-mem c1′ v′)
+        se₁ = mk-stateq memc
+                (trans (consume-pub-out-pis _ cp) (trans (se-pis se)
+                  (sym (consume-pub-out-pis _ cp′))))
+                (trans (consume-pub-out-idx _ cp) (trans (se-idx se)
+                  (sym (consume-pub-out-idx _ cp′))))
+                (trans (consume-pub-out-outputs _ cp) (trans (se-out se)
+                  (sym (consume-pub-out-outputs _ cp′))))
+                (trans (consume-pub-out-skips _ cp) (trans (se-skip se)
+                  (sym (consume-pub-out-skips _ cp′))))
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a} {d = d} rest rest′ o1t se₁ mfeq
+                  poe poe′ pve pve′ (trans (consume-pub-out-idx _ cp) idx≡) tpin
+    in mk-walkeq seq
+         (trans (consume-pub-out-rem _ cp)
+           (trans (cong₂ _∷_ v≡ po≡) (sym (consume-pub-out-rem _ cp′))))
+         (trans (sym (consume-pub-out-priv _ cp))
+           (trans pv≡ (consume-pub-out-priv _ cp′)))
+         af idx tpn
+
+  -- Mixed guard outcomes for `public-input` are impossible.
+  walk-eq pre pre′ (public-input nothing ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-public-input-active _ _) _)
+          (r-step (r-public-input-inactive gf′) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (unguarded-not-inactive gf′)
+  walk-eq pre pre′ (public-input nothing ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-public-input-inactive gf) _)
+          (r-step (r-public-input-active _ _) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (unguarded-not-inactive gf)
+  walk-eq pre pre′ (public-input (just gw) ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-public-input-active gt _) _)
+          (r-step (r-public-input-inactive gf′) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (guard-mismatch gw (se-mem se) gt gf′)
+  walk-eq pre pre′ (public-input (just gw) ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-public-input-inactive gf) _)
+          (r-step (r-public-input-active gt′ _) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (guard-mismatch gw (sym (se-mem se)) gt′ gf)
+
+  -- `private-input` ── INACTIVE / INACTIVE: pushes `0ᶠ`; pure memory.
+  walk-eq pre pre′ (private-input g ∷ is) {s} {s′} {a = a} {d}
+          (r-step step@(r-private-input-inactive gf) rest)
+          (r-step step′@(r-private-input-inactive gf′) rest′)
+          (o1-other _ o1t) se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let se₁ : StateEq (push-mem s 0ᶠ) (push-mem s′ 0ᶠ)
+        se₁ = mk-stateq
+                (step-mem-eq step step′ (se-mem se) mfeq
+                  (proj₂ (mem-prefix rest)) (proj₂ (mem-prefix rest′)))
+                (se-pis se) (se-idx se) (se-out se) (se-skip se)
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a} {d = d} rest rest′ o1t se₁ mfeq
+                  poe poe′ pve pve′ idx≡ tpin
+    in mk-walkeq seq po≡ pv≡ af idx tpn
+
+  -- `private-input` ── ACTIVE / ACTIVE: consumes the next private cell.
+  walk-eq pre pre′ (private-input g ∷ is) {s} {s′} {sf = sf} {sf′ = sf′} {a = a} {d}
+          (r-step (r-private-input-active {v = v} {s₁ = c1} _ cp) rest)
+          (r-step (r-private-input-active {v = v′} {s₁ = c1′} _ cp′) rest′)
+          (o1-other _ o1t) se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let pf  : Preprocessed.memory sf
+            ≡ (Preprocessed.memory s ++ (v ∷ [])) ++ proj₁ (mem-prefix rest)
+        pf  = trans (proj₂ (mem-prefix rest))
+                    (cong (λ m → (m ++ (v ∷ [])) ++ proj₁ (mem-prefix rest))
+                          (consume-priv-mem _ cp))
+        pf′ : Preprocessed.memory sf′
+            ≡ (Preprocessed.memory s′ ++ (v′ ∷ [])) ++ proj₁ (mem-prefix rest′)
+        pf′ = trans (proj₂ (mem-prefix rest′))
+                    (cong (λ m → (m ++ (v′ ∷ [])) ++ proj₁ (mem-prefix rest′))
+                          (consume-priv-mem _ cp′))
+        v≡ : v ≡ v′
+        v≡ = next-cell-eq (se-mem se) mfeq pf pf′
+        memc : Preprocessed.memory (push-mem c1 v)
+             ≡ Preprocessed.memory (push-mem c1′ v′)
+        memc = cong₂ _++_ (trans (consume-priv-mem _ cp)
+                            (trans (se-mem se) (sym (consume-priv-mem _ cp′))))
+                          (cong (_∷ []) v≡)
+        se₁ : StateEq (push-mem c1 v) (push-mem c1′ v′)
+        se₁ = mk-stateq memc
+                (trans (consume-priv-pis _ cp) (trans (se-pis se)
+                  (sym (consume-priv-pis _ cp′))))
+                (trans (consume-priv-idx _ cp) (trans (se-idx se)
+                  (sym (consume-priv-idx _ cp′))))
+                (trans (consume-priv-outputs _ cp) (trans (se-out se)
+                  (sym (consume-priv-outputs _ cp′))))
+                (trans (consume-priv-skips _ cp) (trans (se-skip se)
+                  (sym (consume-priv-skips _ cp′))))
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a} {d = d} rest rest′ o1t se₁ mfeq
+                  poe poe′ pve pve′ (trans (consume-priv-idx _ cp) idx≡) tpin
+    in mk-walkeq seq
+         (trans (sym (consume-priv-pub _ cp))
+           (trans po≡ (consume-priv-pub _ cp′)))
+         (trans (consume-priv-rem _ cp)
+           (trans (cong₂ _∷_ v≡ pv≡) (sym (consume-priv-rem _ cp′))))
+         af idx tpn
+
+  -- Mixed guard outcomes for `private-input` are impossible.
+  walk-eq pre pre′ (private-input nothing ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-private-input-active _ _) _)
+          (r-step (r-private-input-inactive gf′) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (unguarded-not-inactive gf′)
+  walk-eq pre pre′ (private-input nothing ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-private-input-inactive gf) _)
+          (r-step (r-private-input-active _ _) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (unguarded-not-inactive gf)
+  walk-eq pre pre′ (private-input (just gw) ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-private-input-active gt _) _)
+          (r-step (r-private-input-inactive gf′) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (guard-mismatch gw (se-mem se) gt gf′)
+  walk-eq pre pre′ (private-input (just gw) ∷ is) {s} {s′} {a = a} {d = d}
+          (r-step (r-private-input-inactive gf) _)
+          (r-step (r-private-input-active gt′ _) _) _ se _ _ _ _ _ _ _ =
+    ⊥-elim (guard-mismatch gw (sym (se-mem se)) gt′ gf)
+
+  pure-step pre pre′ {i} {is} {s} {s′} {s₁} {s₁′} {sf} {sf′} {a} {d}
+            pm step step′ rest rest′ o1 se mfeq poe poe′ pve pve′ idx≡ tpin =
+    let se₁ : StateEq s₁ s₁′
+        se₁ = mk-stateq
+                (step-mem-eq step step′ (se-mem se) mfeq
+                  (proj₂ (mem-prefix rest)) (proj₂ (mem-prefix rest′)))
+                (trans (pm-pis step pm) (trans (se-pis se) (sym (pm-pis step′ pm))))
+                (trans (pm-idx step pm) (trans (se-idx se) (sym (pm-idx step′ pm))))
+                (trans (pm-out step pm) (trans (se-out se) (sym (pm-out step′ pm))))
+                (trans (pm-skip step pm) (trans (se-skip se) (sym (pm-skip step′ pm))))
+        idx₁ : Preprocessed.pub-in-idx s₁ ≡ a + d
+        idx₁ = trans (pm-idx step pm) idx≡
+        (mk-walkeq seq po≡ pv≡ af idx tpn) =
+          walk-eq pre pre′ is {a = a} {d = d} rest rest′ (o1-pure pm o1) se₁ mfeq
+                  poe poe′ pve pve′ idx₁ tpin
+    in mk-walkeq seq
+         (trans (sym (pm-pubrem step pm)) (trans po≡ (pm-pubrem step′ pm)))
+         (trans (sym (pm-privrem step pm)) (trans pv≡ (pm-privrem step′ pm)))
+         af idx tpn
+
+  ------------------------------------------------------------------------
+  -- Record congruences (each field equal ⇒ records equal); proved by
+  -- matching all components `refl`.
+  ------------------------------------------------------------------------
+  mk-state-cong : ∀ {m m′ p p′ k k′ i i′ po po′ pv pv′ o o′}
+    → m ≡ m′ → p ≡ p′ → k ≡ k′ → i ≡ i′ → po ≡ po′ → pv ≡ pv′ → o ≡ o′
+    → mk-state m p k i po pv o ≡ mk-state m′ p′ k′ i′ po′ pv′ o′
+  mk-state-cong refl refl refl refl refl refl refl = refl
+
+  mk-preimage-cong : ∀ {ins ins′ b b′ cm cm′ ti ti′ to to′ pv pv′}
+    → ins ≡ ins′ → b ≡ b′ → cm ≡ cm′ → ti ≡ ti′ → to ≡ to′ → pv ≡ pv′
+    → mk-preimage ins b cm ti to pv ≡ mk-preimage ins′ b′ cm′ ti′ to′ pv′
+  mk-preimage-cong refl refl refl refl refl refl = refl
+
+  ------------------------------------------------------------------------
+  -- Initial-state field extraction from `init-state src pre ≡ just s₀`.
+  -- `init-state` seeds memory with `inputs pre`, pis with the
+  -- binding-input (plus the commitment value when the flag is set),
+  -- `pub-out-rem` / `priv-rem` with the two transcripts, and the rest
+  -- empty; it also enforces WF1 (`length inputs ≡ num-inputs`).
+  ------------------------------------------------------------------------
+  record InitFields (src : IrSource) (pre : ProofPreimage)
+                    (hc : Bool) (s₀ : Preprocessed) : Set where
+    constructor mk-init
+    field
+      if-mem  : Preprocessed.memory s₀ ≡ ProofPreimage.inputs pre
+      if-pis  : Σ Fr (λ b → Σ (List Fr) (λ rest →
+                  (Preprocessed.pis s₀ ≡ b ∷ rest)
+                × (b ≡ ProofPreimage.binding-input pre)))
+      if-idx  : Preprocessed.pub-in-idx s₀ ≡ 0
+      if-pout : Preprocessed.pub-out-rem s₀ ≡ ProofPreimage.pub-transcript-outputs pre
+      if-priv : Preprocessed.priv-rem s₀ ≡ ProofPreimage.priv-transcript pre
+      if-out  : Preprocessed.outputs s₀ ≡ []
+      if-skip : Preprocessed.pi-skips s₀ ≡ []
+      if-wf1  : length (ProofPreimage.inputs pre) ≡ IrSource.num-inputs src
+      -- The pis preamble length is fixed by the (shared) flag `hc`.
+      if-plen : length (Preprocessed.pis s₀) ≡ (if hc then 2 else 1)
+
+  init-fields : ∀ (src : IrSource) (pre : ProofPreimage) (hc : Bool) {s₀}
+    → IrSource.do-communications-commitment src ≡ hc
+    → init-state src pre ≡ just s₀ → InitFields src pre hc s₀
+  init-fields src pre hc hc≡ eq
+    with length (ProofPreimage.inputs pre) ≡ᵇ IrSource.num-inputs src
+       in wf-eq
+       | IrSource.do-communications-commitment src
+       | hc≡
+       | ProofPreimage.comm-commitment pre
+  init-fields src pre .false refl refl | true | false | refl | _ =
+    mk-init refl (_ , [] , refl , refl) refl refl refl refl refl
+      (≡ᵇ⇒≡ _ _ (subst T (sym wf-eq) tt)) refl
+  init-fields src pre .true refl refl | true | true | refl | just (c , r) =
+    mk-init refl (_ , c ∷ [] , refl , refl) refl refl refl refl refl
+      (≡ᵇ⇒≡ _ _ (subst T (sym wf-eq) tt)) refl
+  init-fields src pre hc hc≡ () | false | _ | _ | _
+  init-fields src pre .true refl () | true | true | refl | nothing
+
+  ------------------------------------------------------------------------
+  -- Commitment-field equality.  Flag off: `CommWF` forces both
+  -- commitments `nothing`.  Flag on: `comm-ok` forces both `just (c , r)`;
+  -- the value `c` sits in the (equal) pis preamble, and the randomness
+  -- `r` equals `comm-rand-of`, pinned by witness equality (E3).
+  ------------------------------------------------------------------------
+
+  comm-rand-of-just : ∀ (pre : ProofPreimage) {c r}
+    → ProofPreimage.comm-commitment pre ≡ just (c , r)
+    → comm-rand-of pre ≡ just r
+  comm-rand-of-just pre eq = cong (Data.Maybe.map (λ (_ , r) → r)) eq
+
+  -- With the flag on, `comm-ok` rules out a missing commitment.
+  comm-ok-just : ∀ (src : IrSource) (pre : ProofPreimage) (s : Preprocessed)
+    → IrSource.do-communications-commitment src ≡ true
+    → T (comm-ok src pre s)
+    → Σ Fr (λ c → Σ Fr (λ r →
+        ProofPreimage.comm-commitment pre ≡ just (c , r)))
+  comm-ok-just src pre s hc≡ co
+    with IrSource.do-communications-commitment src | hc≡
+       | ProofPreimage.comm-commitment pre
+  ... | true | refl | just (c , r) = c , r , refl
+
+  -- With the flag off, `CommWF` rules out a present commitment.
+  commwf-nothing : ∀ (pre : ProofPreimage)
+    → CommWF false (ProofPreimage.comm-commitment pre)
+    → ProofPreimage.comm-commitment pre ≡ nothing
+  commwf-nothing pre cwf with ProofPreimage.comm-commitment pre
+  ... | nothing = refl
+
+  -- The pis preamble's commitment cell, recovered from `init-state` in
+  -- the flag-on case: `pis s₀ ≡ binding ∷ c ∷ []` where `just (c , r)` is
+  -- the carried commitment.
+  init-comm-c : ∀ (src : IrSource) (pre : ProofPreimage) {s₀ c r}
+    → IrSource.do-communications-commitment src ≡ true
+    → ProofPreimage.comm-commitment pre ≡ just (c , r)
+    → init-state src pre ≡ just s₀
+    → Preprocessed.pis s₀ ≡ ProofPreimage.binding-input pre ∷ c ∷ []
+  init-comm-c src pre hc≡ cc≡ eq
+    with length (ProofPreimage.inputs pre) ≡ᵇ IrSource.num-inputs src
+       | IrSource.do-communications-commitment src | hc≡
+       | ProofPreimage.comm-commitment pre | cc≡
+  ... | true | true | refl | just (c , r) | refl =
+    sym (cong Preprocessed.pis (just-injective eq))
+  init-comm-c src pre hc≡ cc≡ ()
+    | false | true | refl | just (c , r) | refl
+
+  ------------------------------------------------------------------------
+  -- `transcripts-consumed` decomposed: the verifier-transcript length
+  -- matches `pub-in-idx`, and the two output cursors are empty.
+  ------------------------------------------------------------------------
+  transcripts-fields : ∀ (pre : ProofPreimage) (s : Preprocessed)
+    → T (transcripts-consumed pre s)
+    → (length (ProofPreimage.pub-transcript-inputs pre)
+         ≡ Preprocessed.pub-in-idx s)
+    × (Preprocessed.pub-out-rem s ≡ [])
+    × (Preprocessed.priv-rem s ≡ [])
+  transcripts-fields pre s tc
+    with Preprocessed.pub-out-rem s | Preprocessed.priv-rem s | tc
+  ... | [] | [] | tc′ =
+    ≡ᵇ⇒≡ _ _ (proj₁ (T-∧ .Equivalence.to tc′)) , refl , refl
+  ... | _ ∷ _ | _     | tc′ = ⊥-elim (proj₂ (T-∧ .Equivalence.to tc′))
+  ... | []    | _ ∷ _ | tc′ = ⊥-elim (proj₂ (T-∧ .Equivalence.to tc′))
+
+------------------------------------------------------------------------
+-- Extraction uniqueness.  For a producer-safe source, two CommWF
+-- preimage/state pairs that realize the same witness are equal.
+------------------------------------------------------------------------
+
+circuit-statement-unique
+  : ∀ (src : IrSource) {pre s pre′ s′}
+  → T (producer-safe src)
+  → CommWF (IrSource.do-communications-commitment src)
+           (ProofPreimage.comm-commitment pre)
+  → CommWF (IrSource.do-communications-commitment src)
+           (ProofPreimage.comm-commitment pre′)
+  → R src pre s → R src pre′ s′
+  → witness-of s pre ≡ witness-of s′ pre′
+  → (pre ≡ pre′) × (s ≡ s′)
+circuit-statement-unique src {pre} {s} {pre′} {s′} ps cwf cwf′
+  (s₀ , init≡ , Rs , tc , co) (s₀′ , init≡′ , Rs′ , tc′ , co′) weq =
+  pre≡ , s≡
+  where
+    hc = IrSource.do-communications-commitment src
+    instrs = IrSource.instructions src
+
+    E1 : Preprocessed.memory s ≡ Preprocessed.memory s′
+    E1 = cong Witness.mem weq
+    E2 : Preprocessed.pis s ≡ Preprocessed.pis s′
+    E2 = cong Witness.pis weq
+    E3 : comm-rand-of pre ≡ comm-rand-of pre′
+    E3 = cong Witness.comm-rand weq
+
+    if₁ = init-fields src pre  hc refl init≡
+    if₂ = init-fields src pre′ hc refl init≡′
+
+    -- Initial memories are equal-length prefixes (length `num-inputs`) of
+    -- the common final memory, hence equal.
+    mem₀≡ : Preprocessed.memory s₀ ≡ Preprocessed.memory s₀′
+    mem₀≡ = proj₁ (split-eq (Preprocessed.memory s₀) (Preprocessed.memory s₀′)
+                     (proj₁ (mem-prefix Rs)) (proj₁ (mem-prefix Rs′))
+                     (trans (sym (proj₂ (mem-prefix Rs)))
+                            (trans E1 (proj₂ (mem-prefix Rs′))))
+                     len₀)
+      where
+        len₀ : length (Preprocessed.memory s₀)
+             ≡ length (Preprocessed.memory s₀′)
+        len₀ = trans (cong length (InitFields.if-mem if₁))
+                 (trans (InitFields.if-wf1 if₁)
+                   (trans (sym (InitFields.if-wf1 if₂))
+                          (sym (cong length (InitFields.if-mem if₂)))))
+
+    -- Initial pis are equal-length prefixes (preamble length) of the
+    -- common final pis, hence equal.
+    pis₀≡ : Preprocessed.pis s₀ ≡ Preprocessed.pis s₀′
+    pis₀≡ = proj₁ (split-eq (Preprocessed.pis s₀) (Preprocessed.pis s₀′)
+                     (proj₁ (pis-prefix Rs)) (proj₁ (pis-prefix Rs′))
+                     (trans (sym (proj₂ (pis-prefix Rs)))
+                            (trans E2 (proj₂ (pis-prefix Rs′))))
+                     (trans (InitFields.if-plen if₁)
+                            (sym (InitFields.if-plen if₂))))
+
+    se₀ : StateEq s₀ s₀′
+    se₀ = mk-stateq mem₀≡ pis₀≡
+            (trans (InitFields.if-idx if₁) (sym (InitFields.if-idx if₂)))
+            (trans (InitFields.if-out if₁) (sym (InitFields.if-out if₂)))
+            (trans (InitFields.if-skip if₁) (sym (InitFields.if-skip if₂)))
+
+    -- The two output cursors at the final states are empty.
+    tf  = transcripts-fields pre  s  tc
+    tf′ = transcripts-fields pre′ s′ tc′
+
+    walk = walk-eq pre pre′ instrs {a = 0} {d = 0} Rs Rs′ (o1-sound src ps)
+             se₀ E1 (proj₁ (proj₂ tf)) (proj₁ (proj₂ tf′))
+             (proj₂ (proj₂ tf)) (proj₂ (proj₂ tf′))
+             (trans (InitFields.if-idx if₁) refl) refl
+    se-fin   = WalkEq.we-state walk
+    pout₀≡   = WalkEq.we-pout  walk
+    priv₀≡   = WalkEq.we-priv  walk
+    af       = WalkEq.we-af    walk
+    pidx-fin = WalkEq.we-idx   walk
+    tpin-fin = WalkEq.we-tpin  walk
+
+    -- `s ≡ s′`: the five `StateEq` fields plus the (empty) cursors.
+    s≡ : s ≡ s′
+    s≡ = mk-state-cong E1 E2 (se-skip se-fin) (se-idx se-fin)
+           (trans (proj₁ (proj₂ tf)) (sym (proj₁ (proj₂ tf′))))
+           (trans (proj₂ (proj₂ tf)) (sym (proj₂ (proj₂ tf′))))
+           (se-out se-fin)
+
+    ----------------------------------------------------------------
+    -- `pre ≡ pre′` field by field.
+    ----------------------------------------------------------------
+    inputs≡ : ProofPreimage.inputs pre ≡ ProofPreimage.inputs pre′
+    inputs≡ = trans (sym (InitFields.if-mem if₁))
+                (trans mem₀≡ (InitFields.if-mem if₂))
+
+    -- The binding-input heads the (equal) pis preamble.
+    bind≡ : ProofPreimage.binding-input pre ≡ ProofPreimage.binding-input pre′
+    bind≡ =
+      let (b , rest , pis≡ , b≡) = InitFields.if-pis if₁
+          (b′ , rest′ , pis≡′ , b≡′) = InitFields.if-pis if₂
+      in trans (sym b≡)
+           (trans (∷-injectiveˡ (trans (sym pis≡) (trans pis₀≡ pis≡′))) b≡′)
+
+    -- Public-output / private transcripts equal via the backward cursor
+    -- equalities at the initial states.
+    pout≡ : ProofPreimage.pub-transcript-outputs pre
+          ≡ ProofPreimage.pub-transcript-outputs pre′
+    pout≡ = trans (sym (InitFields.if-pout if₁))
+              (trans pout₀≡ (InitFields.if-pout if₂))
+
+    priv≡ : ProofPreimage.priv-transcript pre
+          ≡ ProofPreimage.priv-transcript pre′
+    priv≡ = trans (sym (InitFields.if-priv if₁))
+              (trans priv₀≡ (InitFields.if-priv if₂))
+
+    -- Verifier transcript: the pinned prefix is everything, since
+    -- `transcripts-consumed` fixes both lengths to `pub-in-idx`.
+    pti≡ : ProofPreimage.pub-transcript-inputs pre
+         ≡ ProofPreimage.pub-transcript-inputs pre′
+    pti≡ =
+      trans (sym (take-all af (ProofPreimage.pub-transcript-inputs pre) len₁))
+        (trans tpin-fin
+          (take-all af (ProofPreimage.pub-transcript-inputs pre′) len₂))
+      where
+        len₁ : length (ProofPreimage.pub-transcript-inputs pre) ≤ af
+        len₁ = ≤-reflexive (trans (proj₁ tf) pidx-fin)
+        len₂ : length (ProofPreimage.pub-transcript-inputs pre′) ≤ af
+        len₂ = ≤-reflexive (trans (proj₁ tf′)
+                 (trans (sym (se-idx se-fin)) pidx-fin))
+
+    -- Flag off: `CommWF` forces both commitments `nothing`.  Flag on:
+    -- `comm-ok` forces both `just`; the randomness is pinned by E3 and
+    -- the commitment value by the (equal) pis preambles.
+    comm≡ : ProofPreimage.comm-commitment pre
+          ≡ ProofPreimage.comm-commitment pre′
+    comm≡ = go (IrSource.do-communications-commitment src) refl
+      where
+        go : ∀ b → IrSource.do-communications-commitment src ≡ b
+           → ProofPreimage.comm-commitment pre
+             ≡ ProofPreimage.comm-commitment pre′
+        go false hc≡f =
+          trans
+            (commwf-nothing pre
+              (subst (λ x → CommWF x (ProofPreimage.comm-commitment pre))
+                     hc≡f cwf))
+            (sym (commwf-nothing pre′
+              (subst (λ x → CommWF x (ProofPreimage.comm-commitment pre′))
+                     hc≡f cwf′)))
+        go true hc≡t =
+          let (c  , r  , cc≡ ) = comm-ok-just src pre  s  hc≡t co
+              (c′ , r′ , cc≡′) = comm-ok-just src pre′ s′ hc≡t co′
+              r≡ = just-injective
+                     (trans (sym (comm-rand-of-just pre cc≡))
+                            (trans E3 (comm-rand-of-just pre′ cc≡′)))
+              c≡ = ∷-injectiveˡ (∷-injectiveʳ
+                     (trans (sym (init-comm-c src pre hc≡t cc≡ init≡))
+                       (trans pis₀≡
+                              (init-comm-c src pre′ hc≡t cc≡′ init≡′))))
+          in trans cc≡ (trans (cong just (cong₂ _,_ c≡ r≡)) (sym cc≡′))
+
+    pre≡ : pre ≡ pre′
+    pre≡ = mk-preimage-cong inputs≡ bind≡ comm≡ pti≡ pout≡ priv≡
+
+------------------------------------------------------------------------
+-- Exactly-one packaging.  `circuit-statement-sound` (existence) plus
+-- `circuit-statement-unique` (uniqueness): every satisfying witness of
+-- the allocated memory length has exactly one `CommWFRealizer` — one
+-- whose `preimage`/`run` components any other agrees with.
+--
+-- The witness-side condition `RandWF` mirrors `CommWF`: when the
+-- commitment flag is off, `satisfies` does not pin `Witness.comm-rand`
+-- (`Maybe-shape false _` is trivial), and a witness carrying a junk
+-- `just r` there is realized only by preimages carrying a junk
+-- commitment — which `CommWF` excludes.  So a CommWF realizer exists
+-- precisely when the witness does not carry the junk either.
+------------------------------------------------------------------------
+
+RandWF : Bool → Maybe Fr → Set
+RandWF false (just _) = ⊥
+RandWF false nothing  = ⊤
+RandWF true  _        = ⊤
+
+private
+  -- A realizer of a RandWF witness is CommWF: its `comm-rand-of`
+  -- projection IS the witness's `comm-rand` field.
+  realizer-commwf : ∀ (src : IrSource) (pre : ProofPreimage)
+      (s : Preprocessed) (w : Witness)
+    → witness-of s pre ≡ w
+    → RandWF (IrSource.do-communications-commitment src)
+             (Witness.comm-rand w)
+    → CommWF (IrSource.do-communications-commitment src)
+             (ProofPreimage.comm-commitment pre)
+  realizer-commwf src pre s w wo≡ rwf =
+    go (IrSource.do-communications-commitment src) rwf
+    where
+      -- Case split on the commitment via an explicit equality (a `with`
+      -- would abstract `comm-rand-of pre`, which matches on the same
+      -- projection, out of the goal).
+      go2 : ∀ (cc : Maybe (Fr × Fr))
+        → ProofPreimage.comm-commitment pre ≡ cc
+        → RandWF false (Witness.comm-rand w) → CommWF false cc
+      go2 nothing        _   _ = tt
+      go2 (just (c , rv)) cc≡ r =
+        subst (RandWF false)
+              (trans (sym (cong Witness.comm-rand wo≡))
+                     (comm-rand-of-just pre cc≡))
+              r
+
+      go : ∀ b → RandWF b (Witness.comm-rand w)
+         → CommWF b (ProofPreimage.comm-commitment pre)
+      go true  _ = tt
+      go false r = go2 (ProofPreimage.comm-commitment pre) refl r
+
+circuit-statement-sound-unique
+  : ∀ (src : IrSource) (w : Witness)
+  → T (producer-safe src)
+  → WF2 src
+  → satisfies (circuit src) w
+  → RandWF (IrSource.do-communications-commitment src)
+           (Witness.comm-rand w)
+  → Σ (CommWFRealizer src w) (λ can
+      → ∀ (other : CommWFRealizer src w)
+      → (CommWFRealizer.preimage other ≡ CommWFRealizer.preimage can)
+      × (CommWFRealizer.run      other ≡ CommWFRealizer.run      can))
+circuit-statement-sound-unique src w ps wf2 sat rwf =
+  let (mk-realizer pre s Rs wo≡) =
+        circuit-statement-sound src w ps wf2 sat
+      cwf = realizer-commwf src pre s w wo≡ rwf
+  in mk-commwf-realizer (mk-realizer pre s Rs wo≡) cwf
+   , λ (mk-commwf-realizer (mk-realizer _ _ Rs′ wo≡′) cwf′) →
+       circuit-statement-unique src ps cwf′ cwf Rs′ Rs
+         (trans wo≡′ (sym wo≡))
+
+

--- a/formal/src/zkir-v2/Syntax.agda
+++ b/formal/src/zkir-v2/Syntax.agda
@@ -1,0 +1,227 @@
+{-# OPTIONS --safe #-}
+open import zkir-v2.Assumptions
+
+module zkir-v2.Syntax (⋯ : _) (open Assumptions ⋯) where
+
+open import Data.Bool  using (Bool)
+open import Data.List  using (List)
+open import Data.Maybe using (Maybe)
+open import Data.Nat   using (ℕ)
+
+------------------------------------------------------------------------
+-- External carrier types
+--
+-- `Fr` (BLS12-381 scalar field element, transient_crypto::curve::Fr) and
+-- `Alignment` (byte-alignment descriptor, base_crypto::fab::Alignment)
+-- are part of the trust base; they come from the `Assumptions` parameter.
+------------------------------------------------------------------------
+-- Index  (ir.rs: Index = u32)
+--
+-- All operands and outputs are references into the circuit memory by
+-- position.  Named variables and types belong to the v3 IR.
+------------------------------------------------------------------------
+
+Index : Set
+Index = ℕ
+
+------------------------------------------------------------------------
+-- Minor version  (ir.rs: IrMinorVersion)
+------------------------------------------------------------------------
+
+data IrMinorVersion : Set where
+  V0 V1 : IrMinorVersion
+
+------------------------------------------------------------------------
+-- Instructions  (ir.rs: Instruction)
+--
+-- The 26 variants appear in the same order as in the Rust source.
+-- Constructor names are the Rust CamelCase variant names in
+-- kebab-case (`CondSelect` → `cond-select`); field names follow the
+-- Rust names.
+--
+-- Outputs are implicit: each instruction appends a fixed number of
+-- fresh values to the end of the circuit memory.  Arity information
+-- belongs to the typing/semantics layer.
+--
+-- `bits` and `count` fields are u32 in Rust; we use ℕ here.
+------------------------------------------------------------------------
+
+data Instruction : Set where
+
+  -- Assert that cond = 1.  UB if cond ∉ {0, 1}.
+  -- No outputs.
+  assert
+    : (cond : Index)
+    → Instruction
+
+  -- Conditionally select a value.  UB if bit ∉ {0, 1}.
+  -- Output = a when bit = 1, b when bit = 0.  1 output.
+  cond-select
+    : (bit : Index)
+    → (a b : Index)
+    → Instruction
+
+  -- Constrain var to fit in the given number of bits.
+  -- No outputs.
+  constrain-bits
+    : (var  : Index)
+    → (bits : ℕ)
+    → Instruction
+
+  -- Constrain a = b.  No outputs.
+  constrain-eq
+    : (a b : Index)
+    → Instruction
+
+  -- Constrain var ∈ {0, 1}.  No outputs.
+  constrain-to-boolean
+    : (var : Index)
+    → Instruction
+
+  -- Copy a value into a fresh memory cell.  Emits no constraints
+  -- in-circuit (a register-level alias).  1 output.
+  copy
+    : (var : Index)
+    → Instruction
+
+  -- Declare var as the next public input.  No outputs.
+  declare-pub-input
+    : (var : Index)
+    → Instruction
+
+  -- Mark the preceding DeclarePubInput group as conditionally active.
+  -- No outputs.
+  pi-skip
+    : (guard : Maybe Index)
+    → (count : ℕ)
+    → Instruction
+
+  -- Add two Jubjub curve points.  UB if either is not a valid point.
+  -- 2 outputs: c_x, c_y.
+  ec-add
+    : (a_x a_y : Index)
+    → (b_x b_y : Index)
+    → Instruction
+
+  -- Multiply a Jubjub curve point by a scalar.  UB if not a valid point.
+  -- 2 outputs: c_x, c_y.
+  ec-mul
+    : (a_x a_y : Index)
+    → (scalar  : Index)
+    → Instruction
+
+  -- Multiply the Jubjub group generator by a scalar.
+  -- 2 outputs: c_x, c_y.
+  ec-mul-generator
+    : (scalar : Index)
+    → Instruction
+
+  -- Hash a sequence of field elements to a Jubjub point.
+  -- 2 outputs: c_x, c_y.
+  hash-to-curve
+    : (inputs : List Index)
+    → Instruction
+
+  -- Load a constant field element into the circuit.  1 output.
+  load-imm
+    : (imm : Fr)
+    → Instruction
+
+  -- Divide by 2^bits: 2 outputs (val >> bits) and (val mod 2^bits).
+  div-mod-power-of-two
+    : (var  : Index)
+    → (bits : ℕ)
+    → Instruction
+
+  -- Outputs divisor << bits | modulus, guaranteeing no field overflow
+  -- and modulus < 2^bits.  Inverse of div-mod-power-of-two.  1 output.
+  reconstitute-field
+    : (divisor : Index)
+    → (modulus : Index)
+    → (bits    : ℕ)
+    → Instruction
+
+  -- Output var into the communications commitment.  No IR-level output.
+  output
+    : (var : Index)
+    → Instruction
+
+  -- Circuit-friendly (transient) hash: 1 output H(inputs).
+  transient-hash
+    : (inputs : List Index)
+    → Instruction
+
+  -- Long-term (persistent) hash with alignment metadata.
+  -- 2 outputs: (h₁, h₂), with h₁ the high-order byte and h₂ the
+  -- remaining 31 bytes assembled as a field element.
+  persistent-hash
+    : (alignment : Alignment)
+    → (inputs    : List Index)
+    → Instruction
+
+  -- Test equality.  1 output: 1 iff a = b.
+  test-eq
+    : (a b : Index)
+    → Instruction
+
+  -- Field addition.  1 output a + b.
+  add
+    : (a b : Index)
+    → Instruction
+
+  -- Field multiplication.  1 output a * b.
+  mul
+    : (a b : Index)
+    → Instruction
+
+  -- Field negation.  1 output -a.
+  neg
+    : (a : Index)
+    → Instruction
+
+  -- Boolean NOT.  UB if a ∉ {0, 1}.  1 output !a.
+  not
+    : (a : Index)
+    → Instruction
+
+  -- Unsigned less-than in bits-bit precision.
+  -- UB if a or b exceed 2^bits − 1.  1 output: 1 iff a < b.
+  less-than
+    : (a b  : Index)
+    → (bits : ℕ)
+    → Instruction
+
+  -- Retrieve the next value from the *public-output* transcript
+  -- (`pub-transcript-outputs` — values flowing *into* the circuit; the
+  -- Rust names are historical, spec §4.4 sidebar.  Not
+  -- `pub-transcript-inputs`, which `pi-skip` validation reads.)
+  -- Active (guard absent, or guard evaluates to 1) consumes the next
+  -- transcript entry and outputs it; inactive (guard evaluates to 0)
+  -- outputs 0 and consumes nothing.  1 output.
+  public-input
+    : (guard : Maybe Index)
+    → Instruction
+
+  -- Retrieve the next value from the private witness transcript.
+  -- Active (guard absent, or guard evaluates to 1) consumes the next
+  -- transcript entry and outputs it; inactive (guard evaluates to 0)
+  -- outputs 0 and consumes nothing.  1 output.
+  private-input
+    : (guard : Maybe Index)
+    → Instruction
+
+------------------------------------------------------------------------
+-- Circuit source  (ir.rs: IrSource)
+------------------------------------------------------------------------
+
+record IrSource : Set where
+  constructor mk-ir-source
+  field
+    -- Carried for record fidelity with the Rust `IrSource`; nothing in
+    -- the development consumes it.  The preprocess semantics is
+    -- version-independent, and the circuit model implements the V1
+    -- lowering only (spec §5.2).
+    version                       : IrMinorVersion
+    num-inputs                    : ℕ
+    do-communications-commitment  : Bool
+    instructions                  : List Instruction


### PR DESCRIPTION
## What this is

A machine-checked **Agda mechanisation of the ZKIR v2 specification**
(`formal/docs/zkir-v2-spec.md`, companion PR #656), added under
`formal/src/`. It typechecks under Agda's `--safe` flag with **no
postulates**; everything the development does not prove is collected in a
single `Assumptions` record (`zkir-v2/Assumptions.agda`) and taken as a
module parameter, so the trusted base is explicit and inspectable in one
place.

## What is proven

Over a relational model of the preprocess semantics and an abstract
constraint-level model of the synthesised Halo2 circuit:

- **P5, circuit faithfulness** (`circuit-faithful`, proved in
  `CircuitProof.agda`), both directions, for all 26 instructions:
  preprocess acceptance ⇔ the synthesised constraints are satisfied by the
  run's witness.
- **Statement soundness** (`circuit-statement-sound`): for a *producer-safe*
  source, **every** satisfying witness of the circuit is the canonical
  witness of a genuine preprocess run — the bridge that upgrades "a
  satisfying witness exists" to "an execution exists".
- **Extraction uniqueness** (`circuit-statement-unique`): that realising run
  is unique.
- The operational properties P1–P4, and soundness of the O0–O3 producer
  obligation checkers (`producer-safe`) against the dynamic semantics.

## What is *not* covered (the trust base)

The `Assumptions` record contains: the chip primitives (Poseidon, Jubjub
group operations, SHA-256, hash-to-curve), the field's prime-order valuation
and encoding laws, and the abstract constraint model standing in for the
concrete PLONKish circuit. No concrete BLS12-381 instantiation is provided
yet, so soundness of the actual Halo2 backend is out of scope (this is
part (b) of P5's status in the spec §6.2).

## Layout and CI

- `formal/src/zkir-v2/` — the development; `Main.agda` imports every module,
  so checking it verifies everything. See `zkir-v2/README.md` for the module
  map and proof architecture.
- `formal/src/flake.nix` — self-contained Agda toolchain (Agda + stdlib
  pins), independent of the workspace flake.
- `.github/workflows/agda.yml` — typechecks `Main.agda`, **path-filtered to
  `formal/**`** so it never runs on Rust-only PRs. A cold check takes a few
  minutes.

To check locally:

```sh
cd formal/src
nix run .#agda -- zkir-v2/Main.agda
```

## How to review

Reviewing ~17k lines of Agda line-by-line is not the expectation. The
high-leverage checks are:

1. the `Assumptions` record — is everything in the trusted base acceptable
   to assume?
2. the *definitions* (`Syntax.agda`, `Semantics.agda`, `Circuit.agda`,
   `Obligations.agda`) — do they model what the spec (and the Rust) says?
3. the theorem *statements* in `Properties.agda`, `StatementSoundness.agda`,
   `StatementUniqueness.agda` — are they the claims we want?

The proofs in between are checked by Agda itself under `--safe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
