### PR TITLE
proof-server: support GCP Confidential Space

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,12 @@ jobs:
           # failures in `nix develop` command.
           set -o pipefail
           nix develop -c cargo config -Z unstable-options get net.git-fetch-with-cli
-          nix develop -c cargo test --workspace --all-features --release  --no-fail-fast -- --nocapture --test-threads=1 | tee test-output.log
+          {
+            test_status=0
+            nix develop -c cargo test --workspace --all-features --exclude midnight-proof-server --release --no-fail-fast -- --nocapture --test-threads=1 || test_status=$?
+            nix develop -c cargo test --package midnight-proof-server --features experimental --release --no-fail-fast -- --nocapture --test-threads=1 || test_status=$?
+            exit "$test_status"
+          } | tee test-output.log
 
       - name: Upload Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -65,7 +65,8 @@ jobs:
           export CARGO_INCREMENTAL=0
           export RUSTFLAGS='-Cinstrument-coverage'
           export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
-          nix develop -c cargo test --all --all-features --verbose -- --nocapture --test-threads=1
+          nix develop -c cargo test --workspace --all-features --exclude midnight-proof-server --verbose -- --nocapture --test-threads=1
+          nix develop -c cargo test --package midnight-proof-server --features experimental --verbose -- --nocapture --test-threads=1
 
       - name: Generate HTML report
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5886,6 +5886,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "rand 0.10.1",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.6",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +841,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1159,6 +1181,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
+dependencies = [
+ "aead",
+ "crypto_secretbox",
+ "curve25519-dalek",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1723,6 +1800,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2202,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2213,6 +2296,7 @@ dependencies = [
  "http 1.4.0",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2256,6 +2340,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2461,6 +2560,15 @@ dependencies = [
  "quick-xml",
  "rgb",
  "str_stack",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3129,11 +3237,16 @@ dependencies = [
  "actix-web",
  "async-channel",
  "clap",
+ "crypto_box",
  "env_logger",
  "function_name",
  "futures",
  "futures-util",
  "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "hyperlocal",
  "introspection",
  "lazy_static",
  "log",
@@ -3779,6 +3892,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3989,6 +4108,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4690,6 +4820,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -5690,6 +5829,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.6",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/proof-server/Cargo.toml
+++ b/proof-server/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [features]
 default = []
 experimental = ["dep:zkir-v3"]
+gcp_cs = ["dep:http-body-util", "dep:hyper", "dep:hyper-util", "dep:hyperlocal", "dep:crypto_box", "dep:serde_json"]
 
 [dependencies]
 ledger = { path = "../ledger", package = "midnight-ledger", default-features = false, features = ["proving"] }
@@ -40,6 +41,13 @@ tokio = "1.46.1"
 async-channel = "2.5.0"
 time = { version = "0.3.47", features = ["serde-human-readable"] }
 serde = "1.0.219"
+
+http-body-util = { version = "0.1.4", optional = true }
+hyper = { version = "1.11.0", optional = true }
+hyper-util = { version = "0.1.20", features = ["client", "client-legacy", "http1", "tokio"], optional = true }
+hyperlocal = { version = "0.9.1", optional = true }
+crypto_box = { version = "0.9.1", optional = true }
+serde_json = { version = "1.0.140", optional = true }
 
 [dev-dependencies]
 ledger = { path = "../ledger", package = "midnight-ledger", features = ["test-utilities", "proving"] }

--- a/proof-server/Cargo.toml
+++ b/proof-server/Cargo.toml
@@ -35,7 +35,7 @@ tracing-subscriber = "^0.3.19"
 lazy_static = "^1.5.0"
 regex = "1.11.1"
 hex = "^0.4.3"
-uuid = { version = "1.22.0", features = ["v4"] }
+uuid = { version = "1.22.0", features = ["v4", "serde"] }
 thiserror = "2.0.12"
 tokio = "1.46.1"
 async-channel = "2.5.0"

--- a/proof-server/src/endpoints.rs
+++ b/proof-server/src/endpoints.rs
@@ -39,7 +39,7 @@ use tracing::{debug, info};
 use transient_crypto::commitment::PedersenRandomness;
 use transient_crypto::curve::Fr;
 use transient_crypto::proofs::{KeyLocation, ProvingKeyMaterial, Resolver as ResolverT, WrappedIr};
-use uuid::Uuid;
+
 #[cfg(feature = "gcp_cs")]
 use {
     crate::ServerEncryptionKey,
@@ -54,6 +54,7 @@ use {
     hyperlocal::{UnixConnector, Uri},
     std::time::Duration,
     tracing::warn,
+    uuid::Uuid,
 };
 
 use zkir as zkir_v2;
@@ -279,6 +280,7 @@ enum Status {
     Busy,
 }
 
+#[cfg(feature = "gcp_cs")]
 #[derive(Clone, Copy, serde::Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 enum ProofJobState {
@@ -289,12 +291,14 @@ enum ProofJobState {
     Cancelled,
 }
 
+#[cfg(feature = "gcp_cs")]
 impl ProofJobState {
     fn done(self) -> bool {
         matches!(self, Self::Success | Self::Error | Self::Cancelled)
     }
 }
 
+#[cfg(feature = "gcp_cs")]
 impl From<&JobStatus> for ProofJobState {
     fn from(value: &JobStatus) -> Self {
         match value {
@@ -326,6 +330,7 @@ struct ReadyResponse {
     timestamp: time::OffsetDateTime,
 }
 
+#[cfg(feature = "gcp_cs")]
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ProofStatusResponse {
@@ -334,6 +339,7 @@ struct ProofStatusResponse {
     done: bool,
 }
 
+#[cfg(feature = "gcp_cs")]
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ProofStatusQuery {
@@ -361,6 +367,7 @@ pub(crate) async fn ready(pool: web::Data<Arc<WorkerPool>>) -> Result<HttpRespon
     Ok(builder)
 }
 
+#[cfg(feature = "gcp_cs")]
 #[get("/status")]
 pub(crate) async fn proof_status(
     query: web::Query<ProofStatusQuery>,

--- a/proof-server/src/endpoints.rs
+++ b/proof-server/src/endpoints.rs
@@ -46,6 +46,31 @@ use zswap::prove::ZswapResolver;
 use crate::versioned_ir;
 use crate::worker_pool::{JobStatus, WorkError, WorkerPool};
 
+#[cfg(feature = "gcp_cs")]
+use {
+    crate::ServerEncryptionKey,
+    actix_web::HttpRequest,
+    async_channel::Receiver,
+    futures_util::stream::once,
+    http_body_util::{BodyExt, Full},
+    hyper::{Method, Request},
+    hyper_util::client::legacy::Client as HyperClient,
+    hyper_util::rt::TokioExecutor,
+    hyperlocal::{UnixConnector, Uri},
+    uuid::Uuid,
+};
+
+#[cfg(feature = "gcp_cs")]
+const ENCRYPTION_TYPE_HEADER: &str = "encryption-type";
+#[cfg(feature = "gcp_cs")]
+const CLIENT_PUBLIC_KEY_HEADER: &str = "client-public-key";
+#[cfg(feature = "gcp_cs")]
+const REQUEST_NONCE_HEADER: &str = "request-nonce";
+#[cfg(feature = "gcp_cs")]
+const RESPONSE_NONCE_HEADER: &str = "response-nonce";
+#[cfg(feature = "gcp_cs")]
+const PROOF_JOB_ID_HEADER: &str = "proof-job-id";
+
 lazy_static! {
     pub static ref PUBLIC_PARAMS: ZswapResolver = ZswapResolver(
         MidnightDataProvider::new(
@@ -70,6 +95,66 @@ type TransactionProvePayload<S> = (
     Transaction<S, ProofPreimageMarker, PedersenRandomness, InMemoryDB>,
     HashMap<String, ProvingKeyMaterial>,
 );
+
+#[cfg(feature = "gcp_cs")]
+#[derive(serde::Deserialize)]
+pub(crate) struct AttestationQuery {
+    nonce: String,
+}
+
+#[cfg(feature = "gcp_cs")]
+#[derive(serde::Serialize)]
+struct GcpAttestationRequest {
+    audience: String,
+    nonces: Vec<String>,
+    token_type: String,
+}
+
+#[cfg(feature = "gcp_cs")]
+#[derive(Clone)]
+struct EncryptedTransportHeaders {
+    client_public_key_hex: String,
+    request_nonce_hex: String,
+}
+
+#[cfg(feature = "gcp_cs")]
+fn get_encrypted_transport_headers(
+    req: &HttpRequest,
+) -> Result<Option<EncryptedTransportHeaders>, Error> {
+    let client_public_key = req.headers().get(CLIENT_PUBLIC_KEY_HEADER);
+    let request_nonce = req.headers().get(REQUEST_NONCE_HEADER);
+
+    match (client_public_key, request_nonce) {
+        (None, None) => Ok(None),
+        (Some(_), Some(_)) => Ok(Some(EncryptedTransportHeaders {
+            client_public_key_hex: client_public_key
+                .unwrap()
+                .to_str()
+                .map_err(|_| ErrorBadRequest(format!("invalid {CLIENT_PUBLIC_KEY_HEADER} header")))?
+                .to_owned(),
+            request_nonce_hex: request_nonce
+                .unwrap()
+                .to_str()
+                .map_err(|_| ErrorBadRequest(format!("invalid {REQUEST_NONCE_HEADER} header")))?
+                .to_owned(),
+        })),
+        _ => Err(ErrorBadRequest(format!(
+            "{CLIENT_PUBLIC_KEY_HEADER} and {REQUEST_NONCE_HEADER} must both be provided"
+        ))),
+    }
+}
+
+#[cfg(feature = "gcp_cs")]
+fn get_encryption_type(req: &HttpRequest) -> Result<&'static str, Error> {
+    match req.headers().get(ENCRYPTION_TYPE_HEADER) {
+        Some(value) => match value.to_str().unwrap_or("").trim().to_lowercase().as_str() {
+            "oidc" => Ok("OIDC"),
+            "pki" => Ok("PKI"),
+            _ => Err(ErrorBadRequest("the encryption-type is not set correctly")),
+        },
+        None => Err(ErrorBadRequest("the encryption-type is not set correctly")),
+    }
+}
 
 #[get("/version")]
 pub(crate) async fn version() -> impl Responder {
@@ -115,6 +200,79 @@ impl From<Status> for StatusCode {
             Status::Busy => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
+}
+
+#[cfg(feature = "gcp_cs")]
+fn decode_proving_request(
+    request: Bytes,
+    transport_headers: &Option<EncryptedTransportHeaders>,
+    server_encryption_key: &ServerEncryptionKey,
+) -> Result<Vec<u8>, Error> {
+    match transport_headers {
+        Some(headers) => server_encryption_key
+            .decrypt_request(
+                &headers.client_public_key_hex,
+                &headers.request_nonce_hex,
+                &request,
+            )
+            .ok_or_else(|| ErrorBadRequest("failed to decrypt request payload")),
+        None => Ok(request.to_vec()),
+    }
+}
+
+#[cfg(feature = "gcp_cs")]
+fn encode_proving_response_body(
+    response: Vec<u8>,
+    transport_headers: &Option<EncryptedTransportHeaders>,
+    response_nonce_hex: &Option<String>,
+    server_encryption_key: &ServerEncryptionKey,
+) -> Result<Bytes, Error> {
+    match transport_headers {
+        Some(headers) => Ok(Bytes::from(
+            server_encryption_key
+                .encrypt_response_with_nonce(
+                    &headers.client_public_key_hex,
+                    response_nonce_hex.as_deref().ok_or_else(|| {
+                        actix_web::error::ErrorInternalServerError(
+                            "missing response nonce for encrypted payload",
+                        )
+                    })?,
+                    &response,
+                )
+                .ok_or_else(|| {
+                    actix_web::error::ErrorInternalServerError("failed to encrypt response payload")
+                })?,
+        )),
+        None => Ok(Bytes::from(response)),
+    }
+}
+
+#[cfg(feature = "gcp_cs")]
+fn proving_response(
+    job_id: Uuid,
+    updates: Arc<Receiver<JobStatus>>,
+    transport_headers: Option<EncryptedTransportHeaders>,
+    server_encryption_key: ServerEncryptionKey,
+) -> HttpResponse {
+    let response_nonce_hex = transport_headers
+        .as_ref()
+        .map(|_| server_encryption_key.generate_response_nonce_hex());
+
+    let mut builder = HttpResponse::Ok();
+    builder.append_header((PROOF_JOB_ID_HEADER, job_id.to_string()));
+    if let Some(response_nonce_hex) = response_nonce_hex.as_ref() {
+        builder.append_header((RESPONSE_NONCE_HEADER, response_nonce_hex.clone()));
+    }
+
+    builder.streaming(once(async move {
+        let response = JobStatus::wait_for_success(updates.as_ref()).await?;
+        encode_proving_response_body(
+            response,
+            &transport_headers,
+            &response_nonce_hex,
+            &server_encryption_key,
+        )
+    }))
 }
 
 #[derive(serde::Serialize)]
@@ -167,6 +325,55 @@ pub(crate) async fn get_k(payload: Payload) -> Result<HttpResponse, Error> {
     let k = versioned_ir::k(&request).map_err(ErrorBadRequest)?;
 
     Ok(HttpResponse::Ok().body(format!("{k}")))
+}
+
+#[cfg(feature = "gcp_cs")]
+#[post("/attestation")]
+pub(crate) async fn attestation(
+    req: HttpRequest,
+    query: web::Query<AttestationQuery>,
+    server_encryption_key: Data<ServerEncryptionKey>,
+) -> Result<HttpResponse, Error> {
+    info!("Starting to process request for /attestation...");
+
+    let encryption_type = get_encryption_type(&req)?;
+
+    let payload = GcpAttestationRequest {
+        audience: "https://sts.googleapis.com".to_string(),
+        nonces: vec![
+            query.nonce.clone(),
+            server_encryption_key.public_key_hex().to_owned(),
+        ],
+        token_type: encryption_type.to_string(),
+    };
+
+    let body = serde_json::to_vec(&payload).map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let hyper_client: HyperClient<UnixConnector, Full<hyper::body::Bytes>> =
+        HyperClient::builder(TokioExecutor::new()).build(UnixConnector);
+    let uri: hyper::Uri = Uri::new("/run/container_launcher/teeserver.sock", "/v1/token").into();
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header("Host", "localhost")
+        .header("Content-Type", "application/json")
+        .body(Full::new(hyper::body::Bytes::from(body)))
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let response = hyper_client
+        .request(request)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    let response_bytes = response
+        .collect()
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?
+        .to_bytes();
+    let token = String::from_utf8(response_bytes.to_vec())
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "token": token })))
 }
 
 #[post("/check")]
@@ -245,14 +452,25 @@ pub(crate) async fn check(
 #[post("/prove")]
 pub(crate) async fn prove(
     pool: Data<Arc<WorkerPool>>,
+    #[cfg(feature = "gcp_cs")] req: HttpRequest,
+    #[cfg(feature = "gcp_cs")] server_encryption_key: Data<ServerEncryptionKey>,
     payload: Payload,
 ) -> Result<HttpResponse, Error> {
     info!("Starting to process request for /prove...");
     let request = payload_to_bytes(payload).await?;
+
+    #[cfg(feature = "gcp_cs")]
+    let (transport_headers, request) = {
+        let transport_headers = get_encrypted_transport_headers(&req)?;
+        let request = decode_proving_request(request, &transport_headers, &server_encryption_key)?;
+        (transport_headers, request)
+    };
+
     debug!(
         "Received request: {}",
         (&request[..]).encode_hex::<String>()
     );
+
     let (ppi, data, binding_input): (
         ProofPreimageVersioned,
         Option<ProvingKeyMaterial>,
@@ -320,22 +538,44 @@ pub(crate) async fn prove(
             })
         })
         .await?;
-    let response = JobStatus::wait_for_success(&updates).await?;
 
-    Ok(HttpResponse::Ok().body(response))
+    #[cfg(feature = "gcp_cs")]
+    return Ok(proving_response(
+        _id,
+        updates,
+        transport_headers,
+        server_encryption_key.get_ref().clone(),
+    ));
+
+    #[cfg(not(feature = "gcp_cs"))]
+    {
+        let response = JobStatus::wait_for_success(&updates).await?;
+        Ok(HttpResponse::Ok().body(response))
+    }
 }
 
 #[post("/prove-tx")]
 pub(crate) async fn prove_transaction(
     pool: Data<Arc<WorkerPool>>,
+    #[cfg(feature = "gcp_cs")] req: HttpRequest,
+    #[cfg(feature = "gcp_cs")] server_encryption_key: Data<ServerEncryptionKey>,
     payload: Payload,
 ) -> Result<HttpResponse, Error> {
     info!("Starting to process request for /prove-tx...");
     let request = payload_to_bytes(payload).await?;
+
+    #[cfg(feature = "gcp_cs")]
+    let (transport_headers, request) = {
+        let transport_headers = get_encrypted_transport_headers(&req)?;
+        let request = decode_proving_request(request, &transport_headers, &server_encryption_key)?;
+        (transport_headers, request)
+    };
+
     debug!(
         "Received request: {}",
         (&request[..]).encode_hex::<String>()
     );
+
     let (tx, keys): TransactionProvePayload<Signature> =
         tagged_deserialize(&request[..]).map_err(ErrorBadRequest)?;
     let (_id, updates) = pool
@@ -377,6 +617,18 @@ pub(crate) async fn prove_transaction(
             })
         })
         .await?;
-    let response = JobStatus::wait_for_success(&updates).await?;
-    Ok(HttpResponse::Ok().body(response))
+
+    #[cfg(feature = "gcp_cs")]
+    return Ok(proving_response(
+        _id,
+        updates,
+        transport_headers,
+        server_encryption_key.get_ref().clone(),
+    ));
+
+    #[cfg(not(feature = "gcp_cs"))]
+    {
+        let response = JobStatus::wait_for_success(&updates).await?;
+        Ok(HttpResponse::Ok().body(response))
+    }
 }

--- a/proof-server/src/endpoints.rs
+++ b/proof-server/src/endpoints.rs
@@ -19,7 +19,7 @@ use actix_web::web::{self, Bytes, BytesMut, Data, Payload};
 use actix_web::{Error, HttpResponse, HttpResponseBuilder, Responder, get, post};
 use base_crypto::data_provider::{self, MidnightDataProvider};
 use base_crypto::data_provider::{FetchMode, OutputMode};
-use base_crypto::schnorr::Signature;
+use base_crypto::signatures::Signature;
 use futures_util::stream::StreamExt;
 use hex::ToHex;
 use introspection::Introspection;
@@ -39,37 +39,28 @@ use tracing::{debug, info};
 use transient_crypto::commitment::PedersenRandomness;
 use transient_crypto::curve::Fr;
 use transient_crypto::proofs::{KeyLocation, ProvingKeyMaterial, Resolver as ResolverT, WrappedIr};
+use uuid::Uuid;
+#[cfg(feature = "gcp_cs")]
+use {
+    crate::ServerEncryptionKey,
+    actix_web::HttpRequest,
+    actix_web::error::{ErrorBadGateway, ErrorGatewayTimeout},
+    actix_web::http::header::{HeaderName, HeaderValue},
+    async_channel::Receiver,
+    http_body_util::{BodyExt, Full, Limited},
+    hyper::{Method, Request},
+    hyper_util::client::legacy::Client as HyperClient,
+    hyper_util::rt::TokioExecutor,
+    hyperlocal::{UnixConnector, Uri},
+    std::time::Duration,
+    tracing::warn,
+};
 
 use zkir as zkir_v2;
 use zswap::prove::ZswapResolver;
 
 use crate::versioned_ir;
 use crate::worker_pool::{JobStatus, WorkError, WorkerPool};
-
-#[cfg(feature = "gcp_cs")]
-use {
-    crate::ServerEncryptionKey,
-    actix_web::HttpRequest,
-    async_channel::Receiver,
-    futures_util::stream::once,
-    http_body_util::{BodyExt, Full},
-    hyper::{Method, Request},
-    hyper_util::client::legacy::Client as HyperClient,
-    hyper_util::rt::TokioExecutor,
-    hyperlocal::{UnixConnector, Uri},
-    uuid::Uuid,
-};
-
-#[cfg(feature = "gcp_cs")]
-const ENCRYPTION_TYPE_HEADER: &str = "encryption-type";
-#[cfg(feature = "gcp_cs")]
-const CLIENT_PUBLIC_KEY_HEADER: &str = "client-public-key";
-#[cfg(feature = "gcp_cs")]
-const REQUEST_NONCE_HEADER: &str = "request-nonce";
-#[cfg(feature = "gcp_cs")]
-const RESPONSE_NONCE_HEADER: &str = "response-nonce";
-#[cfg(feature = "gcp_cs")]
-const PROOF_JOB_ID_HEADER: &str = "proof-job-id";
 
 lazy_static! {
     pub static ref PUBLIC_PARAMS: ZswapResolver = ZswapResolver(
@@ -95,6 +86,26 @@ type TransactionProvePayload<S> = (
     Transaction<S, ProofPreimageMarker, PedersenRandomness, InMemoryDB>,
     HashMap<String, ProvingKeyMaterial>,
 );
+
+#[cfg(feature = "gcp_cs")]
+const ENCRYPTION_TYPE_HEADER: &str = "encryption-type";
+#[cfg(feature = "gcp_cs")]
+const CLIENT_PUBLIC_KEY_HEADER: &str = "client-public-key";
+#[cfg(feature = "gcp_cs")]
+const REQUEST_NONCE_HEADER: &str = "request-nonce";
+#[cfg(feature = "gcp_cs")]
+const RESPONSE_NONCE_HEADER: &str = "response-nonce";
+#[cfg(feature = "gcp_cs")]
+const PROOF_JOB_ID_HEADER: &str = "proof-job-id";
+
+/// How long the local confidential space token endpoint gets to answer.
+#[cfg(feature = "gcp_cs")]
+const ATTESTATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upper bound on the attestation token we're willing to buffer. Tokens are
+/// JWTs of a few kilobytes; anything beyond this is a malfunction.
+#[cfg(feature = "gcp_cs")]
+const ATTESTATION_MAX_RESPONSE_BYTES: usize = 64 * 1024;
 
 #[cfg(feature = "gcp_cs")]
 #[derive(serde::Deserialize)]
@@ -125,6 +136,12 @@ fn get_encrypted_transport_headers(
     let request_nonce = req.headers().get(REQUEST_NONCE_HEADER);
 
     match (client_public_key, request_nonce) {
+        #[cfg(feature = "gcp_cs")]
+        (None, None) => Err(ErrorBadRequest(format!(
+            "{CLIENT_PUBLIC_KEY_HEADER} and {REQUEST_NONCE_HEADER} are required: \
+             this server only accepts encrypted requests"
+        ))),
+        #[cfg(not(feature = "gcp_cs"))]
         (None, None) => Ok(None),
         (Some(_), Some(_)) => Ok(Some(EncryptedTransportHeaders {
             client_public_key_hex: client_public_key
@@ -154,6 +171,75 @@ fn get_encryption_type(req: &HttpRequest) -> Result<&'static str, Error> {
         },
         None => Err(ErrorBadRequest("the encryption-type is not set correctly")),
     }
+}
+
+#[cfg(feature = "gcp_cs")]
+fn decode_proving_request(
+    request: Bytes,
+    transport_headers: &Option<EncryptedTransportHeaders>,
+    server_encryption_key: &ServerEncryptionKey,
+) -> Result<Vec<u8>, Error> {
+    match transport_headers {
+        Some(headers) => server_encryption_key
+            .decrypt_request(
+                &headers.client_public_key_hex,
+                &headers.request_nonce_hex,
+                &request,
+            )
+            .ok_or_else(|| ErrorBadRequest("failed to decrypt request payload")),
+        None => Ok(request.to_vec()),
+    }
+}
+
+#[cfg(feature = "gcp_cs")]
+fn encode_proving_response_body(
+    response: Vec<u8>,
+    transport_headers: &Option<EncryptedTransportHeaders>,
+    server_encryption_key: &ServerEncryptionKey,
+) -> Result<(Option<String>, Bytes), Error> {
+    match transport_headers {
+        Some(headers) => {
+            let (response_nonce_hex, ciphertext) = server_encryption_key
+                .encrypt_response(&headers.client_public_key_hex, &response)
+                .ok_or_else(|| {
+                    actix_web::error::ErrorInternalServerError("failed to encrypt response payload")
+                })?;
+            Ok((Some(response_nonce_hex), Bytes::from(ciphertext)))
+        }
+        None => Ok((None, Bytes::from(response))),
+    }
+}
+
+#[cfg(feature = "gcp_cs")]
+async fn proving_response(
+    job_id: Uuid,
+    updates: Arc<Receiver<JobStatus>>,
+    transport_headers: Option<EncryptedTransportHeaders>,
+    server_encryption_key: &ServerEncryptionKey,
+) -> HttpResponse {
+    let result = match JobStatus::wait_for_success(updates.as_ref()).await {
+        Ok(response) => {
+            encode_proving_response_body(response, &transport_headers, server_encryption_key)
+        }
+        Err(e) => Err(e.into()),
+    };
+
+    let mut response = match result {
+        Ok((response_nonce_hex, body)) => {
+            let mut builder = HttpResponse::Ok();
+            if let Some(response_nonce_hex) = response_nonce_hex {
+                builder.append_header((RESPONSE_NONCE_HEADER, response_nonce_hex));
+            }
+            builder.body(body)
+        }
+        Err(e) => HttpResponse::from_error(e),
+    };
+
+    response.headers_mut().insert(
+        HeaderName::from_static(PROOF_JOB_ID_HEADER),
+        HeaderValue::try_from(job_id.to_string()).expect("a uuid is a valid header value"),
+    );
+    response
 }
 
 #[get("/version")]
@@ -193,6 +279,34 @@ enum Status {
     Busy,
 }
 
+#[derive(Clone, Copy, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+enum ProofJobState {
+    Pending,
+    Processing,
+    Success,
+    Error,
+    Cancelled,
+}
+
+impl ProofJobState {
+    fn done(self) -> bool {
+        matches!(self, Self::Success | Self::Error | Self::Cancelled)
+    }
+}
+
+impl From<&JobStatus> for ProofJobState {
+    fn from(value: &JobStatus) -> Self {
+        match value {
+            JobStatus::Pending => Self::Pending,
+            JobStatus::Processing => Self::Processing,
+            JobStatus::Cancelled => Self::Cancelled,
+            JobStatus::Error(_) => Self::Error,
+            JobStatus::Success(_) => Self::Success,
+        }
+    }
+}
+
 impl From<Status> for StatusCode {
     fn from(val: Status) -> Self {
         match val {
@@ -200,79 +314,6 @@ impl From<Status> for StatusCode {
             Status::Busy => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
-}
-
-#[cfg(feature = "gcp_cs")]
-fn decode_proving_request(
-    request: Bytes,
-    transport_headers: &Option<EncryptedTransportHeaders>,
-    server_encryption_key: &ServerEncryptionKey,
-) -> Result<Vec<u8>, Error> {
-    match transport_headers {
-        Some(headers) => server_encryption_key
-            .decrypt_request(
-                &headers.client_public_key_hex,
-                &headers.request_nonce_hex,
-                &request,
-            )
-            .ok_or_else(|| ErrorBadRequest("failed to decrypt request payload")),
-        None => Ok(request.to_vec()),
-    }
-}
-
-#[cfg(feature = "gcp_cs")]
-fn encode_proving_response_body(
-    response: Vec<u8>,
-    transport_headers: &Option<EncryptedTransportHeaders>,
-    response_nonce_hex: &Option<String>,
-    server_encryption_key: &ServerEncryptionKey,
-) -> Result<Bytes, Error> {
-    match transport_headers {
-        Some(headers) => Ok(Bytes::from(
-            server_encryption_key
-                .encrypt_response_with_nonce(
-                    &headers.client_public_key_hex,
-                    response_nonce_hex.as_deref().ok_or_else(|| {
-                        actix_web::error::ErrorInternalServerError(
-                            "missing response nonce for encrypted payload",
-                        )
-                    })?,
-                    &response,
-                )
-                .ok_or_else(|| {
-                    actix_web::error::ErrorInternalServerError("failed to encrypt response payload")
-                })?,
-        )),
-        None => Ok(Bytes::from(response)),
-    }
-}
-
-#[cfg(feature = "gcp_cs")]
-fn proving_response(
-    job_id: Uuid,
-    updates: Arc<Receiver<JobStatus>>,
-    transport_headers: Option<EncryptedTransportHeaders>,
-    server_encryption_key: ServerEncryptionKey,
-) -> HttpResponse {
-    let response_nonce_hex = transport_headers
-        .as_ref()
-        .map(|_| server_encryption_key.generate_response_nonce_hex());
-
-    let mut builder = HttpResponse::Ok();
-    builder.append_header((PROOF_JOB_ID_HEADER, job_id.to_string()));
-    if let Some(response_nonce_hex) = response_nonce_hex.as_ref() {
-        builder.append_header((RESPONSE_NONCE_HEADER, response_nonce_hex.clone()));
-    }
-
-    builder.streaming(once(async move {
-        let response = JobStatus::wait_for_success(updates.as_ref()).await?;
-        encode_proving_response_body(
-            response,
-            &transport_headers,
-            &response_nonce_hex,
-            &server_encryption_key,
-        )
-    }))
 }
 
 #[derive(serde::Serialize)]
@@ -283,6 +324,20 @@ struct ReadyResponse {
     jobs_pending: usize,
     job_capacity: usize,
     timestamp: time::OffsetDateTime,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProofStatusResponse {
+    job_id: Uuid,
+    status: ProofJobState,
+    done: bool,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProofStatusQuery {
+    job_id: Uuid,
 }
 
 #[get("/ready")]
@@ -304,6 +359,25 @@ pub(crate) async fn ready(pool: web::Data<Arc<WorkerPool>>) -> Result<HttpRespon
 
     let builder = HttpResponseBuilder::new(status.status.into()).json(status);
     Ok(builder)
+}
+
+#[get("/status")]
+pub(crate) async fn proof_status(
+    query: web::Query<ProofStatusQuery>,
+    pool: web::Data<Arc<WorkerPool>>,
+) -> Result<HttpResponse, Error> {
+    let job_id = query.job_id;
+    let status = pool
+        .poll(job_id)
+        .await
+        .ok_or_else(|| actix_web::error::ErrorNotFound("job not found"))?;
+    let status = ProofJobState::from(&status);
+
+    Ok(HttpResponse::Ok().json(ProofStatusResponse {
+        job_id,
+        status,
+        done: status.done(),
+    }))
 }
 
 #[get("/proof-versions")]
@@ -361,17 +435,37 @@ pub(crate) async fn attestation(
         .body(Full::new(hyper::body::Bytes::from(body)))
         .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    let response = hyper_client
-        .request(request)
-        .await
-        .map_err(actix_web::error::ErrorInternalServerError)?;
-    let response_bytes = response
-        .collect()
-        .await
-        .map_err(actix_web::error::ErrorInternalServerError)?
-        .to_bytes();
+    let response_bytes = tokio::time::timeout(ATTESTATION_TIMEOUT, async move {
+        let response = hyper_client.request(request).await.map_err(|e| {
+            warn!("attestation request to the token endpoint failed: {e}");
+            ErrorBadGateway("attestation request failed")
+        })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            warn!("token endpoint rejected the attestation request with status {status}");
+            return Err(ErrorBadGateway(format!(
+                "attestation request failed with status {status}"
+            )));
+        }
+
+        Limited::new(response.into_body(), ATTESTATION_MAX_RESPONSE_BYTES)
+            .collect()
+            .await
+            .map(|body| body.to_bytes())
+            .map_err(|e| {
+                warn!("failed to read the attestation response: {e}");
+                ErrorBadGateway("attestation response was unreadable or too large")
+            })
+    })
+    .await
+    .map_err(|_| ErrorGatewayTimeout("attestation request timed out"))??;
+
     let token = String::from_utf8(response_bytes.to_vec())
-        .map_err(actix_web::error::ErrorInternalServerError)?;
+        .map_err(|_| ErrorBadGateway("attestation token was not valid UTF-8"))?;
+    if token.is_empty() {
+        return Err(ErrorBadGateway("attestation token was empty"));
+    }
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "token": token })))
 }
@@ -389,7 +483,7 @@ pub(crate) async fn check(
     );
     let (ppi, ir): (ProofPreimageVersioned, Option<WrappedIr>) =
         tagged_deserialize(&request[..]).map_err(ErrorBadRequest)?;
-    let (_id, updates) = pool
+    let (_job_id, updates) = pool
         .submit_and_subscribe(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -467,8 +561,9 @@ pub(crate) async fn prove(
     };
 
     debug!(
-        "Received request: {}",
-        (&request[..]).encode_hex::<String>()
+        endpoint = "/prove",
+        request_bytes = request.len(),
+        "received proving request"
     );
 
     let (ppi, data, binding_input): (
@@ -478,7 +573,7 @@ pub(crate) async fn prove(
     ) = tagged_deserialize(&request[..]).map_err(ErrorBadRequest)?;
 
     let data_resolver = data.clone();
-    let (_id, updates) = pool
+    let (job_id, updates) = pool
         .submit_and_subscribe(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -538,14 +633,16 @@ pub(crate) async fn prove(
             })
         })
         .await?;
+    debug!(endpoint = "/prove", %job_id, "submitted proving job");
 
     #[cfg(feature = "gcp_cs")]
     return Ok(proving_response(
-        _id,
+        job_id,
         updates,
         transport_headers,
-        server_encryption_key.get_ref().clone(),
-    ));
+        server_encryption_key.get_ref(),
+    )
+    .await);
 
     #[cfg(not(feature = "gcp_cs"))]
     {
@@ -572,13 +669,14 @@ pub(crate) async fn prove_transaction(
     };
 
     debug!(
-        "Received request: {}",
-        (&request[..]).encode_hex::<String>()
+        endpoint = "/prove-tx",
+        request_bytes = request.len(),
+        "received proving request"
     );
 
     let (tx, keys): TransactionProvePayload<Signature> =
         tagged_deserialize(&request[..]).map_err(ErrorBadRequest)?;
-    let (_id, updates) = pool
+    let (job_id, updates) = pool
         .submit_and_subscribe(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -617,14 +715,16 @@ pub(crate) async fn prove_transaction(
             })
         })
         .await?;
+    debug!(endpoint = "/prove-tx", %job_id, "submitted proving job");
 
     #[cfg(feature = "gcp_cs")]
     return Ok(proving_response(
-        _id,
+        job_id,
         updates,
         transport_headers,
-        server_encryption_key.get_ref().clone(),
-    ));
+        server_encryption_key.get_ref(),
+    )
+    .await);
 
     #[cfg(not(feature = "gcp_cs"))]
     {

--- a/proof-server/src/lib.rs
+++ b/proof-server/src/lib.rs
@@ -20,17 +20,112 @@ use actix_web::web::{self, Data};
 use actix_web::{App, HttpServer};
 use std::sync::Arc;
 
+#[cfg(feature = "gcp_cs")]
+use {
+    crate::endpoints::attestation,
+    crypto_box::{Nonce, PublicKey, SalsaBox, SecretKey, aead::Aead},
+    hex::{FromHex, ToHex},
+    rand::RngCore,
+};
+
 use crate::endpoints::{
     check, fetch_k, get_k, health, proof_versions, prove, prove_transaction, ready, version,
 };
+
 use crate::worker_pool::WorkerPool;
 
 pub mod endpoints;
 pub mod versioned_ir;
 pub mod worker_pool;
 
+#[cfg(feature = "gcp_cs")]
+#[derive(Clone)]
+pub struct ServerEncryptionKey {
+    _secret_key: SecretKey,
+    public_key_hex: String,
+}
+
+#[cfg(feature = "gcp_cs")]
+impl ServerEncryptionKey {
+    fn generate() -> Self {
+        let mut secret_key_bytes = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut secret_key_bytes);
+        let secret_key = SecretKey::from(secret_key_bytes);
+        let public_key_hex = secret_key.public_key().encode_hex::<String>();
+
+        Self {
+            _secret_key: secret_key,
+            public_key_hex,
+        }
+    }
+
+    pub fn public_key_hex(&self) -> &str {
+        &self.public_key_hex
+    }
+
+    pub fn decrypt_request(
+        &self,
+        client_public_key_hex: &str,
+        nonce_hex: &str,
+        ciphertext: &[u8],
+    ) -> Option<Vec<u8>> {
+        let client_public_key = Self::decode_public_key(client_public_key_hex)?;
+        let nonce = Self::decode_nonce(nonce_hex)?;
+        SalsaBox::new(&client_public_key, &self._secret_key)
+            .decrypt(&nonce, ciphertext)
+            .ok()
+    }
+
+    pub fn encrypt_response(
+        &self,
+        client_public_key_hex: &str,
+        plaintext: &[u8],
+    ) -> Option<(String, Vec<u8>)> {
+        let mut nonce_bytes = [0u8; 24];
+        rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+        let response_nonce_hex = nonce_bytes.encode_hex::<String>();
+        let ciphertext = self.encrypt_response_with_nonce(
+            client_public_key_hex,
+            &response_nonce_hex,
+            plaintext,
+        )?;
+        Some((response_nonce_hex, ciphertext))
+    }
+
+    pub fn generate_response_nonce_hex(&self) -> String {
+        let mut nonce_bytes = [0u8; 24];
+        rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+        nonce_bytes.encode_hex::<String>()
+    }
+
+    pub fn encrypt_response_with_nonce(
+        &self,
+        client_public_key_hex: &str,
+        response_nonce_hex: &str,
+        plaintext: &[u8],
+    ) -> Option<Vec<u8>> {
+        let client_public_key = Self::decode_public_key(client_public_key_hex)?;
+        let nonce = Self::decode_nonce(response_nonce_hex)?;
+        SalsaBox::new(&client_public_key, &self._secret_key)
+            .encrypt(&nonce, plaintext)
+            .ok()
+    }
+
+    fn decode_public_key(public_key_hex: &str) -> Option<PublicKey> {
+        let public_key_bytes = <[u8; 32]>::from_hex(public_key_hex).ok()?;
+        Some(PublicKey::from(public_key_bytes))
+    }
+
+    fn decode_nonce(nonce_hex: &str) -> Option<Nonce> {
+        let nonce_bytes = <[u8; 24]>::from_hex(nonce_hex).ok()?;
+        Some(Nonce::from(nonce_bytes))
+    }
+}
+
 pub fn server(port: u16, fetch_params: bool, pool: WorkerPool) -> std::io::Result<(Server, u16)> {
     let pool = Arc::new(pool);
+    #[cfg(feature = "gcp_cs")]
+    let server_encryption_key = ServerEncryptionKey::generate();
     let http_server = HttpServer::new(move || {
         let app = App::new()
             .app_data(Data::new(pool.clone()))
@@ -45,6 +140,12 @@ pub fn server(port: u16, fetch_params: bool, pool: WorkerPool) -> std::io::Resul
             .route("/health", web::get().to(health))
             .wrap(Logger::new("%a %r; took %Ts"))
             .wrap(Cors::permissive());
+
+        #[cfg(feature = "gcp_cs")]
+        let app = app
+            .app_data(Data::new(server_encryption_key.clone()))
+            .service(attestation);
+
         if fetch_params {
             app.service(fetch_k)
         } else {

--- a/proof-server/src/lib.rs
+++ b/proof-server/src/lib.rs
@@ -23,15 +23,16 @@ use std::sync::Arc;
 #[cfg(feature = "gcp_cs")]
 use {
     crate::endpoints::attestation,
-    crypto_box::{Nonce, PublicKey, SalsaBox, SecretKey, aead::Aead},
+    crypto_box::aead::Aead,
+    crypto_box::{Nonce, PublicKey, SalsaBox, SecretKey},
     hex::{FromHex, ToHex},
     rand::RngCore,
 };
 
 use crate::endpoints::{
-    check, fetch_k, get_k, health, proof_versions, prove, prove_transaction, ready, version,
+    check, fetch_k, get_k, health, proof_status, proof_versions, prove, prove_transaction, ready,
+    version,
 };
-
 use crate::worker_pool::WorkerPool;
 
 pub mod endpoints;
@@ -47,7 +48,7 @@ pub struct ServerEncryptionKey {
 
 #[cfg(feature = "gcp_cs")]
 impl ServerEncryptionKey {
-    fn generate() -> Self {
+    pub fn generate() -> Self {
         let mut secret_key_bytes = [0u8; 32];
         rand::rngs::OsRng.fill_bytes(&mut secret_key_bytes);
         let secret_key = SecretKey::from(secret_key_bytes);
@@ -92,12 +93,6 @@ impl ServerEncryptionKey {
         Some((response_nonce_hex, ciphertext))
     }
 
-    pub fn generate_response_nonce_hex(&self) -> String {
-        let mut nonce_bytes = [0u8; 24];
-        rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
-        nonce_bytes.encode_hex::<String>()
-    }
-
     pub fn encrypt_response_with_nonce(
         &self,
         client_public_key_hex: &str,
@@ -135,6 +130,7 @@ pub fn server(port: u16, fetch_params: bool, pool: WorkerPool) -> std::io::Resul
             .service(get_k)
             .service(version)
             .service(proof_versions)
+            .service(proof_status)
             .service(ready)
             .route("/", web::get().to(health))
             .route("/health", web::get().to(health))

--- a/proof-server/src/lib.rs
+++ b/proof-server/src/lib.rs
@@ -30,9 +30,12 @@ use {
 };
 
 use crate::endpoints::{
-    check, fetch_k, get_k, health, proof_status, proof_versions, prove, prove_transaction, ready,
-    version,
+    check, fetch_k, get_k, health, proof_versions, prove, prove_transaction, ready, version,
 };
+
+#[cfg(feature = "gcp_cs")]
+use crate::endpoints::proof_status;
+
 use crate::worker_pool::WorkerPool;
 
 pub mod endpoints;
@@ -130,7 +133,6 @@ pub fn server(port: u16, fetch_params: bool, pool: WorkerPool) -> std::io::Resul
             .service(get_k)
             .service(version)
             .service(proof_versions)
-            .service(proof_status)
             .service(ready)
             .route("/", web::get().to(health))
             .route("/health", web::get().to(health))
@@ -140,7 +142,8 @@ pub fn server(port: u16, fetch_params: bool, pool: WorkerPool) -> std::io::Resul
         #[cfg(feature = "gcp_cs")]
         let app = app
             .app_data(Data::new(server_encryption_key.clone()))
-            .service(attestation);
+            .service(attestation)
+            .service(proof_status);
 
         if fetch_params {
             app.service(fetch_k)

--- a/proof-server/tests/integration_tests.rs
+++ b/proof-server/tests/integration_tests.rs
@@ -802,6 +802,7 @@ mod prove_endpoint {
     use super::test_data::create_zswap_output_proof_preimage;
     use serialize::{tagged_deserialize, tagged_serialize};
     use transient_crypto::proofs::ProvingKeyMaterial;
+    #[cfg(feature = "gcp_cs")]
     use uuid::Uuid;
 
     #[tokio::test]
@@ -877,13 +878,16 @@ mod prove_endpoint {
             response.status()
         );
 
-        let job_id = response
-            .headers()
-            .get("proof-job-id")
-            .expect("missing proof-job-id header")
-            .to_str()
-            .expect("proof-job-id should be valid ASCII");
-        Uuid::parse_str(job_id).expect("proof-job-id should be a UUID");
+        #[cfg(feature = "gcp_cs")]
+        {
+            let job_id = response
+                .headers()
+                .get("proof-job-id")
+                .expect("missing proof-job-id header")
+                .to_str()
+                .expect("proof-job-id should be valid ASCII");
+            Uuid::parse_str(job_id).expect("proof-job-id should be a UUID");
+        }
 
         let bytes = response
             .bytes()

--- a/proof-server/tests/integration_tests.rs
+++ b/proof-server/tests/integration_tests.rs
@@ -103,7 +103,7 @@ mod common {
 mod test_data {
     use std::sync::{Arc, LazyLock};
 
-    use base_crypto::schnorr::Signature;
+    use base_crypto::signatures::Signature;
     use base_crypto::time::Timestamp;
     use coin_structure::coin;
     use ledger::structure::{
@@ -301,7 +301,7 @@ mod health_endpoints {
 mod prove_tx_endpoint {
     use super::common::*;
     use super::test_data::*;
-    use base_crypto::schnorr::Signature;
+    use base_crypto::signatures::Signature;
     use ledger::structure::{ProofMarker, Transaction};
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
@@ -802,6 +802,7 @@ mod prove_endpoint {
     use super::test_data::create_zswap_output_proof_preimage;
     use serialize::{tagged_deserialize, tagged_serialize};
     use transient_crypto::proofs::ProvingKeyMaterial;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn rejects_empty_body() {
@@ -875,6 +876,14 @@ mod prove_endpoint {
             "Unexpected status: {}",
             response.status()
         );
+
+        let job_id = response
+            .headers()
+            .get("proof-job-id")
+            .expect("missing proof-job-id header")
+            .to_str()
+            .expect("proof-job-id should be valid ASCII");
+        Uuid::parse_str(job_id).expect("proof-job-id should be a UUID");
 
         let bytes = response
             .bytes()


### PR DESCRIPTION
## Description

This adds support for deploying the proof server in GCP's Confidential Space, using the `gcp_cs` feature. There's a new route:  `/attestation`, which returns a token (either OIDC or PKI) depending on the request header.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
