### PR TITLE
feat(formal): Agda mechanisation of ZKIR v3

### DIFF
--- a/.github/workflows/agda.yml
+++ b/.github/workflows/agda.yml
@@ -1,0 +1,36 @@
+name: Check Agda
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'formal/**'
+      - '.github/workflows/agda.yml'
+  push:
+    branches:
+      - 'ledger-*'
+    paths:
+      - 'formal/**'
+      - '.github/workflows/agda.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Typecheck Agda
+        run: |
+          cd formal/src
+          nix run .#agda -- zkir-v3/Main.agda

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ logs
 **/.yarn/install-state.gz
 **/.yarn/cache
 .midnight-pp
+
+# Agda
+formal/src/_build/
+*.agdai

--- a/formal/docs/zkir-v3-divergence-review.md
+++ b/formal/docs/zkir-v3-divergence-review.md
@@ -1,0 +1,307 @@
+# ZKIR v3 — in-circuit / off-circuit divergence review
+
+A review, for the `zkir-v3` implementation team, of the places where the
+in-circuit constraint system (`<IrSource as Relation>::circuit`,
+`ir_vm.rs:705`) enforces strictly less than the off-circuit interpreter
+(`IrSource::preprocess`, `ir_vm.rs:185`) requires. All line numbers refer to
+`midnight-ledger` at `a1d1611c` — the `ledger-9` head at the 2026-07-24
+re-pin, byte-identical in `zkir-v3/` to the earlier pin `b17df9d1`
+(`midnight-zkir-v3 3.0.0-rc.2`), so all line numbers are valid at both.
+
+Background: we maintain a machine-checked model of zkir-v3 (an Agda
+mechanization in this repository) and have proved that any witness
+satisfying the synthesized constraint system corresponds to an execution of
+`preprocess` with the same public inputs — *under explicit side conditions*.
+Each side condition marks a spot where a witness can satisfy the circuit
+even though no `preprocess` run would produce it. We audited every such spot
+against the Rust. Most turned out to be enforced by the real circuit and
+need no attention (listed at the end); this memo reports the cases where
+the divergence is real.
+
+**Scope.** The model covers all seven `IrType`s — `Native`, `JubjubPoint`,
+`JubjubScalar`, `Bytes32`, and (since 2026-07-15) the Secp256k1 triple
+(`Secp256k1Point`, `Secp256k1Base`, `Secp256k1Scalar`) — and every
+instruction over them. The Secp256k1 arms of the type-dispatching
+instructions (`Add`, `Mul`, `Neg`, `Inv`, `EcMul`, `EcMulGenerator`,
+`TestEq`, `ConstrainEq`, `CondSelect`, the coordinate and byte
+conversions, `Encode`) are audited below alongside the rest; the
+foreign-field and foreign-ECC *chips* themselves (`midnight-circuits`
+`AssignedField`/`AssignedForeignPoint`) are modeled at the level of their
+functional contracts and are trusted, not re-verified.
+
+Why it matters: a witness that satisfies the circuit but corresponds to no
+`preprocess` execution is exactly what a malicious prover can use. Whether a
+given divergence is exploitable depends on whether the unconstrained value
+can influence a public input or a circuit output; the findings below note
+this per case. There is precedent for this class being real: the
+DivModPowerOfTwo canonicity issue in an earlier ZKIR version, fixed
+in-circuit by `enforce_canonical`, is the same shape of gap — and our
+model of that version independently flags the same spot (its faithfulness
+proof does not go through without the canonicity guard).
+
+## Summary
+
+| Finding | Assessment | Suggested action |
+|---|---|---|
+| 1. ReconstituteField result can wrap mod the field | genuine divergence | in-circuit no-overflow check |
+| 2. Assert constrains `≠ 0`; semantics requires `= 1` | documented UB | constrain `= 1`, or keep as documented UB |
+| 3. PublicInput/PrivateInput guard–value coupling | by design | document for producers |
+| 4. LessThan bounds enforced at the evened width | minor divergence | document the effective bound |
+| 5. Secp256k1 decode accepts non-canonical limb encodings | completeness gap + panic | reject non-canonical input; validate flag; error instead of panic |
+
+Everything else we audited is already enforced in-circuit — see "Also
+checked, found enforced" at the end.
+
+## 1. ReconstituteField: result can wrap modulo the field
+
+**What the circuit enforces.** For
+`ReconstituteField { divisor, modulus, bits, output }`, the circuit asserts
+two range bounds — `divisor < 2^(FR_BITS − bits)`
+(`assert_lower_than_fixed`, `ir_vm.rs:1036-1040`) and `modulus < 2^bits`
+(`ir_vm.rs:1041-1045`) — and then computes the output as the field
+`linear_combination` `modulus + 2^bits · divisor` (`ir_vm.rs:1048-1055`),
+which reduces modulo `FR_ORDER`.
+
+**What preprocess requires.** The same two range checks, *plus* a
+big-integer comparison against the field maximum:
+`bail!("Reconstituted element overflows field")` when the integer sum
+`modulus + 2^bits · divisor` exceeds it (`ir_vm.rs:445-447`).
+
+**The gap.** The two range bounds do not imply no-overflow. The integer sum
+ranges over `[0, 2^FR_BITS − 1]`, and `FR_ORDER < 2^FR_BITS`, so sums in
+`[FR_ORDER, 2^FR_BITS − 1]` pass both range checks yet overflow. A prover
+can therefore supply in-range `(divisor, modulus)` whose sum wraps: the
+circuit accepts, with `output` bound to the *wrapped* field value — a value
+no honest execution produces — while `preprocess` rejects the same inputs.
+
+**Why it is worth attention.** ReconstituteField is the documented inverse
+of DivModPowerOfTwo (`ir.rs:643`), and this is the same shape as the
+DivModPowerOfTwo canonicity issue that motivated `enforce_canonical`: the
+in-circuit relation admits non-canonical (wrapping) witnesses that the
+off-circuit function never emits. If a reconstituted output can flow into a
+public input or circuit output, the prover controls a value the semantics
+says cannot exist.
+
+**Suggested action.** Add an in-circuit no-overflow assertion mirroring the
+off-circuit comparison — e.g. a bound on the reconstituted result against
+`FR_ORDER`, as `enforce_canonical` does for DivModPowerOfTwo. Cost: one
+comparison constraint per ReconstituteField. Alternatively, first assess
+whether a reconstituted output can reach a public input under the intended
+producer discipline, and if not, document no-overflow as an explicit
+producer obligation.
+
+## 2. Assert: constrains `≠ 0` where the semantics requires `= 1`
+
+**What the circuit enforces.** `std.assert_non_zero(layouter, &cond)`
+(`ir_vm.rs:833`): the condition is non-zero. Neither `cond = 1` nor
+booleanity is constrained.
+
+**What preprocess requires.** The condition is resolved as a bool and must
+be `true` (`ir_vm.rs:337-338`); any value other than `0` or `1` is rejected
+outright (`resolve_operand_bool`, `ir_vm.rs:240-251`). So off-circuit,
+Assert passes only on exactly `1`.
+
+**The gap.** A witness with `cond ∈ {2, …, p−1}` satisfies the circuit but
+is rejected off-circuit. The instruction documentation already acknowledges
+this: "Assert that `cond` has value `1`. UB if `cond` is not `0` or `1`"
+(`ir.rs:380`).
+
+**Why it is (only) moderate.** Assert has no output, so it is not directly
+a value-forgery vector. The divergence matters when the asserted wire is
+*not* produced by an instruction that already constrains it boolean
+(TestEq, LessThan, Not all do). For a wire coming from arbitrary arithmetic
+or a free witness, "assert" in-circuit means only "non-zero", which is
+weaker than the intended "true".
+
+**Suggested action.** Either keep the documented-UB contract (no code
+change) and rely on producers asserting only boolean-producing wires, or
+strengthen the constraint to `cond = 1` (one equality constraint per
+Assert), which removes the UB surface entirely.
+
+## 3. PublicInput / PrivateInput: guard and value are uncoupled in-circuit
+
+**What the circuit enforces.** Both instructions witness a fresh value and
+allocate it well-typed via `assign_incircuit` (`ir_vm.rs:999-1003`), so the
+*type* of the cell is constrained. The guard deliberately takes no part in
+the constraints — the instruction documentation is explicit: "the `guard`
+DOES NOT participate in in-circuit constraints" (`ir.rs:804-805`,
+`827-828`).
+
+**What preprocess requires.** The guard is read as a bool (rejecting
+non-`0`/`1`, `ir_vm.rs:240-251`) and branches: guard-false binds the
+default value for the type; guard-true decodes the next transcript element
+(`ir_vm.rs:353-365` public, `367-383` private).
+
+**The gap.** In-circuit, nothing ties the witnessed value to the guard: a
+witness may put any well-typed value in an "inactive" cell (where
+preprocess would bind the default), and the guard wire itself need not be
+boolean unless constrained elsewhere. Several distinct witnesses therefore
+satisfy the circuit for the same public inputs.
+
+**Why this is by design.** These cells are the prover's inputs — the
+witnessed value is *supposed* to be free, and the public inputs are pinned
+independently (via Impact). The divergence does not let the circuit accept
+a false statement; it only means the in-circuit relation does not
+distinguish active from inactive input cells. This is the intended slack of
+any circuit with private inputs.
+
+**Suggested action.** Document for producers and auditors: transcript-input
+cells are free in-circuit (only their type is constrained), and the guard
+is not a circuit input — any guard/value coupling must come from how the
+value is used downstream. No code change suggested unless that coupling is
+ever made load-bearing.
+
+## 4. LessThan: operand bounds enforced at the evened bit width
+
+**What the circuit enforces.** `LessThan { a, b, bits, output }` lowers to
+`std.lower_than(layouter, &a, &b, max(bits + bits%2, 4))` (`ir_vm.rs:966`;
+the library requires an even bound ≥ 4). The wrapper converts each operand
+via `bounded_of_element`, which **does** emit an enforced range check —
+`assert_lower_than_fixed(x, 2^n)` (`midnight-circuits 7.2.2`,
+`field/native/native_gadget.rs:332-348`, verified 2026-07-24) — but at the
+*evened* bound `n = max(bits + bits%2, 4)`.
+
+**What preprocess requires.** Both operands strictly below the exact
+`2^bits` (`resolve_operand_bits(_, Some(*bits))`, bailing with "Bit bound
+failed" otherwise).
+
+**The gap.** For odd `bits`, the circuit admits operands in
+`[2^bits, 2^(bits+1))`; for `bits < 4` the slack widens to `2^4` (e.g.
+`bits = 1`: preprocess demands operands in `{0, 1}`, the circuit accepts
+up to 15). The comparison *result* is still correct for whatever in-bound
+values are supplied — the divergence is only in which operand values are
+admissible.
+
+**Why it is minor.** The output bit is boolean and correct for the admitted
+values, so no wrong comparison can be proven; the slack only widens the
+witness set beyond what preprocess accepts, in a bounded, predictable way.
+
+**Suggested action.** Document the evened bound in the `LessThan` doc
+comment (producers choosing odd or tiny `bits` should know the effective
+in-circuit bound), or round the bound up on the preprocess side to match.
+
+## 5. Secp256k1 decode: non-canonical limb encodings accepted off-circuit
+
+Unlike findings 1–4, the lax side here is the *off-circuit* decoder: it
+accepts prover-supplied data the canonical encoder never emits. The
+functions are `midnight-circuits 7.2.2` (the version resolved by
+`zkir-v3` at the pin), reached from `decode_offcircuit` (`encode.rs`) on
+preimage inputs and transcript reads (`ir_vm.rs:201, 360-363, 379-383`).
+
+**What decode accepts.** `AssignedField::from_public_input`
+(`field_chip.rs:141-160`) reconstructs an integer from the two native
+limbs and maps it into the foreign field via `bigint_to_fe`
+(`utils/util.rs:91-100`), which **silently reduces modulo the foreign
+modulus** — there is no canonicity check, so every integer in
+`[0, 2²⁵⁶)` is accepted (~2³² non-canonical encodings per `Fp` element,
+~1.27·2¹²⁸ per `Fq` element). `AssignedForeignPoint::from_public_input`
+(`weierstrass_chip.rs:249-268`) short-circuits on identity flag `= 1`
+**before any coordinate or length check** (arbitrary coordinate limbs
+accepted; the canonical identity encoding is the limbs of `p−1` twice
+plus flag `1`, so even zeroed coordinates are non-canonical), and never
+inspects flag values other than `1` (flag `42` decodes like flag `0`).
+Separately, limb values ≥ `2¹⁹²` make `bi_to_limbs` (`util.rs:113-118`)
+**panic** rather than return an error — prover-supplied data crashing
+`preprocess`, the same defect class as the `Bytes32` decode
+`assert_eq!` (`encode.rs:126-131`).
+
+**What the circuit does.** The in-circuit side re-encodes the *decoded*
+(hence canonical-valued) inputs — for the communications commitment, the
+Poseidon preimage is built from the re-encoded memory values, while
+`preprocess` commits the **raw** input stream (`ir_vm.rs:662-681`).
+
+**The gap.** For a preimage containing a non-canonical Secp256k1
+encoding, `preprocess` succeeds (decoding reduces silently, TC2 checks
+the commitment over the raw stream) but the synthesized circuit pins the
+commitment to the canonical re-encoding — the two disagree, so proof
+generation fails. This is a *completeness* gap (an accepted preimage
+that cannot prove), not a soundness one, and it is reachable only
+through the declared `inputs` with the communications commitment
+enabled.
+
+**Ledger-level scope (traced through the ledger crates at the pin).**
+The two transcript vectors are prover-local: `ProofPreimage`s are
+discarded after proving (`structure.rs:546-554`, `prove.rs:253+`), and
+validators rebuild every pis cell from the *typed* on-chain `Transcript`
+(`verify.rs:1946-1961`; `Popeq` results re-encoded canonically via
+`field_repr`, `ops.rs:476-479`). The raw `public_transcript_outputs`
+vector is never hashed, committed, or serialized into the proven
+transaction, so a non-canonical encoding there is protocol-invisible —
+it decodes to the same typed values, the same witnessed cells, the same
+pis, the same statement. The panic region is the exception: any service
+that runs `preprocess` on third-party preimages (`ProvingProvider::
+check/prove`, `transient-crypto/proofs.rs:683-697`; `zkir-v3-wasm`) can
+be crashed by an oversized limb — an availability concern for proof
+servers, though not for validators, who only encode typed values and
+never decode raw Fr.
+
+**Model status.** Our mechanization's decoders are the canonical partial
+inverses (they reject what the encoder cannot emit), so its theorems
+transfer to the deployed decoder exactly on canonically-encoded data;
+the round-trip laws on canonical encodings, off-curve rejection, and the
+coordinate conversions were verified faithful.
+
+**Suggested action.** In `from_public_input`: reject reconstructed
+integers ≥ the foreign modulus, validate the identity flag as boolean
+(and check the coordinate limbs on the identity path or require the
+canonical identity encoding), and return an error instead of panicking
+on oversized limbs. Each is a cheap host-side check in a function that
+already returns `Option`.
+
+## Also checked, found enforced (no action needed)
+
+For completeness, the remaining candidate divergences from the audit are
+all enforced by the real circuit:
+
+- **Declared-input typing** — every declared circuit input is allocated
+  through `assign_incircuit` (`ir_vm.rs:729-730`;
+  `ir_instructions/assign.rs:36-106`), whose type-specific chips constrain
+  well-formedness (on-curve/subgroup for JubjubPoint, per-byte range for
+  Bytes32, canonical scalars).
+- **FromCoordinates subgroup membership (Jubjub)** — enforced in-circuit:
+  `jubjub().point_from_coordinates` (`midnight-circuits 7.2.2`,
+  `src/ecc/native/edwards_chip.rs:783`) assigns a fresh point under the
+  curve-equation gate, multiplies it by the cofactor **in-circuit**
+  (`assign` → `clear_cofactor`, annihilating any 8-torsion), and constrains
+  the input coordinates equal to the result — so on-curve, non-subgroup
+  coordinates are unsatisfiable, matching the off-circuit `into_subgroup`
+  rejection (`from_coordinates.rs:40-41`). The chip's
+  `point_from_coordinates_unsafe` / `assign_without_subgroup_check` paths
+  skip this check, but zkir-v3 does not call them. The guarantee is not
+  stated in the chip's doc comment — worth an upstream documentation
+  request. (Verified 2026-07-24 against the crates.io sources.)
+- **Impact guard booleanity, including empty input lists** — the guard is
+  converted to an `AssignedBit` before the inputs loop (`ir_vm.rs:871-875`),
+  so booleanity is constrained even when there is nothing to push.
+- **DivModPowerOfTwo output arity** — wrong arity is rejected on both
+  sides: `Error::Synthesis` in-circuit (`ir_vm.rs:1006-1010`), `bail!`
+  off-circuit (`ir_vm.rs:396-398`).
+- **FromBytes32 unsupported result types** — rejected on both sides
+  (`ir_instructions/from_bytes32.rs:101-103`, `from_bytes32.rs:58-60`).
+- **FromBytes32 result-type ↔ `val_t` coupling** — in-circuit the chip is
+  selected by the instruction's `val_t` (`from_bytes32.rs:79-105`), so the
+  output cell's type is pinned by the source. (Our model's synthesized
+  constraint is looser — it does not record `val_t` — and compensates with
+  a witness-shape side condition tying the output cell's type to `val_t`;
+  the audit confirms the real circuit enforces this by construction.)
+- **FromBytes32 non-canonical bytes on the foreign fields** — off-circuit
+  reduces via `from_le_bytes_with_reduction` (`from_bytes32.rs:109-114`);
+  in-circuit `assigned_from_le_bytes` (upstream `midnight-zk`,
+  `circuits/src/field/foreign/field_chip.rs:1264-1290`) computes the byte
+  integer by a linear combination *in the emulated field* and normalizes,
+  i.e. also reduces mod the order. The two sides agree on all inputs,
+  canonical or not. (The `Native`-target analogue remains unverified —
+  see the spec §9.)
+- **IntoCoordinates on the Secp256k1 identity** — rejected on both sides:
+  off-circuit errors on `is_identity`
+  (`ir_instructions/into_coordinates.rs:39-61`); in-circuit
+  `assert_non_zero` makes the constraint unsatisfiable there
+  (`into_coordinates.rs:75-102`).
+- **Output (terminator) arity and per-position types** — checked in-circuit
+  (`ir_vm.rs:1151-1167`) and off-circuit (`ir_vm.rs:626-647`).
+
+One observation that may still interest the team: there is no separate
+validation/well-formedness pass over an `IrSource` — malformed instructions
+(wrong arity, unsupported types) surface as errors only when `preprocess`
+or `circuit` runs. That is sound (no proof is produced), but an up-front
+validation pass would fail earlier and more uniformly.

--- a/formal/src/README.md
+++ b/formal/src/README.md
@@ -1,0 +1,25 @@
+# Agda development — toolchain and type-checking
+
+This directory holds the Agda code ([zkir-v3/](zkir-v3/)) and the Nix flake
+providing the toolchain (the same one CI uses, via
+[.github/workflows/agda.yml](../../.github/workflows/agda.yml)).
+
+Everything runs from this directory via the flake:
+
+```sh
+cd formal/src
+nix run .#agda -- zkir-v3/Main.agda    # type-checks the entire zkir-v3 development
+```
+
+Inside a nix shell (or with a suitable Agda + standard-library setup) the
+bare invocation works from the repository root:
+
+```sh
+agda --safe -i formal/src formal/src/zkir-v3/Main.agda
+```
+
+`zkir-v3/Main.agda` imports every module, so checking it verifies the whole
+development. `CircuitProof.agda` is large — a cold check can take several
+minutes. Dependencies are declared in
+[zkir-formal-spec.agda-lib](zkir-formal-spec.agda-lib)
+(`standard-library`, `standard-library-classes`, `standard-library-meta`).

--- a/formal/src/flake.lock
+++ b/formal/src/flake.lock
@@ -1,0 +1,200 @@
+{
+  "nodes": {
+    "abstract-set-theory": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771423838,
+        "narHash": "sha256-IFTHS6C44PHdwYQVWNW/0WZf+3fWtzSfR21c3UmihLU=",
+        "owner": "input-output-hk",
+        "repo": "agda-sets",
+        "rev": "2253231ad856b9b95f32d6b06709748e59bdbb3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "agda-sets",
+        "type": "github"
+      }
+    },
+    "agda-nix": {
+      "inputs": {
+        "abstract-set-theory": "abstract-set-theory",
+        "categorical-crypto": "categorical-crypto",
+        "flake-utils": "flake-utils",
+        "iog-prelude": "iog-prelude",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "standard-library-classes": "standard-library-classes",
+        "standard-library-meta": "standard-library-meta"
+      },
+      "locked": {
+        "lastModified": 1774867665,
+        "narHash": "sha256-gyw9Eu1alpRcG6cMnsZBVKVRjYWQWeILH9S7Qgx5akM=",
+        "owner": "input-output-hk",
+        "repo": "agda.nix",
+        "rev": "2fc7a81e385d01b30a5df57902f93c46d7d21bff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "agda.nix",
+        "type": "github"
+      }
+    },
+    "categorical-crypto": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774441400,
+        "narHash": "sha256-t0HXmhW3C4VPkl1IMiwa16lgZVomxuu74O30qwoEeNU=",
+        "owner": "input-output-hk",
+        "repo": "categorical-crypto",
+        "rev": "6cdf63785fb39f5e340240667e7a0c5aed473d90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "categorical-crypto",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "iog-prelude": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765201741,
+        "narHash": "sha256-xTivBEzcpJBqzdjj+gJqJ7wrEMmh/ZwXRi8h575XPFs=",
+        "owner": "input-output-hk",
+        "repo": "iog-agda-prelude",
+        "rev": "e12e69e8cc76cd41d19d0e38a44afa4358969a47",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iog-agda-prelude",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777983031,
+        "narHash": "sha256-vmhC9xelEeYwg2IQJ3DzBv6u7NKuSZgBXpKqInP528U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cadd3b008c77da2d2e4d1c40c4e49dccc8706318",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agda-nix": "agda-nix",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "standard-library-classes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754406591,
+        "narHash": "sha256-tuXuZcwu6XNFP979oSZg0yfFY9eMyqpkUNddk+QchVc=",
+        "owner": "agda",
+        "repo": "agda-stdlib-classes",
+        "rev": "e732956fb01eb616bb3429f290d9434f4ab59b6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "repo": "agda-stdlib-classes",
+        "type": "github"
+      }
+    },
+    "standard-library-meta": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754406588,
+        "narHash": "sha256-YH8OqGsQ2DKhKqhSUWBDTimQSZsNCnqwZqNqQwnnVS0=",
+        "owner": "agda",
+        "repo": "agda-stdlib-meta",
+        "rev": "ba0159a198c99185bda86541362f8e0a4a82538a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "repo": "agda-stdlib-meta",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/formal/src/flake.nix
+++ b/formal/src/flake.nix
@@ -1,0 +1,57 @@
+# Warning: only edit this file if you know what you're doing!
+# In this case, consider using `agda.nix` directly.
+{
+  description = "Pagda nix template";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    agda-nix = {
+      url = "github:input-output-hk/agda.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+  };
+
+  outputs =
+    inputs@{
+      self,
+        nixpkgs,
+        flake-utils,
+        ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+    in
+      flake-utils.lib.eachDefaultSystem (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              inputs.agda-nix.overlays.default
+            ];
+          };
+
+          pagda = import ./pagda.nix { agdaPackages = pkgs.agdaPackages; };
+
+          agda = pkgs.agdaPackages.agda.withPackages
+            (builtins.filter (p: p ? isAgdaDerivation) pagda.default.buildInputs);
+        in
+          {
+            packages = pagda // {
+              inherit agda;
+            };
+
+            # The Darwin stdenv used to build the Agda packages exports
+            # DEVELOPER_DIR/SDKROOT pointing at the Nix apple-sdk, which
+            # redirects the /usr/bin/git stub at an SDK that ships no git.
+            # Ship a real git in the shell so it works regardless.
+            devShells.default = pkgs.mkShell {
+              packages = [ agda pkgs.git ];
+            };
+          }
+      );
+}

--- a/formal/src/pagda.nix
+++ b/formal/src/pagda.nix
@@ -1,0 +1,17 @@
+{ agdaPackages }: with agdaPackages; rec {
+
+  zkir-formal-spec = mkDerivation {
+    pname = "zkir-formal-spec";
+    version = "0.1";
+    src = ./.;
+    meta = { };
+    libraryFile = "zkir-formal-spec.agda-lib";
+    buildInputs = [
+      standard-library
+      standard-library-classes
+      standard-library-meta
+    ];
+  };
+
+  default = zkir-formal-spec;
+}

--- a/formal/src/zkir-formal-spec.agda-lib
+++ b/formal/src/zkir-formal-spec.agda-lib
@@ -1,0 +1,5 @@
+name: zkir-formal-spec
+depend: standard-library
+--        standard-library-classes
+--        standard-library-meta
+include: .

--- a/formal/src/zkir-v3/Assumptions.agda
+++ b/formal/src/zkir-v3/Assumptions.agda
@@ -1,0 +1,323 @@
+{-# OPTIONS --safe #-}
+
+------------------------------------------------------------------------
+-- Assumptions of the zkir-v3 formalization
+--
+-- The trust base of the development, collected into a single flat record
+-- `Assumptions`, in the style of zkir-v2.  Downstream modules take an
+-- `Assumptions` value as a module parameter
+-- (`module M (⋯ : _) (open Assumptions ⋯) where`), so the development
+-- typechecks under `--safe` with no `postulate`s.
+--
+-- The assumed laws are only those the faithfulness proofs consume: the
+-- field non-triviality `1ᶠ≢0ᶠ` (Group A) and the typed-encoding
+-- round-trips (Group C).  Laws are admitted only when a proof needs
+-- them.
+--
+-- Chips are modeled at the level of their *functional contract*: each
+-- field below is the relation a `midnight-zk-stdlib` operation
+-- guarantees, not its gate-level lowering (see docs/zkir-v3-spec.md §7.0).
+------------------------------------------------------------------------
+
+module zkir-v3.Assumptions where
+
+open import Data.Bool    using (Bool; if_then_else_)
+open import Data.Fin     using (Fin)
+open import Data.List    using (List; []; _∷_)
+open import Data.Maybe   using (Maybe; just)
+open import Data.Nat     using (ℕ; _+_; _*_)
+open import Data.Product using (_×_; _,_; uncurry)
+open import Data.Vec     using (Vec)
+open import Relation.Binary.Definitions using (DecidableEquality)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+open import Relation.Nullary using (¬_)
+
+-- Integer value of a little-endian bit list (used by the valuation `valFr`).
+bits-to-ℕ : List Bool → ℕ
+bits-to-ℕ []       = 0
+bits-to-ℕ (b ∷ bs) = (if b then 1 else 0) + 2 * bits-to-ℕ bs
+
+------------------------------------------------------------------------
+-- Concrete byte types (ir_types.rs: Bytes32 = [u8; 32]).
+--
+-- A byte is an element of Fin 256; a `Bytes32` is a length-32 vector of
+-- bytes.  These are concrete (they do not depend on the trust base) and
+-- are shared by the record fields below and by downstream modules.
+------------------------------------------------------------------------
+
+Byte : Set
+Byte = Fin 256
+
+Bytes32 : Set
+Bytes32 = Vec Byte 32
+
+record Assumptions : Set₁ where
+
+  ----------------------------------------------------------------------
+  -- Carrier types.
+  ----------------------------------------------------------------------
+
+  field
+    Fr           : Set
+    -- ^ BLS12-381 scalar field element; the native field and the base
+    --   field of Jubjub (transient_crypto::curve::Fr).
+    Alignment    : Set
+    -- ^ Byte-alignment descriptor (base_crypto::fab::Alignment).
+    JubjubPoint  : Set
+    -- ^ Point of the Jubjub curve (in its prime-order subgroup).
+    JubjubScalar : Set
+    -- ^ Element of the Jubjub scalar field.
+    SecpPoint    : Set
+    -- ^ Point of the Secp256k1 curve (midnight_curves::k256::K256, a
+    --   Weierstrass curve of cofactor 1 over a foreign field), including
+    --   the identity.
+    SecpBase     : Set
+    -- ^ Secp256k1 base field element (k256::Fp).
+    SecpScalar   : Set
+    -- ^ Secp256k1 scalar field element (k256::Fq).
+
+  ----------------------------------------------------------------------
+  -- Native field (ZkStdLib arithmetic over Fr).
+  ----------------------------------------------------------------------
+
+  field
+    0ᶠ 1ᶠ : Fr
+    _+ᶠ_ _*ᶠ_ : Fr → Fr → Fr
+    -ᶠ_       : Fr → Fr
+    -- Inversion is partial: `nothing` exactly on 0ᶠ (Inv errors on zero).
+    invᶠ      : Fr → Maybe Fr
+    _≟ᶠ_      : DecidableEquality Fr
+
+    -- Bit decomposition.  `FR-BITS` is the number of bits (255), and
+    -- `FR-ORDER` the field order; `to-le-bits` yields the canonical
+    -- little-endian bits and `from-le-bits` reads bits as an integer
+    -- reduced modulo the order.  Used by the bit/field instructions.
+    FR-BITS FR-ORDER : ℕ
+    to-le-bits       : Fr → List Bool
+    from-le-bits     : List Bool → Fr
+
+  ----------------------------------------------------------------------
+  -- Jubjub (native embedded curve) gadget contracts.
+  ----------------------------------------------------------------------
+
+  field
+    _+J_ : JubjubPoint → JubjubPoint → JubjubPoint   -- point addition
+    _·J_ : JubjubScalar → JubjubPoint → JubjubPoint  -- scalar mult.
+    genJ : JubjubPoint                               -- group generator
+    idJ  : JubjubPoint                               -- identity (default)
+    negJ : JubjubPoint → JubjubPoint                 -- point negation
+    _≟J_ : DecidableEquality JubjubPoint
+
+    -- Affine coordinates.  `coordsJ` is total (every subgroup point has
+    -- affine coordinates on the Edwards model); `fromCoordsJ` is partial
+    -- (the coordinates must denote a point in the prime-order subgroup).
+    --
+    -- `fromCoordsJ` is also the *in-circuit* contract of
+    -- `from-coordinates` (`Circuit.from-coords`), and this is VERIFIED
+    -- faithful (2026-07-24, midnight-circuits 7.2.2): the chip's
+    -- `point_from_coordinates` enforces subgroup membership in-circuit by
+    -- cofactor-clearing — a fresh point under the curve-equation gate,
+    -- constrained multiply-by-8, input coordinates pinned to the result
+    -- (edwards_chip.rs:783; spec §9, "Contract strength").
+    coordsJ     : JubjubPoint → Fr × Fr
+    fromCoordsJ : Fr → Fr → Maybe JubjubPoint
+
+    -- Scalar encoding (canonical 252-bit) and the Native → JubjubScalar
+    -- reduction (JubjubScalarFromNative).
+    jubjubScalarToFr   : JubjubScalar → Fr
+    jubjubScalarFromFr : Fr → Maybe JubjubScalar
+    native→jubjubScalar : Fr → JubjubScalar
+
+    -- Hash a sequence of native elements to a Jubjub point.
+    hash-to-curve-fn : List Fr → JubjubPoint
+
+  ----------------------------------------------------------------------
+  -- Secp256k1 (foreign-field emulated curve) gadget contracts.
+  --
+  -- The in-circuit side is the `midnight-circuits` foreign-field /
+  -- foreign-ECC chips (`AssignedField`, `AssignedForeignPoint`), modeled
+  -- here by their functional contracts; the CRT/limb internals stay
+  -- inside the trust base (spec §7.0, decision record).
+  ----------------------------------------------------------------------
+
+  field
+    -- Base field Fp (k256::Fp).  Inversion is partial: `nothing`
+    -- exactly on 0 (Inv errors on zero).
+    _+ᵇ_ _*ᵇ_ : SecpBase → SecpBase → SecpBase
+    -ᵇ_       : SecpBase → SecpBase
+    invᵇ      : SecpBase → Maybe SecpBase
+    _≟ᵇ_      : DecidableEquality SecpBase
+
+    -- Scalar field Fq (k256::Fq).
+    _+ˢ_ _*ˢ_ : SecpScalar → SecpScalar → SecpScalar
+    -ˢ_       : SecpScalar → SecpScalar
+    invˢ      : SecpScalar → Maybe SecpScalar
+    _≟ˢ_      : DecidableEquality SecpScalar
+
+    -- Curve group.
+    _+K_ : SecpPoint → SecpPoint → SecpPoint    -- point addition
+    negK : SecpPoint → SecpPoint                -- point negation
+    _·K_ : SecpScalar → SecpPoint → SecpPoint   -- scalar mult. (msm)
+    genK : SecpPoint                            -- group generator
+    idK  : SecpPoint                            -- identity (default)
+    _≟K_ : DecidableEquality SecpPoint
+
+    -- Affine coordinates.  `coordsK` is partial: `nothing` exactly on
+    -- the Weierstrass identity, which has no affine coordinates
+    -- (IntoCoordinates errors off-circuit / asserts non-zero
+    -- in-circuit).  `fromCoordsK` is partial (on-curve check); the
+    -- identity is not constructible from coordinates.
+    coordsK     : SecpPoint → Maybe (SecpBase × SecpBase)
+    fromCoordsK : SecpBase → SecpBase → Maybe SecpPoint
+
+    -- Limb encodings (`as_public_input` / `from_public_input` of the
+    -- assigned foreign types): a 256-bit field element is two native
+    -- limbs; a point is x-limbs ++ y-limbs ++ an identity flag (widths
+    -- 2 / 2 / 5, ir_types.rs encoded_len).
+    --
+    -- TRUST NOTE (audited 2026-07-24, midnight-circuits 7.2.2): the
+    -- decoders modeled here are the *canonical* partial inverses — they
+    -- reject any limb vector the encoder cannot emit, as the Group C
+    -- `secp*-sound` laws demand.  The deployed off-circuit
+    -- `from_public_input` is laxer: it accepts every in-range limb
+    -- vector, silently reducing integers ≥ the foreign modulus
+    -- (field_chip.rs:141-160), short-circuits on a set identity flag
+    -- without inspecting the coordinate limbs, never rejects flag
+    -- values outside {0,1} (weierstrass_chip.rs:249-268), and panics
+    -- (rather than erroring) on limbs ≥ 2¹⁹².  The `secp*-round` laws
+    -- and both `coordsK` laws were verified TRUE of the same code.
+    -- Consequently the development's theorems transfer to the deployed
+    -- decoder exactly on canonically-encoded preimage/transcript data —
+    -- see spec §9 ("Secp256k1 decode canonicity") and the divergence
+    -- review, finding 5.
+    secpBase→limbs   : SecpBase → Fr × Fr
+    limbs→secpBase   : Fr → Fr → Maybe SecpBase
+    secpScalar→limbs : SecpScalar → Fr × Fr
+    limbs→secpScalar : Fr → Fr → Maybe SecpScalar
+    secpPoint→limbs  : SecpPoint → Fr × Fr × Fr × Fr × Fr
+    limbs→secpPoint  : Fr → Fr → Fr → Fr → Fr → Maybe SecpPoint
+
+    -- Bytes32 conversions (IntoBytes32 / FromBytes32 on the foreign
+    -- fields): `to_bytes_le` and the *total* little-endian reduction
+    -- `from_le_bytes_with_reduction` (non-canonical bytes reduce mod
+    -- the field order).
+    secpBaseToBytes     : SecpBase → Bytes32
+    secpBaseFromBytes   : Bytes32 → SecpBase
+    secpScalarToBytes   : SecpScalar → Bytes32
+    secpScalarFromBytes : Bytes32 → SecpScalar
+
+  ----------------------------------------------------------------------
+  -- Bytes32 ↔ field conversions.
+  ----------------------------------------------------------------------
+
+  field
+    -- IntoBytes32 / FromBytes32 on Native.  `nativeFromBytes` is total
+    -- (non-canonical inputs are reduced modulo the field order).
+    nativeToBytes   : Fr → Bytes32
+    nativeFromBytes : Bytes32 → Fr
+
+    -- The (low, high) decomposition shared by the Bytes32 encoding and
+    -- the Bytes32IntoLowHigh / Bytes32FromLowHigh instructions: `low` is
+    -- the first 31 bytes as a field element, `high` the 32nd byte.
+    -- `low-high→bytes32` is partial (requires low < 2²⁴⁸ and high < 256).
+    bytes32→low-high : Bytes32 → Fr × Fr
+    low-high→bytes32 : Fr → Fr → Maybe Bytes32
+
+  ----------------------------------------------------------------------
+  -- Hashing and the communications commitment.
+  ----------------------------------------------------------------------
+
+  field
+    transient-hash-fn  : List Fr → Fr
+    -- Persistent (SHA-256) and Keccak-256 hashes parse their inputs under
+    -- the alignment, hence partial; each yields a 32-byte digest.
+    -- `persistent-hash-fn` models SHA-256 (`Sha256::digest`); `keccak-fn`
+    -- models Keccak-256.  Both remain opaque.
+    persistent-hash-fn : Alignment → List Fr → Maybe Bytes32
+    keccak-fn          : Alignment → List Fr → Maybe Bytes32
+    -- Communications commitment: transient_commit(values, randomness).
+    transient-commit   : List Fr → Fr → Fr
+
+  ----------------------------------------------------------------------
+  -- Field non-triviality (faithfulness Group A).
+  --
+  -- The only algebraic law assumed about the field operations: `1ᶠ ≢ 0ᶠ`
+  -- bridges `assert` (off-circuit cond = 1ᶠ ⟹ in-circuit cond ≠ 0ᶠ) and
+  -- the boolean reasoning of `not` / `cond-select` / `impact` guards.
+  -- The gate atoms' `holds` clauses relate resolved values through the
+  -- operations themselves, so no further field laws are consumed.
+  ----------------------------------------------------------------------
+
+  field
+    1ᶠ≢0ᶠ : ¬ (1ᶠ ≡ 0ᶠ)
+
+  ----------------------------------------------------------------------
+  -- Canonical valuation (faithfulness Group B).
+  --
+  -- The integer value of a field element, `valFr = bits-to-ℕ ∘
+  -- to-le-bits`.  The range/decomposition contracts (`in-range`,
+  -- `less-than`, `div-mod`, `reconstitute`) and the reconstitute
+  -- no-overflow guard state their numeric bounds directly in terms of
+  -- it; no laws about the valuation are assumed — canonicity of the
+  -- underlying decompositions is part of the trusted chip contracts
+  -- (spec §7.0, decision record).
+  ----------------------------------------------------------------------
+
+  valFr : Fr → ℕ
+  valFr x = bits-to-ℕ (to-le-bits x)
+
+  ----------------------------------------------------------------------
+  -- Typed-encoding round-trips (faithfulness Group C).
+  --
+  -- The decode/encode primitives for the non-native types are mutually
+  -- inverse on valid data: the `*-round` laws give `decode ∘ encode = id`
+  -- (for the backward direction / statement-soundness); the `*-sound`
+  -- laws give `encode ∘ decode = id` on raw data (used by the
+  -- communications-commitment faithfulness case, where the in-circuit
+  -- preimage re-encodes the decoded inputs and must recover the raw
+  -- input stream).  Native carries no law — its encoding is the identity.
+  --
+  -- The `secp*-sound` laws pin the decoders to the canonical partial
+  -- inverses; the deployed off-circuit decoder is laxer (accepts and
+  -- reduces non-canonical limb vectors) — see the TRUST NOTE at the
+  -- limb-encoding fields above and spec §9.
+  ----------------------------------------------------------------------
+
+  field
+    coordsJ-fromCoordsJ : ∀ p → uncurry fromCoordsJ (coordsJ p) ≡ just p
+    fromCoordsJ-coordsJ : ∀ {x y p}
+      → fromCoordsJ x y ≡ just p → coordsJ p ≡ (x , y)
+
+    jubjubScalar-round : ∀ s
+      → jubjubScalarFromFr (jubjubScalarToFr s) ≡ just s
+    jubjubScalar-sound : ∀ {f s}
+      → jubjubScalarFromFr f ≡ just s → jubjubScalarToFr s ≡ f
+
+    bytes32-round : ∀ b
+      → uncurry low-high→bytes32 (bytes32→low-high b) ≡ just b
+    bytes32-sound : ∀ {lo hi b}
+      → low-high→bytes32 lo hi ≡ just b → bytes32→low-high b ≡ (lo , hi)
+
+    secpBase-round : ∀ x
+      → uncurry limbs→secpBase (secpBase→limbs x) ≡ just x
+    secpBase-sound : ∀ {l h x}
+      → limbs→secpBase l h ≡ just x → secpBase→limbs x ≡ (l , h)
+
+    secpScalar-round : ∀ s
+      → uncurry limbs→secpScalar (secpScalar→limbs s) ≡ just s
+    secpScalar-sound : ∀ {l h s}
+      → limbs→secpScalar l h ≡ just s → secpScalar→limbs s ≡ (l , h)
+
+    secpPoint-round : ∀ {p a b c d e}
+      → secpPoint→limbs p ≡ (a , b , c , d , e)
+      → limbs→secpPoint a b c d e ≡ just p
+    secpPoint-sound : ∀ {a b c d e p}
+      → limbs→secpPoint a b c d e ≡ just p
+      → secpPoint→limbs p ≡ (a , b , c , d , e)
+
+    -- Coordinate round-trips (both directions partial: `coordsK` on the
+    -- identity, `fromCoordsK` off-curve).
+    coordsK-fromCoordsK : ∀ {p x y}
+      → coordsK p ≡ just (x , y) → fromCoordsK x y ≡ just p
+    fromCoordsK-coordsK : ∀ {x y p}
+      → fromCoordsK x y ≡ just p → coordsK p ≡ just (x , y)

--- a/formal/src/zkir-v3/Circuit.agda
+++ b/formal/src/zkir-v3/Circuit.agda
@@ -1,0 +1,826 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- In-circuit (constraint-system) semantics of zkir-v3
+-- (ir_vm.rs: `impl Relation for IrSource`, the `circuit` method).
+--
+-- This module defines (spec §7):
+--
+--   • A closed vocabulary of arithmetization primitives (`Constraint`)
+--     and the structural synthesis function (`synth-instr`, `synth`)
+--     that lowers each source instruction to a *list of constraints*,
+--     mirroring §7.2's emission contracts.  Synthesis is a deterministic
+--     function of the source alone — independent of the prover's
+--     preimage (§7.5).
+--
+--   • A witness model (`CircuitWitness`) and the satisfaction relation
+--     (`holds`, `satisfies`).  `holds` is a single interpreter over the
+--     closed `Constraint` vocabulary: every gadget atom requires the
+--     resolved values to stand in the relation given by the
+--     corresponding trust-base function (§7.0, the contract-level
+--     reading).
+--
+-- MODEL.  Unlike zkir-v2 (a positional `List Fr` register file indexed
+-- by `Index`), v3's value store is *named* and *typed*: a constraint
+-- refers to its inputs by `Operand` and to its outputs by `Identifier`,
+-- and resolution reuses the off-circuit modeling of `Semantics`
+-- (`resolveᶜ` mirrors `resolve`).  The deterministic instructions emit a
+-- constraint asserting the same functional relation the off-circuit
+-- `step` computes; the type dispatch matches `Semantics`.
+--
+-- This module defines only the
+-- constraint syntax, the witness, satisfaction, and synthesis; the
+-- faithfulness theorems live in CircuitFaithfulness / CircuitProof.
+------------------------------------------------------------------------
+
+module zkir-v3.Circuit (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+open import zkir-v3.Semantics ⋯ using (valEq?)
+open import zkir-v3.Semantics ⋯ using (χ; pow2ᶠ) public
+
+open import Data.Bool using (Bool; true; false; if_then_else_)
+  renaming (not to bnot)
+open import Data.List using (List; []; _∷_; _++_; _∷ʳ_; length; map; drop;
+                             take)
+open import Data.Maybe using (Maybe; just; nothing; _>>=_)
+open import Data.Nat using (ℕ; zero; suc; _+_; _*_; _^_; _∸_; _<_; _<?_;
+                            _≤_; _⊔_)
+open import Data.Nat.DivMod using (_%_)
+open import Data.Nat.Properties using (≤-trans; m≤m+n; m≤m⊔n; <-≤-trans;
+                                       ^-monoʳ-≤)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.Vec using (reverse)
+open import Data.Unit using (⊤; tt)
+open import Data.Empty using (⊥)
+open import Data.Sum using (_⊎_)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+open import Relation.Nullary using (¬_)
+open import Relation.Nullary.Decidable using (isYes)
+open import Function using (case_of_)
+
+------------------------------------------------------------------------
+-- The circuit witness.
+--
+-- The in-circuit prover commits to:
+--   • `assign` — the value of every named cell (the in-circuit `memory`).
+--   • `pis`    — the public-input vector (binding input, optional
+--                commitment, then the guarded `Impact` groups).
+--   • `comm-rand` — the commitment randomness, present iff the circuit
+--                has a communications commitment.
+------------------------------------------------------------------------
+
+record CircuitWitness : Set where
+  constructor mk-witness
+  field
+    assign    : Identifier → Maybe IrValue
+    pis       : List Fr
+    comm-rand : Maybe Fr
+
+------------------------------------------------------------------------
+-- Resolution against the witness (mirrors `Semantics.resolve`).
+------------------------------------------------------------------------
+
+resolveᶜ : CircuitWitness → Operand → Maybe IrValue
+resolveᶜ w (var id) = CircuitWitness.assign w id
+resolveᶜ w (imm x)  = just (val-native x)
+
+-- Resolve, expecting a Native value (an immediate, or a Native cell).
+resolveᶜ-Fr : CircuitWitness → Operand → Maybe Fr
+resolveᶜ-Fr w op =
+  resolveᶜ w op >>= λ { (val-native x) → just x ; _ → nothing }
+
+-- Resolve a list of operands to Native field values.
+resolveᶜ-all-Fr : CircuitWitness → List Operand → Maybe (List Fr)
+resolveᶜ-all-Fr w []         = just []
+resolveᶜ-all-Fr w (op ∷ ops) =
+  resolveᶜ-Fr w op        >>= λ x  →
+  resolveᶜ-all-Fr w ops   >>= λ xs →
+  just (x ∷ xs)
+
+-- Resolve each operand and flatten its raw encoding (used by `comm`,
+-- which commits to encode(inputs) ‖ encode(outputs), not to Native cells).
+resolve-encode : CircuitWitness → List Operand → Maybe (List Fr)
+resolve-encode w []         = just []
+resolve-encode w (op ∷ ops) =
+  resolveᶜ w op        >>= λ v    →
+  resolve-encode w ops >>= λ rest →
+  just (encodeᵉ v ++ rest)
+
+-- Look up the n-th public-input entry.
+pi-lookup : List Fr → ℕ → Maybe Fr
+pi-lookup []       _       = nothing
+pi-lookup (x ∷ _)  zero    = just x
+pi-lookup (_ ∷ xs) (suc n) = pi-lookup xs n
+
+-- The boolean embedding `χ` and `pow2ᶠ` are shared with `Semantics`
+-- (re-exported at the top of this module).
+
+-- `bits-to-ℕ` and `valFr` come from the trust base (`Assumptions`).
+
+-- v ∈ {0, 1}, the booleanity predicate (an `AssignedBit` conversion).
+is-bit : Fr → Set
+is-bit v = (v ≡ 0ᶠ) ⊎ (v ≡ 1ᶠ)
+
+-- "Operand `op` resolves to value `v`" / "cell `id` holds value `v`":
+-- propositional equalities, for readability in the constraint relations.
+_⊢_↦_ : CircuitWitness → Operand → IrValue → Set
+w ⊢ op ↦ v = resolveᶜ w op ≡ just v
+
+infix 1 _⊢_↦_
+
+_⊢ᶠ_↦_ : CircuitWitness → Operand → Fr → Set
+w ⊢ᶠ op ↦ x = resolveᶜ-Fr w op ≡ just x
+
+infix 1 _⊢ᶠ_↦_
+
+------------------------------------------------------------------------
+-- The evened bit bound of the deployed range chip.
+--
+-- `ZkStdLib.lower_than` requires an even bit bound of at least 4, so the
+-- Rust lowering evens the instruction's `bits` up
+-- (`max(bits + bits % 2, 4)`, ir_vm.rs:966).  The `less-than`
+-- constraint states this bound — the one the deployed circuit enforces —
+-- while the off-circuit run checks the exact `2 ^ bits` bound; for odd
+-- or small `bits` the slack is a witness-shape condition
+-- (`StatementSoundness.WSteps`).
+------------------------------------------------------------------------
+
+even4 : ℕ → ℕ
+even4 bits = (bits + bits % 2) ⊔ 4
+
+bits≤even4 : ∀ bits → bits ≤ even4 bits
+bits≤even4 bits =
+  ≤-trans (m≤m+n bits (bits % 2)) (m≤m⊔n (bits + bits % 2) 4)
+
+-- The exact off-circuit bound implies the chip's evened bound.
+<-even4 : ∀ {v} bits → v < 2 ^ bits → v < 2 ^ even4 bits
+<-even4 bits lt = <-≤-trans lt (^-monoʳ-≤ 2 (bits≤even4 bits))
+
+------------------------------------------------------------------------
+-- Constraints
+--
+-- The closed vocabulary of arithmetization primitives (§7.0).  Inputs
+-- are referenced by `Operand`, outputs by `Identifier`.  A `gate-*`
+-- constructor is a native polynomial relation between resolved values;
+-- every other constructor is a gadget atom whose meaning (`holds`,
+-- below) is fixed by the corresponding trust-base function.
+--
+-- The range/decomposition atoms (`div-mod`, `less-than`, `in-range`,
+-- `reconstitute`) are contract-level like the rest: their `holds`
+-- clauses state the canonical numeric answer directly, trusting the
+-- lookup-based chips that implement them to pin it (spec §7.0).
+-- Canonicity of these decompositions is part of the trusted chip
+-- contract, not derived from gate equations in this development.
+------------------------------------------------------------------------
+
+data Constraint : Set where
+
+  -- add: out = a ⊕ b, where ⊕ is the type-directed addition (Native,
+  -- JubjubPoint, SecpPoint, SecpBase, or SecpScalar) selected by the
+  -- operand types.
+  gate-add
+    : (out : Identifier) → (a b : Operand) → Constraint
+
+  -- mul: out = a · b  (Native, SecpBase, or SecpScalar).
+  gate-mul
+    : (out : Identifier) → (a b : Operand) → Constraint
+
+  -- neg: out = ⊖ a  (Native, JubjubPoint, SecpPoint, SecpBase, or
+  -- SecpScalar).
+  gate-neg
+    : (out : Identifier) → (a : Operand) → Constraint
+
+  -- inv: out = a⁻¹  (Native, SecpBase, or SecpScalar; unsatisfiable on
+  -- a = 0).
+  gate-inv
+    : (out : Identifier) → (a : Operand) → Constraint
+
+  -- copy / encode-component: out holds the resolved value of `a`.
+  gate-copy
+    : (out : Identifier) → (a : Operand) → Constraint
+
+  -- encode(input): the `outputs` hold the raw field elements of `input`.
+  encode-eq
+    : (input : Operand) → (outputs : List Identifier) → Constraint
+
+  -- constrain_eq(a, b): a and b resolve to the same value.
+  eq
+    : (a b : Operand) → Constraint
+
+  -- constrain_to_boolean(v): ⟦v⟧ ∈ {0, 1}.
+  boolean
+    : (v : Operand) → Constraint
+
+  -- assert(c): ⟦c⟧ ≠ 0  (NOT ⟦c⟧ = 1; §7.2).
+  non-zero
+    : (c : Operand) → Constraint
+
+  -- constrain_bits(v, n): ⟦v⟧ < 2ⁿ.
+  in-range
+    : (v : Operand) → (bits : ℕ) → Constraint
+
+  -- cond_select(bit, a, b): bit ∈ {0,1} ∧ out = (if bit then a else b).
+  -- The bit-to-`AssignedBit` conversion adds the booleanity conjunct.
+  select
+    : (out : Identifier) → (bit a b : Operand) → Constraint
+
+  -- test_eq(a, b): out = χ(a = b)  (a Native 0/1 flag).
+  test-eq
+    : (out : Identifier) → (a b : Operand) → Constraint
+
+  -- not(a): a ∈ {0,1} ∧ out = χ(¬a)  (bit conversion adds booleanity).
+  is-not
+    : (out : Identifier) → (a : Operand) → Constraint
+
+  -- less_than(a, b, n): a < 2ᵉ ∧ b < 2ᵉ ∧ out = χ(a < b), where
+  -- e = even4 n is the evened bound the deployed chip enforces.  The
+  -- exact 2ⁿ bound checked off-circuit is a witness-shape condition
+  -- (`WSteps`), not part of the constraint.
+  less-than
+    : (out : Identifier) → (a b : Operand) → (bits : ℕ) → Constraint
+
+  -- div_mod_power_of_two(v, n): out0 = v ≫ n, out1 = v mod 2ⁿ, via the
+  -- canonical little-endian bit decomposition of v.
+  div-mod
+    : (q r : Identifier) → (v : Operand) → (bits : ℕ) → Constraint
+
+  -- reconstitute_field(d, m, n): d < 2^(FR_BITS − n) ∧ m < 2ⁿ ∧
+  -- out = 2ⁿ·d + m.  No field-no-overflow check (a producer obligation).
+  reconstitute
+    : (out : Identifier) → (d m : Operand) → (bits : ℕ) → Constraint
+
+  -- jubjub_scalar_from_native(a): out = native→jubjubScalar a  (Native).
+  scalar-from-native
+    : (out : Identifier) → (a : Operand) → Constraint
+
+  -- transient_hash(I): out = Poseidon(⟦I⟧)  (inputs Native).
+  poseidon
+    : (out : Identifier) → (inputs : List Operand) → Constraint
+
+  -- persistent_hash(α, I): out = SHA-256 digest of ⟦I⟧ under α (Bytes32).
+  sha256
+    : (out : Identifier) → (alignment : Alignment)
+    → (inputs : List Operand) → Constraint
+
+  -- keccak256(α, I): out = Keccak-256 digest of ⟦I⟧ under α (Bytes32).
+  keccak
+    : (out : Identifier) → (alignment : Alignment)
+    → (inputs : List Operand) → Constraint
+
+  -- ec_mul(a, s): out = ⟦s⟧ · ⟦a⟧  (JubjubPoint × JubjubScalar or
+  -- SecpPoint × SecpScalar).
+  ec-mul
+    : (out : Identifier) → (a scalar : Operand) → Constraint
+
+  -- ec_mul_generator(s): out = ⟦s⟧ · G  (JubjubScalar or SecpScalar,
+  -- with the respective curve's generator).
+  ec-gen
+    : (out : Identifier) → (scalar : Operand) → Constraint
+
+  -- hash_to_curve(I): out = H2C(⟦I⟧)  (inputs Native → JubjubPoint).
+  h2c
+    : (out : Identifier) → (inputs : List Operand) → Constraint
+
+  -- into_coordinates(p): (xo, yo) = affine coordinates of ⟦p⟧ (Jubjub,
+  -- or Secp256k1 where the identity is unsatisfiable).
+  into-coords
+    : (xo yo : Identifier) → (point : Operand) → Constraint
+
+  -- from_coordinates(x, y): out = the curve point with coordinates
+  -- (⟦x⟧, ⟦y⟧)  (Jubjub: fails if not in the prime-order subgroup — the
+  -- chip enforces this via in-circuit cofactor-clearing, verified; see
+  -- the note on `fromCoordsJ` in Assumptions and spec §9;
+  -- Secp256k1: fails if not on the curve).
+  from-coords
+    : (out : Identifier) → (x y : Operand) → Constraint
+
+  -- into_bytes32(a): out = the little-endian bytes of ⟦a⟧  (Native,
+  -- SecpBase, or SecpScalar → Bytes32).
+  into-bytes
+    : (out : Identifier) → (a : Operand) → Constraint
+
+  -- from_bytes32(b): out = ⟦b⟧ read as a field element  (Bytes32 →
+  -- Native, SecpBase, or SecpScalar; on the foreign fields non-canonical
+  -- bytes reduce mod the order).
+  from-bytes
+    : (out : Identifier) → (b : Operand) → Constraint
+
+  -- reverse_bytes(b): out = reverse ⟦b⟧  (Bytes32 → Bytes32).
+  reverse-bytes
+    : (out : Identifier) → (b : Operand) → Constraint
+
+  -- bytes32_into_low_high(b): (lo, hi) = low/high split of ⟦b⟧.
+  bytes-into-low-high
+    : (lo hi : Identifier) → (b : Operand) → Constraint
+
+  -- bytes32_from_low_high(lo, hi): out = the Bytes32 reassembled from
+  -- (⟦lo⟧, ⟦hi⟧)  (asserts low < 2²⁴⁸, high < 256).
+  bytes-from-low-high
+    : (out : Identifier) → (lo hi : Operand) → Constraint
+
+  -- Public-input binding: pis[entry] = the binding input the prover
+  -- assigned (a free witness cell, π[0]).  Carries the value as a field.
+  pi-binding
+    : (entry : ℕ) → Constraint
+
+  -- Guarded `Impact` public input: pis[entry] = select(g, ⟦x⟧, 0), where
+  -- the guard `g` is converted to a bit (booleanity).
+  pi-impact
+    : (entry : ℕ) → (guard x : Operand) → Constraint
+
+  -- Communications commitment (§7.4): pis[1] = Poseidon(comm-rand ‖
+  -- encode(inputs) ‖ encode(outputs)), where the in-circuit Poseidon is
+  -- assumed to agree with `transient-commit` (trust base).  `inputs` are
+  -- the operands resolving to the declared circuit inputs, `outputs` the
+  -- operands of the terminal `Output`.
+  comm
+    : (inputs outputs : List Operand) → Constraint
+
+------------------------------------------------------------------------
+-- The constraint system: structurally a list of constraints, plus the
+-- structural shape (PI-vector length, comm-commitment flag).  Determined
+-- by the source alone.
+------------------------------------------------------------------------
+
+record Circuit : Set where
+  constructor mk-circuit
+  field
+    constraints : List Constraint
+    pi-len      : ℕ          -- expected length of the verifier's PI vector
+    has-comm    : Bool
+
+------------------------------------------------------------------------
+-- Satisfaction of a single constraint.
+--
+-- `holds w c` is the proposition "witness `w` satisfies constraint `c`".
+-- Gadget atoms defer to the trust-base functions of `Assumptions`,
+-- baking in the chips' soundness (the contract-level reading, §7.0).
+------------------------------------------------------------------------
+
+-- `bind-each w vs ids`: position-wise, each cell `ids` holds the value
+-- `vs` (the output binding of the `encode-eq` clause of `holds`).  Kept
+-- top-level so the faithfulness proofs can name and transport it.
+bind-each : CircuitWitness → List IrValue → List Identifier → Set
+bind-each w []       []         = ⊤
+bind-each w (v ∷ vs) (id ∷ ids) =
+  (CircuitWitness.assign w id ≡ just v) × bind-each w vs ids
+bind-each w _        _          = ⊥
+
+holds : CircuitWitness → Constraint → Set
+
+holds w (gate-add out a b) =
+  ∃-syntax (λ av → ∃-syntax (λ bv → ∃-syntax (λ ov →
+      (w ⊢ a ↦ av) × (w ⊢ b ↦ bv)
+    × (CircuitWitness.assign w out ≡ just ov)
+    × ( ∃-syntax (λ x → ∃-syntax (λ y →
+          (av ≡ val-native x) × (bv ≡ val-native y)
+        × (ov ≡ val-native (x +ᶠ y))))
+      ⊎ ∃-syntax (λ p → ∃-syntax (λ q →
+          (av ≡ val-jubjub-point p) × (bv ≡ val-jubjub-point q)
+        × (ov ≡ val-jubjub-point (p +J q))))
+      ⊎ ∃-syntax (λ p → ∃-syntax (λ q →
+          (av ≡ val-secp-point p) × (bv ≡ val-secp-point q)
+        × (ov ≡ val-secp-point (p +K q))))
+      ⊎ ∃-syntax (λ x → ∃-syntax (λ y →
+          (av ≡ val-secp-base x) × (bv ≡ val-secp-base y)
+        × (ov ≡ val-secp-base (x +ᵇ y))))
+      ⊎ ∃-syntax (λ x → ∃-syntax (λ y →
+          (av ≡ val-secp-scalar x) × (bv ≡ val-secp-scalar y)
+        × (ov ≡ val-secp-scalar (x +ˢ y))))))))
+
+holds w (gate-mul out a b) =
+  ∃-syntax (λ av → ∃-syntax (λ bv → ∃-syntax (λ ov →
+      (w ⊢ a ↦ av) × (w ⊢ b ↦ bv)
+    × (CircuitWitness.assign w out ≡ just ov)
+    × ( ∃-syntax (λ x → ∃-syntax (λ y →
+          (av ≡ val-native x) × (bv ≡ val-native y)
+        × (ov ≡ val-native (x *ᶠ y))))
+      ⊎ ∃-syntax (λ x → ∃-syntax (λ y →
+          (av ≡ val-secp-base x) × (bv ≡ val-secp-base y)
+        × (ov ≡ val-secp-base (x *ᵇ y))))
+      ⊎ ∃-syntax (λ x → ∃-syntax (λ y →
+          (av ≡ val-secp-scalar x) × (bv ≡ val-secp-scalar y)
+        × (ov ≡ val-secp-scalar (x *ˢ y))))))))
+
+holds w (gate-neg out a) =
+  ∃-syntax (λ av → ∃-syntax (λ ov →
+      (w ⊢ a ↦ av)
+    × (CircuitWitness.assign w out ≡ just ov)
+    × ( ∃-syntax (λ x →
+          (av ≡ val-native x) × (ov ≡ val-native (-ᶠ x)))
+      ⊎ ∃-syntax (λ p →
+          (av ≡ val-jubjub-point p) × (ov ≡ val-jubjub-point (negJ p)))
+      ⊎ ∃-syntax (λ p →
+          (av ≡ val-secp-point p) × (ov ≡ val-secp-point (negK p)))
+      ⊎ ∃-syntax (λ x →
+          (av ≡ val-secp-base x) × (ov ≡ val-secp-base (-ᵇ x)))
+      ⊎ ∃-syntax (λ x →
+          (av ≡ val-secp-scalar x) × (ov ≡ val-secp-scalar (-ˢ x))))))
+
+holds w (gate-inv out a) =
+  ∃-syntax (λ av → ∃-syntax (λ ov →
+      (w ⊢ a ↦ av)
+    × (CircuitWitness.assign w out ≡ just ov)
+    × ( ∃-syntax (λ x → ∃-syntax (λ xi →
+          (av ≡ val-native x) × (invᶠ x ≡ just xi)
+        × (ov ≡ val-native xi)))
+      ⊎ ∃-syntax (λ x → ∃-syntax (λ xi →
+          (av ≡ val-secp-base x) × (invᵇ x ≡ just xi)
+        × (ov ≡ val-secp-base xi)))
+      ⊎ ∃-syntax (λ x → ∃-syntax (λ xi →
+          (av ≡ val-secp-scalar x) × (invˢ x ≡ just xi)
+        × (ov ≡ val-secp-scalar xi))))))
+
+holds w (gate-copy out a) =
+  ∃-syntax (λ av →
+      (w ⊢ a ↦ av) × (CircuitWitness.assign w out ≡ just av))
+
+holds w (encode-eq input outputs) =
+  ∃-syntax (λ v →
+      (w ⊢ input ↦ v)
+    × bind-each w (map val-native (encodeᵉ v)) outputs)
+
+holds w (eq a b) =
+  ∃-syntax (λ v → (w ⊢ a ↦ v) × (w ⊢ b ↦ v))
+
+holds w (boolean v) =
+  ∃-syntax (λ x → (w ⊢ᶠ v ↦ x) × is-bit x)
+
+holds w (non-zero c) =
+  ∃-syntax (λ x → (w ⊢ᶠ c ↦ x) × ¬ (x ≡ 0ᶠ))
+
+holds w (in-range v bits) =
+  ∃-syntax (λ x → (w ⊢ᶠ v ↦ x) × (valFr x < 2 ^ bits))
+
+holds w (select out bit a b) =
+  ∃-syntax (λ bv → ∃-syntax (λ av → ∃-syntax (λ bvl → ∃-syntax (λ ov →
+      (w ⊢ᶠ bit ↦ bv) × (w ⊢ a ↦ av) × (w ⊢ b ↦ bvl)
+    × (CircuitWitness.assign w out ≡ just ov)
+    × is-bit bv
+    × ((bv ≡ 1ᶠ → ov ≡ av) × (bv ≡ 0ᶠ → ov ≡ bvl))))))
+
+holds w (test-eq out a b) =
+  ∃-syntax (λ av → ∃-syntax (λ bv → ∃-syntax (λ eq →
+      (w ⊢ a ↦ av) × (w ⊢ b ↦ bv)
+    × (valEq? av bv ≡ just eq)
+    × (CircuitWitness.assign w out ≡ just (val-native (χ eq))))))
+
+holds w (is-not out a) =
+  ∃-syntax (λ x →
+      (w ⊢ᶠ a ↦ x) × is-bit x
+    × (CircuitWitness.assign w out
+         ≡ just (val-native (χ (bnot (isYes (x ≟ᶠ 1ᶠ)))))))
+  -- The booleanity conjunct restricts `x` to {0,1}; there `isYes (x ≟ᶠ
+  -- 1ᶠ)` is the boolean reading of `x` (matches `Semantics.to𝔹`).
+
+holds w (less-than out a b bits) =
+  ∃-syntax (λ x → ∃-syntax (λ y →
+      (w ⊢ᶠ a ↦ x) × (w ⊢ᶠ b ↦ y)
+    × (valFr x < 2 ^ even4 bits) × (valFr y < 2 ^ even4 bits)
+    × (CircuitWitness.assign w out
+         ≡ just (val-native (χ (isYes (valFr x <? valFr y)))))))
+
+holds w (div-mod q r v bits) =
+  ∃-syntax (λ x →
+      (w ⊢ᶠ v ↦ x)
+    × (CircuitWitness.assign w q
+         ≡ just (val-native (from-le-bits (drop bits (to-le-bits x)))))
+    × (CircuitWitness.assign w r
+         ≡ just (val-native (from-le-bits (take bits (to-le-bits x))))))
+
+holds w (reconstitute out d m bits) =
+  ∃-syntax (λ dv → ∃-syntax (λ mv →
+      (w ⊢ᶠ d ↦ dv) × (w ⊢ᶠ m ↦ mv)
+    × (valFr dv < 2 ^ (FR-BITS ∸ bits)) × (valFr mv < 2 ^ bits)
+    × (CircuitWitness.assign w out
+         ≡ just (val-native ((pow2ᶠ bits *ᶠ dv) +ᶠ mv)))))
+
+holds w (scalar-from-native out a) =
+  ∃-syntax (λ x →
+      (w ⊢ᶠ a ↦ x)
+    × (CircuitWitness.assign w out
+         ≡ just (val-jubjub-scalar (native→jubjubScalar x))))
+
+holds w (poseidon out inputs) =
+  ∃-syntax (λ frs →
+      (resolveᶜ-all-Fr w inputs ≡ just frs)
+    × (CircuitWitness.assign w out
+         ≡ just (val-native (transient-hash-fn frs))))
+
+holds w (sha256 out alignment inputs) =
+  ∃-syntax (λ frs → ∃-syntax (λ v →
+      (resolveᶜ-all-Fr w inputs ≡ just frs)
+    × (persistent-hash-fn alignment frs ≡ just v)
+    × (CircuitWitness.assign w out ≡ just (val-bytes32 v))))
+
+holds w (keccak out alignment inputs) =
+  ∃-syntax (λ frs → ∃-syntax (λ v →
+      (resolveᶜ-all-Fr w inputs ≡ just frs)
+    × (keccak-fn alignment frs ≡ just v)
+    × (CircuitWitness.assign w out ≡ just (val-bytes32 v))))
+
+holds w (ec-mul out a scalar) =
+    ∃-syntax (λ p → ∃-syntax (λ s →
+      (w ⊢ a ↦ val-jubjub-point p) × (w ⊢ scalar ↦ val-jubjub-scalar s)
+    × (CircuitWitness.assign w out ≡ just (val-jubjub-point (s ·J p)))))
+  ⊎ ∃-syntax (λ p → ∃-syntax (λ s →
+      (w ⊢ a ↦ val-secp-point p) × (w ⊢ scalar ↦ val-secp-scalar s)
+    × (CircuitWitness.assign w out ≡ just (val-secp-point (s ·K p)))))
+
+holds w (ec-gen out scalar) =
+    ∃-syntax (λ s →
+      (w ⊢ scalar ↦ val-jubjub-scalar s)
+    × (CircuitWitness.assign w out ≡ just (val-jubjub-point (s ·J genJ))))
+  ⊎ ∃-syntax (λ s →
+      (w ⊢ scalar ↦ val-secp-scalar s)
+    × (CircuitWitness.assign w out ≡ just (val-secp-point (s ·K genK))))
+
+holds w (h2c out inputs) =
+  ∃-syntax (λ frs →
+      (resolveᶜ-all-Fr w inputs ≡ just frs)
+    × (CircuitWitness.assign w out
+         ≡ just (val-jubjub-point (hash-to-curve-fn frs))))
+
+holds w (into-coords xo yo point) =
+    ∃-syntax (λ p → ∃-syntax (λ x → ∃-syntax (λ y →
+      (w ⊢ point ↦ val-jubjub-point p)
+    × (coordsJ p ≡ (x , y))
+    × (CircuitWitness.assign w xo ≡ just (val-native x))
+    × (CircuitWitness.assign w yo ≡ just (val-native y)))))
+  ⊎ ∃-syntax (λ p → ∃-syntax (λ x → ∃-syntax (λ y →
+      (w ⊢ point ↦ val-secp-point p)
+      -- The `just` is the in-circuit `assert_non_zero`: the identity has
+      -- no affine coordinates, and the constraint is unsatisfiable there.
+    × (coordsK p ≡ just (x , y))
+    × (CircuitWitness.assign w xo ≡ just (val-secp-base x))
+    × (CircuitWitness.assign w yo ≡ just (val-secp-base y)))))
+
+holds w (from-coords out x y) =
+    ∃-syntax (λ xv → ∃-syntax (λ yv → ∃-syntax (λ p →
+      (w ⊢ᶠ x ↦ xv) × (w ⊢ᶠ y ↦ yv)
+    × (fromCoordsJ xv yv ≡ just p)
+    × (CircuitWitness.assign w out ≡ just (val-jubjub-point p)))))
+  ⊎ ∃-syntax (λ xv → ∃-syntax (λ yv → ∃-syntax (λ p →
+      (w ⊢ x ↦ val-secp-base xv) × (w ⊢ y ↦ val-secp-base yv)
+    × (fromCoordsK xv yv ≡ just p)
+    × (CircuitWitness.assign w out ≡ just (val-secp-point p)))))
+
+holds w (into-bytes out a) =
+  ∃-syntax (λ av → ∃-syntax (λ ov →
+      (w ⊢ a ↦ av)
+    × (CircuitWitness.assign w out ≡ just ov)
+    × ( ∃-syntax (λ x →
+          (av ≡ val-native x) × (ov ≡ val-bytes32 (nativeToBytes x)))
+      ⊎ ∃-syntax (λ x →
+          (av ≡ val-secp-base x) × (ov ≡ val-bytes32 (secpBaseToBytes x)))
+      ⊎ ∃-syntax (λ s →
+          (av ≡ val-secp-scalar s)
+        × (ov ≡ val-bytes32 (secpScalarToBytes s))))))
+
+-- The target type is not recorded in the constraint (as in the Rust,
+-- the chip is selected by the instruction's `val_t`; the executability
+-- of the declared target is a witness-shape condition, `WShape`).
+holds w (from-bytes out b) =
+  ∃-syntax (λ bs →
+      (w ⊢ b ↦ val-bytes32 bs)
+    × ( (CircuitWitness.assign w out ≡ just (val-native (nativeFromBytes bs)))
+      ⊎ (CircuitWitness.assign w out
+           ≡ just (val-secp-base (secpBaseFromBytes bs)))
+      ⊎ (CircuitWitness.assign w out
+           ≡ just (val-secp-scalar (secpScalarFromBytes bs)))))
+
+holds w (reverse-bytes out b) =
+  ∃-syntax (λ bs →
+      (w ⊢ b ↦ val-bytes32 bs)
+    × (CircuitWitness.assign w out ≡ just (val-bytes32 (reverse bs))))
+
+holds w (bytes-into-low-high lo hi b) =
+  ∃-syntax (λ bs → ∃-syntax (λ l → ∃-syntax (λ h →
+      (w ⊢ b ↦ val-bytes32 bs)
+    × (bytes32→low-high bs ≡ (l , h))
+    × (CircuitWitness.assign w lo ≡ just (val-native l))
+    × (CircuitWitness.assign w hi ≡ just (val-native h)))))
+
+holds w (bytes-from-low-high out lo hi) =
+  ∃-syntax (λ l → ∃-syntax (λ h → ∃-syntax (λ bs →
+      (w ⊢ᶠ lo ↦ l) × (w ⊢ᶠ hi ↦ h)
+    × (low-high→bytes32 l h ≡ just bs)
+    × (CircuitWitness.assign w out ≡ just (val-bytes32 bs)))))
+
+holds w (pi-binding entry) =
+  ∃-syntax (λ bv → pi-lookup (CircuitWitness.pis w) entry ≡ just bv)
+
+holds w (pi-impact entry guard x) =
+  ∃-syntax (λ g → ∃-syntax (λ xv → ∃-syntax (λ pv →
+      (w ⊢ᶠ guard ↦ g) × (w ⊢ᶠ x ↦ xv) × is-bit g
+    × (pi-lookup (CircuitWitness.pis w) entry ≡ just pv)
+    × ((g ≡ 1ᶠ → pv ≡ xv) × (g ≡ 0ᶠ → pv ≡ 0ᶠ)))))
+
+holds w (comm inputs outputs) =
+  ∃-syntax (λ ivs → ∃-syntax (λ ovs → ∃-syntax (λ rv → ∃-syntax (λ pv →
+      (resolve-encode w inputs ≡ just ivs)
+    × (resolve-encode w outputs ≡ just ovs)
+    × (CircuitWitness.comm-rand w ≡ just rv)
+    × (pi-lookup (CircuitWitness.pis w) 1 ≡ just pv)
+    × (pv ≡ transient-commit (ivs ++ ovs) rv)))))
+
+------------------------------------------------------------------------
+-- Conjunctive satisfaction of the whole constraint list.
+------------------------------------------------------------------------
+
+satisfies-constraints : List Constraint → CircuitWitness → Set
+satisfies-constraints []       _ = ⊤
+satisfies-constraints (c ∷ cs) w = holds w c × satisfies-constraints cs w
+
+-- The witness carries commitment randomness iff the circuit has-comm.
+Maybe-shape : Bool → Maybe Fr → Set
+Maybe-shape true  (just _) = ⊤
+Maybe-shape true  nothing  = ⊥
+Maybe-shape false _        = ⊤
+
+-- Top-level satisfaction: all constraints hold, the randomness shape
+-- matches the comm-commitment flag, and the PI vector has the recorded
+-- structural length (= preamble + Σ Impact group sizes).
+record satisfies (c : Circuit) (w : CircuitWitness) : Set where
+  constructor mk-sat
+  field
+    pi-length     : length (CircuitWitness.pis w) ≡ Circuit.pi-len c
+    rand-shape    : Maybe-shape (Circuit.has-comm c) (CircuitWitness.comm-rand w)
+    constraint-ok : satisfies-constraints (Circuit.constraints c) w
+
+------------------------------------------------------------------------
+-- Synthesis
+--
+-- `synth-instr` processes one instruction, appending constraints and
+-- threading the PI-entry cursor and the recorded inputs/outputs used by
+-- the comm-commitment.  It is total (synthesis cannot fail; §7.5) and
+-- preimage-independent.
+------------------------------------------------------------------------
+
+record SynthState : Set where
+  constructor mk-synth
+  field
+    constraints  : List Constraint    -- in emission order
+    next-pi      : ℕ                  -- next PI entry to be assigned
+    output-ops   : List Operand       -- operands of `Output`, in order
+
+private
+  push : SynthState → Constraint → SynthState
+  push st c = record st { constraints = SynthState.constraints st ∷ʳ c }
+
+  push* : SynthState → List Constraint → SynthState
+  push* st cs = record st { constraints = SynthState.constraints st ++ cs }
+
+-- Number of "preamble" PI entries: binding input (+ optional comm).
+preamble-pi-count : Bool → ℕ
+preamble-pi-count true  = 2
+preamble-pi-count false = 1
+
+-- The guarded `Impact` constraints: one PI entry per input, each
+-- `select(guard, x, 0)`, allocated consecutively from `start`.  (Public,
+-- so the faithfulness proof can name and reason about it.)
+impact-constraints : ℕ → Operand → List Operand → List Constraint
+impact-constraints _     _     []         = []
+impact-constraints start guard (x ∷ xs) =
+  pi-impact start guard x ∷ impact-constraints (suc start) guard xs
+
+synth-instr : Instruction → SynthState → SynthState
+
+synth-instr (encode input outputs) st =
+  push st (encode-eq input outputs)
+
+synth-instr (assert cond) st =
+  push st (non-zero cond)
+
+synth-instr (cond-select bit a b output) st =
+  push st (select output bit a b)
+
+synth-instr (constrain-bits val bits) st =
+  push st (in-range val bits)
+
+synth-instr (constrain-eq a b) st =
+  push st (eq a b)
+
+synth-instr (constrain-to-boolean val) st =
+  push st (boolean val)
+
+synth-instr (copy val output) st =
+  push st (gate-copy output val)
+
+synth-instr (impact guard inputs) st =
+  let start = SynthState.next-pi st
+      cs    = impact-constraints start guard inputs
+  in record (push* st cs) { next-pi = start + length inputs }
+
+synth-instr (ec-mul a scalar output) st =
+  push st (ec-mul output a scalar)
+
+synth-instr (ec-mul-generator scalar output) st =
+  push st (ec-gen output scalar)
+
+synth-instr (hash-to-curve inputs output) st =
+  push st (h2c output inputs)
+
+synth-instr (into-coordinates point (xo , yo)) st =
+  push st (into-coords xo yo point)
+
+synth-instr (from-coordinates (x , y) output) st =
+  push st (from-coords output x y)
+
+synth-instr (into-bytes32 input output) st =
+  push st (into-bytes output input)
+
+synth-instr (from-bytes32 bytes val-t output) st =
+  push st (from-bytes output bytes)
+
+synth-instr (reverse-bytes bytes output) st =
+  push st (reverse-bytes output bytes)
+
+synth-instr (bytes32-into-low-high bytes (lo , hi)) st =
+  push st (bytes-into-low-high lo hi bytes)
+
+synth-instr (bytes32-from-low-high (lo , hi) output) st =
+  push st (bytes-from-low-high output lo hi)
+
+synth-instr (div-mod-power-of-two val bits outputs) st =
+  case outputs of λ
+    { (q ∷ r ∷ []) → push st (div-mod q r val bits)
+    ; _            → st }
+  -- WF3 fixes |outputs| = 2; other shapes emit no constraint.
+
+synth-instr (reconstitute-field divisor modulus bits output) st =
+  push st (reconstitute output divisor modulus bits)
+
+synth-instr (transient-hash inputs output) st =
+  push st (poseidon output inputs)
+
+synth-instr (persistent-hash alignment inputs output) st =
+  push st (sha256 output alignment inputs)
+
+synth-instr (keccak256 alignment inputs output) st =
+  push st (keccak output alignment inputs)
+
+synth-instr (test-eq a b output) st =
+  push st (test-eq output a b)
+
+synth-instr (add a b output) st =
+  push st (gate-add output a b)
+
+synth-instr (mul a b output) st =
+  push st (gate-mul output a b)
+
+synth-instr (neg a output) st =
+  push st (gate-neg output a)
+
+synth-instr (inv a output) st =
+  push st (gate-inv output a)
+
+synth-instr (not a output) st =
+  push st (is-not output a)
+
+synth-instr (less-than a b bits output) st =
+  push st (less-than output a b bits)
+
+synth-instr (jubjub-scalar-from-native a output) st =
+  push st (scalar-from-native output a)
+
+synth-instr (public-input guard val-t output) st =
+  st  -- a free witness cell of type `val-t`; the guard is ignored (§7.2).
+
+synth-instr (private-input guard val-t output) st =
+  st  -- as `public-input`: a free witness cell, guard ignored.
+
+synth-instr (circuit-output vals) st =
+  record st { output-ops = SynthState.output-ops st ++ vals }
+
+-- Fold over an instruction list.
+synth-instrs : List Instruction → SynthState → SynthState
+synth-instrs []       st = st
+synth-instrs (i ∷ is) st = synth-instrs is (synth-instr i st)
+
+-- Resolve the declared inputs to operands (their names as variables),
+-- in declaration order, for the comm-commitment preimage.
+input-operands : List TypedIdentifier → List Operand
+input-operands = map (λ ti → var (TypedIdentifier.name ti))
+
+-- Top-level synthesis (§7.1, §7.3).  The PI preamble (binding input,
+-- optional commitment) seeds `next-pi`; the instruction list emits the
+-- per-instruction constraints (including the guarded `Impact` PI
+-- entries); finally, if has-comm, the binding constraint for π[0] and
+-- the comm-commitment over the inputs and outputs are appended.  The PI
+-- length is the preamble plus the total `Impact` group sizes.
+synth : IrSource → Circuit
+synth src =
+  let hc   = IrSource.do-communications-commitment src
+      st₀  = mk-synth (pi-binding 0 ∷ []) (preamble-pi-count hc) []
+      st   = synth-instrs (IrSource.instructions src) st₀
+      ins  = input-operands (IrSource.inputs src)
+      cs   = SynthState.constraints st
+      cs′  = if hc
+             then cs ∷ʳ comm ins (SynthState.output-ops st)
+             else cs
+  in mk-circuit cs′ (SynthState.next-pi st) hc

--- a/formal/src/zkir-v3/CircuitBackward.agda
+++ b/formal/src/zkir-v3/CircuitBackward.agda
@@ -1,0 +1,1175 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Per-instruction BACKWARD faithfulness of zkir-v3.
+--
+-- The converse of the `*-fwd` lemmas: for each instruction, from the
+-- emitted constraint holding at the immediate post-step witness (plus
+-- output freshness and a minimal type-support hypothesis) reconstruct
+-- the off-circuit `step`.  The backward driver (`bwd-go`,
+-- CircuitProof.agda) feeds each lemma its `holds` premise via
+-- `holds-lower` + the spine's monotonicity data.
+------------------------------------------------------------------------
+
+module zkir-v3.CircuitBackward (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Semantics ⋯ using (ProofPreimage; State; resolve; resolveᶠ)
+open import zkir-v3.SemanticsProperties ⋯
+open import zkir-v3.Circuit ⋯
+open import zkir-v3.CircuitBridge ⋯
+
+open import zkir-v3.Semantics ⋯
+  using (Mem; ins; step; to𝔹; out1; valEq?; resolve-all-Fr)
+open import zkir-v3.Semantics ⋯
+  using (insertMany; eval-guard; collectOutputs; _≟LFr_; default-val; run)
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+
+open import Data.Bool using (Bool; true; false; if_then_else_)
+  renaming (not to bnot)
+open import Data.Maybe using (Maybe; just; nothing; _>>=_)
+open import Data.Nat using (ℕ; _+_; _*_; _<?_; _<_; _^_; _∸_)
+open import Data.List using (List; []; _∷_; map; _++_; length; take; drop)
+open import Data.Product using (_×_; _,_; ∃; proj₁; proj₂)
+open import Data.Sum using (inj₁; inj₂; _⊎_)
+open import Data.Unit using (⊤; tt)
+open import Data.Empty using (⊥)
+open import Data.String using () renaming (_≟_ to _≟str_)
+open import Function using (case_of_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; cong₂)
+open import Relation.Nullary using (yes; no; ¬_)
+open import Relation.Nullary.Decidable using (isYes)
+open import Data.Maybe.Properties using (just-injective)
+
+------------------------------------------------------------------------
+-- Per-instruction BACKWARD faithfulness  (deterministic fragment).
+--
+-- The converse of the `*-fwd` lemmas: from the emitted constraint holding
+-- at the immediate post-step witness `witness-of P (out1 st out v)` (the
+-- state where `out` is freshly bound to `v`), plus output freshness and a
+-- minimal type-support hypothesis, conclude the off-circuit step produces
+-- exactly that state.
+--
+-- The type-support hypothesis is stated as an off-circuit resolution at
+-- `st` itself (e.g. `resolve (State.mem st) a ≡ just (val-native x)`).  It
+-- does double duty: it pins the operand type into the supported case that
+-- `step` needs to reduce, AND — being a resolution in `st`, where `out` is
+-- fresh — it rules out an input aliasing the output (which `holds` alone
+-- at the post-witness cannot, since the post-witness binds `out`).
+------------------------------------------------------------------------
+
+-- Backward transport: an operand that resolves off-circuit at `st` and
+-- resolves against the post-step witness resolves to the same value.
+⊢-back : ∀ P st (out : Identifier) v op {w₀ w₁}
+  → State.mem st out ≡ nothing
+  → resolve (State.mem st) op ≡ just w₀
+  → resolveᶜ (witness-of P (out1 st out v)) op ≡ just w₁
+  → w₀ ≡ w₁
+⊢-back P st out v op fresh r₀ r₁ =
+  just-injective (trans (sym (⊢-pres P st out v op fresh r₀)) r₁)
+
+⊢ᶠ-back : ∀ P st (out : Identifier) v op {x₀ x₁}
+  → State.mem st out ≡ nothing
+  → resolveᶠ (State.mem st) op ≡ just x₀
+  → resolveᶜ-Fr (witness-of P (out1 st out v)) op ≡ just x₁
+  → x₀ ≡ x₁
+⊢ᶠ-back P st out v op fresh r₀ r₁ =
+  just-injective (trans (sym (⊢ᶠ-pres P st out v op fresh r₀)) r₁)
+
+-- The freshly-bound cell reads back its value: `assign w out ≡ just ov`
+-- forces `v ≡ ov`.
+out-val : ∀ P st (out : Identifier) v {ov}
+  → CircuitWitness.assign (witness-of P (out1 st out v)) out ≡ just ov
+  → v ≡ ov
+out-val P st out v h = just-injective (trans (sym (assign-here P st out v)) h)
+
+-- `assign w out ≡ just ov` together with `ov ≡ e` gives the output value
+-- `e` that off-circuit `step` wrote back equal to the bound `v` — in the
+-- orientation `step`'s reduced state needs (`e ≡ v`).
+out-back : ∀ P st (out : Identifier) v {ov e}
+  → CircuitWitness.assign (witness-of P (out1 st out v)) out ≡ just ov
+  → ov ≡ e → e ≡ v
+out-back P st out v h ov≡e = sym (trans (out-val P st out v h) ov≡e)
+
+------------------------------------------------------------------------
+-- copy  (single native/any-type input; type already pinned by the
+-- resolution, no extra type hypothesis).
+------------------------------------------------------------------------
+
+copy-bwd : ∀ {P S st output val v w}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) val ≡ just w
+  → holds (witness-of P (out1 st output v)) (gate-copy output val)
+  → step P S st (copy val output) ≡ just (out1 st output v)
+copy-bwd {P} {S} {st} {output} {val} {v} {w} fresh rv (av , ⊢a , ⊢out)
+  rewrite rv =
+    cong (λ z → just (out1 st output z))
+      (trans (⊢-back P st output v val fresh rv ⊢a)
+             (sym (out-val P st output v ⊢out)))
+
+------------------------------------------------------------------------
+-- constrain-eq  (no output; post-state is `st`).
+--
+-- Type support: the operand resolves to a value on which `valEq?` reads
+-- reflexively `true` — i.e. a `valEq?`-supported type (Native / Bytes32 /
+-- JubjubPoint; JubjubScalar is excluded, `valEq?` being `nothing` there).
+------------------------------------------------------------------------
+
+constrain-eq-bwd : ∀ {P S st a b}
+  → (∃ λ av → resolve (State.mem st) a ≡ just av
+                   × valEq? av av ≡ just true)
+  → holds (witness-of P st) (eq a b)
+  → step P S st (constrain-eq a b) ≡ just st
+constrain-eq-bwd {P} {S} {st} {a} {b} (av , ra , veq) (v , ⊢a , ⊢b)
+  with just-injective
+         (trans (sym ra) (trans (sym (resolve-agree P st a)) ⊢a))
+... | refl
+  rewrite ra
+        | trans (sym (resolve-agree P st b)) ⊢b
+        | veq = refl
+
+------------------------------------------------------------------------
+-- add   (Native or JubjubPoint, type-directed).
+------------------------------------------------------------------------
+
+add-bwd : ∀ {P S st a b output v}
+  → State.mem st output ≡ nothing
+  → ( (∃ λ x → ∃ λ y →
+         resolve (State.mem st) a ≡ just (val-native x)
+       × resolve (State.mem st) b ≡ just (val-native y))
+    ⊎ (∃ λ p → ∃ λ q →
+         resolve (State.mem st) a ≡ just (val-jubjub-point p)
+       × resolve (State.mem st) b ≡ just (val-jubjub-point q))
+    ⊎ (∃ λ p → ∃ λ q →
+         resolve (State.mem st) a ≡ just (val-secp-point p)
+       × resolve (State.mem st) b ≡ just (val-secp-point q))
+    ⊎ (∃ λ x → ∃ λ y →
+         resolve (State.mem st) a ≡ just (val-secp-base x)
+       × resolve (State.mem st) b ≡ just (val-secp-base y))
+    ⊎ (∃ λ x → ∃ λ y →
+         resolve (State.mem st) a ≡ just (val-secp-scalar x)
+       × resolve (State.mem st) b ≡ just (val-secp-scalar y)))
+  → holds (witness-of P (out1 st output v)) (gate-add output a b)
+  → step P S st (add a b output) ≡ just (out1 st output v)
+add-bwd {P} {S} {st} {a} {b} {output} {v} fresh (inj₁ (x , y , ra , rb))
+  (av , bv , ov , ⊢a , ⊢b , ⊢out , disj)
+  rewrite ra | rb
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl with disj
+... | inj₂ (inj₁ (_ , _ , () , _))
+... | inj₂ (inj₂ (inj₁ (_ , _ , () , _)))
+... | inj₂ (inj₂ (inj₂ (inj₁ (_ , _ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₂ (_ , _ , () , _))))
+... | inj₁ (x' , y' , eax , eby , eov) with eax | eby
+...   | refl | refl =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+add-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+  (inj₂ (inj₁ (p , q , ra , rb)))
+  (av , bv , ov , ⊢a , ⊢b , ⊢out , disj)
+  rewrite ra | rb
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl with disj
+... | inj₁ (_ , _ , () , _)
+... | inj₂ (inj₂ (inj₁ (_ , _ , () , _)))
+... | inj₂ (inj₂ (inj₂ (inj₁ (_ , _ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₂ (_ , _ , () , _))))
+... | inj₂ (inj₁ (p' , q' , eap , ebq , eov)) with eap | ebq
+...   | refl | refl =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+add-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+  (inj₂ (inj₂ (inj₁ (p , q , ra , rb))))
+  (av , bv , ov , ⊢a , ⊢b , ⊢out , disj)
+  rewrite ra | rb
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl with disj
+... | inj₁ (_ , _ , () , _)
+... | inj₂ (inj₁ (_ , _ , () , _))
+... | inj₂ (inj₂ (inj₂ (inj₁ (_ , _ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₂ (_ , _ , () , _))))
+... | inj₂ (inj₂ (inj₁ (p' , q' , eap , ebq , eov))) with eap | ebq
+...   | refl | refl =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+add-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+  (inj₂ (inj₂ (inj₂ (inj₁ (x , y , ra , rb)))))
+  (av , bv , ov , ⊢a , ⊢b , ⊢out , disj)
+  rewrite ra | rb
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl with disj
+... | inj₁ (_ , _ , () , _)
+... | inj₂ (inj₁ (_ , _ , () , _))
+... | inj₂ (inj₂ (inj₁ (_ , _ , () , _)))
+... | inj₂ (inj₂ (inj₂ (inj₂ (_ , _ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₁ (x' , y' , eax , eby , eov)))) with eax | eby
+...   | refl | refl =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+add-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+  (inj₂ (inj₂ (inj₂ (inj₂ (x , y , ra , rb)))))
+  (av , bv , ov , ⊢a , ⊢b , ⊢out , disj)
+  rewrite ra | rb
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl with disj
+... | inj₁ (_ , _ , () , _)
+... | inj₂ (inj₁ (_ , _ , () , _))
+... | inj₂ (inj₂ (inj₁ (_ , _ , () , _)))
+... | inj₂ (inj₂ (inj₂ (inj₁ (_ , _ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₂ (x' , y' , eax , eby , eov)))) with eax | eby
+...   | refl | refl =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+
+------------------------------------------------------------------------
+-- mul   (Native).
+------------------------------------------------------------------------
+
+mul-bwd : ∀ {P S st a b output v}
+  → State.mem st output ≡ nothing
+  → ( (∃ λ x → ∃ λ y →
+         resolve (State.mem st) a ≡ just (val-native x)
+       × resolve (State.mem st) b ≡ just (val-native y))
+    ⊎ (∃ λ x → ∃ λ y →
+         resolve (State.mem st) a ≡ just (val-secp-base x)
+       × resolve (State.mem st) b ≡ just (val-secp-base y))
+    ⊎ (∃ λ x → ∃ λ y →
+         resolve (State.mem st) a ≡ just (val-secp-scalar x)
+       × resolve (State.mem st) b ≡ just (val-secp-scalar y)))
+  → holds (witness-of P (out1 st output v)) (gate-mul output a b)
+  → step P S st (mul a b output) ≡ just (out1 st output v)
+mul-bwd {P} {S} {st} {a} {b} {output} {v} fresh (inj₁ (x , y , ra , rb))
+  (av , bv , ov , ⊢a , ⊢b , ⊢out , disj)
+  rewrite ra | rb
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl with disj
+... | inj₂ (inj₁ (_ , _ , () , _))
+... | inj₂ (inj₂ (_ , _ , () , _))
+... | inj₁ (x' , y' , eax , eby , eov) with eax | eby
+...   | refl | refl =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+mul-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+  (inj₂ (inj₁ (x , y , ra , rb)))
+  (av , bv , ov , ⊢a , ⊢b , ⊢out , disj)
+  rewrite ra | rb
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl with disj
+... | inj₁ (_ , _ , () , _)
+... | inj₂ (inj₂ (_ , _ , () , _))
+... | inj₂ (inj₁ (x' , y' , eax , eby , eov)) with eax | eby
+...   | refl | refl =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+mul-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+  (inj₂ (inj₂ (x , y , ra , rb)))
+  (av , bv , ov , ⊢a , ⊢b , ⊢out , disj)
+  rewrite ra | rb
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl with disj
+... | inj₁ (_ , _ , () , _)
+... | inj₂ (inj₁ (_ , _ , () , _))
+... | inj₂ (inj₂ (x' , y' , eax , eby , eov)) with eax | eby
+...   | refl | refl =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+
+------------------------------------------------------------------------
+-- neg   (Native or JubjubPoint).
+------------------------------------------------------------------------
+
+neg-bwd : ∀ {P S st a output v}
+  → State.mem st output ≡ nothing
+  → ( (∃ λ x → resolve (State.mem st) a ≡ just (val-native x))
+    ⊎ (∃ λ p → resolve (State.mem st) a ≡ just (val-jubjub-point p))
+    ⊎ (∃ λ p → resolve (State.mem st) a ≡ just (val-secp-point p))
+    ⊎ (∃ λ x → resolve (State.mem st) a ≡ just (val-secp-base x))
+    ⊎ (∃ λ x → resolve (State.mem st) a ≡ just (val-secp-scalar x)))
+  → holds (witness-of P (out1 st output v)) (gate-neg output a)
+  → step P S st (neg a output) ≡ just (out1 st output v)
+neg-bwd {P} {S} {st} {a} {output} {v} fresh (inj₁ (x , ra))
+  (av , ov , ⊢a , ⊢out , disj)
+  rewrite ra with ⊢-back P st output v a fresh ra ⊢a
+... | refl with disj
+... | inj₂ (inj₁ (_ , () , _))
+... | inj₂ (inj₂ (inj₁ (_ , () , _)))
+... | inj₂ (inj₂ (inj₂ (inj₁ (_ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₂ (_ , () , _))))
+... | inj₁ (x' , eax , eov) with eax
+...   | refl = cong (λ z → just (out1 st output z))
+                 (out-back P st output v ⊢out eov)
+neg-bwd {P} {S} {st} {a} {output} {v} fresh (inj₂ (inj₁ (p , ra)))
+  (av , ov , ⊢a , ⊢out , disj)
+  rewrite ra with ⊢-back P st output v a fresh ra ⊢a
+... | refl with disj
+... | inj₁ (_ , () , _)
+... | inj₂ (inj₂ (inj₁ (_ , () , _)))
+... | inj₂ (inj₂ (inj₂ (inj₁ (_ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₂ (_ , () , _))))
+... | inj₂ (inj₁ (p' , eap , eov)) with eap
+...   | refl = cong (λ z → just (out1 st output z))
+                 (out-back P st output v ⊢out eov)
+neg-bwd {P} {S} {st} {a} {output} {v} fresh (inj₂ (inj₂ (inj₁ (p , ra))))
+  (av , ov , ⊢a , ⊢out , disj)
+  rewrite ra with ⊢-back P st output v a fresh ra ⊢a
+... | refl with disj
+... | inj₁ (_ , () , _)
+... | inj₂ (inj₁ (_ , () , _))
+... | inj₂ (inj₂ (inj₂ (inj₁ (_ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₂ (_ , () , _))))
+... | inj₂ (inj₂ (inj₁ (p' , eap , eov))) with eap
+...   | refl = cong (λ z → just (out1 st output z))
+                 (out-back P st output v ⊢out eov)
+neg-bwd {P} {S} {st} {a} {output} {v} fresh
+  (inj₂ (inj₂ (inj₂ (inj₁ (x , ra)))))
+  (av , ov , ⊢a , ⊢out , disj)
+  rewrite ra with ⊢-back P st output v a fresh ra ⊢a
+... | refl with disj
+... | inj₁ (_ , () , _)
+... | inj₂ (inj₁ (_ , () , _))
+... | inj₂ (inj₂ (inj₁ (_ , () , _)))
+... | inj₂ (inj₂ (inj₂ (inj₂ (_ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₁ (x' , eax , eov)))) with eax
+...   | refl = cong (λ z → just (out1 st output z))
+                 (out-back P st output v ⊢out eov)
+neg-bwd {P} {S} {st} {a} {output} {v} fresh
+  (inj₂ (inj₂ (inj₂ (inj₂ (x , ra)))))
+  (av , ov , ⊢a , ⊢out , disj)
+  rewrite ra with ⊢-back P st output v a fresh ra ⊢a
+... | refl with disj
+... | inj₁ (_ , () , _)
+... | inj₂ (inj₁ (_ , () , _))
+... | inj₂ (inj₂ (inj₁ (_ , () , _)))
+... | inj₂ (inj₂ (inj₂ (inj₁ (_ , () , _))))
+... | inj₂ (inj₂ (inj₂ (inj₂ (x' , eax , eov)))) with eax
+...   | refl = cong (λ z → just (out1 st output z))
+                 (out-back P st output v ⊢out eov)
+
+------------------------------------------------------------------------
+-- inv   (Native; `invᶠ` is the off-circuit inverse).
+------------------------------------------------------------------------
+
+inv-bwd : ∀ {P S st a output v}
+  → State.mem st output ≡ nothing
+  → ( (∃ λ x → resolve (State.mem st) a ≡ just (val-native x))
+    ⊎ (∃ λ x → resolve (State.mem st) a ≡ just (val-secp-base x))
+    ⊎ (∃ λ x → resolve (State.mem st) a ≡ just (val-secp-scalar x)))
+  → holds (witness-of P (out1 st output v)) (gate-inv output a)
+  → step P S st (inv a output) ≡ just (out1 st output v)
+inv-bwd {P} {S} {st} {a} {output} {v} fresh (inj₁ (x , ra))
+  (av , ov , ⊢a , ⊢out , disj)
+  rewrite ra with ⊢-back P st output v a fresh ra ⊢a
+... | refl with disj
+... | inj₂ (inj₁ (_ , _ , () , _ , _))
+... | inj₂ (inj₂ (_ , _ , () , _ , _))
+... | inj₁ (x' , xi , eax , ei , eov) with eax
+...   | refl rewrite ei =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+inv-bwd {P} {S} {st} {a} {output} {v} fresh (inj₂ (inj₁ (x , ra)))
+  (av , ov , ⊢a , ⊢out , disj)
+  rewrite ra with ⊢-back P st output v a fresh ra ⊢a
+... | refl with disj
+... | inj₁ (_ , _ , () , _ , _)
+... | inj₂ (inj₂ (_ , _ , () , _ , _))
+... | inj₂ (inj₁ (x' , xi , eax , ei , eov)) with eax
+...   | refl rewrite ei =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+inv-bwd {P} {S} {st} {a} {output} {v} fresh (inj₂ (inj₂ (x , ra)))
+  (av , ov , ⊢a , ⊢out , disj)
+  rewrite ra with ⊢-back P st output v a fresh ra ⊢a
+... | refl with disj
+... | inj₁ (_ , _ , () , _ , _)
+... | inj₂ (inj₁ (_ , _ , () , _ , _))
+... | inj₂ (inj₂ (x' , xi , eax , ei , eov)) with eax
+...   | refl rewrite ei =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out eov)
+
+------------------------------------------------------------------------
+-- test-eq   (output is the 0/1 equality flag; `valEq?`-supported inputs).
+------------------------------------------------------------------------
+
+test-eq-bwd : ∀ {P S st a b output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ av → resolve (State.mem st) a ≡ just av)
+  → (∃ λ bv → resolve (State.mem st) b ≡ just bv)
+  → holds (witness-of P (out1 st output v)) (test-eq output a b)
+  → step P S st (test-eq a b output) ≡ just (out1 st output v)
+test-eq-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+  (av₀ , ra) (bv₀ , rb) (av , bv , e , ⊢a , ⊢b , veq , ⊢out)
+  with ⊢-back P st output v a fresh ra ⊢a
+     | ⊢-back P st output v b fresh rb ⊢b
+... | refl | refl
+  rewrite ra | rb | veq =
+      cong (λ z → just (out1 st output z))
+        (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- jubjub-scalar-from-native.
+------------------------------------------------------------------------
+
+jubjub-scalar-from-native-bwd : ∀ {P S st a output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ x → resolveᶠ (State.mem st) a ≡ just x)
+  → holds (witness-of P (out1 st output v)) (scalar-from-native output a)
+  → step P S st (jubjub-scalar-from-native a output) ≡ just (out1 st output v)
+jubjub-scalar-from-native-bwd {P} {S} {st} {a} {output} {v} fresh
+  (x , ra) (x' , ⊢a , ⊢out)
+  with ⊢ᶠ-back P st output v a fresh ra ⊢a
+... | refl rewrite ra =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- ec-mul   (JubjubPoint × JubjubScalar).
+------------------------------------------------------------------------
+
+ec-mul-bwd : ∀ {P S st a scalar output v}
+  → State.mem st output ≡ nothing
+  → ( ((∃ λ p → resolve (State.mem st) a ≡ just (val-jubjub-point p))
+      × (∃ λ s → resolve (State.mem st) scalar ≡ just (val-jubjub-scalar s)))
+    ⊎ ((∃ λ p → resolve (State.mem st) a ≡ just (val-secp-point p))
+      × (∃ λ s → resolve (State.mem st) scalar ≡ just (val-secp-scalar s))))
+  → holds (witness-of P (out1 st output v)) (ec-mul output a scalar)
+  → step P S st (ec-mul a scalar output) ≡ just (out1 st output v)
+ec-mul-bwd {P} {S} {st} {a} {scalar} {output} {v} fresh
+  (inj₁ ((p , ra) , (s , rs))) (inj₁ (p' , s' , ⊢a , ⊢s , ⊢out))
+  with ⊢-back P st output v a      fresh ra ⊢a
+     | ⊢-back P st output v scalar fresh rs ⊢s
+... | refl | refl rewrite ra | rs =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+ec-mul-bwd {P} {S} {st} {a} {scalar} {output} {v} fresh
+  (inj₁ ((p , ra) , _)) (inj₂ (p' , s' , ⊢a , _))
+  = case ⊢-back P st output v a fresh ra ⊢a of λ ()
+ec-mul-bwd {P} {S} {st} {a} {scalar} {output} {v} fresh
+  (inj₂ ((p , ra) , (s , rs))) (inj₂ (p' , s' , ⊢a , ⊢s , ⊢out))
+  with ⊢-back P st output v a      fresh ra ⊢a
+     | ⊢-back P st output v scalar fresh rs ⊢s
+... | refl | refl rewrite ra | rs =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+ec-mul-bwd {P} {S} {st} {a} {scalar} {output} {v} fresh
+  (inj₂ ((p , ra) , _)) (inj₁ (p' , s' , ⊢a , _))
+  = case ⊢-back P st output v a fresh ra ⊢a of λ ()
+
+------------------------------------------------------------------------
+-- ec-mul-generator   (JubjubScalar).
+------------------------------------------------------------------------
+
+ec-mul-generator-bwd : ∀ {P S st scalar output v}
+  → State.mem st output ≡ nothing
+  → ( (∃ λ s → resolve (State.mem st) scalar ≡ just (val-jubjub-scalar s))
+    ⊎ (∃ λ s → resolve (State.mem st) scalar ≡ just (val-secp-scalar s)))
+  → holds (witness-of P (out1 st output v)) (ec-gen output scalar)
+  → step P S st (ec-mul-generator scalar output) ≡ just (out1 st output v)
+ec-mul-generator-bwd {P} {S} {st} {scalar} {output} {v} fresh
+  (inj₁ (s , rs)) (inj₁ (s' , ⊢s , ⊢out))
+  with ⊢-back P st output v scalar fresh rs ⊢s
+... | refl rewrite rs =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+ec-mul-generator-bwd {P} {S} {st} {scalar} {output} {v} fresh
+  (inj₁ (s , rs)) (inj₂ (s' , ⊢s , _))
+  = case ⊢-back P st output v scalar fresh rs ⊢s of λ ()
+ec-mul-generator-bwd {P} {S} {st} {scalar} {output} {v} fresh
+  (inj₂ (s , rs)) (inj₂ (s' , ⊢s , ⊢out))
+  with ⊢-back P st output v scalar fresh rs ⊢s
+... | refl rewrite rs =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+ec-mul-generator-bwd {P} {S} {st} {scalar} {output} {v} fresh
+  (inj₂ (s , rs)) (inj₁ (s' , ⊢s , _))
+  = case ⊢-back P st output v scalar fresh rs ⊢s of λ ()
+
+------------------------------------------------------------------------
+-- Backward list transport (converse of `⊢all-pres`).
+------------------------------------------------------------------------
+
+⊢all-back : ∀ P st (out : Identifier) v ops {frs₀ frs₁}
+  → State.mem st out ≡ nothing
+  → resolve-all-Fr (State.mem st) ops ≡ just frs₀
+  → resolveᶜ-all-Fr (witness-of P (out1 st out v)) ops ≡ just frs₁
+  → frs₀ ≡ frs₁
+⊢all-back P st out v ops fresh r₀ r₁ =
+  just-injective (trans (sym (⊢all-pres P st out v ops fresh r₀)) r₁)
+
+------------------------------------------------------------------------
+-- hash-to-curve   (Native inputs → JubjubPoint).
+------------------------------------------------------------------------
+
+hash-to-curve-bwd : ∀ {P S st inputs output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ frs → resolve-all-Fr (State.mem st) inputs ≡ just frs)
+  → holds (witness-of P (out1 st output v)) (h2c output inputs)
+  → step P S st (hash-to-curve inputs output) ≡ just (out1 st output v)
+hash-to-curve-bwd {P} {S} {st} {inputs} {output} {v} fresh
+  (frs , ri) (frs' , ⊢i , ⊢out)
+  with ⊢all-back P st output v inputs fresh ri ⊢i
+... | refl rewrite ri =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- transient-hash   (Native inputs → Native).
+------------------------------------------------------------------------
+
+transient-hash-bwd : ∀ {P S st inputs output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ frs → resolve-all-Fr (State.mem st) inputs ≡ just frs)
+  → holds (witness-of P (out1 st output v)) (poseidon output inputs)
+  → step P S st (transient-hash inputs output) ≡ just (out1 st output v)
+transient-hash-bwd {P} {S} {st} {inputs} {output} {v} fresh
+  (frs , ri) (frs' , ⊢i , ⊢out)
+  with ⊢all-back P st output v inputs fresh ri ⊢i
+... | refl rewrite ri =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- into-bytes32   (Native → Bytes32).
+------------------------------------------------------------------------
+
+into-bytes32-bwd : ∀ {P S st input output v}
+  → State.mem st output ≡ nothing
+  → ( (∃ λ x → resolve (State.mem st) input ≡ just (val-native x))
+    ⊎ (∃ λ x → resolve (State.mem st) input ≡ just (val-secp-base x))
+    ⊎ (∃ λ s → resolve (State.mem st) input ≡ just (val-secp-scalar s)))
+  → holds (witness-of P (out1 st output v)) (into-bytes output input)
+  → step P S st (into-bytes32 input output) ≡ just (out1 st output v)
+into-bytes32-bwd {P} {S} {st} {input} {output} {v} fresh (inj₁ (x , ri))
+  (av , ov , ⊢i , ⊢out , disj)
+  rewrite ri with ⊢-back P st output v input fresh ri ⊢i
+... | refl with disj
+... | inj₂ (inj₁ (_ , () , _))
+... | inj₂ (inj₂ (_ , () , _))
+... | inj₁ (x' , eax , eov) with eax
+...   | refl = cong (λ z → just (out1 st output z))
+                 (out-back P st output v ⊢out eov)
+into-bytes32-bwd {P} {S} {st} {input} {output} {v} fresh
+  (inj₂ (inj₁ (x , ri))) (av , ov , ⊢i , ⊢out , disj)
+  rewrite ri with ⊢-back P st output v input fresh ri ⊢i
+... | refl with disj
+... | inj₁ (_ , () , _)
+... | inj₂ (inj₂ (_ , () , _))
+... | inj₂ (inj₁ (x' , eax , eov)) with eax
+...   | refl = cong (λ z → just (out1 st output z))
+                 (out-back P st output v ⊢out eov)
+into-bytes32-bwd {P} {S} {st} {input} {output} {v} fresh
+  (inj₂ (inj₂ (s , ri))) (av , ov , ⊢i , ⊢out , disj)
+  rewrite ri with ⊢-back P st output v input fresh ri ⊢i
+... | refl with disj
+... | inj₁ (_ , () , _)
+... | inj₂ (inj₁ (_ , () , _))
+... | inj₂ (inj₂ (s' , eax , eov)) with eax
+...   | refl = cong (λ z → just (out1 st output z))
+                 (out-back P st output v ⊢out eov)
+
+------------------------------------------------------------------------
+-- from-bytes32   (Bytes32 → Native / SecpBase / SecpScalar).
+--
+-- The target type `val-t` is part of the instruction and selects the
+-- conversion chip; `step` succeeds at the three field targets and the
+-- output is a total function of the resolved bytes.  Because the emitted
+-- constraint `from-bytes` leaves the output type as a *disjunction*, the
+-- output value is not pinned by `holds`; the run's own step determines it.
+-- One lemma per succeeding `val-t`, each stating the concrete output.
+------------------------------------------------------------------------
+
+from-bytes32-native-bwd : ∀ {P S st bytes output b}
+  → resolve (State.mem st) bytes ≡ just (val-bytes32 b)
+  → step P S st (from-bytes32 bytes native output)
+      ≡ just (out1 st output (val-native (nativeFromBytes b)))
+from-bytes32-native-bwd rb rewrite rb = refl
+
+from-bytes32-secp-base-bwd : ∀ {P S st bytes output b}
+  → resolve (State.mem st) bytes ≡ just (val-bytes32 b)
+  → step P S st (from-bytes32 bytes secp-base output)
+      ≡ just (out1 st output (val-secp-base (secpBaseFromBytes b)))
+from-bytes32-secp-base-bwd rb rewrite rb = refl
+
+from-bytes32-secp-scalar-bwd : ∀ {P S st bytes output b}
+  → resolve (State.mem st) bytes ≡ just (val-bytes32 b)
+  → step P S st (from-bytes32 bytes secp-scalar output)
+      ≡ just (out1 st output (val-secp-scalar (secpScalarFromBytes b)))
+from-bytes32-secp-scalar-bwd rb rewrite rb = refl
+
+------------------------------------------------------------------------
+-- reverse-bytes   (Bytes32 → Bytes32).
+------------------------------------------------------------------------
+
+reverse-bytes-bwd : ∀ {P S st bytes output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ b → resolve (State.mem st) bytes ≡ just (val-bytes32 b))
+  → holds (witness-of P (out1 st output v)) (reverse-bytes output bytes)
+  → step P S st (reverse-bytes bytes output) ≡ just (out1 st output v)
+reverse-bytes-bwd {P} {S} {st} {bytes} {output} {v} fresh
+  (b , rb) (bs , ⊢b , ⊢out)
+  with ⊢-back P st output v bytes fresh rb ⊢b
+... | refl rewrite rb =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- from-coordinates   (Native × Native → JubjubPoint).
+------------------------------------------------------------------------
+
+from-coordinates-bwd : ∀ {P S st xop yop output v}
+  → State.mem st output ≡ nothing
+  → ( ((∃ λ x → resolve (State.mem st) xop ≡ just (val-native x))
+      × (∃ λ y → resolve (State.mem st) yop ≡ just (val-native y)))
+    ⊎ ((∃ λ x → resolve (State.mem st) xop ≡ just (val-secp-base x))
+      × (∃ λ y → resolve (State.mem st) yop ≡ just (val-secp-base y))))
+  → holds (witness-of P (out1 st output v)) (from-coords output xop yop)
+  → step P S st (from-coordinates (xop , yop) output) ≡ just (out1 st output v)
+from-coordinates-bwd {P} {S} {st} {xop} {yop} {output} {v} fresh
+  (inj₁ ((x , rx) , (y , ry))) (inj₁ (xv , yv , p , ⊢x , ⊢y , efc , ⊢out))
+  with ⊢ᶠ-back P st output v xop fresh (resolveᶠ-intro (State.mem st) xop rx) ⊢x
+     | ⊢ᶠ-back P st output v yop fresh (resolveᶠ-intro (State.mem st) yop ry) ⊢y
+... | refl | refl rewrite rx | ry | efc =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+from-coordinates-bwd {P} {S} {st} {xop} {yop} {output} {v} fresh
+  (inj₁ ((x , rx) , _)) (inj₂ (xv , yv , p , ⊢x , _))
+  = case ⊢-back P st output v xop fresh rx ⊢x of λ ()
+from-coordinates-bwd {P} {S} {st} {xop} {yop} {output} {v} fresh
+  (inj₂ ((x , rx) , (y , ry))) (inj₂ (xv , yv , p , ⊢x , ⊢y , efcK , ⊢out))
+  with ⊢-back P st output v xop fresh rx ⊢x
+     | ⊢-back P st output v yop fresh ry ⊢y
+... | refl | refl rewrite rx | ry | efcK =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+from-coordinates-bwd {P} {S} {st} {xop} {yop} {output} {v} fresh
+  (inj₂ ((x , rx) , _)) (inj₁ (xv , yv , p , ⊢x , _))
+  = case ⊢-back P st output v xop fresh rx
+           (resolveᶜ-Fr-inv (witness-of P (out1 st output v)) xop ⊢x) of λ ()
+
+------------------------------------------------------------------------
+-- bytes32-from-low-high   (Native × Native → Bytes32).
+------------------------------------------------------------------------
+
+bytes32-from-low-high-bwd : ∀ {P S st loop hiop output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ lo → resolveᶠ (State.mem st) loop ≡ just lo)
+  → (∃ λ hi → resolveᶠ (State.mem st) hiop ≡ just hi)
+  → holds (witness-of P (out1 st output v)) (bytes-from-low-high output loop hiop)
+  → step P S st (bytes32-from-low-high (loop , hiop) output)
+      ≡ just (out1 st output v)
+bytes32-from-low-high-bwd {P} {S} {st} {loop} {hiop} {output} {v} fresh
+  (lo , rl) (hi , rh) (l , h , bs , ⊢l , ⊢h , eb , ⊢out)
+  with ⊢ᶠ-back P st output v loop fresh rl ⊢l
+     | ⊢ᶠ-back P st output v hiop fresh rh ⊢h
+... | refl | refl rewrite rl | rh | eb =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- Backward transport across two distinct fresh bindings.
+------------------------------------------------------------------------
+
+⊢-back2 : ∀ P st (i₁ : Identifier) v₁ (i₂ : Identifier) v₂ op {w₀ w₁}
+  → State.mem st i₁ ≡ nothing → State.mem st i₂ ≡ nothing → ¬ (i₂ ≡ i₁)
+  → resolve (State.mem st) op ≡ just w₀
+  → resolveᶜ (witness-of P (out1 (out1 st i₁ v₁) i₂ v₂)) op ≡ just w₁
+  → w₀ ≡ w₁
+⊢-back2 P st i₁ v₁ i₂ v₂ op f₁ f₂ i₂≢i₁ r₀ r₁ =
+  just-injective
+    (trans (sym (⊢-pres2 P st i₁ v₁ i₂ v₂ op f₁ f₂ i₂≢i₁ r₀)) r₁)
+
+⊢ᶠ-back2 : ∀ P st (i₁ : Identifier) v₁ (i₂ : Identifier) v₂ op {x₀ x₁}
+  → State.mem st i₁ ≡ nothing → State.mem st i₂ ≡ nothing → ¬ (i₂ ≡ i₁)
+  → resolveᶠ (State.mem st) op ≡ just x₀
+  → resolveᶜ-Fr (witness-of P (out1 (out1 st i₁ v₁) i₂ v₂)) op ≡ just x₁
+  → x₀ ≡ x₁
+⊢ᶠ-back2 P st i₁ v₁ i₂ v₂ op f₁ f₂ i₂≢i₁ r₀ r₁ =
+  just-injective
+    (trans (sym (⊢ᶠ-pres2 P st i₁ v₁ i₂ v₂ op f₁ f₂ i₂≢i₁ r₀)) r₁)
+
+-- The two output cells read back their bound values.
+out-val-inner : ∀ P st (i₁ : Identifier) v₁ (i₂ : Identifier) v₂ {ov}
+  → ¬ (i₁ ≡ i₂)
+  → CircuitWitness.assign (witness-of P (out1 (out1 st i₁ v₁) i₂ v₂)) i₁
+      ≡ just ov
+  → ov ≡ v₁
+out-val-inner P st i₁ v₁ i₂ v₂ i₁≢i₂ h =
+  sym (just-injective (trans (sym (assign-inner P st i₁ v₁ i₂ v₂ i₁≢i₂)) h))
+
+out-val-outer : ∀ P st (i₁ : Identifier) v₁ (i₂ : Identifier) v₂ {ov}
+  → CircuitWitness.assign (witness-of P (out1 (out1 st i₁ v₁) i₂ v₂)) i₂
+      ≡ just ov
+  → ov ≡ v₂
+out-val-outer P st i₁ v₁ i₂ v₂ h =
+  sym (just-injective (trans (sym (assign-outer P st i₁ v₁ i₂ v₂)) h))
+
+------------------------------------------------------------------------
+-- into-coordinates   (JubjubPoint → Native × Native, two distinct outs).
+------------------------------------------------------------------------
+
+into-coordinates-bwd : ∀ {P S st point xid yid v₁ v₂}
+  → State.mem st xid ≡ nothing → State.mem st yid ≡ nothing → ¬ (xid ≡ yid)
+  → ( (∃ λ p → resolve (State.mem st) point ≡ just (val-jubjub-point p))
+    ⊎ (∃ λ p → resolve (State.mem st) point ≡ just (val-secp-point p)))
+  → holds (witness-of P (out1 (out1 st xid v₁) yid v₂)) (into-coords xid yid point)
+  → step P S st (into-coordinates point (xid , yid))
+      ≡ just (out1 (out1 st xid v₁) yid v₂)
+into-coordinates-bwd {P} {S} {st} {point} {xid} {yid} {v₁} {v₂}
+  fx fy xid≢yid (inj₁ (p , rp)) (inj₁ (p' , x , y , ⊢p , ecoords , ⊢x , ⊢y))
+  with ⊢-back2 P st xid v₁ yid v₂ point fx fy (λ y≡x → xid≢yid (sym y≡x)) rp ⊢p
+... | refl rewrite rp | ecoords =
+      cong₂ (λ z₁ z₂ → just (out1 (out1 st xid z₁) yid z₂))
+        (out-val-inner P st xid v₁ yid v₂ xid≢yid ⊢x)
+        (out-val-outer P st xid v₁ yid v₂ ⊢y)
+into-coordinates-bwd {P} {S} {st} {point} {xid} {yid} {v₁} {v₂}
+  fx fy xid≢yid (inj₁ (p , rp)) (inj₂ (p' , x , y , ⊢p , _))
+  = case ⊢-back2 P st xid v₁ yid v₂ point fx fy
+           (λ y≡x → xid≢yid (sym y≡x)) rp ⊢p of λ ()
+into-coordinates-bwd {P} {S} {st} {point} {xid} {yid} {v₁} {v₂}
+  fx fy xid≢yid (inj₂ (p , rp)) (inj₂ (p' , x , y , ⊢p , ecoordsK , ⊢x , ⊢y))
+  with ⊢-back2 P st xid v₁ yid v₂ point fx fy (λ y≡x → xid≢yid (sym y≡x)) rp ⊢p
+... | refl rewrite rp | ecoordsK =
+      cong₂ (λ z₁ z₂ → just (out1 (out1 st xid z₁) yid z₂))
+        (out-val-inner P st xid v₁ yid v₂ xid≢yid ⊢x)
+        (out-val-outer P st xid v₁ yid v₂ ⊢y)
+into-coordinates-bwd {P} {S} {st} {point} {xid} {yid} {v₁} {v₂}
+  fx fy xid≢yid (inj₂ (p , rp)) (inj₁ (p' , x , y , ⊢p , _))
+  = case ⊢-back2 P st xid v₁ yid v₂ point fx fy
+           (λ y≡x → xid≢yid (sym y≡x)) rp ⊢p of λ ()
+
+------------------------------------------------------------------------
+-- bytes32-into-low-high   (Bytes32 → Native × Native, two distinct outs).
+------------------------------------------------------------------------
+
+bytes32-into-low-high-bwd : ∀ {P S st bytes loid hiid v₁ v₂}
+  → State.mem st loid ≡ nothing → State.mem st hiid ≡ nothing → ¬ (loid ≡ hiid)
+  → (∃ λ b → resolve (State.mem st) bytes ≡ just (val-bytes32 b))
+  → holds (witness-of P (out1 (out1 st loid v₁) hiid v₂))
+          (bytes-into-low-high loid hiid bytes)
+  → step P S st (bytes32-into-low-high bytes (loid , hiid))
+      ≡ just (out1 (out1 st loid v₁) hiid v₂)
+bytes32-into-low-high-bwd {P} {S} {st} {bytes} {loid} {hiid} {v₁} {v₂}
+  fl fh loid≢hiid (b , rb) (bs , lo , hi , ⊢b , esplit , ⊢lo , ⊢hi)
+  with ⊢-back2 P st loid v₁ hiid v₂ bytes fl fh
+         (λ h≡l → loid≢hiid (sym h≡l)) rb ⊢b
+... | refl rewrite rb | esplit =
+      cong₂ (λ z₁ z₂ → just (out1 (out1 st loid z₁) hiid z₂))
+        (out-val-inner P st loid v₁ hiid v₂ loid≢hiid ⊢lo)
+        (out-val-outer P st loid v₁ hiid v₂ ⊢hi)
+
+------------------------------------------------------------------------
+-- div-mod-power-of-two   (two distinct outputs q, r).
+------------------------------------------------------------------------
+
+div-mod-power-of-two-bwd : ∀ {P S st val bits q r v₁ v₂}
+  → State.mem st q ≡ nothing → State.mem st r ≡ nothing → ¬ (q ≡ r)
+  → (∃ λ x → resolveᶠ (State.mem st) val ≡ just x)
+  → holds (witness-of P (out1 (out1 st q v₁) r v₂)) (div-mod q r val bits)
+  → step P S st (div-mod-power-of-two val bits (q ∷ r ∷ []))
+      ≡ just (out1 (out1 st q v₁) r v₂)
+div-mod-power-of-two-bwd {P} {S} {st} {val} {bits} {q} {r} {v₁} {v₂}
+  fq fr q≢r (x , rf) (x' , ⊢v , ⊢q , ⊢r)
+  with ⊢ᶠ-back2 P st q v₁ r v₂ val fq fr (λ r≡q → q≢r (sym r≡q)) rf ⊢v
+... | refl rewrite rf =
+      cong₂ (λ z₁ z₂ → just (out1 (out1 st q z₁) r z₂))
+        (out-val-inner P st q v₁ r v₂ q≢r ⊢q)
+        (out-val-outer P st q v₁ r v₂ ⊢r)
+
+------------------------------------------------------------------------
+-- persistent-hash   (Native inputs → single Bytes32 output).
+------------------------------------------------------------------------
+
+persistent-hash-bwd : ∀ {P S st alignment inputs output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ frs → resolve-all-Fr (State.mem st) inputs ≡ just frs)
+  → holds (witness-of P (out1 st output v)) (sha256 output alignment inputs)
+  → step P S st (persistent-hash alignment inputs output)
+      ≡ just (out1 st output v)
+persistent-hash-bwd {P} {S} {st} {alignment} {inputs} {output} {v} fresh
+  (frs , ri) (frs' , hv , ⊢i , ehp , ⊢out)
+  with ⊢all-back P st output v inputs fresh ri ⊢i
+... | refl rewrite ri | ehp =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- keccak256   (Native inputs → single Bytes32 output).
+------------------------------------------------------------------------
+
+keccak256-bwd : ∀ {P S st alignment inputs output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ frs → resolve-all-Fr (State.mem st) inputs ≡ just frs)
+  → holds (witness-of P (out1 st output v)) (keccak output alignment inputs)
+  → step P S st (keccak256 alignment inputs output)
+      ≡ just (out1 st output v)
+keccak256-bwd {P} {S} {st} {alignment} {inputs} {output} {v} fresh
+  (frs , ri) (frs' , hv , ⊢i , ehk , ⊢out)
+  with ⊢all-back P st output v inputs fresh ri ⊢i
+... | refl rewrite ri | ehk =
+      cong (λ z → just (out1 st output z)) (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- encode   (input → `insertMany` of its encoding onto `outputs`).
+--
+-- The operational converse of `encode-fwd`.  The post-state is the
+-- `insertMany` result — encode's only per-cell content is that each
+-- output holds its encoding element, which `insertMany` establishes by
+-- construction; `bind-each` (hence `encode-eq`) forces the output/encoding
+-- lengths to agree, so `insertMany` succeeds.  Both facts are captured by
+-- the `insertMany … ≡ just st'` premise, which names the post-state.
+------------------------------------------------------------------------
+
+encode-bwd : ∀ {P S st input outputs v st'}
+  → resolve (State.mem st) input ≡ just v
+  → insertMany st outputs (map val-native (encodeᵉ v)) ≡ just st'
+  → step P S st (encode input outputs) ≡ just st'
+encode-bwd {P} {S} {st} {input} {outputs} {v} {st'} ri im
+  rewrite ri = im
+
+------------------------------------------------------------------------
+-- assert   (no output; post-state is `st`).
+--
+-- Obligation: the condition resolves to a field element whose boolean
+-- reading is `true` (`to𝔹 x ≡ just true`).  `non-zero` alone gives only
+-- `x ≢ 0ᶠ`; running `step` backward needs the guard to read `true`, which
+-- for a booleanity-restricted `x` means `x ≡ 1ᶠ`.
+------------------------------------------------------------------------
+
+assert-bwd : ∀ {P S st cond}
+  → (∃ λ x → resolveᶠ (State.mem st) cond ≡ just x × to𝔹 x ≡ just true)
+  → step P S st (assert cond) ≡ just st
+assert-bwd {P} {S} {st} {cond} (x , rf , tb)
+  rewrite rf | tb = refl
+
+------------------------------------------------------------------------
+-- constrain-to-boolean   (no output; post-state is `st`).
+--
+-- Obligation: the `boolean` constraint holds at the pre-step witness.  Its
+-- `is-bit` conjunct restricts the resolved value to `{0,1}`, so `to𝔹`
+-- succeeds and `resolve𝔹` produces a bit; the resolution itself is read
+-- off the constraint (via `resolveᶜ-Fr-agree`, the post-state being `st`).
+------------------------------------------------------------------------
+
+constrain-to-boolean-bwd : ∀ {P S st val}
+  → holds (witness-of P st) (boolean val)
+  → step P S st (constrain-to-boolean val) ≡ just st
+constrain-to-boolean-bwd {P} {S} {st} {val} (x , ⊢val , inj₁ x≡0)
+  rewrite trans (sym (resolveᶜ-Fr-agree P st val)) ⊢val | x≡0 with 0ᶠ ≟ᶠ 0ᶠ
+... | yes _  = refl
+... | no ¬p  = case ¬p refl of λ ()
+constrain-to-boolean-bwd {P} {S} {st} {val} (x , ⊢val , inj₂ x≡1)
+  rewrite trans (sym (resolveᶜ-Fr-agree P st val)) ⊢val | x≡1 with 1ᶠ ≟ᶠ 0ᶠ
+... | no _   with 1ᶠ ≟ᶠ 1ᶠ
+...   | yes _  = refl
+...   | no ¬p  = case ¬p refl of λ ()
+constrain-to-boolean-bwd {P} {S} {st} {val} (x , ⊢val , inj₂ x≡1)
+    | yes 1≡0 = case 1ᶠ≢0ᶠ 1≡0 of λ ()
+
+------------------------------------------------------------------------
+-- not   (booleanity from the constraint).
+--
+-- Obligation: the operand resolves off-circuit (`∃ x`).  Booleanity is
+-- supplied by the `is-not` constraint's own `is-bit` conjunct (at the
+-- post-step witness, transported to the pre-step resolution by
+-- `⊢ᶠ-back`, since the output is fresh).  Under `is-bit`, `to𝔹 x` agrees
+-- with the in-circuit reading `isYes (x ≟ᶠ 1ᶠ)`, so the off-circuit output
+-- `χ (bnot (to𝔹 x))` matches the value `is-not` records.
+------------------------------------------------------------------------
+
+not-bwd : ∀ {P S st a output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ x → resolveᶠ (State.mem st) a ≡ just x)
+  → holds (witness-of P (out1 st output v)) (is-not output a)
+  → step P S st (not a output) ≡ just (out1 st output v)
+not-bwd {P} {S} {st} {a} {output} {v} fresh (x , rf)
+  (x' , ⊢a , inj₁ x'≡0 , ⊢out)
+  with ⊢ᶠ-back P st output v a fresh rf ⊢a
+... | refl rewrite rf | x'≡0 with 0ᶠ ≟ᶠ 0ᶠ | 0ᶠ ≟ᶠ 1ᶠ
+...   | yes _ | no _   =
+        cong (λ z → just (out1 st output z))
+          (out-back P st output v ⊢out refl)
+...   | yes _ | yes 0≡1 = case 1ᶠ≢0ᶠ (sym 0≡1) of λ ()
+...   | no ¬p | _       = case ¬p refl of λ ()
+not-bwd {P} {S} {st} {a} {output} {v} fresh (x , rf)
+  (x' , ⊢a , inj₂ x'≡1 , ⊢out)
+  with ⊢ᶠ-back P st output v a fresh rf ⊢a
+... | refl rewrite rf | x'≡1 with 1ᶠ ≟ᶠ 0ᶠ
+...   | no _ with 1ᶠ ≟ᶠ 1ᶠ
+...     | yes _ =
+          cong (λ z → just (out1 st output z))
+            (out-back P st output v ⊢out refl)
+...     | no ¬p = case ¬p refl of λ ()
+not-bwd {P} {S} {st} {a} {output} {v} fresh (x , rf)
+  (x' , ⊢a , inj₂ x'≡1 , ⊢out)
+    | refl | yes 1≡0 = case 1ᶠ≢0ᶠ 1≡0 of λ ()
+
+------------------------------------------------------------------------
+-- cond-select   (booleanity of the selector + a type match).
+--
+-- Obligations: the selector resolves off-circuit (`∃ x`); each branch
+-- resolves; the two branches share a type (`typeof av ≡ typeof bvl`, the
+-- `guardD (… ≟T …)` off-circuit `step` enforces).  Booleanity of the
+-- selector is supplied by the `select` constraint's own `is-bit bv`
+-- conjunct (transported to the pre-step resolution by `⊢ᶠ-back`, the
+-- output being fresh).  Under `is-bit`, the off-circuit `if to𝔹 bit …`
+-- picks exactly the branch the two `select` implications constrain the
+-- output to.
+------------------------------------------------------------------------
+
+cond-select-bwd : ∀ {P S st bit a b output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ x → resolveᶠ (State.mem st) bit ≡ just x)
+  → (∃ λ av → resolve (State.mem st) a ≡ just av
+       × ∃ λ bvl → resolve (State.mem st) b ≡ just bvl
+                        × typeof av ≡ typeof bvl)
+  → holds (witness-of P (out1 st output v)) (select output bit a b)
+  → step P S st (cond-select bit a b output) ≡ just (out1 st output v)
+cond-select-bwd {P} {S} {st} {bit} {a} {b} {output} {v} fresh
+  (x , rbit) (av₀ , ra , bvl₀ , rb , ta≡tb)
+  (bv , av , bvl , ov , ⊢bit , ⊢a , ⊢b , ⊢out , inj₁ bv≡0 , _ , imp0)
+  with ⊢ᶠ-back P st output v bit fresh rbit ⊢bit
+     | ⊢-back  P st output v a   fresh ra   ⊢a
+     | ⊢-back  P st output v b   fresh rb   ⊢b
+... | refl | refl | refl
+  rewrite rbit | ra | rb | bv≡0 with 0ᶠ ≟ᶠ 0ᶠ
+...   | no ¬p = case ¬p refl of λ ()
+...   | yes _ with typeof av₀ ≟T typeof bvl₀
+...     | no ¬t = case ¬t ta≡tb of λ ()
+...     | yes _ =
+          cong (λ z → just (out1 st output z))
+            (out-back P st output v ⊢out (imp0 refl))
+cond-select-bwd {P} {S} {st} {bit} {a} {b} {output} {v} fresh
+  (x , rbit) (av₀ , ra , bvl₀ , rb , ta≡tb)
+  (bv , av , bvl , ov , ⊢bit , ⊢a , ⊢b , ⊢out , inj₂ bv≡1 , imp1 , _)
+  with ⊢ᶠ-back P st output v bit fresh rbit ⊢bit
+     | ⊢-back  P st output v a   fresh ra   ⊢a
+     | ⊢-back  P st output v b   fresh rb   ⊢b
+... | refl | refl | refl
+  rewrite rbit | ra | rb | bv≡1 with 1ᶠ ≟ᶠ 0ᶠ
+...   | yes 1≡0 = case 1ᶠ≢0ᶠ 1≡0 of λ ()
+...   | no _ with 1ᶠ ≟ᶠ 1ᶠ
+...     | no ¬p = case ¬p refl of λ ()
+...     | yes _ with typeof av₀ ≟T typeof bvl₀
+...       | no ¬t = case ¬t ta≡tb of λ ()
+...       | yes _ =
+            cong (λ z → just (out1 st output z))
+              (out-back P st output v ⊢out (imp1 refl))
+
+------------------------------------------------------------------------
+-- less-than   (exact range bounds carried as side data).
+--
+-- Obligation: both operands resolve AND satisfy the exact `2 ^ bits`
+-- bound the off-circuit step checks.  The constraint `less-than` pins
+-- only the chip's evened `2 ^ even4 bits` bound, which is too weak for
+-- odd or small `bits`; the exact bounds are therefore step side data
+-- (`BwdStep` / `WSteps`), consumed here after the operand values are
+-- pinned by `⊢ᶠ-back`.
+------------------------------------------------------------------------
+
+less-than-bwd : ∀ {P S st a b bits output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ x → resolveᶠ (State.mem st) a ≡ just x × valFr x < 2 ^ bits)
+  → (∃ λ y → resolveᶠ (State.mem st) b ≡ just y × valFr y < 2 ^ bits)
+  → holds (witness-of P (out1 st output v)) (less-than output a b bits)
+  → step P S st (less-than a b bits output) ≡ just (out1 st output v)
+less-than-bwd {P} {S} {st} {a} {b} {bits} {output} {v} fresh
+  (x₀ , ra , px) (y₀ , rb , py) (x , y , ⊢a , ⊢b , _ , _ , ⊢out)
+  with ⊢ᶠ-back P st output v a fresh ra ⊢a
+     | ⊢ᶠ-back P st output v b fresh rb ⊢b
+... | refl | refl rewrite ra | rb with valFr x <? 2 ^ bits
+...   | no ¬px = case ¬px px of λ ()
+...   | yes _ with valFr y <? 2 ^ bits
+...     | no ¬py = case ¬py py of λ ()
+...     | yes _ =
+          cong (λ z → just (out1 st output z))
+            (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- reconstitute-field   (two range bounds + a no-overflow obligation).
+--
+-- Obligation: both operands resolve, and the recombined value does not
+-- overflow the field order (`valFr mo + 2 ^ bits * valFr d < FR-ORDER`,
+-- the third off-circuit guard).  The two range bounds live inside the
+-- constraint `reconstitute`, so `holds` supplies them once the operand
+-- values are pinned; the no-overflow fact is a producer obligation not
+-- recorded by the constraint.
+------------------------------------------------------------------------
+
+reconstitute-field-bwd : ∀ {P S st divisor modulus bits output v}
+  → State.mem st output ≡ nothing
+  → (∃ λ d → resolveᶠ (State.mem st) divisor ≡ just d
+       × ∃ λ mo → resolveᶠ (State.mem st) modulus ≡ just mo
+                       × (valFr mo + 2 ^ bits * valFr d < FR-ORDER))
+  → holds (witness-of P (out1 st output v))
+          (reconstitute output divisor modulus bits)
+  → step P S st (reconstitute-field divisor modulus bits output)
+      ≡ just (out1 st output v)
+reconstitute-field-bwd {P} {S} {st} {divisor} {modulus} {bits} {output} {v}
+  fresh (d , rd , mo , rm , novf) (dv , mv , ⊢d , ⊢m , pd , pm , ⊢out)
+  with ⊢ᶠ-back P st output v divisor fresh rd ⊢d
+     | ⊢ᶠ-back P st output v modulus fresh rm ⊢m
+... | refl | refl rewrite rd | rm with valFr mo <? 2 ^ bits
+...   | no ¬pm = case ¬pm pm of λ ()
+...   | yes _ with valFr d <? 2 ^ (FR-BITS ∸ bits)
+...     | no ¬pd = case ¬pd pd of λ ()
+...     | yes _ with valFr mo + 2 ^ bits * valFr d <? FR-ORDER
+...       | no ¬novf = case ¬novf novf of λ ()
+...       | yes _ =
+            cong (λ z → just (out1 st output z))
+              (out-back P st output v ⊢out refl)
+
+------------------------------------------------------------------------
+-- constrain-bits   (no output; post-state is `st`).
+--
+-- The range obligation `valFr x < 2 ^ bits` lives inside the constraint
+-- `in-range`, so `holds` supplies both the resolution (via
+-- `resolveᶜ-Fr-agree`, no output binding to invert) and the guard proof.
+------------------------------------------------------------------------
+
+constrain-bits-bwd : ∀ {P S st val bits}
+  → holds (witness-of P st) (in-range val bits)
+  → step P S st (constrain-bits val bits) ≡ just st
+constrain-bits-bwd {P} {S} {st} {val} {bits} (x , ⊢v , px)
+  rewrite trans (sym (resolveᶜ-Fr-agree P st val)) ⊢v
+  with valFr x <? 2 ^ bits
+... | yes _  = refl
+... | no ¬px = case ¬px px of λ ()
+
+------------------------------------------------------------------------
+-- impact   (pi/transcript cluster; the only pis-appending instruction).
+--
+-- `step` inspects: the input list resolves (`vals`), the guard resolves
+-- to a field element `gᶠ` with a bit reading `b = to𝔹 gᶠ`, and — when
+-- `b = true` — the pushed values match the public transcript slice.  The
+-- two branches build distinct post-states (active: append the actual
+-- `vals` and advance the transcript cursor; skipped: append zeros and
+-- record the skip), so each has its own converse.  These are pure `step`
+-- inversions: `impact` synthesises `impact-constraints`, but running the
+-- step backward needs the operational transcript facts, not the
+-- constraint (whose `pi-impact` entries are a *consequence* of the push).
+------------------------------------------------------------------------
+
+impact-true-bwd : ∀ {P S st guard inputs gᶠ vals}
+  → resolve-all-Fr (State.mem st) inputs ≡ just vals
+  → resolveᶠ (State.mem st) guard ≡ just gᶠ
+  → to𝔹 gᶠ ≡ just true
+  → take (length vals)
+       (drop (State.pti-idx st)
+         (ProofPreimage.pub-transcript-inputs P)) ≡ vals
+  → step P S st (impact guard inputs)
+      ≡ just (record st { pis      = State.pis st ++ vals
+                        ; pi-skips = State.pi-skips st ++ (nothing ∷ [])
+                        ; pti-idx  = State.pti-idx st + length vals })
+impact-true-bwd {P} {S} {st} {guard} {inputs} {gᶠ} {vals}
+  ri rg tb tm
+  rewrite ri | rg | tb
+  with take (length vals)
+         (drop (State.pti-idx st)
+           (ProofPreimage.pub-transcript-inputs P)) ≟LFr vals
+... | yes _   = refl
+... | no ¬tm  = case ¬tm tm of λ ()
+
+impact-false-bwd : ∀ {P S st guard inputs gᶠ vals}
+  → resolve-all-Fr (State.mem st) inputs ≡ just vals
+  → resolveᶠ (State.mem st) guard ≡ just gᶠ
+  → to𝔹 gᶠ ≡ just false
+  → step P S st (impact guard inputs)
+      ≡ just (record st
+                { pis      = State.pis st ++ map (λ _ → 0ᶠ) vals
+                ; pi-skips = State.pi-skips st ++ (just (length vals) ∷ []) })
+impact-false-bwd {P} {S} {st} {guard} {inputs} {gᶠ} {vals}
+  ri rg tb
+  rewrite ri | rg | tb = refl
+
+------------------------------------------------------------------------
+-- public-input   (transcript cluster; `synth-instr` emits no constraint,
+-- so there is no `holds`/`satisfies` premise — the converse is a pure
+-- `step` inversion driven by the guard reading and the transcript read).
+--
+-- Guard evaluation (`eval-guard`, which passes through `resolve𝔹` for a
+-- present guard and reads `true` for an absent one) is stated as
+-- `eval-guard m guard ≡ just b`, covering both guard shapes uniformly.
+-- The two branches produce distinct post-states: active reads and binds a
+-- decoded transcript value and advances the output cursor; inactive binds
+-- the type's default value.
+------------------------------------------------------------------------
+
+public-input-active-bwd : ∀ {P S st guard val-t output v}
+  → eval-guard (State.mem st) guard ≡ just true
+  → decode val-t (take (encoded-len val-t) (State.pto-rem st)) ≡ just v
+  → step P S st (public-input guard val-t output)
+      ≡ just (record st
+                { mem     = ins output v (State.mem st)
+                ; pto-rem = drop (encoded-len val-t) (State.pto-rem st) })
+public-input-active-bwd {P} {S} {st} {guard} {val-t} {output} {v} eg dv
+  rewrite eg | dv = refl
+
+public-input-inactive-bwd : ∀ {P S st guard val-t output}
+  → eval-guard (State.mem st) guard ≡ just false
+  → step P S st (public-input guard val-t output)
+      ≡ just (out1 st output (default-val val-t))
+public-input-inactive-bwd {P} {S} {st} {guard} {val-t} {output} eg
+  rewrite eg = refl
+
+------------------------------------------------------------------------
+-- private-input   (as `public-input`, over the private transcript).
+------------------------------------------------------------------------
+
+private-input-active-bwd : ∀ {P S st guard val-t output v}
+  → eval-guard (State.mem st) guard ≡ just true
+  → decode val-t (take (encoded-len val-t) (State.priv-rem st)) ≡ just v
+  → step P S st (private-input guard val-t output)
+      ≡ just (record st
+                { mem      = ins output v (State.mem st)
+                ; priv-rem = drop (encoded-len val-t) (State.priv-rem st) })
+private-input-active-bwd {P} {S} {st} {guard} {val-t} {output} {v} eg dv
+  rewrite eg | dv = refl
+
+private-input-inactive-bwd : ∀ {P S st guard val-t output}
+  → eval-guard (State.mem st) guard ≡ just false
+  → step P S st (private-input guard val-t output)
+      ≡ just (out1 st output (default-val val-t))
+private-input-inactive-bwd {P} {S} {st} {guard} {val-t} {output} eg
+  rewrite eg = refl
+
+------------------------------------------------------------------------
+-- circuit-output   (output cluster; `synth-instr` only appends to
+-- `output-ops`, emitting no constraint).  `step` collects the declared
+-- source outputs into concrete values and appends them to `State.outs`.
+-- The converse is a pure inversion: given that collection succeeds, the
+-- step produces the extended-`outs` state.
+------------------------------------------------------------------------
+
+circuit-output-bwd : ∀ {P S st vals vs}
+  → collectOutputs (State.mem st) (IrSource.outputs S) vals ≡ just vs
+  → step P S st (circuit-output vals)
+      ≡ just (record st { outs = State.outs st ++ vs })
+circuit-output-bwd {P} {S} {st} {vals} {vs} co
+  rewrite co = refl
+
+------------------------------------------------------------------------
+-- Shape machinery for the backward direction (v3 analogue of v2's
+-- `preprocess-shaped` / `Tr-shaped`).
+--
+-- The backward direction reconstructs, from a satisfying witness, the
+-- operational run that produced it.  Unlike zkir-v2 — whose per-step
+-- backward lemmas yield an abstract `R-instr` relation and need a
+-- `next-state-from-osd`/`op-side-data-list` layer to sequence them — the
+-- v3 per-instruction `*-bwd` lemmas already conclude the *operational*
+-- `step P S st i ≡ just st'`.  So the v3 shape "walk" is just v3's own
+-- `run`: sequencing the reconstructed steps is `run`'s cons rule
+-- (`run-inv` is its inverse).  The shape record therefore carries only
+--   • the initial state (`init S P ≡ just st0`), and
+--   • that the run over the source's instructions ends EXACTLY at `s`
+--     (`run P S (instructions S) st0 ≡ just s`), plus
+--   • the terminal transcript-consumption facts that `satisfies` is blind
+--     to (`Consumed`, below) — the v3 counterpart of v2's
+--     `T (transcripts-consumed pre s)`.
+--
+-- The per-step side data (guard evaluations, transcript reads, output
+-- collection) that `satisfies` does not determine is NOT part of this
+-- record: it is supplied by the backward driver at each step, threaded
+-- alongside the `TyEq` context and the lowered
+-- `holds` (`holds-lower` + `Defd`).  This keeps the shape record minimal
+-- and the driver the single place the side data is consumed.
+------------------------------------------------------------------------
+

--- a/formal/src/zkir-v3/CircuitBridge.agda
+++ b/formal/src/zkir-v3/CircuitBridge.agda
@@ -1,0 +1,1059 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- The off-circuit / in-circuit bridge core.
+--
+-- This module collects the definitions that mediate between the
+-- off-circuit (preprocess) semantics and the in-circuit (constraint)
+-- semantics, independently of the per-instruction faithfulness proofs:
+--
+--   • per-step constraint extraction over `synth`/`satisfies` (`csOf`
+--     and friends) — the per-instruction contribution of an instruction
+--     list, and the peeling/projection lemmas the backward driver uses;
+--   • the in-circuit witness of a preprocess run (`witness-of`) and the
+--     resolution-agreement lemmas (`resolve-agree` /
+--     `resolveᶜ-Fr-agree`) through which every per-instruction lemma
+--     transports its hypotheses across the boundary;
+--   • the single- and two-output binding transports (`⊢-pres`,
+--     `⊢ᶠ-pres`, `assign-*`, `⊢all-pres`, …);
+--   • constraint-satisfaction monotonicity (`holds-mono`) and its
+--     converse lowering (`holds-lower`, with the `Defd` definedness
+--     side-condition and the `down-*` reverse transports).
+------------------------------------------------------------------------
+
+module zkir-v3.CircuitBridge (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Semantics ⋯
+  using (ProofPreimage; State; resolve; resolveᶠ; Mem; ins; step; out1;
+         resolve-all-Fr)
+open import zkir-v3.SemanticsProperties ⋯
+open import zkir-v3.Circuit ⋯
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+
+open import Data.Maybe using (Maybe; just; nothing; _>>=_)
+open import Data.Bool using (Bool; true; false; if_then_else_)
+open import Data.Nat using (ℕ; zero; suc; _+_; _*_; _<?_; _<_; _^_; _∸_)
+open import Data.List using (List; []; _∷_; _++_; _∷ʳ_; map)
+open import Data.List.Properties using (++-identityʳ; ++-assoc)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃)
+open import Data.Sum using (inj₁; inj₂)
+open import Data.Unit using (⊤; tt)
+open import Data.String using () renaming (_≟_ to _≟str_)
+open import Data.Maybe.Properties using (just-injective)
+open import Function using (case_of_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; subst)
+open import Relation.Nullary using (yes; no; ¬_)
+open import Relation.Nullary.Decidable using (isYes)
+
+-- Splitting a satisfied constraint list (inverse of `sat-++`).
+sat-++⁻ : ∀ xs {ys w}
+  → satisfies-constraints (xs ++ ys) w
+  → satisfies-constraints xs w × satisfies-constraints ys w
+sat-++⁻ []       h         = tt , h
+sat-++⁻ (c ∷ xs) (hc , hr) =
+  let (hx , hy) = sat-++⁻ xs hr in (hc , hx) , hy
+
+-- The constraints `synth-instr i` appends to the accumulator `ss` (in
+-- emission order).  Single-output instructions push one gate; `impact`
+-- pushes one `pi-impact` per input; the transcript-input and output
+-- terminators push none.
+pushed : Instruction → SynthState → List Constraint
+pushed (encode input outputs)              ss = encode-eq input outputs ∷ []
+pushed (assert cond)                       ss = non-zero cond ∷ []
+pushed (cond-select bit a b o)             ss = select o bit a b ∷ []
+pushed (constrain-bits val bits)           ss = in-range val bits ∷ []
+pushed (constrain-eq a b)                  ss = eq a b ∷ []
+pushed (constrain-to-boolean val)          ss = boolean val ∷ []
+pushed (copy val o)                        ss = gate-copy o val ∷ []
+pushed (impact guard inputs)               ss =
+  impact-constraints (SynthState.next-pi ss) guard inputs
+pushed (ec-mul a scalar o)                 ss = ec-mul o a scalar ∷ []
+pushed (ec-mul-generator scalar o)         ss = ec-gen o scalar ∷ []
+pushed (hash-to-curve inputs o)            ss = h2c o inputs ∷ []
+pushed (into-coordinates point (xo , yo))  ss = into-coords xo yo point ∷ []
+pushed (from-coordinates (x , y) o)        ss = from-coords o x y ∷ []
+pushed (into-bytes32 input o)              ss = into-bytes o input ∷ []
+pushed (from-bytes32 bytes val-t o)        ss = from-bytes o bytes ∷ []
+pushed (reverse-bytes bytes o)             ss = reverse-bytes o bytes ∷ []
+pushed (bytes32-into-low-high bytes (lo , hi)) ss =
+  bytes-into-low-high lo hi bytes ∷ []
+pushed (bytes32-from-low-high (lo , hi) o) ss = bytes-from-low-high o lo hi ∷ []
+pushed (div-mod-power-of-two val bits outs) ss =
+  case outs of λ { (q ∷ r ∷ []) → div-mod q r val bits ∷ [] ; _ → [] }
+pushed (reconstitute-field d m bits o)     ss = reconstitute o d m bits ∷ []
+pushed (transient-hash inputs o)           ss = poseidon o inputs ∷ []
+pushed (persistent-hash al inputs o)       ss = sha256 o al inputs ∷ []
+pushed (keccak256 al inputs o)             ss = keccak o al inputs ∷ []
+pushed (test-eq a b o)                     ss = test-eq o a b ∷ []
+pushed (add a b o)                         ss = gate-add o a b ∷ []
+pushed (mul a b o)                         ss = gate-mul o a b ∷ []
+pushed (neg a o)                           ss = gate-neg o a ∷ []
+pushed (inv a o)                           ss = gate-inv o a ∷ []
+pushed (not a o)                           ss = is-not o a ∷ []
+pushed (less-than a b bits o)              ss = less-than o a b bits ∷ []
+pushed (jubjub-scalar-from-native a o)     ss = scalar-from-native o a ∷ []
+pushed (public-input guard val-t o)        ss = []
+pushed (private-input guard val-t o)       ss = []
+pushed (circuit-output vals)               ss = []
+
+-- `synth-instr` appends exactly `pushed i ss` to the constraint list.
+push-cs : ∀ i ss
+  → SynthState.constraints (synth-instr i ss)
+      ≡ SynthState.constraints ss ++ pushed i ss
+push-cs (encode input outputs)              ss = refl
+push-cs (assert cond)                       ss = refl
+push-cs (cond-select bit a b o)             ss = refl
+push-cs (constrain-bits val bits)           ss = refl
+push-cs (constrain-eq a b)                  ss = refl
+push-cs (constrain-to-boolean val)          ss = refl
+push-cs (copy val o)                        ss = refl
+push-cs (impact guard inputs)               ss = refl
+push-cs (ec-mul a scalar o)                 ss = refl
+push-cs (ec-mul-generator scalar o)         ss = refl
+push-cs (hash-to-curve inputs o)            ss = refl
+push-cs (into-coordinates point (xo , yo))  ss = refl
+push-cs (from-coordinates (x , y) o)        ss = refl
+push-cs (into-bytes32 input o)              ss = refl
+push-cs (from-bytes32 bytes val-t o)        ss = refl
+push-cs (reverse-bytes bytes o)             ss = refl
+push-cs (bytes32-into-low-high bytes (lo , hi)) ss = refl
+push-cs (bytes32-from-low-high (lo , hi) o) ss = refl
+push-cs (div-mod-power-of-two val bits (q ∷ r ∷ [])) ss = refl
+push-cs (div-mod-power-of-two val bits [])           ss = sym (++-identityʳ _)
+push-cs (div-mod-power-of-two val bits (_ ∷ []))     ss = sym (++-identityʳ _)
+push-cs (div-mod-power-of-two val bits (_ ∷ _ ∷ _ ∷ _)) ss = sym (++-identityʳ _)
+push-cs (reconstitute-field d m bits o)     ss = refl
+push-cs (transient-hash inputs o)           ss = refl
+push-cs (persistent-hash al inputs o)       ss = refl
+push-cs (keccak256 al inputs o)             ss = refl
+push-cs (test-eq a b o)                     ss = refl
+push-cs (add a b o)                         ss = refl
+push-cs (mul a b o)                         ss = refl
+push-cs (neg a o)                           ss = refl
+push-cs (inv a o)                           ss = refl
+push-cs (not a o)                           ss = refl
+push-cs (less-than a b bits o)              ss = refl
+push-cs (jubjub-scalar-from-native a o)     ss = refl
+push-cs (public-input guard val-t o)        ss = sym (++-identityʳ _)
+push-cs (private-input guard val-t o)       ss = sym (++-identityʳ _)
+push-cs (circuit-output vals)               ss = sym (++-identityʳ _)
+
+-- The constraints an instruction list contributes to the accumulator.
+csOf : List Instruction → SynthState → List Constraint
+csOf []       ss = []
+csOf (i ∷ is) ss = pushed i ss ++ csOf is (synth-instr i ss)
+
+-- `synth-instrs` grows the constraint list by exactly `csOf is ss`.
+synth-cs-acc : ∀ is ss
+  → SynthState.constraints (synth-instrs is ss)
+      ≡ SynthState.constraints ss ++ csOf is ss
+synth-cs-acc []       ss = sym (++-identityʳ _)
+synth-cs-acc (i ∷ is) ss =
+  trans (synth-cs-acc is (synth-instr i ss))
+    (trans (cong (_++ csOf is (synth-instr i ss)) (push-cs i ss))
+           (++-assoc (SynthState.constraints ss) (pushed i ss)
+                     (csOf is (synth-instr i ss))))
+
+-- Peel the head instruction's contributed constraints off `csOf` — the
+-- per-step interface the backward driver consumes.
+csOf-peel : ∀ i is ss {w}
+  → satisfies-constraints (csOf (i ∷ is) ss) w
+  → satisfies-constraints (pushed i ss) w
+    × satisfies-constraints (csOf is (synth-instr i ss)) w
+csOf-peel i is ss h = sat-++⁻ (pushed i ss) h
+
+-- The initial synth accumulators: the PI preamble is the input-binding
+-- entry (`ss₁`), plus the commitment entry when has-comm (`ss₂`).
+ss₁ ss₂ : SynthState
+ss₁ = mk-synth (pi-binding 0 ∷ []) 1 []
+ss₂ = mk-synth (pi-binding 0 ∷ []) 2 []
+
+-- Top-level entry (no-comm): the source's contributed constraints all hold
+-- at the witness, after dropping the leading input-binding PI entry.
+csOf-from-sat-false : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ false
+  → satisfies (synth S) w
+  → satisfies-constraints (csOf (IrSource.instructions S) ss₁) w
+csOf-from-sat-false {S} {w} hc sat
+  with IrSource.do-communications-commitment S | hc
+... | false | refl =
+  let cok : satisfies-constraints
+              (SynthState.constraints
+                (synth-instrs (IrSource.instructions S) ss₁)) w
+      cok = satisfies.constraint-ok sat
+      cok′ : satisfies-constraints
+               (SynthState.constraints ss₁
+                 ++ csOf (IrSource.instructions S) ss₁) w
+      cok′ = subst (λ z → satisfies-constraints z w)
+               (synth-cs-acc (IrSource.instructions S) ss₁) cok
+      (_ , rest) = cok′
+  in rest
+
+-- Top-level entry (comm): the source's constraint list, after the
+-- `synth-cs-acc`/`++-assoc` reshaping, is `pi-binding 0` ∷ the source's
+-- contributed constraints ∷ the trailing `comm`.  Split it into all three:
+-- the leading input-binding PI entry, the middle contributed constraints,
+-- and the trailing comm-commitment constraint.
+synth-true-split : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ true
+  → satisfies (synth S) w
+  → holds w (pi-binding 0)
+  × satisfies-constraints (csOf (IrSource.instructions S) ss₂) w
+  × holds w (comm (input-operands (IrSource.inputs S))
+              (SynthState.output-ops
+                (synth-instrs (IrSource.instructions S) ss₂)))
+synth-true-split {S} {w} hc sat
+  with IrSource.do-communications-commitment S | hc
+... | true | refl =
+  let ins  = input-operands (IrSource.inputs S)
+      st   = synth-instrs (IrSource.instructions S) ss₂
+      outs = SynthState.output-ops st
+      cok  : satisfies-constraints
+               (SynthState.constraints st ∷ʳ comm ins outs) w
+      cok  = satisfies.constraint-ok sat
+      eqc  : SynthState.constraints st ∷ʳ comm ins outs
+             ≡ pi-binding 0
+                 ∷ (csOf (IrSource.instructions S) ss₂ ++ (comm ins outs ∷ []))
+      eqc  = trans (cong (_++ (comm ins outs ∷ []))
+                         (synth-cs-acc (IrSource.instructions S) ss₂))
+                   (++-assoc (pi-binding 0 ∷ [])
+                             (csOf (IrSource.instructions S) ss₂)
+                             (comm ins outs ∷ []))
+      cok′ : satisfies-constraints
+               (pi-binding 0
+                 ∷ (csOf (IrSource.instructions S) ss₂
+                     ++ (comm ins outs ∷ []))) w
+      cok′ = subst (λ z → satisfies-constraints z w) eqc cok
+      (mid , commHold , _) =
+        sat-++⁻ (csOf (IrSource.instructions S) ss₂) (proj₂ cok′)
+  in proj₁ cok′ , mid , commHold
+
+-- Drop the leading input-binding entry and the trailing comm-commitment
+-- constraint, keeping the source's contributed constraints.
+csOf-from-sat-true : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ true
+  → satisfies (synth S) w
+  → satisfies-constraints (csOf (IrSource.instructions S) ss₂) w
+csOf-from-sat-true {S} {w} hc sat =
+  proj₁ (proj₂ (synth-true-split {S} {w} hc sat))
+
+------------------------------------------------------------------------
+-- The in-circuit witness of a preprocess run.
+--
+-- The in-circuit `memory` is the preprocess `memory`; the public-input
+-- vector is the one the run produced; the commitment randomness is the
+-- second component of the preimage's commitment (present iff the circuit
+-- has a communications commitment).
+------------------------------------------------------------------------
+
+comm-rand-of : Maybe (Fr × Fr) → Maybe Fr
+comm-rand-of (just (_ , r)) = just r
+comm-rand-of nothing        = nothing
+
+witness-of : ProofPreimage → State → CircuitWitness
+witness-of P st =
+  mk-witness (State.mem st) (State.pis st)
+             (comm-rand-of (ProofPreimage.comm-commitment P))
+
+------------------------------------------------------------------------
+-- Resolution agreement.
+--
+-- An operand resolves identically under the off-circuit `resolve` (over
+-- the preprocess memory) and the in-circuit `resolveᶜ` (over the witness
+-- built from the same state) — definitionally, since the witness's
+-- `assign` is precisely that memory.  These are the bridge through which
+-- every per-instruction faithfulness lemma transports its hypotheses.
+------------------------------------------------------------------------
+
+resolve-agree : ∀ P st op
+  → resolveᶜ (witness-of P st) op ≡ resolve (State.mem st) op
+resolve-agree P st (var id) = refl
+resolve-agree P st (imm x)  = refl
+
+resolveᶜ-Fr-agree : ∀ P st op
+  → resolveᶜ-Fr (witness-of P st) op ≡ resolveᶠ (State.mem st) op
+resolveᶜ-Fr-agree P st (imm x)  = refl
+resolveᶜ-Fr-agree P st (var id) with State.mem st id
+... | nothing                    = refl
+... | just (val-native _)        = refl
+... | just (val-bytes32 _)       = refl
+... | just (val-jubjub-point _)  = refl
+... | just (val-jubjub-scalar _) = refl
+... | just (val-secp-point _)    = refl
+... | just (val-secp-base _)     = refl
+... | just (val-secp-scalar _)   = refl
+
+------------------------------------------------------------------------
+-- Transport a resolution at `st` to one against the post-step witness.
+--
+-- After a single output binding `st' = out1 st out v`, an input operand
+-- that resolved in `st` resolves identically against `witness-of P st'`
+-- (freshness of `out` rules out aliasing).
+------------------------------------------------------------------------
+
+⊢-pres : ∀ P st (out : Identifier) v op {w}
+  → State.mem st out ≡ nothing
+  → resolve (State.mem st) op ≡ just w
+  → resolveᶜ (witness-of P (out1 st out v)) op ≡ just w
+⊢-pres P st out v op fresh r =
+  trans (resolve-agree P (out1 st out v) op)
+        (resolve-pres out v (State.mem st) op fresh r)
+
+⊢ᶠ-pres : ∀ P st (out : Identifier) v op {x}
+  → State.mem st out ≡ nothing
+  → resolveᶠ (State.mem st) op ≡ just x
+  → resolveᶜ-Fr (witness-of P (out1 st out v)) op ≡ just x
+⊢ᶠ-pres P st out v op fresh r =
+  trans (resolveᶜ-Fr-agree P (out1 st out v) op)
+        (resolveᶠ-pres out v (State.mem st) op fresh r)
+
+-- The freshly-bound cell `out` holds `v` in the post-step witness.
+assign-here : ∀ P st (out : Identifier) v
+  → CircuitWitness.assign (witness-of P (out1 st out v)) out ≡ just v
+assign-here P st out v = ins-here out v (State.mem st)
+
+-- List-resolution agreement across the off/in-circuit boundary.
+resolve-all-agree : ∀ P st ops
+  → resolveᶜ-all-Fr (witness-of P st) ops ≡ resolve-all-Fr (State.mem st) ops
+resolve-all-agree P st []         = refl
+resolve-all-agree P st (op ∷ ops)
+  rewrite resolveᶜ-Fr-agree P st op
+        | resolve-all-agree P st ops = refl
+
+-- List resolution is preserved by a fresh output binding (each element
+-- is preserved by `resolveᶠ-pres`).
+resolve-all-pres : ∀ (out : Identifier) v (m : Mem) ops {frs}
+  → m out ≡ nothing
+  → resolve-all-Fr m ops ≡ just frs
+  → resolve-all-Fr (ins out v m) ops ≡ just frs
+resolve-all-pres out v m []         _     r = r
+resolve-all-pres out v m (op ∷ ops) fresh r
+  with resolveᶠ m op in eqop
+... | just x
+        rewrite resolveᶠ-pres out v m op fresh eqop
+  with resolve-all-Fr m ops in eqrest
+...   | just xs rewrite resolve-all-pres out v m ops fresh eqrest = r
+
+------------------------------------------------------------------------
+-- Two-output bindings  (st' = out1 (out1 st id₁ v₁) id₂ v₂).
+------------------------------------------------------------------------
+
+-- An input operand survives two distinct fresh bindings.
+⊢-pres2 : ∀ P st (id₁ : Identifier) v₁ (id₂ : Identifier) v₂ op {w}
+  → State.mem st id₁ ≡ nothing
+  → State.mem st id₂ ≡ nothing
+  → ¬ (id₂ ≡ id₁)
+  → resolve (State.mem st) op ≡ just w
+  → resolveᶜ (witness-of P (out1 (out1 st id₁ v₁) id₂ v₂)) op ≡ just w
+⊢-pres2 P st id₁ v₁ id₂ v₂ op fresh₁ fresh₂ id₂≢id₁ r =
+  trans (resolve-agree P (out1 (out1 st id₁ v₁) id₂ v₂) op)
+    (resolve-pres id₂ v₂ (ins id₁ v₁ (State.mem st)) op
+      (trans (ins-other v₁ (State.mem st) id₂≢id₁) fresh₂)
+      (resolve-pres id₁ v₁ (State.mem st) op fresh₁ r))
+
+-- The first (inner) of two distinct bindings is still readable.
+assign-inner : ∀ P st (id₁ : Identifier) v₁ (id₂ : Identifier) v₂
+  → ¬ (id₁ ≡ id₂)
+  → CircuitWitness.assign (witness-of P (out1 (out1 st id₁ v₁) id₂ v₂)) id₁
+      ≡ just v₁
+assign-inner P st id₁ v₁ id₂ v₂ id₁≢id₂ =
+  trans (ins-other v₂ (ins id₁ v₁ (State.mem st)) id₁≢id₂)
+        (ins-here id₁ v₁ (State.mem st))
+
+-- The second (outer) of two bindings.
+assign-outer : ∀ P st (id₁ : Identifier) v₁ (id₂ : Identifier) v₂
+  → CircuitWitness.assign (witness-of P (out1 (out1 st id₁ v₁) id₂ v₂)) id₂
+      ≡ just v₂
+assign-outer P st id₁ v₁ id₂ v₂ =
+  ins-here id₂ v₂ (ins id₁ v₁ (State.mem st))
+
+-- Native-resolution survives two distinct fresh bindings.
+⊢ᶠ-pres2 : ∀ P st (id₁ : Identifier) v₁ (id₂ : Identifier) v₂ op {x}
+  → State.mem st id₁ ≡ nothing
+  → State.mem st id₂ ≡ nothing
+  → ¬ (id₂ ≡ id₁)
+  → resolveᶠ (State.mem st) op ≡ just x
+  → resolveᶜ-Fr (witness-of P (out1 (out1 st id₁ v₁) id₂ v₂)) op ≡ just x
+⊢ᶠ-pres2 P st id₁ v₁ id₂ v₂ op fresh₁ fresh₂ id₂≢id₁ r =
+  trans (resolveᶜ-Fr-agree P (out1 (out1 st id₁ v₁) id₂ v₂) op)
+    (resolveᶠ-pres id₂ v₂ (ins id₁ v₁ (State.mem st)) op
+      (trans (ins-other v₁ (State.mem st) id₂≢id₁) fresh₂)
+      (resolveᶠ-pres id₁ v₁ (State.mem st) op fresh₁ r))
+
+-- Transport list resolution to the post-step witness.
+⊢all-pres : ∀ P st (out : Identifier) v ops {frs}
+  → State.mem st out ≡ nothing
+  → resolve-all-Fr (State.mem st) ops ≡ just frs
+  → resolveᶜ-all-Fr (witness-of P (out1 st out v)) ops ≡ just frs
+⊢all-pres P st out v ops fresh r =
+  trans (resolve-all-agree P (out1 st out v) ops)
+        (resolve-all-pres out v (State.mem st) ops fresh r)
+
+-- List resolution survives two distinct fresh bindings.
+⊢all-pres2 : ∀ P st (id₁ : Identifier) v₁ (id₂ : Identifier) v₂ ops {frs}
+  → State.mem st id₁ ≡ nothing
+  → State.mem st id₂ ≡ nothing
+  → ¬ (id₂ ≡ id₁)
+  → resolve-all-Fr (State.mem st) ops ≡ just frs
+  → resolveᶜ-all-Fr (witness-of P (out1 (out1 st id₁ v₁) id₂ v₂)) ops
+      ≡ just frs
+⊢all-pres2 P st id₁ v₁ id₂ v₂ ops fresh₁ fresh₂ id₂≢id₁ r =
+  trans (resolve-all-agree P (out1 (out1 st id₁ v₁) id₂ v₂) ops)
+    (resolve-all-pres id₂ v₂ (ins id₁ v₁ (State.mem st)) ops
+      (trans (ins-other v₁ (State.mem st) id₂≢id₁) fresh₂)
+      (resolve-all-pres id₁ v₁ (State.mem st) ops fresh₁ r))
+
+------------------------------------------------------------------------
+-- Memory and public-input monotonicity.
+--
+-- A single step only *extends* the named store (inserting fresh keys)
+-- and *appends* to the public-input vector.  A constraint that holds at
+-- the immediate post-step witness therefore still holds at any later
+-- witness — the mechanism by which the local forward lemmas lift to the
+-- program's final witness.
+------------------------------------------------------------------------
+
+-- A present public-input entry survives extension of the vector.
+pi-lookup-++ : ∀ xs {i v} zs
+  → pi-lookup xs i ≡ just v → pi-lookup (xs ++ zs) i ≡ just v
+pi-lookup-++ []       zs p = case p of λ ()
+pi-lookup-++ (x ∷ xs) {zero}  zs p = p
+pi-lookup-++ (x ∷ xs) {suc i} zs p = pi-lookup-++ xs zs p
+
+pi-lookup-mono : ∀ {xs ys i v}
+  → xs ≼ ys → pi-lookup xs i ≡ just v → pi-lookup ys i ≡ just v
+pi-lookup-mono {xs} (zs , refl) p = pi-lookup-++ xs zs p
+
+-- Resolution is monotone in the store.
+resolveᶜ-mono : ∀ {m m′ pis pis′ cr cr′} op {v}
+  → m ⊑ m′
+  → resolveᶜ (mk-witness m pis cr) op ≡ just v
+  → resolveᶜ (mk-witness m′ pis′ cr′) op ≡ just v
+resolveᶜ-mono (var id) sub p = sub p
+resolveᶜ-mono (imm x)  sub p = p
+
+resolveᶜ-Fr-inv : ∀ w op {x}
+  → resolveᶜ-Fr w op ≡ just x → resolveᶜ w op ≡ just (val-native x)
+resolveᶜ-Fr-inv w op r with resolveᶜ w op
+... | just (val-native _) with refl ← r = refl
+
+resolveᶜ-Fr-intro : ∀ w op {x}
+  → resolveᶜ w op ≡ just (val-native x) → resolveᶜ-Fr w op ≡ just x
+resolveᶜ-Fr-intro w op r rewrite r = refl
+
+resolveᶜ-Fr-mono : ∀ {m m′ pis pis′ cr cr′} op {x}
+  → m ⊑ m′
+  → resolveᶜ-Fr (mk-witness m pis cr) op ≡ just x
+  → resolveᶜ-Fr (mk-witness m′ pis′ cr′) op ≡ just x
+resolveᶜ-Fr-mono {m} {m′} {pis} {pis′} {cr} {cr′} op sub p =
+  resolveᶜ-Fr-intro (mk-witness m′ pis′ cr′) op
+    (resolveᶜ-mono op sub (resolveᶜ-Fr-inv (mk-witness m pis cr) op p))
+
+resolveᶜ-all-Fr-mono : ∀ {m m′ pis pis′ cr cr′} ops {frs}
+  → m ⊑ m′
+  → resolveᶜ-all-Fr (mk-witness m pis cr) ops ≡ just frs
+  → resolveᶜ-all-Fr (mk-witness m′ pis′ cr′) ops ≡ just frs
+resolveᶜ-all-Fr-mono []         sub p = p
+resolveᶜ-all-Fr-mono {m}{m′}{pis}{pis′}{cr}{cr′} (op ∷ ops) sub p
+  with resolveᶜ-Fr (mk-witness m pis cr) op in eqop
+... | just x
+  with resolveᶜ-all-Fr (mk-witness m pis cr) ops in eqrest
+...   | just xs
+      rewrite resolveᶜ-Fr-mono {m}{m′}{pis}{pis′}{cr}{cr′} op sub eqop
+            | resolveᶜ-all-Fr-mono {m}{m′}{pis}{pis′}{cr}{cr′} ops sub eqrest = p
+
+-- The `comm`-commitment preimage (raw encodings) survives extension too.
+resolve-encode-mono : ∀ {m m′ pis pis′ cr cr′} ops {vs}
+  → m ⊑ m′
+  → resolve-encode (mk-witness m pis cr) ops ≡ just vs
+  → resolve-encode (mk-witness m′ pis′ cr′) ops ≡ just vs
+resolve-encode-mono []         sub p = p
+resolve-encode-mono {m}{m′}{pis}{pis′}{cr}{cr′} (op ∷ ops) sub p
+  with resolveᶜ (mk-witness m pis cr) op in eqop
+... | just v
+  with resolve-encode (mk-witness m pis cr) ops in eqrest
+...   | just rest
+      rewrite resolveᶜ-mono {m}{m′}{pis}{pis′}{cr}{cr′} op sub eqop
+            | resolve-encode-mono {m}{m′}{pis}{pis′}{cr}{cr′} ops sub eqrest
+            = p
+
+------------------------------------------------------------------------
+-- Constraint satisfaction is monotone.
+--
+-- Extending the named store (`m ⊑ m′`) and the public-input vector
+-- (`pis ≼ pis′`), with the commitment randomness unchanged, preserves
+-- every constraint: each atom is transported by the corresponding
+-- monotonicity lemma above, while the pure-`Set` side-conditions (bit,
+-- range, coordinate round-trips, the `select`/`pi-impact` implications)
+-- carry over untouched.
+------------------------------------------------------------------------
+
+-- `bind-each` (the `encode-eq` output binding) transports cell-by-cell.
+bind-each-mono : ∀ {m m′ pis pis′ cr} vs ids
+  → m ⊑ m′
+  → bind-each (mk-witness m pis cr) vs ids
+  → bind-each (mk-witness m′ pis′ cr) vs ids
+bind-each-mono []       []         sub be       = be
+bind-each-mono (v ∷ vs) (id ∷ ids) sub (b , bs) =
+  sub b , bind-each-mono vs ids sub bs
+bind-each-mono []       (_ ∷ _)    sub ()
+bind-each-mono (_ ∷ _)  []         sub ()
+
+holds-mono : ∀ {m m′ pis pis′ cr} (c : Constraint)
+  → m ⊑ m′
+  → pis ≼ pis′
+  → holds (mk-witness m pis cr) c
+  → holds (mk-witness m′ pis′ cr) c
+
+holds-mono (gate-add out a b) sub pre
+  (av , bv , ov , ra , rb , ro , rest) =
+    av , bv , ov
+  , resolveᶜ-mono a sub ra , resolveᶜ-mono b sub rb , sub ro , rest
+
+holds-mono (gate-mul out a b) sub pre
+  (av , bv , ov , ra , rb , ro , rest) =
+    av , bv , ov
+  , resolveᶜ-mono a sub ra , resolveᶜ-mono b sub rb , sub ro , rest
+
+holds-mono (gate-neg out a) sub pre (av , ov , ra , ro , rest) =
+    av , ov , resolveᶜ-mono a sub ra , sub ro , rest
+
+holds-mono (gate-inv out a) sub pre (av , ov , ra , ro , rest) =
+    av , ov , resolveᶜ-mono a sub ra , sub ro , rest
+
+holds-mono (gate-copy out a) sub pre (av , ra , ro) =
+    av , resolveᶜ-mono a sub ra , sub ro
+
+holds-mono (encode-eq input outputs) sub pre (v , ri , be) =
+    v , resolveᶜ-mono input sub ri
+  , bind-each-mono (map val-native (encodeᵉ v)) outputs sub be
+
+
+holds-mono (eq a b) sub pre (v , ra , rb) =
+    v , resolveᶜ-mono a sub ra , resolveᶜ-mono b sub rb
+
+holds-mono (boolean v) sub pre (x , rv , bit) =
+    x , resolveᶜ-Fr-mono v sub rv , bit
+
+holds-mono (non-zero c) sub pre (x , rc , nz) =
+    x , resolveᶜ-Fr-mono c sub rc , nz
+
+holds-mono (in-range v bits) sub pre (x , rv , lt) =
+    x , resolveᶜ-Fr-mono v sub rv , lt
+
+holds-mono (select out bit a b) sub pre
+  (bv , av , bvl , ov , rbit , ra , rb , ro , bitp , imps) =
+    bv , av , bvl , ov
+  , resolveᶜ-Fr-mono bit sub rbit
+  , resolveᶜ-mono a sub ra , resolveᶜ-mono b sub rb
+  , sub ro , bitp , imps
+
+holds-mono (test-eq out a b) sub pre (av , bv , eqv , ra , rb , veq , ro) =
+    av , bv , eqv
+  , resolveᶜ-mono a sub ra , resolveᶜ-mono b sub rb , veq , sub ro
+
+holds-mono (is-not out a) sub pre (x , ra , bit , ro) =
+    x , resolveᶜ-Fr-mono a sub ra , bit , sub ro
+
+holds-mono (less-than out a b bits) sub pre
+  (x , y , ra , rb , lx , ly , ro) =
+    x , y , resolveᶜ-Fr-mono a sub ra , resolveᶜ-Fr-mono b sub rb
+  , lx , ly , sub ro
+
+holds-mono (div-mod q r v bits) sub pre (x , rv , rq , rr) =
+    x , resolveᶜ-Fr-mono v sub rv , sub rq , sub rr
+
+holds-mono (reconstitute out d m bits) sub pre
+  (dv , mv , rd , rm , ld , lm , ro) =
+    dv , mv , resolveᶜ-Fr-mono d sub rd , resolveᶜ-Fr-mono m sub rm
+  , ld , lm , sub ro
+
+holds-mono (scalar-from-native out a) sub pre (x , ra , ro) =
+    x , resolveᶜ-Fr-mono a sub ra , sub ro
+
+holds-mono (poseidon out inputs) sub pre (frs , ri , ro) =
+    frs , resolveᶜ-all-Fr-mono inputs sub ri , sub ro
+
+holds-mono (sha256 out alignment inputs) sub pre
+  (frs , v , ri , hp , ro) =
+    frs , v , resolveᶜ-all-Fr-mono inputs sub ri , hp , sub ro
+
+holds-mono (keccak out alignment inputs) sub pre
+  (frs , v , ri , hp , ro) =
+    frs , v , resolveᶜ-all-Fr-mono inputs sub ri , hp , sub ro
+
+holds-mono (ec-mul out a scalar) sub pre (inj₁ (p , s , ra , rs , ro)) =
+    inj₁ (p , s , resolveᶜ-mono a sub ra , resolveᶜ-mono scalar sub rs , sub ro)
+holds-mono (ec-mul out a scalar) sub pre (inj₂ (p , s , ra , rs , ro)) =
+    inj₂ (p , s , resolveᶜ-mono a sub ra , resolveᶜ-mono scalar sub rs , sub ro)
+
+holds-mono (ec-gen out scalar) sub pre (inj₁ (s , rs , ro)) =
+    inj₁ (s , resolveᶜ-mono scalar sub rs , sub ro)
+holds-mono (ec-gen out scalar) sub pre (inj₂ (s , rs , ro)) =
+    inj₂ (s , resolveᶜ-mono scalar sub rs , sub ro)
+
+holds-mono (h2c out inputs) sub pre (frs , ri , ro) =
+    frs , resolveᶜ-all-Fr-mono inputs sub ri , sub ro
+
+holds-mono (into-coords xo yo point) sub pre
+  (inj₁ (p , x , y , rp , cp , rx , ry)) =
+    inj₁ (p , x , y , resolveᶜ-mono point sub rp , cp , sub rx , sub ry)
+holds-mono (into-coords xo yo point) sub pre
+  (inj₂ (p , x , y , rp , cp , rx , ry)) =
+    inj₂ (p , x , y , resolveᶜ-mono point sub rp , cp , sub rx , sub ry)
+
+holds-mono (from-coords out x y) sub pre
+  (inj₁ (xv , yv , p , rx , ry , fc , ro)) =
+    inj₁ (xv , yv , p , resolveᶜ-Fr-mono x sub rx , resolveᶜ-Fr-mono y sub ry
+         , fc , sub ro)
+holds-mono (from-coords out x y) sub pre
+  (inj₂ (xv , yv , p , rx , ry , fc , ro)) =
+    inj₂ (xv , yv , p , resolveᶜ-mono x sub rx , resolveᶜ-mono y sub ry
+         , fc , sub ro)
+
+holds-mono (into-bytes out a) sub pre (av , ov , ra , ro , rest) =
+    av , ov , resolveᶜ-mono a sub ra , sub ro , rest
+
+holds-mono (from-bytes out b) sub pre (bs , rb , inj₁ ro) =
+    bs , resolveᶜ-mono b sub rb , inj₁ (sub ro)
+holds-mono (from-bytes out b) sub pre (bs , rb , inj₂ (inj₁ ro)) =
+    bs , resolveᶜ-mono b sub rb , inj₂ (inj₁ (sub ro))
+holds-mono (from-bytes out b) sub pre (bs , rb , inj₂ (inj₂ ro)) =
+    bs , resolveᶜ-mono b sub rb , inj₂ (inj₂ (sub ro))
+
+holds-mono (reverse-bytes out b) sub pre (bs , rb , ro) =
+    bs , resolveᶜ-mono b sub rb , sub ro
+
+holds-mono (bytes-into-low-high lo hi b) sub pre (bs , l , h , rb , sp , rl , rh) =
+    bs , l , h , resolveᶜ-mono b sub rb , sp , sub rl , sub rh
+
+holds-mono (bytes-from-low-high out lo hi) sub pre (l , h , bs , rl , rh , as , ro) =
+    l , h , bs , resolveᶜ-Fr-mono lo sub rl , resolveᶜ-Fr-mono hi sub rh
+  , as , sub ro
+
+holds-mono (pi-binding entry) sub pre (bv , pl) =
+    bv , pi-lookup-mono pre pl
+
+holds-mono (pi-impact entry guard x) sub pre
+  (g , xv , pv , rg , rx , bit , pl , imps) =
+    g , xv , pv , resolveᶜ-Fr-mono guard sub rg , resolveᶜ-Fr-mono x sub rx
+  , bit , pi-lookup-mono pre pl , imps
+
+holds-mono (comm inputs outputs) sub pre
+  (ivs , ovs , rv , pv , ri , ro , cr≡ , pl , c≡) =
+    ivs , ovs , rv , pv
+  , resolve-encode-mono inputs sub ri , resolve-encode-mono outputs sub ro
+  , cr≡ , pi-lookup-mono pre pl , c≡
+
+------------------------------------------------------------------------
+-- `holds`-lowering  (the converse of `holds-mono`).
+--
+-- `holds-mono` lifts a constraint from a small witness up to a larger one
+-- (more store bindings, a longer PI vector).  Backward faithfulness needs
+-- the opposite: to run a step in reverse we must recover the constraint
+-- it appended at the *immediate* post-step witness from the constraint
+-- holding at the *final* witness.  This is NOT unconditional — a value
+-- may resolve at the final witness yet be unbound at the post-step one.
+--
+-- The side-condition is that every wire the constraint references is
+-- already *defined* at the small witness (`Defd`, below): the operands
+-- resolved before the step and the outputs were just written.  Under
+-- single assignment this holds structurally.  Given definedness at the
+-- small witness `w` and the forward sub-map `m ⊑ m′`, each wire resolves
+-- at `w` to *some* value which — pushed up by `resolveᶜ-mono` — must
+-- equal the value `holds w′` uses; so it resolves at `w` to exactly that
+-- value, and the pure side-conditions (bit, range, round-trips, the
+-- select/pi-impact implications) carry down untouched.
+------------------------------------------------------------------------
+
+-- Reverse transport of an output-cell binding, given the small binding
+-- `d`, its upward image `up = sub d`, and the large binding `big`.  The
+-- two large facts pin `u₀ ≡ u₁`, so the small binding reads the large
+-- value.  Stated generically over the looked-up cell `X` (a `Maybe`
+-- value) so no store/witness implicit needs solving — the caller supplies
+-- `up = sub d` where the identifier is in scope, sidestepping the `_⊑_`
+-- Π-implicit stall, and `X` is fixed by the small binding `d`.
+down-out : ∀ {A : Set} {X Y : Maybe A} {u₀ u₁}
+  → X ≡ just u₀ → Y ≡ just u₀ → Y ≡ just u₁ → X ≡ just u₁
+down-out d up big with just-injective (trans (sym up) big)
+... | refl = d
+
+-- Reverse transport of a single resolution: a wire defined at the small
+-- witness resolves there to whatever value it resolves to at the large
+-- one (the two agree by `⊑`).  Each specialises `down-out` with the
+-- matching monotonicity lemma as the upward image.
+down-r : ∀ {m m′ pis pis′ cr cr′} op {u₀ u₁}
+  → m ⊑ m′
+  → resolveᶜ (mk-witness m pis cr) op ≡ just u₀
+  → resolveᶜ (mk-witness m′ pis′ cr′) op ≡ just u₁
+  → resolveᶜ (mk-witness m pis cr) op ≡ just u₁
+down-r {pis′ = pis′}{cr′ = cr′} op sub d big =
+  down-out d (resolveᶜ-mono {pis′ = pis′}{cr′ = cr′} op sub d) big
+
+down-fr : ∀ {m m′ pis pis′ cr cr′} op {x₀ x₁}
+  → m ⊑ m′
+  → resolveᶜ-Fr (mk-witness m pis cr) op ≡ just x₀
+  → resolveᶜ-Fr (mk-witness m′ pis′ cr′) op ≡ just x₁
+  → resolveᶜ-Fr (mk-witness m pis cr) op ≡ just x₁
+down-fr {pis′ = pis′}{cr′ = cr′} op sub d big =
+  down-out d (resolveᶜ-Fr-mono {pis′ = pis′}{cr′ = cr′} op sub d) big
+
+down-all : ∀ {m m′ pis pis′ cr cr′} ops {frs₀ frs₁}
+  → m ⊑ m′
+  → resolveᶜ-all-Fr (mk-witness m pis cr) ops ≡ just frs₀
+  → resolveᶜ-all-Fr (mk-witness m′ pis′ cr′) ops ≡ just frs₁
+  → resolveᶜ-all-Fr (mk-witness m pis cr) ops ≡ just frs₁
+down-all {pis′ = pis′}{cr′ = cr′} ops sub d big =
+  down-out d (resolveᶜ-all-Fr-mono {pis′ = pis′}{cr′ = cr′} ops sub d) big
+
+-- Each output identifier is defined at the witness.
+AllDefd : CircuitWitness → List Identifier → Set
+AllDefd w []         = ⊤
+AllDefd w (id ∷ ids) =
+  (∃ λ ov → CircuitWitness.assign w id ≡ just ov) × AllDefd w ids
+
+-- Reverse transport of a `bind-each` binding: with each cell defined at
+-- the small witness, the large-witness binding lowers cell-by-cell.
+down-bind : ∀ {m m′ pis pis′ cr cr′} vs ids
+  → m ⊑ m′
+  → AllDefd (mk-witness m pis cr) ids
+  → bind-each (mk-witness m′ pis′ cr′) vs ids
+  → bind-each (mk-witness m pis cr) vs ids
+down-bind []       []         sub _              _        = tt
+down-bind (v ∷ vs) (id ∷ ids) sub ((ov , d) , ds) (b , bs) =
+  down-out d (sub {id} d) b , down-bind vs ids sub ds bs
+down-bind []       (_ ∷ _)    sub _              ()
+down-bind (_ ∷ _)  []         sub _              ()
+
+-- Definedness at the small witness: every wire the constraint references
+-- resolves.  One clause per constructor, mirroring the wires `holds`
+-- reads (operands via `resolveᶜ`/`resolveᶜ-Fr`/lists, outputs via
+-- `assign`).  The pure side-conditions are omitted — only definedness.
+Defd : CircuitWitness → Constraint → Set
+Defd w (gate-add out a b) =
+    (∃ λ av → resolveᶜ w a ≡ just av) × (∃ λ bv → resolveᶜ w b ≡ just bv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (gate-mul out a b) =
+    (∃ λ av → resolveᶜ w a ≡ just av) × (∃ λ bv → resolveᶜ w b ≡ just bv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (gate-neg out a) =
+    (∃ λ av → resolveᶜ w a ≡ just av)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (gate-inv out a) =
+    (∃ λ av → resolveᶜ w a ≡ just av)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (gate-copy out a) =
+    (∃ λ av → resolveᶜ w a ≡ just av)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (encode-eq input outputs) =
+    (∃ λ v → resolveᶜ w input ≡ just v)
+  × AllDefd w outputs
+Defd w (eq a b) =
+    (∃ λ av → resolveᶜ w a ≡ just av) × (∃ λ bv → resolveᶜ w b ≡ just bv)
+Defd w (boolean v) = ∃ λ x → resolveᶜ-Fr w v ≡ just x
+Defd w (non-zero c) = ∃ λ x → resolveᶜ-Fr w c ≡ just x
+Defd w (in-range v bits) = ∃ λ x → resolveᶜ-Fr w v ≡ just x
+Defd w (select out bit a b) =
+    (∃ λ bv → resolveᶜ-Fr w bit ≡ just bv)
+  × (∃ λ av → resolveᶜ w a ≡ just av) × (∃ λ bvl → resolveᶜ w b ≡ just bvl)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (test-eq out a b) =
+    (∃ λ av → resolveᶜ w a ≡ just av) × (∃ λ bv → resolveᶜ w b ≡ just bv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (is-not out a) =
+    (∃ λ x → resolveᶜ-Fr w a ≡ just x)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (less-than out a b bits) =
+    (∃ λ x → resolveᶜ-Fr w a ≡ just x) × (∃ λ y → resolveᶜ-Fr w b ≡ just y)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (div-mod q r v bits) =
+    (∃ λ x → resolveᶜ-Fr w v ≡ just x)
+  × (∃ λ qv → CircuitWitness.assign w q ≡ just qv)
+  × (∃ λ rv → CircuitWitness.assign w r ≡ just rv)
+Defd w (reconstitute out d m bits) =
+    (∃ λ dv → resolveᶜ-Fr w d ≡ just dv)
+  × (∃ λ mv → resolveᶜ-Fr w m ≡ just mv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (scalar-from-native out a) =
+    (∃ λ x → resolveᶜ-Fr w a ≡ just x)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (poseidon out inputs) =
+    (∃ λ frs → resolveᶜ-all-Fr w inputs ≡ just frs)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (sha256 out alignment inputs) =
+    (∃ λ frs → resolveᶜ-all-Fr w inputs ≡ just frs)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (keccak out alignment inputs) =
+    (∃ λ frs → resolveᶜ-all-Fr w inputs ≡ just frs)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (ec-mul out a scalar) =
+    (∃ λ av → resolveᶜ w a ≡ just av)
+  × (∃ λ sv → resolveᶜ w scalar ≡ just sv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (ec-gen out scalar) =
+    (∃ λ sv → resolveᶜ w scalar ≡ just sv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (h2c out inputs) =
+    (∃ λ frs → resolveᶜ-all-Fr w inputs ≡ just frs)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (into-coords xo yo point) =
+    (∃ λ pv → resolveᶜ w point ≡ just pv)
+  × (∃ λ xv → CircuitWitness.assign w xo ≡ just xv)
+  × (∃ λ yv → CircuitWitness.assign w yo ≡ just yv)
+Defd w (from-coords out x y) =
+    (∃ λ xv → resolveᶜ w x ≡ just xv)
+  × (∃ λ yv → resolveᶜ w y ≡ just yv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (into-bytes out a) =
+    (∃ λ av → resolveᶜ w a ≡ just av)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (from-bytes out b) =
+    (∃ λ bv → resolveᶜ w b ≡ just bv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (reverse-bytes out b) =
+    (∃ λ bv → resolveᶜ w b ≡ just bv)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (bytes-into-low-high lo hi b) =
+    (∃ λ bv → resolveᶜ w b ≡ just bv)
+  × (∃ λ lv → CircuitWitness.assign w lo ≡ just lv)
+  × (∃ λ hv → CircuitWitness.assign w hi ≡ just hv)
+Defd w (bytes-from-low-high out lo hi) =
+    (∃ λ l → resolveᶜ-Fr w lo ≡ just l)
+  × (∃ λ h → resolveᶜ-Fr w hi ≡ just h)
+  × (∃ λ ov → CircuitWitness.assign w out ≡ just ov)
+Defd w (pi-binding entry) =
+  ∃ λ bv → pi-lookup (CircuitWitness.pis w) entry ≡ just bv
+Defd w (pi-impact entry guard x) =
+    (∃ λ g → resolveᶜ-Fr w guard ≡ just g)
+  × (∃ λ xv → resolveᶜ-Fr w x ≡ just xv)
+  × (∃ λ pv → pi-lookup (CircuitWitness.pis w) entry ≡ just pv)
+Defd w (comm inputs outputs) =
+    (∃ λ ivs → resolve-encode w inputs ≡ just ivs)
+  × (∃ λ ovs → resolve-encode w outputs ≡ just ovs)
+  × (∃ λ pv → pi-lookup (CircuitWitness.pis w) 1 ≡ just pv)
+
+-- Reverse transport of a PI entry: an index present at the small vector
+-- reads there whatever it reads at the large one (a prefix-preserved
+-- entry).
+down-pi : ∀ {pis pis′ entry pv₀ pv₁}
+  → pis ≼ pis′
+  → pi-lookup pis entry ≡ just pv₀
+  → pi-lookup pis′ entry ≡ just pv₁
+  → pi-lookup pis entry ≡ just pv₁
+down-pi pre d big = down-out d (pi-lookup-mono pre d) big
+
+-- Reverse transport of an `encode`-flattened resolution list.
+down-enc : ∀ {m m′ pis pis′ cr cr′} ops {vs₀ vs₁}
+  → m ⊑ m′
+  → resolve-encode (mk-witness m pis cr) ops ≡ just vs₀
+  → resolve-encode (mk-witness m′ pis′ cr′) ops ≡ just vs₁
+  → resolve-encode (mk-witness m pis cr) ops ≡ just vs₁
+down-enc {pis′ = pis′}{cr′ = cr′} ops sub d big =
+  down-out d (resolve-encode-mono {pis′ = pis′}{cr′ = cr′} ops sub d) big
+
+-- Lowering: from `holds` at the large witness, plus definedness at the
+-- small one, recover `holds` at the small witness.  Structurally dual to
+-- `holds-mono`: each resolution is pulled down by the matching `down-*`
+-- helper; the pure side-conditions and (for gadget atoms with a fixed
+-- output value) the output binding transport unchanged from the large
+-- witness once its wire is pinned by definedness.
+holds-lower : ∀ {m m′ pis pis′ cr} (c : Constraint)
+  → m ⊑ m′
+  → pis ≼ pis′
+  → Defd (mk-witness m pis cr) c
+  → holds (mk-witness m′ pis′ cr) c
+  → holds (mk-witness m pis cr) c
+
+holds-lower (gate-add out a b) sub pre
+  ((av₀ , da) , (bv₀ , db) , (ov₀ , do′))
+  (av , bv , ov , ra , rb , ro , rest) =
+    av , bv , ov
+  , down-r a sub da ra , down-r b sub db rb , down-out do′ (sub {out} do′) ro , rest
+
+holds-lower (gate-mul out a b) sub pre
+  ((av₀ , da) , (bv₀ , db) , (ov₀ , do′))
+  (av , bv , ov , ra , rb , ro , rest) =
+    av , bv , ov
+  , down-r a sub da ra , down-r b sub db rb
+  , down-out do′ (sub {out} do′) ro , rest
+
+holds-lower (gate-neg out a) sub pre ((av₀ , da) , (ov₀ , do′))
+  (av , ov , ra , ro , rest) =
+    av , ov , down-r a sub da ra , down-out do′ (sub {out} do′) ro , rest
+
+holds-lower (gate-inv out a) sub pre ((av₀ , da) , (ov₀ , do′))
+  (av , ov , ra , ro , rest) =
+    av , ov , down-r a sub da ra , down-out do′ (sub {out} do′) ro , rest
+
+holds-lower (gate-copy out a) sub pre ((av₀ , da) , (ov₀ , do′))
+  (av , ra , ro) =
+    av , down-r a sub da ra , down-out do′ (sub {out} do′) ro
+
+holds-lower (encode-eq input outputs) sub pre ((v₀ , di) , alldefd)
+  (v , ri , be) =
+    v , down-r input sub di ri
+  , down-bind (map val-native (encodeᵉ v)) outputs sub alldefd be
+
+holds-lower (eq a b) sub pre ((av₀ , da) , (bv₀ , db)) (v , ra , rb) =
+    v , down-r a sub da ra , down-r b sub db rb
+
+holds-lower (boolean v) sub pre (x₀ , dv) (x , rv , bit) =
+    x , down-fr v sub dv rv , bit
+
+holds-lower (non-zero c) sub pre (x₀ , dc) (x , rc , nz) =
+    x , down-fr c sub dc rc , nz
+
+holds-lower (in-range v bits) sub pre (x₀ , dv) (x , rv , lt) =
+    x , down-fr v sub dv rv , lt
+
+holds-lower (select out bit a b) sub pre
+  ((bv₀ , dbit) , (av₀ , da) , (bvl₀ , db) , (ov₀ , do′))
+  (bv , av , bvl , ov , rbit , ra , rb , ro , bitp , imps) =
+    bv , av , bvl , ov
+  , down-fr bit sub dbit rbit
+  , down-r a sub da ra , down-r b sub db rb
+  , down-out do′ (sub {out} do′) ro , bitp , imps
+
+holds-lower (test-eq out a b) sub pre
+  ((av₀ , da) , (bv₀ , db) , (ov₀ , do′))
+  (av , bv , eqv , ra , rb , veq , ro) =
+    av , bv , eqv
+  , down-r a sub da ra , down-r b sub db rb , veq , down-out do′ (sub {out} do′) ro
+
+holds-lower (is-not out a) sub pre ((x₀ , da) , (ov₀ , do′))
+  (x , ra , bit , ro) =
+    x , down-fr a sub da ra , bit , down-out do′ (sub {out} do′) ro
+
+holds-lower (less-than out a b bits) sub pre
+  ((x₀ , da) , (y₀ , db) , (ov₀ , do′))
+  (x , y , ra , rb , lx , ly , ro) =
+    x , y , down-fr a sub da ra , down-fr b sub db rb
+  , lx , ly , down-out do′ (sub {out} do′) ro
+
+holds-lower (div-mod q r v bits) sub pre
+  ((x₀ , dv) , (qv₀ , dq) , (rv₀ , dr))
+  (x , rvw , rq , rr) =
+    x , down-fr v sub dv rvw
+  , down-out dq (sub {q} dq) rq , down-out dr (sub {r} dr) rr
+
+holds-lower (reconstitute out d m bits) sub pre
+  ((dv₀ , dd) , (mv₀ , dm) , (ov₀ , do′))
+  (dv , mv , rd , rm , ld , lm , ro) =
+    dv , mv , down-fr d sub dd rd , down-fr m sub dm rm
+  , ld , lm , down-out do′ (sub {out} do′) ro
+
+holds-lower (scalar-from-native out a) sub pre ((x₀ , da) , (ov₀ , do′))
+  (x , ra , ro) =
+    x , down-fr a sub da ra , down-out do′ (sub {out} do′) ro
+
+holds-lower (poseidon out inputs) sub pre ((frs₀ , di) , (ov₀ , do′))
+  (frs , ri , ro) =
+    frs , down-all inputs sub di ri , down-out do′ (sub {out} do′) ro
+
+holds-lower (sha256 out alignment inputs) sub pre
+  ((frs₀ , di) , (ov₀ , do′))
+  (frs , v , ri , hp , ro) =
+    frs , v , down-all inputs sub di ri , hp
+  , down-out do′ (sub {out} do′) ro
+
+holds-lower (keccak out alignment inputs) sub pre
+  ((frs₀ , di) , (ov₀ , do′))
+  (frs , v , ri , hp , ro) =
+    frs , v , down-all inputs sub di ri , hp
+  , down-out do′ (sub {out} do′) ro
+
+holds-lower (ec-mul out a scalar) sub pre
+  ((av₀ , da) , (sv₀ , ds) , (ov₀ , do′))
+  (inj₁ (p , s , ra , rs , ro)) =
+    inj₁ (p , s , down-r a sub da ra , down-r scalar sub ds rs
+         , down-out do′ (sub {out} do′) ro)
+holds-lower (ec-mul out a scalar) sub pre
+  ((av₀ , da) , (sv₀ , ds) , (ov₀ , do′))
+  (inj₂ (p , s , ra , rs , ro)) =
+    inj₂ (p , s , down-r a sub da ra , down-r scalar sub ds rs
+         , down-out do′ (sub {out} do′) ro)
+
+holds-lower (ec-gen out scalar) sub pre ((sv₀ , ds) , (ov₀ , do′))
+  (inj₁ (s , rs , ro)) =
+    inj₁ (s , down-r scalar sub ds rs , down-out do′ (sub {out} do′) ro)
+holds-lower (ec-gen out scalar) sub pre ((sv₀ , ds) , (ov₀ , do′))
+  (inj₂ (s , rs , ro)) =
+    inj₂ (s , down-r scalar sub ds rs , down-out do′ (sub {out} do′) ro)
+
+holds-lower (h2c out inputs) sub pre ((frs₀ , di) , (ov₀ , do′))
+  (frs , ri , ro) =
+    frs , down-all inputs sub di ri , down-out do′ (sub {out} do′) ro
+
+holds-lower (into-coords xo yo point) sub pre
+  ((pv₀ , dp) , (xv₀ , dx) , (yv₀ , dy))
+  (inj₁ (p , x , y , rp , cp , rx , ry)) =
+    inj₁ (p , x , y , down-r point sub dp rp , cp
+         , down-out dx (sub {xo} dx) rx , down-out dy (sub {yo} dy) ry)
+holds-lower (into-coords xo yo point) sub pre
+  ((pv₀ , dp) , (xv₀ , dx) , (yv₀ , dy))
+  (inj₂ (p , x , y , rp , cp , rx , ry)) =
+    inj₂ (p , x , y , down-r point sub dp rp , cp
+         , down-out dx (sub {xo} dx) rx , down-out dy (sub {yo} dy) ry)
+
+holds-lower (from-coords out x y) sub pre
+  ((xv₀ , dx) , (yv₀ , dy) , (ov₀ , do′))
+  (inj₁ (xv , yv , p , rx , ry , fc , ro)) =
+    inj₁ (xv , yv , p
+         , resolveᶜ-Fr-intro _ x (down-r x sub dx (resolveᶜ-Fr-inv _ x rx))
+         , resolveᶜ-Fr-intro _ y (down-r y sub dy (resolveᶜ-Fr-inv _ y ry))
+         , fc , down-out do′ (sub {out} do′) ro)
+holds-lower (from-coords out x y) sub pre
+  ((xv₀ , dx) , (yv₀ , dy) , (ov₀ , do′))
+  (inj₂ (xv , yv , p , rx , ry , fc , ro)) =
+    inj₂ (xv , yv , p , down-r x sub dx rx , down-r y sub dy ry
+         , fc , down-out do′ (sub {out} do′) ro)
+
+holds-lower (into-bytes out a) sub pre ((av₀ , da) , (ov₀ , do′))
+  (av , ov , ra , ro , rest) =
+    av , ov , down-r a sub da ra , down-out do′ (sub {out} do′) ro , rest
+
+holds-lower (from-bytes out b) sub pre ((bv₀ , db) , (ov₀ , do′))
+  (bs , rb , inj₁ ro) =
+    bs , down-r b sub db rb , inj₁ (down-out do′ (sub {out} do′) ro)
+holds-lower (from-bytes out b) sub pre ((bv₀ , db) , (ov₀ , do′))
+  (bs , rb , inj₂ (inj₁ ro)) =
+    bs , down-r b sub db rb , inj₂ (inj₁ (down-out do′ (sub {out} do′) ro))
+holds-lower (from-bytes out b) sub pre ((bv₀ , db) , (ov₀ , do′))
+  (bs , rb , inj₂ (inj₂ ro)) =
+    bs , down-r b sub db rb , inj₂ (inj₂ (down-out do′ (sub {out} do′) ro))
+
+holds-lower (reverse-bytes out b) sub pre ((bv₀ , db) , (ov₀ , do′))
+  (bs , rb , ro) =
+    bs , down-r b sub db rb , down-out do′ (sub {out} do′) ro
+
+holds-lower (bytes-into-low-high lo hi b) sub pre
+  ((bv₀ , db) , (lv₀ , dl) , (hv₀ , dh))
+  (bs , l , h , rb , sp , rl , rh) =
+    bs , l , h , down-r b sub db rb , sp
+  , down-out dl (sub {lo} dl) rl , down-out dh (sub {hi} dh) rh
+
+holds-lower (bytes-from-low-high out lo hi) sub pre
+  ((l₀ , dl) , (h₀ , dh) , (ov₀ , do′))
+  (l , h , bs , rl , rh , as , ro) =
+    l , h , bs , down-fr lo sub dl rl , down-fr hi sub dh rh
+  , as , down-out do′ (sub {out} do′) ro
+
+holds-lower (pi-binding entry) sub pre (bv₀ , dp) (bv , pl) =
+    bv , down-pi pre dp pl
+
+holds-lower (pi-impact entry guard x) sub pre
+  ((g₀ , dg) , (xv₀ , dx) , (pv₀ , dp))
+  (g , xv , pv , rg , rx , bit , pl , imps) =
+    g , xv , pv , down-fr guard sub dg rg , down-fr x sub dx rx
+  , bit , down-pi pre dp pl , imps
+
+holds-lower (comm inputs outputs) sub pre
+  ((ivs₀ , di) , (ovs₀ , do′) , (pv₀ , dp))
+  (ivs , ovs , rv , pv , ri , ro , cr≡ , pl , c≡) =
+    ivs , ovs , rv , pv
+  , down-enc inputs sub di ri , down-enc outputs sub do′ ro
+  , cr≡ , down-pi pre dp pl , c≡

--- a/formal/src/zkir-v3/CircuitFaithfulness.agda
+++ b/formal/src/zkir-v3/CircuitFaithfulness.agda
@@ -1,0 +1,2108 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- FORWARD faithfulness of zkir-v3: every successful preprocess run
+-- yields a witness satisfying the synthesized constraint system.
+--
+-- Contents: the per-instruction `*-fwd` lemmas (at the immediate
+-- post-step witness), the program-level induction `fwd-go`, the
+-- output-collection coupling `out-go`, the communications-commitment
+-- case `comm-fwd` (with `decode-reencode` and `init-pi1`), and the
+-- headline `forward`.  The witness/constraint bridge (`witness-of`,
+-- `holds-mono`, …) lives in CircuitBridge; the static-check form
+-- `forward-sa` and the iff live in CircuitProof.
+------------------------------------------------------------------------
+
+module zkir-v3.CircuitFaithfulness (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Semantics ⋯ using (ProofPreimage; State; resolve; resolveᶠ)
+open import zkir-v3.SemanticsProperties ⋯
+open import zkir-v3.Circuit ⋯
+open import zkir-v3.CircuitBridge ⋯
+
+open import Data.Maybe   using (Maybe; just; nothing)
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+------------------------------------------------------------------------
+-- Per-instruction FORWARD faithfulness  (deterministic + assert).
+--
+-- For each instruction `I` of the deterministic / `assert` fragment, a
+-- local lemma: from a successful off-circuit step
+-- (`step P S st (I …) ≡ just st'`) and freshness/distinctness of the
+-- output identifier(s), the constraint that `synth-instr (I …)` appends
+-- holds at the immediate post-step witness `witness-of P st'`.
+--
+-- These are stated at the immediate post-step witness only: no
+-- program-level induction, no monotonicity, no backward direction.  The
+-- hypotheses are transported across the off/in-circuit boundary by
+-- `resolve-agree` / `resolveᶜ-Fr-agree`; the output binding is read off
+-- the `ins` that `step` performed.
+------------------------------------------------------------------------
+
+open import zkir-v3.Semantics ⋯
+  using (Mem; step; resolve𝔹; to𝔹; out1; valEq?; _≟B_;
+         resolve-all-Fr)
+  renaming (χ to χˢ; pow2ᶠ to pow2ᶠˢ)
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+
+open import Data.Bool using (Bool; true; false; if_then_else_)
+  renaming (not to bnot)
+open import Data.Maybe using (_>>=_)
+open import Data.Nat using (ℕ; zero; suc; _+_; _*_; _<?_; _<_; _^_; _∸_)
+open import Data.List using (List; []; _∷_; map)
+open import Data.Sum using (inj₁; inj₂; _⊎_)
+open import Data.Unit using (⊤; tt)
+open import Function using (case_of_)
+open import Relation.Binary.PropositionalEquality
+  using (sym; trans; cong)
+open import Relation.Nullary using (Dec; yes; no; ¬_)
+open import Relation.Nullary.Decidable using (isYes)
+
+------------------------------------------------------------------------
+-- assert  ⟶  non-zero
+--
+-- A successful step forces the condition to read as `true`, which (via
+-- `to𝔹`) means it resolves to a field element distinct from `0ᶠ`.
+------------------------------------------------------------------------
+
+assert-fwd : ∀ {P S st st' cond}
+  → step P S st (assert cond) ≡ just st'
+  → holds (witness-of P st') (non-zero cond)
+assert-fwd {P} {S} {st} {st'} {cond} st≡
+  with resolveᶠ (State.mem st) cond in eqf
+... | just x with x ≟ᶠ 0ᶠ
+...   | no x≢0 with x ≟ᶠ 1ᶠ
+...     | yes _ with refl ← st≡ =
+          x , trans (resolveᶜ-Fr-agree P st cond) eqf , x≢0
+
+------------------------------------------------------------------------
+-- constrain-eq  ⟶  eq
+--
+-- A `valEq?` reading `true` means the two values are equal (at any of
+-- the supported types), so both operands resolve to a single value.
+------------------------------------------------------------------------
+
+-- A `valEq?` that reads `true` witnesses equality of the two values.
+valEq?-true : ∀ {av bv} → valEq? av bv ≡ just true → av ≡ bv
+valEq?-true {val-native x}       {val-native y}       e
+  with x ≟ᶠ y
+... | yes refl = refl
+valEq?-true {val-bytes32 a}      {val-bytes32 b}      e
+  with a ≟B b
+... | yes refl = refl
+valEq?-true {val-jubjub-point p} {val-jubjub-point q} e
+  with p ≟J q
+... | yes refl = refl
+valEq?-true {val-secp-point p}   {val-secp-point q}   e
+  with p ≟K q
+... | yes refl = refl
+valEq?-true {val-secp-base x}    {val-secp-base y}    e
+  with x ≟ᵇ y
+... | yes refl = refl
+valEq?-true {val-secp-scalar x}  {val-secp-scalar y}  e
+  with x ≟ˢ y
+... | yes refl = refl
+
+constrain-eq-fwd : ∀ {P S st st' a b}
+  → step P S st (constrain-eq a b) ≡ just st'
+  → holds (witness-of P st') (eq a b)
+constrain-eq-fwd {P} {S} {st} {st'} {a} {b} st≡
+  with resolve (State.mem st) a in eqa | resolve (State.mem st) b in eqb
+... | just av | just bv with valEq? av bv in eqv
+...   | just true with refl ← st≡ with refl ← valEq?-true {av} {bv} eqv =
+          av
+        , trans (resolve-agree P st a) eqa
+        , trans (resolve-agree P st b) eqb
+
+------------------------------------------------------------------------
+-- constrain-to-boolean  ⟶  boolean
+--
+-- A successful `resolve𝔹` forces the value to read as a boolean, i.e.
+-- it equals `0ᶠ` or `1ᶠ` (the two `to𝔹` success branches).
+------------------------------------------------------------------------
+
+constrain-to-boolean-fwd : ∀ {P S st st' val}
+  → step P S st (constrain-to-boolean val) ≡ just st'
+  → holds (witness-of P st') (boolean val)
+constrain-to-boolean-fwd {P} {S} {st} {st'} {val} st≡
+  with resolveᶠ (State.mem st) val in eqf
+... | just x with x ≟ᶠ 0ᶠ
+...   | yes x≡0 with refl ← st≡ =
+          x , trans (resolveᶜ-Fr-agree P st val) eqf , inj₁ x≡0
+...   | no _ with x ≟ᶠ 1ᶠ
+...     | yes x≡1 with refl ← st≡ =
+            x , trans (resolveᶜ-Fr-agree P st val) eqf , inj₂ x≡1
+
+------------------------------------------------------------------------
+-- constrain-bits  ⟶  in-range
+--
+-- The off-circuit guard `valFr x <? 2 ^ bits` succeeds exactly with the
+-- range proof that `in-range` requires.
+------------------------------------------------------------------------
+
+constrain-bits-fwd : ∀ {P S st st' val bits}
+  → step P S st (constrain-bits val bits) ≡ just st'
+  → holds (witness-of P st') (in-range val bits)
+constrain-bits-fwd {P} {S} {st} {st'} {val} {bits} st≡
+  with resolveᶠ (State.mem st) val in eqf
+... | just x with valFr x <? 2 ^ bits
+...   | yes p with refl ← st≡ =
+          x , trans (resolveᶜ-Fr-agree P st val) eqf , p
+
+------------------------------------------------------------------------
+-- copy  ⟶  gate-copy
+--
+-- The output cell holds the resolved input value; freshness keeps the
+-- input resolving identically across the binding.
+------------------------------------------------------------------------
+
+copy-fwd : ∀ {P S st st' val output}
+  → State.mem st output ≡ nothing
+  → step P S st (copy val output) ≡ just st'
+  → holds (witness-of P st') (gate-copy output val)
+copy-fwd {P} {S} {st} {st'} {val} {output} fresh st≡
+  with resolve (State.mem st) val in eqv
+... | just v with refl ← st≡ =
+        v , ⊢-pres P st output v val fresh eqv , assign-here P st output v
+
+------------------------------------------------------------------------
+-- add  ⟶  gate-add        (Native or JubjubPoint, type-directed)
+------------------------------------------------------------------------
+
+add-fwd : ∀ {P S st st' a b output}
+  → State.mem st output ≡ nothing
+  → step P S st (add a b output) ≡ just st'
+  → holds (witness-of P st') (gate-add output a b)
+add-fwd {P} {S} {st} {st'} {a} {b} {output} fresh st≡
+  with resolve (State.mem st) a in eqa | resolve (State.mem st) b in eqb
+... | just (val-native x) | just (val-native y) with refl ← st≡ =
+        val-native x , val-native y , val-native (x +ᶠ y)
+      , ⊢-pres P st output _ a fresh eqa
+      , ⊢-pres P st output _ b fresh eqb
+      , assign-here P st output _
+      , inj₁ (x , y , refl , refl , refl)
+... | just (val-jubjub-point p) | just (val-jubjub-point q) with refl ← st≡ =
+        val-jubjub-point p , val-jubjub-point q , val-jubjub-point (p +J q)
+      , ⊢-pres P st output _ a fresh eqa
+      , ⊢-pres P st output _ b fresh eqb
+      , assign-here P st output _
+      , inj₂ (inj₁ (p , q , refl , refl , refl))
+... | just (val-secp-point p) | just (val-secp-point q) with refl ← st≡ =
+        val-secp-point p , val-secp-point q , val-secp-point (p +K q)
+      , ⊢-pres P st output _ a fresh eqa
+      , ⊢-pres P st output _ b fresh eqb
+      , assign-here P st output _
+      , inj₂ (inj₂ (inj₁ (p , q , refl , refl , refl)))
+... | just (val-secp-base x) | just (val-secp-base y) with refl ← st≡ =
+        val-secp-base x , val-secp-base y , val-secp-base (x +ᵇ y)
+      , ⊢-pres P st output _ a fresh eqa
+      , ⊢-pres P st output _ b fresh eqb
+      , assign-here P st output _
+      , inj₂ (inj₂ (inj₂ (inj₁ (x , y , refl , refl , refl))))
+... | just (val-secp-scalar x) | just (val-secp-scalar y) with refl ← st≡ =
+        val-secp-scalar x , val-secp-scalar y , val-secp-scalar (x +ˢ y)
+      , ⊢-pres P st output _ a fresh eqa
+      , ⊢-pres P st output _ b fresh eqb
+      , assign-here P st output _
+      , inj₂ (inj₂ (inj₂ (inj₂ (x , y , refl , refl , refl))))
+
+------------------------------------------------------------------------
+-- mul  ⟶  gate-mul        (Native)
+------------------------------------------------------------------------
+
+mul-fwd : ∀ {P S st st' a b output}
+  → State.mem st output ≡ nothing
+  → step P S st (mul a b output) ≡ just st'
+  → holds (witness-of P st') (gate-mul output a b)
+mul-fwd {P} {S} {st} {st'} {a} {b} {output} fresh st≡
+  with resolve (State.mem st) a in eqa | resolve (State.mem st) b in eqb
+... | just (val-native x) | just (val-native y) with refl ← st≡ =
+        val-native x , val-native y , val-native (x *ᶠ y)
+      , ⊢-pres P st output _ a fresh eqa
+      , ⊢-pres P st output _ b fresh eqb
+      , assign-here P st output _
+      , inj₁ (x , y , refl , refl , refl)
+... | just (val-secp-base x) | just (val-secp-base y) with refl ← st≡ =
+        val-secp-base x , val-secp-base y , val-secp-base (x *ᵇ y)
+      , ⊢-pres P st output _ a fresh eqa
+      , ⊢-pres P st output _ b fresh eqb
+      , assign-here P st output _
+      , inj₂ (inj₁ (x , y , refl , refl , refl))
+... | just (val-secp-scalar x) | just (val-secp-scalar y) with refl ← st≡ =
+        val-secp-scalar x , val-secp-scalar y , val-secp-scalar (x *ˢ y)
+      , ⊢-pres P st output _ a fresh eqa
+      , ⊢-pres P st output _ b fresh eqb
+      , assign-here P st output _
+      , inj₂ (inj₂ (x , y , refl , refl , refl))
+
+------------------------------------------------------------------------
+-- neg  ⟶  gate-neg        (Native or JubjubPoint)
+------------------------------------------------------------------------
+
+neg-fwd : ∀ {P S st st' a output}
+  → State.mem st output ≡ nothing
+  → step P S st (neg a output) ≡ just st'
+  → holds (witness-of P st') (gate-neg output a)
+neg-fwd {P} {S} {st} {st'} {a} {output} fresh st≡
+  with resolve (State.mem st) a in eqa
+... | just (val-native x) with refl ← st≡ =
+        val-native x , val-native (-ᶠ x)
+      , ⊢-pres P st output _ a fresh eqa
+      , assign-here P st output _
+      , inj₁ (x , refl , refl)
+... | just (val-jubjub-point p) with refl ← st≡ =
+        val-jubjub-point p , val-jubjub-point (negJ p)
+      , ⊢-pres P st output _ a fresh eqa
+      , assign-here P st output _
+      , inj₂ (inj₁ (p , refl , refl))
+... | just (val-secp-point p) with refl ← st≡ =
+        val-secp-point p , val-secp-point (negK p)
+      , ⊢-pres P st output _ a fresh eqa
+      , assign-here P st output _
+      , inj₂ (inj₂ (inj₁ (p , refl , refl)))
+... | just (val-secp-base x) with refl ← st≡ =
+        val-secp-base x , val-secp-base (-ᵇ x)
+      , ⊢-pres P st output _ a fresh eqa
+      , assign-here P st output _
+      , inj₂ (inj₂ (inj₂ (inj₁ (x , refl , refl))))
+... | just (val-secp-scalar x) with refl ← st≡ =
+        val-secp-scalar x , val-secp-scalar (-ˢ x)
+      , ⊢-pres P st output _ a fresh eqa
+      , assign-here P st output _
+      , inj₂ (inj₂ (inj₂ (inj₂ (x , refl , refl))))
+
+------------------------------------------------------------------------
+-- inv  ⟶  gate-inv        (Native; off-circuit `invᶠ` mirrors the gate)
+------------------------------------------------------------------------
+
+inv-fwd : ∀ {P S st st' a output}
+  → State.mem st output ≡ nothing
+  → step P S st (inv a output) ≡ just st'
+  → holds (witness-of P st') (gate-inv output a)
+inv-fwd {P} {S} {st} {st'} {a} {output} fresh st≡
+  with resolve (State.mem st) a in eqa
+... | just (val-native x) with invᶠ x in eqi
+...   | just xi with refl ← st≡ =
+          val-native x , val-native xi
+        , ⊢-pres P st output _ a fresh eqa
+        , assign-here P st output _
+        , inj₁ (x , xi , refl , eqi , refl)
+inv-fwd {P} {S} {st} {st'} {a} {output} fresh st≡
+    | just (val-secp-base x) with invᵇ x in eqi
+...   | just xi with refl ← st≡ =
+          val-secp-base x , val-secp-base xi
+        , ⊢-pres P st output _ a fresh eqa
+        , assign-here P st output _
+        , inj₂ (inj₁ (x , xi , refl , eqi , refl))
+inv-fwd {P} {S} {st} {st'} {a} {output} fresh st≡
+    | just (val-secp-scalar x) with invˢ x in eqi
+...   | just xi with refl ← st≡ =
+          val-secp-scalar x , val-secp-scalar xi
+        , ⊢-pres P st output _ a fresh eqa
+        , assign-here P st output _
+        , inj₂ (inj₂ (x , xi , refl , eqi , refl))
+
+------------------------------------------------------------------------
+-- not  ⟶  is-not          (booleanity from the `to𝔹` success branches)
+------------------------------------------------------------------------
+
+not-fwd : ∀ {P S st st' a output}
+  → State.mem st output ≡ nothing
+  → step P S st (not a output) ≡ just st'
+  → holds (witness-of P st') (is-not output a)
+not-fwd {P} {S} {st} {st'} {a} {output} fresh st≡
+  with resolveᶠ (State.mem st) a in eqf
+... | just x with x ≟ᶠ 0ᶠ
+...   | yes x≡0 with x ≟ᶠ 1ᶠ in eq1
+...     | no _    with refl ← st≡ =
+            x , ⊢ᶠ-pres P st output _ a fresh eqf , inj₁ x≡0
+          , trans (assign-here P st output (val-native 1ᶠ))
+                  (cong (λ d → just (val-native (χ (bnot (isYes d)))))
+                        (sym eq1))
+...     | yes x≡1 = case 1ᶠ≢0ᶠ (trans (sym x≡1) x≡0) of λ ()
+not-fwd {P} {S} {st} {st'} {a} {output} fresh st≡
+    | just x | no _ with x ≟ᶠ 1ᶠ in eq1
+...   | yes x≡1 with refl ← st≡ =
+          x , ⊢ᶠ-pres P st output _ a fresh eqf , inj₂ x≡1
+        , trans (assign-here P st output (val-native 0ᶠ))
+                (cong (λ d → just (val-native (χ (bnot (isYes d)))))
+                      (sym eq1))
+
+------------------------------------------------------------------------
+-- test-eq  ⟶  test-eq      (output is the 0/1 equality flag)
+------------------------------------------------------------------------
+
+test-eq-fwd : ∀ {P S st st' a b output}
+  → State.mem st output ≡ nothing
+  → step P S st (test-eq a b output) ≡ just st'
+  → holds (witness-of P st') (test-eq output a b)
+test-eq-fwd {P} {S} {st} {st'} {a} {b} {output} fresh st≡
+  with resolve (State.mem st) a in eqa | resolve (State.mem st) b in eqb
+... | just av | just bv with valEq? av bv in eqv
+...   | just e with refl ← st≡ =
+          av , bv , e
+        , ⊢-pres P st output _ a fresh eqa
+        , ⊢-pres P st output _ b fresh eqb
+        , eqv
+        , assign-here P st output (val-native (χˢ e))
+
+------------------------------------------------------------------------
+-- less-than  ⟶  less-than   (two range proofs + the comparison flag)
+--
+-- The step checks the exact `2 ^ bits` operand bounds; the constraint
+-- states the chip's evened `2 ^ even4 bits` bound, so the range proofs
+-- are weakened via `<-even4`.
+------------------------------------------------------------------------
+
+less-than-fwd : ∀ {P S st st' a b bits output}
+  → State.mem st output ≡ nothing
+  → step P S st (less-than a b bits output) ≡ just st'
+  → holds (witness-of P st') (less-than output a b bits)
+less-than-fwd {P} {S} {st} {st'} {a} {b} {bits} {output} fresh st≡
+  with resolveᶠ (State.mem st) a in eqa | resolveᶠ (State.mem st) b in eqb
+... | just x | just y with valFr x <? 2 ^ bits
+...   | yes px with valFr y <? 2 ^ bits
+...     | yes py with refl ← st≡ =
+            x , y
+          , ⊢ᶠ-pres P st output _ a fresh eqa
+          , ⊢ᶠ-pres P st output _ b fresh eqb
+          , <-even4 bits px , <-even4 bits py
+          , assign-here P st output
+              (val-native (χˢ (isYes (valFr x <? valFr y))))
+
+------------------------------------------------------------------------
+-- reconstitute-field  ⟶  reconstitute
+--
+-- The first two off-circuit guards supply exactly the two range proofs
+-- `reconstitute` asks for; the third (no field overflow) is a producer
+-- obligation not part of the constraint.
+------------------------------------------------------------------------
+
+reconstitute-field-fwd : ∀ {P S st st' divisor modulus bits output}
+  → State.mem st output ≡ nothing
+  → step P S st (reconstitute-field divisor modulus bits output) ≡ just st'
+  → holds (witness-of P st') (reconstitute output divisor modulus bits)
+reconstitute-field-fwd {P} {S} {st} {st'} {divisor} {modulus} {bits} {output}
+  fresh st≡
+  with resolveᶠ (State.mem st) divisor in eqd
+     | resolveᶠ (State.mem st) modulus in eqm
+... | just d | just mo with valFr mo <? 2 ^ bits
+...   | yes pm with valFr d <? 2 ^ (FR-BITS ∸ bits)
+...     | yes pd with valFr mo + 2 ^ bits * valFr d <? FR-ORDER
+...       | yes _ with refl ← st≡ =
+              d , mo
+            , ⊢ᶠ-pres P st output _ divisor fresh eqd
+            , ⊢ᶠ-pres P st output _ modulus fresh eqm
+            , pd , pm
+            , assign-here P st output
+                (val-native ((pow2ᶠˢ bits *ᶠ d) +ᶠ mo))
+
+------------------------------------------------------------------------
+-- jubjub-scalar-from-native  ⟶  scalar-from-native
+------------------------------------------------------------------------
+
+jubjub-scalar-from-native-fwd : ∀ {P S st st' a output}
+  → State.mem st output ≡ nothing
+  → step P S st (jubjub-scalar-from-native a output) ≡ just st'
+  → holds (witness-of P st') (scalar-from-native output a)
+jubjub-scalar-from-native-fwd {P} {S} {st} {st'} {a} {output} fresh st≡
+  with resolveᶠ (State.mem st) a in eqf
+... | just x with refl ← st≡ =
+        x , ⊢ᶠ-pres P st output _ a fresh eqf
+      , assign-here P st output _
+
+------------------------------------------------------------------------
+-- ec-mul  ⟶  ec-mul        (JubjubPoint × JubjubScalar)
+------------------------------------------------------------------------
+
+ec-mul-fwd : ∀ {P S st st' a scalar output}
+  → State.mem st output ≡ nothing
+  → step P S st (ec-mul a scalar output) ≡ just st'
+  → holds (witness-of P st') (ec-mul output a scalar)
+ec-mul-fwd {P} {S} {st} {st'} {a} {scalar} {output} fresh st≡
+  with resolve (State.mem st) a in eqa | resolve (State.mem st) scalar in eqs
+... | just (val-jubjub-point p) | just (val-jubjub-scalar s)
+        with refl ← st≡ =
+          inj₁ ( p , s
+               , ⊢-pres P st output _ a fresh eqa
+               , ⊢-pres P st output _ scalar fresh eqs
+               , assign-here P st output _ )
+... | just (val-secp-point p) | just (val-secp-scalar s)
+        with refl ← st≡ =
+          inj₂ ( p , s
+               , ⊢-pres P st output _ a fresh eqa
+               , ⊢-pres P st output _ scalar fresh eqs
+               , assign-here P st output _ )
+
+------------------------------------------------------------------------
+-- ec-mul-generator  ⟶  ec-gen        (JubjubScalar)
+------------------------------------------------------------------------
+
+ec-mul-generator-fwd : ∀ {P S st st' scalar output}
+  → State.mem st output ≡ nothing
+  → step P S st (ec-mul-generator scalar output) ≡ just st'
+  → holds (witness-of P st') (ec-gen output scalar)
+ec-mul-generator-fwd {P} {S} {st} {st'} {scalar} {output} fresh st≡
+  with resolve (State.mem st) scalar in eqs
+... | just (val-jubjub-scalar s) with refl ← st≡ =
+        inj₁ ( s , ⊢-pres P st output _ scalar fresh eqs
+             , assign-here P st output _ )
+... | just (val-secp-scalar s) with refl ← st≡ =
+        inj₂ ( s , ⊢-pres P st output _ scalar fresh eqs
+             , assign-here P st output _ )
+
+------------------------------------------------------------------------
+-- hash-to-curve  ⟶  h2c       (Native inputs → JubjubPoint)
+------------------------------------------------------------------------
+
+hash-to-curve-fwd : ∀ {P S st st' inputs output}
+  → State.mem st output ≡ nothing
+  → step P S st (hash-to-curve inputs output) ≡ just st'
+  → holds (witness-of P st') (h2c output inputs)
+hash-to-curve-fwd {P} {S} {st} {st'} {inputs} {output} fresh st≡
+  with resolve-all-Fr (State.mem st) inputs in eqi
+... | just frs with refl ← st≡ =
+        frs , ⊢all-pres P st output _ inputs fresh eqi
+      , assign-here P st output _
+
+------------------------------------------------------------------------
+-- into-bytes32  ⟶  into-bytes        (Native → Bytes32)
+------------------------------------------------------------------------
+
+into-bytes32-fwd : ∀ {P S st st' input output}
+  → State.mem st output ≡ nothing
+  → step P S st (into-bytes32 input output) ≡ just st'
+  → holds (witness-of P st') (into-bytes output input)
+into-bytes32-fwd {P} {S} {st} {st'} {input} {output} fresh st≡
+  with resolve (State.mem st) input in eqv
+... | just (val-native x) with refl ← st≡ =
+        val-native x , val-bytes32 (nativeToBytes x)
+      , ⊢-pres P st output _ input fresh eqv
+      , assign-here P st output _
+      , inj₁ (x , refl , refl)
+... | just (val-secp-base x) with refl ← st≡ =
+        val-secp-base x , val-bytes32 (secpBaseToBytes x)
+      , ⊢-pres P st output _ input fresh eqv
+      , assign-here P st output _
+      , inj₂ (inj₁ (x , refl , refl))
+... | just (val-secp-scalar s) with refl ← st≡ =
+        val-secp-scalar s , val-bytes32 (secpScalarToBytes s)
+      , ⊢-pres P st output _ input fresh eqv
+      , assign-here P st output _
+      , inj₂ (inj₂ (s , refl , refl))
+
+------------------------------------------------------------------------
+-- from-bytes32  ⟶  from-bytes        (Bytes32 → Native; val-t = native)
+------------------------------------------------------------------------
+
+from-bytes32-fwd : ∀ {P S st st' bytes val-t output}
+  → State.mem st output ≡ nothing
+  → step P S st (from-bytes32 bytes val-t output) ≡ just st'
+  → holds (witness-of P st') (from-bytes output bytes)
+from-bytes32-fwd {P} {S} {st} {st'} {bytes} {native} {output} fresh st≡
+  with resolve (State.mem st) bytes in eqv
+... | just (val-bytes32 b) with refl ← st≡ =
+        b , ⊢-pres P st output _ bytes fresh eqv
+      , inj₁ (assign-here P st output _)
+from-bytes32-fwd {P} {S} {st} {st'} {bytes} {secp-base} {output} fresh st≡
+  with resolve (State.mem st) bytes in eqv
+... | just (val-bytes32 b) with refl ← st≡ =
+        b , ⊢-pres P st output _ bytes fresh eqv
+      , inj₂ (inj₁ (assign-here P st output _))
+from-bytes32-fwd {P} {S} {st} {st'} {bytes} {secp-scalar} {output} fresh st≡
+  with resolve (State.mem st) bytes in eqv
+... | just (val-bytes32 b) with refl ← st≡ =
+        b , ⊢-pres P st output _ bytes fresh eqv
+      , inj₂ (inj₂ (assign-here P st output _))
+from-bytes32-fwd {st = st} {bytes = bytes} {bytes32} _ st≡
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 _) = case st≡ of λ ()
+from-bytes32-fwd {st = st} {bytes = bytes} {jubjub-point} _ st≡
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 _) = case st≡ of λ ()
+from-bytes32-fwd {st = st} {bytes = bytes} {jubjub-scalar} _ st≡
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 _) = case st≡ of λ ()
+from-bytes32-fwd {st = st} {bytes = bytes} {secp-point} _ st≡
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 _) = case st≡ of λ ()
+
+------------------------------------------------------------------------
+-- reverse-bytes  ⟶  reverse-bytes        (Bytes32 → Bytes32)
+------------------------------------------------------------------------
+
+reverse-bytes-fwd : ∀ {P S st st' bytes output}
+  → State.mem st output ≡ nothing
+  → step P S st (reverse-bytes bytes output) ≡ just st'
+  → holds (witness-of P st') (reverse-bytes output bytes)
+reverse-bytes-fwd {P} {S} {st} {st'} {bytes} {output} fresh st≡
+  with resolve (State.mem st) bytes in eqv
+... | just (val-bytes32 b) with refl ← st≡ =
+        b , ⊢-pres P st output _ bytes fresh eqv , assign-here P st output _
+
+------------------------------------------------------------------------
+-- transient-hash  ⟶  poseidon        (Native inputs → Native)
+------------------------------------------------------------------------
+
+transient-hash-fwd : ∀ {P S st st' inputs output}
+  → State.mem st output ≡ nothing
+  → step P S st (transient-hash inputs output) ≡ just st'
+  → holds (witness-of P st') (poseidon output inputs)
+transient-hash-fwd {P} {S} {st} {st'} {inputs} {output} fresh st≡
+  with resolve-all-Fr (State.mem st) inputs in eqi
+... | just frs with refl ← st≡ =
+        frs , ⊢all-pres P st output _ inputs fresh eqi
+      , assign-here P st output _
+
+------------------------------------------------------------------------
+-- from-coordinates  ⟶  from-coords        (single output, pair input)
+------------------------------------------------------------------------
+
+from-coordinates-fwd : ∀ {P S st st' xop yop output}
+  → State.mem st output ≡ nothing
+  → step P S st (from-coordinates (xop , yop) output) ≡ just st'
+  → holds (witness-of P st') (from-coords output xop yop)
+from-coordinates-fwd {P} {S} {st} {st'} {xop} {yop} {output} fresh st≡
+  with resolve (State.mem st) xop in eqx | resolve (State.mem st) yop in eqy
+... | just (val-native x) | just (val-native y) with fromCoordsJ x y in eqp
+...   | just p with refl ← st≡ =
+          inj₁ ( x , y , p
+               , ⊢ᶠ-pres P st output _ xop fresh
+                   (resolveᶠ-intro (State.mem st) xop eqx)
+               , ⊢ᶠ-pres P st output _ yop fresh
+                   (resolveᶠ-intro (State.mem st) yop eqy)
+               , eqp
+               , assign-here P st output _ )
+from-coordinates-fwd {P} {S} {st} {st'} {xop} {yop} {output} fresh st≡
+    | just (val-secp-base x) | just (val-secp-base y)
+        with fromCoordsK x y in eqp
+...   | just p with refl ← st≡ =
+          inj₂ ( x , y , p
+               , ⊢-pres P st output _ xop fresh eqx
+               , ⊢-pres P st output _ yop fresh eqy
+               , eqp
+               , assign-here P st output _ )
+
+------------------------------------------------------------------------
+-- bytes32-from-low-high  ⟶  bytes-from-low-high
+------------------------------------------------------------------------
+
+bytes32-from-low-high-fwd : ∀ {P S st st' loop hiop output}
+  → State.mem st output ≡ nothing
+  → step P S st (bytes32-from-low-high (loop , hiop) output) ≡ just st'
+  → holds (witness-of P st') (bytes-from-low-high output loop hiop)
+bytes32-from-low-high-fwd {P} {S} {st} {st'} {loop} {hiop} {output} fresh st≡
+  with resolveᶠ (State.mem st) loop in eql | resolveᶠ (State.mem st) hiop in eqh
+... | just lo | just hi with low-high→bytes32 lo hi in eqb
+...   | just b with refl ← st≡ =
+          lo , hi , b
+        , ⊢ᶠ-pres P st output _ loop fresh eql
+        , ⊢ᶠ-pres P st output _ hiop fresh eqh
+        , eqb
+        , assign-here P st output _
+
+------------------------------------------------------------------------
+-- into-coordinates  ⟶  into-coords        (two distinct outputs)
+------------------------------------------------------------------------
+
+into-coordinates-fwd : ∀ {P S st st' point xid yid}
+  → State.mem st xid ≡ nothing
+  → State.mem st yid ≡ nothing
+  → ¬ (xid ≡ yid)
+  → step P S st (into-coordinates point (xid , yid)) ≡ just st'
+  → holds (witness-of P st') (into-coords xid yid point)
+into-coordinates-fwd {P} {S} {st} {st'} {point} {xid} {yid}
+  freshx freshy xid≢yid st≡
+  with resolve (State.mem st) point in eqp
+... | just (val-jubjub-point p) with coordsJ p in eqc
+...   | (x , y) with refl ← st≡ =
+          inj₁ ( p , x , y
+               , ⊢-pres2 P st xid (val-native x) yid (val-native y) point
+                   freshx freshy (λ yid≡xid → xid≢yid (sym yid≡xid)) eqp
+               , eqc
+               , assign-inner P st xid (val-native x) yid (val-native y)
+                   xid≢yid
+               , assign-outer P st xid (val-native x) yid (val-native y) )
+into-coordinates-fwd {P} {S} {st} {st'} {point} {xid} {yid}
+  freshx freshy xid≢yid st≡
+    | just (val-secp-point p) with coordsK p in eqc
+...   | just (x , y) with refl ← st≡ =
+          inj₂ ( p , x , y
+               , ⊢-pres2 P st xid (val-secp-base x) yid (val-secp-base y) point
+                   freshx freshy (λ yid≡xid → xid≢yid (sym yid≡xid)) eqp
+               , eqc
+               , assign-inner P st xid (val-secp-base x) yid (val-secp-base y)
+                   xid≢yid
+               , assign-outer P st xid (val-secp-base x) yid (val-secp-base y) )
+
+------------------------------------------------------------------------
+-- bytes32-into-low-high  ⟶  bytes-into-low-high   (two distinct outputs)
+------------------------------------------------------------------------
+
+bytes32-into-low-high-fwd : ∀ {P S st st' bytes loid hiid}
+  → State.mem st loid ≡ nothing
+  → State.mem st hiid ≡ nothing
+  → ¬ (loid ≡ hiid)
+  → step P S st (bytes32-into-low-high bytes (loid , hiid)) ≡ just st'
+  → holds (witness-of P st') (bytes-into-low-high loid hiid bytes)
+bytes32-into-low-high-fwd {P} {S} {st} {st'} {bytes} {loid} {hiid}
+  freshl freshh loid≢hiid st≡
+  with resolve (State.mem st) bytes in eqv
+... | just (val-bytes32 b) with bytes32→low-high b in eqs
+...   | (lo , hi) with refl ← st≡ =
+          b , lo , hi
+        , ⊢-pres2 P st loid (val-native lo) hiid (val-native hi) bytes
+            freshl freshh (λ hiid≡loid → loid≢hiid (sym hiid≡loid)) eqv
+        , eqs
+        , assign-inner P st loid (val-native lo) hiid (val-native hi) loid≢hiid
+        , assign-outer P st loid (val-native lo) hiid (val-native hi)
+
+------------------------------------------------------------------------
+-- div-mod-power-of-two  ⟶  div-mod      (two distinct outputs q, r)
+--
+-- Stated for the WF3-mandated two-output shape; other shapes emit no
+-- constraint.
+------------------------------------------------------------------------
+
+div-mod-power-of-two-fwd : ∀ {P S st st' val bits q r}
+  → State.mem st q ≡ nothing
+  → State.mem st r ≡ nothing
+  → ¬ (q ≡ r)
+  → step P S st (div-mod-power-of-two val bits (q ∷ r ∷ [])) ≡ just st'
+  → holds (witness-of P st') (div-mod q r val bits)
+div-mod-power-of-two-fwd {P} {S} {st} {st'} {val} {bits} {q} {r}
+  freshq freshr q≢r st≡
+  with resolveᶠ (State.mem st) val in eqf
+... | just x with refl ← st≡ =
+        x
+      , ⊢ᶠ-pres2 P st q _ r _ val freshq freshr (λ r≡q → q≢r (sym r≡q)) eqf
+      , assign-inner P st q _ r _ q≢r
+      , assign-outer P st q _ r _
+
+------------------------------------------------------------------------
+-- persistent-hash  ⟶  sha256       (single Bytes32 output)
+------------------------------------------------------------------------
+
+persistent-hash-fwd : ∀ {P S st st' alignment inputs output}
+  → State.mem st output ≡ nothing
+  → step P S st (persistent-hash alignment inputs output) ≡ just st'
+  → holds (witness-of P st') (sha256 output alignment inputs)
+persistent-hash-fwd {P} {S} {st} {st'} {alignment} {inputs} {output}
+  fresh st≡
+  with resolve-all-Fr (State.mem st) inputs in eqi
+... | just frs with persistent-hash-fn alignment frs in eqhp
+...   | just v with refl ← st≡ =
+          frs , v
+        , ⊢all-pres P st output _ inputs fresh eqi
+        , eqhp
+        , assign-here P st output _
+
+------------------------------------------------------------------------
+-- keccak256  ⟶  keccak        (single Bytes32 output)
+------------------------------------------------------------------------
+
+keccak256-fwd : ∀ {P S st st' alignment inputs output}
+  → State.mem st output ≡ nothing
+  → step P S st (keccak256 alignment inputs output) ≡ just st'
+  → holds (witness-of P st') (keccak output alignment inputs)
+keccak256-fwd {P} {S} {st} {st'} {alignment} {inputs} {output}
+  fresh st≡
+  with resolve-all-Fr (State.mem st) inputs in eqi
+... | just frs with keccak-fn alignment frs in eqhk
+...   | just v with refl ← st≡ =
+          frs , v
+        , ⊢all-pres P st output _ inputs fresh eqi
+        , eqhk
+        , assign-here P st output _
+
+------------------------------------------------------------------------
+-- cond-select  ⟶  select
+--
+-- The off-circuit selector reads the bit through `to𝔹`; booleanity comes
+-- from the `to𝔹` success branches, and the two select implications hold
+-- because `to𝔹 0ᶠ = false` and `to𝔹 1ᶠ = true`.
+------------------------------------------------------------------------
+
+cond-select-fwd : ∀ {P S st st' bit a b output}
+  → State.mem st output ≡ nothing
+  → step P S st (cond-select bit a b output) ≡ just st'
+  → holds (witness-of P st') (select output bit a b)
+cond-select-fwd {P} {S} {st} {st'} {bit} {a} {b} {output} fresh st≡
+  with resolveᶠ (State.mem st) bit in eqf
+... | just x with x ≟ᶠ 0ᶠ
+...   | yes x≡0
+        with resolve (State.mem st) a in eqa | resolve (State.mem st) b in eqb
+...     | just av | just bvl with typeof av ≟T typeof bvl
+...       | yes _ with refl ← st≡ =
+              x , av , bvl , bvl
+            , ⊢ᶠ-pres P st output _ bit fresh eqf
+            , ⊢-pres P st output _ a fresh eqa
+            , ⊢-pres P st output _ b fresh eqb
+            , assign-here P st output _
+            , inj₁ x≡0
+            , (λ x≡1 → case 1ᶠ≢0ᶠ (trans (sym x≡1) x≡0) of λ ())
+            , (λ _ → refl)
+cond-select-fwd {P} {S} {st} {st'} {bit} {a} {b} {output} fresh st≡
+    | just x | no _ with x ≟ᶠ 1ᶠ
+...   | yes x≡1
+        with resolve (State.mem st) a in eqa | resolve (State.mem st) b in eqb
+...     | just av | just bvl with typeof av ≟T typeof bvl
+...       | yes _ with refl ← st≡ =
+              x , av , bvl , av
+            , ⊢ᶠ-pres P st output _ bit fresh eqf
+            , ⊢-pres P st output _ a fresh eqa
+            , ⊢-pres P st output _ b fresh eqb
+            , assign-here P st output _
+            , inj₂ x≡1
+            , (λ _ → refl)
+            , (λ x≡0 → case 1ᶠ≢0ᶠ (trans (sym x≡1) x≡0) of λ ())
+
+open import Data.List using (_++_)
+open import Data.List.Properties using (++-assoc)
+open import Data.Product using (∃)
+open import Data.Maybe.Properties using (just-injective)
+
+-- (`out-fresh`, `step-extends`, and the other single-step facts these
+-- lemmas consume live in SemanticsProperties.)
+
+open import zkir-v3.Semantics ⋯
+  using (insertMany; eval-guard; collectOutputs; _≟LFr_; run;
+         init; decode-inputs)
+open import Data.List using (length; take; drop)
+
+------------------------------------------------------------------------
+-- encode  ⟶  encode-eq
+--
+-- A successful step resolves `input` to a value `v` and binds the raw
+-- field elements `map val-native (encodeᵉ v)` to `outputs` via
+-- `insertMany`.  The constraint `encode-eq input outputs` asks for that
+-- same `v`, that `input` resolve to it at the post-step witness, and that
+-- each output cell hold its element.  The input resolution is transported
+-- through the (fresh, distinct-from-the-input) output bindings by memory
+-- monotonicity; the output binding is read off `insertMany` with `NoDup`
+-- ensuring earlier cells survive the later ones.
+------------------------------------------------------------------------
+
+-- Each `insertMany`-bound cell holds its value at the final state, given
+-- the keys were fresh and duplicate-free.
+insertMany-bind-each : ∀ P st ids vs {st'}
+  → insertMany st ids vs ≡ just st'
+  → AllFresh ids (State.mem st) → NoDup ids
+  → bind-each (witness-of P st') vs ids
+insertMany-bind-each P st []        []       refl _           _            = tt
+insertMany-bind-each P st (id ∷ ids) (v ∷ vs) e (fid , frs) (nin , ndup) =
+    insertMany-⊑ (out1 st id v) ids vs e
+      (allfresh-ins id v ids (State.mem st) frs nin) ndup
+      {id} (ins-here id v (State.mem st))
+  , insertMany-bind-each P (out1 st id v) ids vs e
+      (allfresh-ins id v ids (State.mem st) frs nin) ndup
+insertMany-bind-each P st []        (_ ∷ _)  ()  _           _
+insertMany-bind-each P st (_ ∷ _)   []       ()  _           _
+
+encode-fwd : ∀ {P S st st' input outputs}
+  → out-fresh (encode input outputs) (State.mem st)
+  → step P S st (encode input outputs) ≡ just st'
+  → holds (witness-of P st') (encode-eq input outputs)
+encode-fwd {P} {S} {st} {st'} {input} {outputs} (af , nd) e
+  with resolve (State.mem st) input in eqi
+... | just v =
+      v
+    , trans (resolve-agree P st' input)
+        (resolve-mono input
+          (insertMany-⊑ st outputs (map val-native (encodeᵉ v)) e af nd) eqi)
+    , insertMany-bind-each P st outputs (map val-native (encodeᵉ v)) e af nd
+
+------------------------------------------------------------------------
+-- impact  ⟶  impact-constraints
+--
+-- A successful `impact` step appends, for each input, one field element
+-- to the public-input vector: the input's value when the guard reads
+-- `true`, or `0ᶠ` when it reads `false`.  The synthesised constraint
+-- list `impact-constraints start guard inputs` (with `start` the cursor
+-- the synth maintains, here `length (State.pis st)`) places one
+-- `pi-impact` per input, asking that the matching public-input entry be
+-- the guarded value.  Memory is unchanged by the step, so every operand
+-- resolves at `witness-of P st'` exactly as it did off-circuit; the
+-- public-input vector is `State.pis st ++ guarded`, so the entry at
+-- `length (State.pis st) + k` is the k-th element of `guarded`.
+------------------------------------------------------------------------
+
+-- Resolution against an explicit `mk-witness` depends only on its
+-- `assign` field (the named store), so it agrees with `resolveᶠ`.
+resolveᶜ-Fr-mem-agree : ∀ (m : Mem) pis cr op
+  → resolveᶜ-Fr (mk-witness m pis cr) op ≡ resolveᶠ m op
+resolveᶜ-Fr-mem-agree m pis cr (imm x) = refl
+resolveᶜ-Fr-mem-agree m pis cr (var id) with m id
+... | nothing                    = refl
+... | just (val-native _)        = refl
+... | just (val-bytes32 _)       = refl
+... | just (val-jubjub-point _)  = refl
+... | just (val-jubjub-scalar _) = refl
+... | just (val-secp-point _)    = refl
+... | just (val-secp-base _)     = refl
+... | just (val-secp-scalar _)   = refl
+
+-- "The public-input entries from `start` onward are exactly `guarded`."
+-- A structured lookup hypothesis that unfolds one entry per step,
+-- matching the `impact-constraints` recursion (which advances `start`).
+PisAt : (full : List Fr) (start : ℕ) (guarded : List Fr) → Set
+PisAt full start []          = ⊤
+PisAt full start (pv ∷ rest) =
+  (pi-lookup full start ≡ just pv) × PisAt full (suc start) rest
+
+-- Prepending one entry to `full` shifts every index up by one.
+PisAt-cons : ∀ z full start guarded
+  → PisAt full start guarded → PisAt (z ∷ full) (suc start) guarded
+PisAt-cons z full start []          p        = tt
+PisAt-cons z full start (pv ∷ rest) (h , hs) =
+  h , PisAt-cons z full (suc start) rest hs
+
+-- A list reads itself off from index `0`.
+PisAt-self : ∀ (guarded : List Fr) → PisAt guarded 0 guarded
+PisAt-self []          = tt
+PisAt-self (pv ∷ rest) =
+  refl , PisAt-cons pv rest 0 rest (PisAt-self rest)
+
+-- The guarded suffix appended after `pre` is found from index
+-- `length pre` onward.
+PisAt-app : ∀ (pre guarded : List Fr)
+  → PisAt (pre ++ guarded) (length pre) guarded
+PisAt-app []        guarded = PisAt-self guarded
+PisAt-app (z ∷ pre) guarded =
+  PisAt-cons z (pre ++ guarded) (length pre) guarded (PisAt-app pre guarded)
+
+-- The guard's field reading is a bit (it is `0ᶠ` or `1ᶠ`).
+to𝔹-is-bit : ∀ {gᶠ b} → to𝔹 gᶠ ≡ just b → is-bit gᶠ
+to𝔹-is-bit {gᶠ} {false} e = inj₁ (to𝔹-false e)
+to𝔹-is-bit {gᶠ} {true}  e = inj₂ (to𝔹-true e)
+
+-- The select implications of `pi-impact`, given the guard's field value
+-- `gᶠ`, the bit reading `b = to𝔹 gᶠ`, and the appended entry `pv`.  When
+-- `b = true` the entry is the input value; when `b = false` it is `0ᶠ`.
+impact-select-true : ∀ {gᶠ xv}
+  → to𝔹 gᶠ ≡ just true
+  → (gᶠ ≡ 1ᶠ → xv ≡ xv) × (gᶠ ≡ 0ᶠ → xv ≡ 0ᶠ)
+impact-select-true {gᶠ} {xv} e =
+    (λ _ → refl)
+  , (λ gᶠ≡0 → case 1ᶠ≢0ᶠ (trans (sym (to𝔹-true e)) gᶠ≡0) of λ ())
+
+impact-select-false : ∀ {gᶠ xv}
+  → to𝔹 gᶠ ≡ just false
+  → (gᶠ ≡ 1ᶠ → 0ᶠ ≡ xv) × (gᶠ ≡ 0ᶠ → 0ᶠ ≡ 0ᶠ)
+impact-select-false {gᶠ} e =
+    (λ gᶠ≡1 → case 1ᶠ≢0ᶠ (trans (sym gᶠ≡1) (to𝔹-false e)) of λ ())
+  , (λ _ → refl)
+
+-- The core induction.  The witness public-input vector is a fixed list
+-- `full`; the entries from `start` onward are the guarded values
+-- (`PisAt full start guarded`).  Each `pi-impact start guard xₖ` holds:
+-- the guard reads the single field value `gᶠ` (its bit reading `b` fixed
+-- for the whole run), `xₖ` reads `valₖ`, and the entry at `start + k` is
+-- `valₖ` when `b = true`, else `0ᶠ`.  The `impact-constraints` recursion
+-- advances `start`, matching the `PisAt` unfolding.
+impact-sat : ∀ (m : Mem) full cr start guard {gᶠ b}
+  → (inputs : List Operand) (vals : List Fr)
+  → resolveᶠ m guard ≡ just gᶠ
+  → to𝔹 gᶠ ≡ just b
+  → resolve-all-Fr m inputs ≡ just vals
+  → PisAt full start (if b then vals else map (λ _ → 0ᶠ) vals)
+  → satisfies-constraints
+      (impact-constraints start guard inputs)
+      (mk-witness m full cr)
+impact-sat m full cr start guard []       _   rg tb rv at = tt
+impact-sat m full cr start guard {gᶠ} {true}  (x ∷ xs) vals rg tb rv at
+  with resolveᶠ m x in eqx | resolve-all-Fr m xs in eqxs
+... | nothing  | _        = case rv of λ ()
+... | just vx  | nothing  = case rv of λ ()
+... | just vx  | just vxs with refl ← rv =
+      let (pl , at-rest) = at in
+      ( gᶠ , vx , vx
+      , trans (resolveᶜ-Fr-mem-agree m full cr guard) rg
+      , trans (resolveᶜ-Fr-mem-agree m full cr x) eqx
+      , to𝔹-is-bit tb , pl , impact-select-true {gᶠ} {vx} tb )
+    , impact-sat m full cr (suc start) guard {gᶠ} {true} xs vxs rg tb eqxs
+        at-rest
+impact-sat m full cr start guard {gᶠ} {false} (x ∷ xs) vals rg tb rv at
+  with resolveᶠ m x in eqx | resolve-all-Fr m xs in eqxs
+... | nothing  | _        = case rv of λ ()
+... | just vx  | nothing  = case rv of λ ()
+... | just vx  | just vxs with refl ← rv =
+      let (pl , at-rest) = at in
+      ( gᶠ , vx , 0ᶠ
+      , trans (resolveᶜ-Fr-mem-agree m full cr guard) rg
+      , trans (resolveᶜ-Fr-mem-agree m full cr x) eqx
+      , to𝔹-is-bit tb , pl , impact-select-false {gᶠ} {vx} tb )
+    , impact-sat m full cr (suc start) guard {gᶠ} {false} xs vxs rg tb eqxs
+        at-rest
+
+impact-fwd : ∀ {P S st st' guard inputs}
+  → step P S st (impact guard inputs) ≡ just st'
+  → satisfies-constraints
+      (impact-constraints (length (State.pis st)) guard inputs)
+      (witness-of P st')
+impact-fwd {P} {S} {st} {st'} {guard} {inputs} st≡
+  with resolve-all-Fr (State.mem st) inputs in eqi
+... | just vals with resolveᶠ (State.mem st) guard in eqg
+...   | just gᶠ with to𝔹 gᶠ in eqb
+...     | just true
+          with take (length vals)
+                 (drop (State.pti-idx st)
+                   (ProofPreimage.pub-transcript-inputs P))
+               ≟LFr vals
+...       | yes _ with refl ← st≡ =
+            impact-sat (State.mem st)
+              (State.pis st ++ vals)
+              (comm-rand-of (ProofPreimage.comm-commitment P))
+              (length (State.pis st)) guard {gᶠ} {true} inputs vals
+              eqg eqb eqi (PisAt-app (State.pis st) vals)
+impact-fwd {P} {S} {st} {st'} {guard} {inputs} st≡
+    | just vals | just gᶠ | just false with refl ← st≡ =
+        impact-sat (State.mem st)
+          (State.pis st ++ map (λ _ → 0ᶠ) vals)
+          (comm-rand-of (ProofPreimage.comm-commitment P))
+          (length (State.pis st)) guard {gᶠ} {false} inputs vals
+          eqg eqb eqi (PisAt-app (State.pis st) (map (λ _ → 0ᶠ) vals))
+
+------------------------------------------------------------------------
+-- Lifting constraints from an intermediate witness to the final one.
+--
+-- The rest of a run only extends the store and the public inputs
+-- (`run-extends`), and satisfaction is monotone under that — so a
+-- constraint (or list) proven at an intermediate run-state still holds
+-- at the run's final witness.
+------------------------------------------------------------------------
+
+sat-mono : ∀ {m m′ pis pis′ cr} cs
+  → m ⊑ m′ → pis ≼ pis′
+  → satisfies-constraints cs (mk-witness m pis cr)
+  → satisfies-constraints cs (mk-witness m′ pis′ cr)
+sat-mono []       sub pre _        = tt
+sat-mono (c ∷ cs) sub pre (hc , h) =
+  holds-mono c sub pre hc , sat-mono cs sub pre h
+
+lift-cs : ∀ {P S s} cs is st-mid
+  → run P S st-mid is ≡ just s → WF-run P S is st-mid
+  → satisfies-constraints cs (witness-of P st-mid)
+  → satisfies-constraints cs (witness-of P s)
+lift-cs cs is st-mid run-rest wf h =
+  let (m⊑ , p≼) = run-extends is st-mid run-rest wf
+  in sat-mono cs m⊑ p≼ h
+
+sat-++ : ∀ xs ys w
+  → satisfies-constraints xs w → satisfies-constraints ys w
+  → satisfies-constraints (xs ++ ys) w
+sat-++ []       ys w _        hys = hys
+sat-++ (x ∷ xs) ys w (hx , h) hys = hx , sat-++ xs ys w h hys
+
+------------------------------------------------------------------------
+-- The forward direction of circuit faithfulness.
+--
+-- A successful preprocess run, under single-assignment well-formedness
+-- (`WF-run`), satisfies every synthesised constraint at its final
+-- witness.  `fwd-go` folds a single per-instruction dispatch through the
+-- run: for the head instruction `i`, `pushed-fwd` proves its contributed
+-- constraints `pushed i ss` hold at the witness of the state *just after*
+-- it; `push-cs` reassociates `synth-instr i ss` as the accumulator plus
+-- that contribution; and `lift-cs` carries the fact forward to the run's
+-- final witness, since the remaining run only extends the store and the
+-- public inputs.  The synth cursor `next-pi` is kept in lock-step with
+-- the length of the public-input vector (`pi-inv-step`), which is what
+-- makes the single `impact` instruction place its `pi-impact` entries at
+-- the right indices.
+------------------------------------------------------------------------
+
+open import Data.List.Properties using (length-++; length-map)
+open import Data.List using (length)
+open import Relation.Binary.PropositionalEquality using (subst)
+
+-- `insertMany` only rebinds memory, so it leaves `outs` untouched.
+outs-insertMany : ∀ st ids vs {st'}
+  → insertMany st ids vs ≡ just st' → State.outs st' ≡ State.outs st
+outs-insertMany st []         []        refl = refl
+outs-insertMany st (id ∷ ids) (v ∷ vs)  e    =
+  outs-insertMany (out1 st id v) ids vs e
+outs-insertMany st []         (_ ∷ _)   ()
+outs-insertMany st (_ ∷ _)    []        ()
+
+-- The public-input cursor and the output stream across one step, both
+-- read off a single inversion of the step.  Cursor: every instruction
+-- except `impact` leaves `pis` untouched while `synth-instr` leaves
+-- `next-pi` untouched, so the invariant transports unchanged; `impact`
+-- grows both sides by the input count.  Output stream: every instruction
+-- except `circuit-output` leaves `outs` untouched.  `pi-inv-step` and
+-- `step-outs-≡` are the two projections.
+step-pi-outs : ∀ {P S st st'} (i : Instruction) ss
+  → step P S st i ≡ just st'
+  → SynthState.next-pi ss ≡ length (State.pis st)
+  → (SynthState.next-pi (synth-instr i ss) ≡ length (State.pis st'))
+    × (¬ (∃ λ vals → i ≡ circuit-output vals)
+        → State.outs st' ≡ State.outs st)
+step-pi-outs {st = st} (encode input outputs) ss e pi
+  with resolve (State.mem st) input
+... | just v rewrite insertMany-pis st outputs
+                       (map val-native (encodeᵉ v)) e =
+        pi , λ _ → outs-insertMany st outputs (map val-native (encodeᵉ v)) e
+step-pi-outs {st = st} (assert cond) ss e pi
+  with resolve𝔹 (State.mem st) cond
+... | just true with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (cond-select bit a b output) ss e pi
+  with resolve𝔹 (State.mem st) bit
+... | just bv with resolve (State.mem st) a | resolve (State.mem st) b
+...   | just av | just bvl with typeof av ≟T typeof bvl
+...     | yes _ with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (constrain-bits val bits) ss e pi
+  with resolveᶠ (State.mem st) val
+... | just x with valFr x <? 2 ^ bits
+...   | yes _ with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (constrain-eq a b) ss e pi
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just true with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (constrain-to-boolean val) ss e pi
+  with resolve𝔹 (State.mem st) val
+... | just _ with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (copy val output) ss e pi
+  with resolve (State.mem st) val
+... | just v with refl ← e = pi , λ _ → refl
+step-pi-outs {P = P} {st = st} (impact guard inputs) ss e pi
+  with resolve-all-Fr (State.mem st) inputs in eqi
+... | just vals with resolve𝔹 (State.mem st) guard
+...   | just g with g
+...     | true
+          with take (length vals)
+                 (drop (State.pti-idx st)
+                   (ProofPreimage.pub-transcript-inputs P))
+               ≟LFr vals
+...       | yes _ with refl ← e =
+            trans (cong (SynthState.next-pi ss +_)
+                        (sym (resolve-all-Fr-length (State.mem st) inputs eqi)))
+              (trans (cong (_+ length vals) pi)
+                (sym (length-++ (State.pis st) {vals})))
+            , λ _ → refl
+step-pi-outs {st = st} (impact guard inputs) ss e pi
+    | just vals | just g | false with refl ← e =
+        trans (cong (SynthState.next-pi ss +_)
+                    (sym (resolve-all-Fr-length (State.mem st) inputs eqi)))
+          (trans (cong (_+ length vals) pi)
+            (trans (cong (length (State.pis st) +_)
+                         (sym (length-map (λ _ → 0ᶠ) vals)))
+              (sym (length-++ (State.pis st) {map (λ _ → 0ᶠ) vals}))))
+        , λ _ → refl
+step-pi-outs {st = st} (ec-mul a scalar output) ss e pi
+  with resolve (State.mem st) a | resolve (State.mem st) scalar
+... | just (val-jubjub-point p) | just (val-jubjub-scalar s)
+        with refl ← e = pi , λ _ → refl
+... | just (val-secp-point p) | just (val-secp-scalar s)
+        with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (ec-mul-generator scalar output) ss e pi
+  with resolve (State.mem st) scalar
+... | just (val-jubjub-scalar s) with refl ← e = pi , λ _ → refl
+... | just (val-secp-scalar s) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (hash-to-curve inputs output) ss e pi
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (into-coordinates point (xid , yid)) ss e pi
+  with resolve (State.mem st) point
+... | just (val-jubjub-point p) with coordsJ p
+...   | (x , y) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (into-coordinates point (xid , yid)) ss e pi
+    | just (val-secp-point p) with coordsK p
+...   | just (x , y) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (from-coordinates (xop , yop) output) ss e pi
+  with resolve (State.mem st) xop | resolve (State.mem st) yop
+... | just (val-native x) | just (val-native y) with fromCoordsJ x y
+...   | just p with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (from-coordinates (xop , yop) output) ss e pi
+    | just (val-secp-base x) | just (val-secp-base y) with fromCoordsK x y
+...   | just p with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (into-bytes32 input output) ss e pi
+  with resolve (State.mem st) input
+... | just (val-native x) with refl ← e = pi , λ _ → refl
+... | just (val-secp-base x) with refl ← e = pi , λ _ → refl
+... | just (val-secp-scalar s) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (from-bytes32 bytes native output) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (from-bytes32 bytes secp-base output) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (from-bytes32 bytes secp-scalar output) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (from-bytes32 bytes bytes32 output) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-pi-outs {st = st} (from-bytes32 bytes jubjub-point output) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-pi-outs {st = st} (from-bytes32 bytes jubjub-scalar output) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-pi-outs {st = st} (from-bytes32 bytes secp-point output) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-pi-outs {st = st} (reverse-bytes bytes output) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (bytes32-into-low-high bytes (loid , hiid)) ss e pi
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with bytes32→low-high b
+...   | (lo , hi) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (bytes32-from-low-high (loop , hiop) output) ss e pi
+  with resolveᶠ (State.mem st) loop | resolveᶠ (State.mem st) hiop
+... | just lo | just hi with low-high→bytes32 lo hi
+...   | just b with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (div-mod-power-of-two val bits []) ss e pi
+  with resolveᶠ (State.mem st) val
+... | just x = case e of λ ()
+step-pi-outs {st = st} (div-mod-power-of-two val bits (o ∷ [])) ss e pi
+  with resolveᶠ (State.mem st) val
+... | just x = case e of λ ()
+step-pi-outs {st = st} (div-mod-power-of-two val bits (q ∷ r ∷ [])) ss e pi
+  with resolveᶠ (State.mem st) val
+... | just x rewrite insertMany-pis st (q ∷ r ∷ [])
+                       ( val-native (from-le-bits (drop bits (to-le-bits x)))
+                       ∷ val-native (from-le-bits (take bits (to-le-bits x)))
+                       ∷ []) e =
+        pi , λ _ → outs-insertMany st (q ∷ r ∷ [])
+          ( val-native (from-le-bits (drop bits (to-le-bits x)))
+          ∷ val-native (from-le-bits (take bits (to-le-bits x))) ∷ []) e
+step-pi-outs {st = st} (div-mod-power-of-two val bits (q ∷ r ∷ o ∷ outs)) ss e pi
+  with resolveᶠ (State.mem st) val
+... | just x = case e of λ ()
+step-pi-outs {st = st} (reconstitute-field divisor modulus bits output) ss e pi
+  with resolveᶠ (State.mem st) divisor | resolveᶠ (State.mem st) modulus
+... | just d | just mo with valFr mo <? 2 ^ bits
+...   | yes _ with valFr d <? 2 ^ (FR-BITS ∸ bits)
+...     | yes _ with valFr mo + 2 ^ bits * valFr d <? FR-ORDER
+...       | yes _ with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (transient-hash inputs output) ss e pi
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (persistent-hash alignment inputs output) ss e pi
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with persistent-hash-fn alignment frs
+...   | just h with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (keccak256 alignment inputs output) ss e pi
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with keccak-fn alignment frs
+...   | just h with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (test-eq a b output) ss e pi
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just eqv with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (add a b output) ss e pi
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just (val-native x) | just (val-native y) with refl ← e = pi , λ _ → refl
+... | just (val-jubjub-point p) | just (val-jubjub-point q)
+        with refl ← e = pi , λ _ → refl
+... | just (val-secp-point p) | just (val-secp-point q)
+        with refl ← e = pi , λ _ → refl
+... | just (val-secp-base x) | just (val-secp-base y)
+        with refl ← e = pi , λ _ → refl
+... | just (val-secp-scalar x) | just (val-secp-scalar y)
+        with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (mul a b output) ss e pi
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just (val-native x) | just (val-native y) with refl ← e = pi , λ _ → refl
+... | just (val-secp-base x) | just (val-secp-base y)
+        with refl ← e = pi , λ _ → refl
+... | just (val-secp-scalar x) | just (val-secp-scalar y)
+        with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (neg a output) ss e pi
+  with resolve (State.mem st) a
+... | just (val-native x) with refl ← e = pi , λ _ → refl
+... | just (val-jubjub-point p) with refl ← e = pi , λ _ → refl
+... | just (val-secp-point p) with refl ← e = pi , λ _ → refl
+... | just (val-secp-base x) with refl ← e = pi , λ _ → refl
+... | just (val-secp-scalar x) with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (inv a output) ss e pi
+  with resolve (State.mem st) a
+... | just (val-native x) with invᶠ x
+...   | just xi with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (inv a output) ss e pi
+    | just (val-secp-base x) with invᵇ x
+...   | just xi with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (inv a output) ss e pi
+    | just (val-secp-scalar x) with invˢ x
+...   | just xi with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (not a output) ss e pi
+  with resolve𝔹 (State.mem st) a
+... | just b with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (less-than a b bits output) ss e pi
+  with resolveᶠ (State.mem st) a | resolveᶠ (State.mem st) b
+... | just x | just y with valFr x <? 2 ^ bits
+...   | yes _ with valFr y <? 2 ^ bits
+...     | yes _ with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (jubjub-scalar-from-native a output) ss e pi
+  with resolveᶠ (State.mem st) a
+... | just x with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (public-input guard val-t output) ss e pi
+  with eval-guard (State.mem st) guard
+... | just g with g
+...   | true with decode val-t
+                    (take (encoded-len val-t) (State.pto-rem st))
+...     | just v with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (public-input guard val-t output) ss e pi
+    | just g | false with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (private-input guard val-t output) ss e pi
+  with eval-guard (State.mem st) guard
+... | just g with g
+...   | true with decode val-t
+                    (take (encoded-len val-t) (State.priv-rem st))
+...     | just v with refl ← e = pi , λ _ → refl
+step-pi-outs {st = st} (private-input guard val-t output) ss e pi
+    | just g | false with refl ← e = pi , λ _ → refl
+step-pi-outs {S = S} {st = st} (circuit-output vals) ss e pi
+  with collectOutputs (State.mem st) (IrSource.outputs S) vals
+... | just vs with refl ← e = pi , λ ¬co → case ¬co (vals , refl) of λ ()
+
+-- The public-input cursor projection: `synth-instr`'s cursor stays in
+-- lock-step with the public-input length across the step.
+pi-inv-step : ∀ {P S st st'} (i : Instruction) ss
+  → step P S st i ≡ just st'
+  → SynthState.next-pi ss ≡ length (State.pis st)
+  → SynthState.next-pi (synth-instr i ss) ≡ length (State.pis st')
+pi-inv-step i ss e pi = proj₁ (step-pi-outs i ss e pi)
+
+------------------------------------------------------------------------
+-- Per-instruction forward dispatch.
+--
+-- The constraints an instruction contributes to the accumulator are
+-- exactly `pushed i ss` (CircuitBridge); `pushed-fwd` shows they all
+-- hold at the witness of the state just after the instruction.  Every
+-- clause defers to that instruction's `*-fwd` lemma; the shared
+-- signature carries the union of hypotheses those lemmas need — the
+-- step equation, the output-freshness `out-fresh i` (consumed by the
+-- output-producing gates and by `impact`/`div-mod` distinctness), and
+-- the public-input cursor invariant (used by `impact` to place its
+-- `pi-impact` entries at the right indices).  The transcript-input and
+-- output terminators push nothing, so their proof is `tt`.
+------------------------------------------------------------------------
+pushed-fwd : ∀ {P S st st'} i ss
+  → step P S st i ≡ just st'
+  → out-fresh i (State.mem st)
+  → SynthState.next-pi ss ≡ length (State.pis st)
+  → satisfies-constraints (pushed i ss) (witness-of P st')
+pushed-fwd {P} {S} {st} {st'} (encode input outputs) ss se of pi =
+  encode-fwd {P} {S} {st} {st'} {input} {outputs} of se , tt
+pushed-fwd {P} {S} {st} {st'} (assert cond) ss se of pi =
+  assert-fwd {P} {S} {st} {st'} {cond} se , tt
+pushed-fwd {P} {S} {st} {st'} (cond-select bit a b o) ss se of pi =
+  cond-select-fwd {P} {S} {st} {st'} {bit} {a} {b} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (constrain-bits val bits) ss se of pi =
+  constrain-bits-fwd {P} {S} {st} {st'} {val} {bits} se , tt
+pushed-fwd {P} {S} {st} {st'} (constrain-eq a b) ss se of pi =
+  constrain-eq-fwd {P} {S} {st} {st'} {a} {b} se , tt
+pushed-fwd {P} {S} {st} {st'} (constrain-to-boolean val) ss se of pi =
+  constrain-to-boolean-fwd {P} {S} {st} {st'} {val} se , tt
+pushed-fwd {P} {S} {st} {st'} (copy val o) ss se of pi =
+  copy-fwd {P} {S} {st} {st'} {val} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (impact guard inputs) ss se of pi =
+  subst
+    (λ n → satisfies-constraints
+             (impact-constraints n guard inputs) (witness-of P st'))
+    (sym pi)
+    (impact-fwd {P} {S} {st} {st'} {guard} {inputs} se)
+pushed-fwd {P} {S} {st} {st'} (ec-mul a scalar o) ss se of pi =
+  ec-mul-fwd {P} {S} {st} {st'} {a} {scalar} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (ec-mul-generator scalar o) ss se of pi =
+  ec-mul-generator-fwd {P} {S} {st} {st'} {scalar} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (hash-to-curve inputs o) ss se of pi =
+  hash-to-curve-fwd {P} {S} {st} {st'} {inputs} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (into-coordinates point (xo , yo)) ss se of pi =
+  let (fx , fy , x≢y) = of in
+  into-coordinates-fwd {P} {S} {st} {st'} {point} {xo} {yo} fx fy x≢y se , tt
+pushed-fwd {P} {S} {st} {st'} (from-coordinates (x , y) o) ss se of pi =
+  from-coordinates-fwd {P} {S} {st} {st'} {x} {y} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (into-bytes32 input o) ss se of pi =
+  into-bytes32-fwd {P} {S} {st} {st'} {input} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (from-bytes32 bytes val-t o) ss se of pi =
+  from-bytes32-fwd {P} {S} {st} {st'} {bytes} {val-t} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (reverse-bytes bytes o) ss se of pi =
+  reverse-bytes-fwd {P} {S} {st} {st'} {bytes} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (bytes32-into-low-high bytes (lo , hi)) ss se of pi =
+  let (fl , fh , l≢h) = of in
+  bytes32-into-low-high-fwd {P} {S} {st} {st'} {bytes} {lo} {hi}
+    fl fh l≢h se , tt
+pushed-fwd {P} {S} {st} {st'} (bytes32-from-low-high (lo , hi) o) ss se of pi =
+  bytes32-from-low-high-fwd {P} {S} {st} {st'} {lo} {hi} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (div-mod-power-of-two val bits (q ∷ r ∷ []))
+  ss se of pi =
+  let ((fq , fr , _) , ((q≢r , _) , _)) = of in
+  div-mod-power-of-two-fwd {P} {S} {st} {st'} {val} {bits} {q} {r}
+    fq fr q≢r se , tt
+pushed-fwd (div-mod-power-of-two val bits []) ss se of pi = tt
+pushed-fwd (div-mod-power-of-two val bits (_ ∷ [])) ss se of pi = tt
+pushed-fwd (div-mod-power-of-two val bits (_ ∷ _ ∷ _ ∷ _)) ss se of pi = tt
+pushed-fwd {P} {S} {st} {st'} (reconstitute-field d m bits o) ss se of pi =
+  reconstitute-field-fwd {P} {S} {st} {st'} {d} {m} {bits} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (transient-hash inputs o) ss se of pi =
+  transient-hash-fwd {P} {S} {st} {st'} {inputs} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (persistent-hash al inputs o) ss se of pi =
+  persistent-hash-fwd {P} {S} {st} {st'} {al} {inputs} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (keccak256 al inputs o) ss se of pi =
+  keccak256-fwd {P} {S} {st} {st'} {al} {inputs} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (test-eq a b o) ss se of pi =
+  test-eq-fwd {P} {S} {st} {st'} {a} {b} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (add a b o) ss se of pi =
+  add-fwd {P} {S} {st} {st'} {a} {b} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (mul a b o) ss se of pi =
+  mul-fwd {P} {S} {st} {st'} {a} {b} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (neg a o) ss se of pi =
+  neg-fwd {P} {S} {st} {st'} {a} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (inv a o) ss se of pi =
+  inv-fwd {P} {S} {st} {st'} {a} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (not a o) ss se of pi =
+  not-fwd {P} {S} {st} {st'} {a} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (less-than a b bits o) ss se of pi =
+  less-than-fwd {P} {S} {st} {st'} {a} {b} {bits} {o} of se , tt
+pushed-fwd {P} {S} {st} {st'} (jubjub-scalar-from-native a o) ss se of pi =
+  jubjub-scalar-from-native-fwd {P} {S} {st} {st'} {a} {o} of se , tt
+pushed-fwd (public-input guard val-t o) ss se of pi = tt
+pushed-fwd (private-input guard val-t o) ss se of pi = tt
+pushed-fwd (circuit-output vals) ss se of pi = tt
+
+fwd-go : ∀ {P S s} is st ss
+  → run P S st is ≡ just s
+  → WF-run P S is st
+  → SynthState.next-pi ss ≡ length (State.pis st)
+  → satisfies-constraints (SynthState.constraints ss) (witness-of P s)
+  → satisfies-constraints
+      (SynthState.constraints (synth-instrs is ss)) (witness-of P s)
+    × (SynthState.next-pi (synth-instrs is ss) ≡ length (State.pis s))
+fwd-go []       st ss run-eq wf pi prev
+  rewrite just-injective run-eq = prev , pi
+fwd-go {P} {S} {s} (i ∷ is) st ss run-eq (of , wf-rest) pi prev =
+  let (st-mid , step-eq , run-rest) = run-inv i is st run-eq
+      prev′ = subst (λ cs → satisfies-constraints cs (witness-of P s))
+                (sym (push-cs i ss))
+                (sat-++ (SynthState.constraints ss) (pushed i ss)
+                  (witness-of P s) prev
+                  (lift-cs {P} {S} {s} (pushed i ss) is st-mid run-rest
+                    (wf-rest step-eq)
+                    (pushed-fwd {P} {S} {st} {st-mid} i ss step-eq of pi)))
+  in fwd-go {P} {S} {s} is st-mid (synth-instr i ss) run-rest (wf-rest step-eq)
+       (pi-inv-step {P} {S} i ss step-eq pi) prev′
+
+------------------------------------------------------------------------
+-- Top-level forward faithfulness, commitment-free case.
+--
+-- For a single-assignment well-formed source with no communications
+-- commitment, a successful preprocess run yields a witness that
+-- satisfies the synthesized circuit.  (The commitment case adds
+-- `comm-fwd`; the single-assignment hypothesis `WF-run` is the producer
+-- obligation, to be discharged from a static check later.)
+------------------------------------------------------------------------
+
+-- Every init state's public-input vector is the concrete preamble
+-- (`binding ∷ []` with no commitment, `binding ∷ c ∷ []` with one), so
+-- its head is the binding input and its length is the preamble PI count.
+-- One inversion of `init` yields both; `init-pis-cons`/`init-pi0`/
+-- `init-pis-len` read them off.
+init-pis-shape : ∀ {S P st0} → init S P ≡ just st0
+  → (∃ λ rest → State.pis st0 ≡ ProofPreimage.binding-input P ∷ rest)
+  × (length (State.pis st0)
+       ≡ preamble-pi-count (IrSource.do-communications-commitment S))
+init-pis-shape {S} {P} ieq
+  with decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P)
+... | nothing = case ieq of λ ()
+... | just m with IrSource.do-communications-commitment S
+...   | false = ([] , sym (cong State.pis (just-injective ieq)))
+              , sym (cong (λ z → length (State.pis z)) (just-injective ieq))
+...   | true with ProofPreimage.comm-commitment P
+...     | just (c , _) =
+            (c ∷ [] , sym (cong State.pis (just-injective ieq)))
+          , sym (cong (λ z → length (State.pis z)) (just-injective ieq))
+...     | nothing = case ieq of λ ()
+
+init-pis-cons : ∀ {S P st0} → init S P ≡ just st0
+  → ∃ λ rest → State.pis st0 ≡ ProofPreimage.binding-input P ∷ rest
+init-pis-cons {S} {P} {st0} ieq = proj₁ (init-pis-shape {S} {P} {st0} ieq)
+
+init-pi0 : ∀ {S P st0} → init S P ≡ just st0
+  → pi-lookup (State.pis st0) 0 ≡ just (ProofPreimage.binding-input P)
+init-pi0 {S} {P} {st0} ieq with init-pis-cons {S} {P} {st0} ieq
+... | (rest , p) rewrite p = refl
+
+init-pis-len : ∀ {S P st0} → init S P ≡ just st0
+  → length (State.pis st0)
+      ≡ preamble-pi-count (IrSource.do-communications-commitment S)
+init-pis-len {S} {P} {st0} ieq = proj₂ (init-pis-shape {S} {P} {st0} ieq)
+
+-- Package the commitment-free circuit's constraint and PI-length facts
+-- (stated for the singleton-preamble fold) into `satisfies (synth S)`.
+-- The `do-comm = false` case-split makes `synth S` reduce; the inputs
+-- carry no `do-comm S`, so the split entangles nothing.
+satisfies-synth-false : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ false
+  → satisfies-constraints
+      (SynthState.constraints
+        (synth-instrs (IrSource.instructions S)
+          (mk-synth (pi-binding 0 ∷ []) 1 []))) w
+  → length (CircuitWitness.pis w)
+      ≡ SynthState.next-pi
+          (synth-instrs (IrSource.instructions S)
+            (mk-synth (pi-binding 0 ∷ []) 1 []))
+  → satisfies (synth S) w
+satisfies-synth-false {S} hc cok pil
+  with IrSource.do-communications-commitment S | hc
+... | false | refl =
+  record { pi-length = pil ; rand-shape = tt ; constraint-ok = cok }
+
+forward-no-comm : ∀ {S P s st0}
+  → IrSource.do-communications-commitment S ≡ false
+  → init S P ≡ just st0
+  → run P S st0 (IrSource.instructions S) ≡ just s
+  → WF-run P S (IrSource.instructions S) st0
+  → satisfies (synth S) (witness-of P s)
+forward-no-comm {S} {P} {s} {st0} hc≡false init-eq run-eq wf =
+  satisfies-synth-false {S = S} hc≡false (proj₁ result) (sym (proj₂ result))
+  where
+  ss₀ : SynthState
+  ss₀ = mk-synth (pi-binding 0 ∷ []) 1 []
+
+  pi-inv₀ : SynthState.next-pi ss₀ ≡ length (State.pis st0)
+  pi-inv₀ = sym (trans (init-pis-len {S} {P} {st0} init-eq)
+                       (cong preamble-pi-count hc≡false))
+
+  ext : (State.mem st0 ⊑ State.mem s) × (State.pis st0 ≼ State.pis s)
+  ext = run-extends {P} {S} {s} (IrSource.instructions S) st0 run-eq wf
+
+  prev₀ : satisfies-constraints (SynthState.constraints ss₀) (witness-of P s)
+  prev₀ = (ProofPreimage.binding-input P
+          , pi-lookup-mono (proj₂ ext) (init-pi0 {S} {P} {st0} init-eq))
+        , tt
+
+  result : satisfies-constraints
+             (SynthState.constraints
+               (synth-instrs (IrSource.instructions S) ss₀))
+             (witness-of P s)
+         × (SynthState.next-pi
+               (synth-instrs (IrSource.instructions S) ss₀)
+             ≡ length (State.pis s))
+  result = fwd-go (IrSource.instructions S) st0 ss₀ run-eq wf pi-inv₀ prev₀
+
+------------------------------------------------------------------------
+-- Commitment preimage round-trip and assembly.
+--
+-- The communications commitment (`comm`) constraint asks that
+-- π[1] = transient-commit (encode(inputs) ‖ encode(outputs)) r, where the
+-- in-circuit `resolve-encode` reconstructs `encode(inputs)` from the named
+-- input cells and `encode(outputs)` from the terminal `Output` operands.
+-- The off-circuit TC2 check (which `preprocess` enforces) commits to the
+-- raw input stream `ProofPreimage.inputs P` and `concatMap encode outs`.
+-- The two preimages coincide: the named input cells re-encode to the raw
+-- input stream (`decode-reencode`, an inverse of `decode-inputs`), and the
+-- terminal `Output` operands resolve to exactly the collected `outs`
+-- (`out-go`, a run/synth induction).
+------------------------------------------------------------------------
+
+open import Data.List.Properties using (take++drop≡id; concatMap-++)
+open import Data.List using (concatMap)
+
+-- A single typed chunk that `decode` accepts re-encodes to itself.  The
+-- only successful `(type, chunk)` shapes are the four supported types at
+-- their exact widths; every other shape sends `decode` to `nothing`.
+decode-encode-chunk : ∀ t chunk {v}
+  → decode t chunk ≡ just v → encodeᵉ v ≡ chunk
+decode-encode-chunk native (x ∷ []) ieq with refl ← ieq = refl
+decode-encode-chunk jubjub-scalar (f ∷ []) {v} ieq
+  with jubjubScalarFromFr f in e
+... | just s with refl ← ieq =
+        cong (_∷ []) (jubjubScalar-sound {f} {s} e)
+decode-encode-chunk bytes32 (lo ∷ hi ∷ []) {v} ieq
+  with low-high→bytes32 lo hi in e
+... | just b with refl ← ieq
+        rewrite bytes32-sound {lo} {hi} {b} e = refl
+decode-encode-chunk jubjub-point (x ∷ y ∷ []) {v} ieq
+  with fromCoordsJ x y in e
+... | just p with refl ← ieq
+        rewrite fromCoordsJ-coordsJ {x} {y} {p} e = refl
+decode-encode-chunk secp-base (l ∷ h ∷ []) {v} ieq
+  with limbs→secpBase l h in e
+... | just x with refl ← ieq
+        rewrite secpBase-sound {l} {h} {x} e = refl
+decode-encode-chunk secp-scalar (l ∷ h ∷ []) {v} ieq
+  with limbs→secpScalar l h in e
+... | just s with refl ← ieq
+        rewrite secpScalar-sound {l} {h} {s} e = refl
+decode-encode-chunk secp-point (a ∷ b ∷ c ∷ d ∷ e ∷ []) {v} ieq
+  with limbs→secpPoint a b c d e in pr
+... | just p with refl ← ieq
+        rewrite secpPoint-sound {a} {b} {c} {d} {e} {p} pr = refl
+decode-encode-chunk native [] ieq = case ieq of λ ()
+decode-encode-chunk native (_ ∷ _ ∷ _) ieq = case ieq of λ ()
+decode-encode-chunk bytes32 [] ieq = case ieq of λ ()
+decode-encode-chunk bytes32 (_ ∷ []) ieq = case ieq of λ ()
+decode-encode-chunk bytes32 (_ ∷ _ ∷ _ ∷ _) ieq = case ieq of λ ()
+decode-encode-chunk jubjub-point [] ieq = case ieq of λ ()
+decode-encode-chunk jubjub-point (_ ∷ []) ieq = case ieq of λ ()
+decode-encode-chunk jubjub-point (_ ∷ _ ∷ _ ∷ _) ieq = case ieq of λ ()
+decode-encode-chunk jubjub-scalar [] ieq = case ieq of λ ()
+decode-encode-chunk jubjub-scalar (_ ∷ _ ∷ _) ieq = case ieq of λ ()
+decode-encode-chunk secp-base [] ieq = case ieq of λ ()
+decode-encode-chunk secp-base (_ ∷ []) ieq = case ieq of λ ()
+decode-encode-chunk secp-base (_ ∷ _ ∷ _ ∷ _) ieq = case ieq of λ ()
+decode-encode-chunk secp-scalar [] ieq = case ieq of λ ()
+decode-encode-chunk secp-scalar (_ ∷ []) ieq = case ieq of λ ()
+decode-encode-chunk secp-scalar (_ ∷ _ ∷ _ ∷ _) ieq = case ieq of λ ()
+decode-encode-chunk secp-point [] ieq = case ieq of λ ()
+decode-encode-chunk secp-point (_ ∷ []) ieq = case ieq of λ ()
+decode-encode-chunk secp-point (_ ∷ _ ∷ []) ieq = case ieq of λ ()
+decode-encode-chunk secp-point (_ ∷ _ ∷ _ ∷ []) ieq = case ieq of λ ()
+decode-encode-chunk secp-point (_ ∷ _ ∷ _ ∷ _ ∷ []) ieq = case ieq of λ ()
+decode-encode-chunk secp-point (_ ∷ _ ∷ _ ∷ _ ∷ _ ∷ _ ∷ _) ieq =
+  case ieq of λ ()
+
+-- A name absent from the declared tail is unbound in the memory the tail
+-- decodes to: `decode-inputs` only ever binds the names it processes.
+decode-inputs-fresh : ∀ (nm : Identifier) tis raw {m'}
+  → decode-inputs tis raw ≡ just m'
+  → NotIn nm (map TypedIdentifier.name tis)
+  → m' nm ≡ nothing
+decode-inputs-fresh nm []         []      refl nin = refl
+decode-inputs-fresh nm []         (_ ∷ _) ieq  nin = case ieq of λ ()
+decode-inputs-fresh nm (ti ∷ tis) raw ieq (nm≢ , nin)
+  with decode (TypedIdentifier.val-t ti)
+              (take (encoded-len (TypedIdentifier.val-t ti)) raw)
+... | just v
+  with decode-inputs tis (drop (encoded-len (TypedIdentifier.val-t ti)) raw)
+         in erest
+...   | just m' with refl ← ieq =
+        trans (ins-other v m' nm≢)
+              (decode-inputs-fresh nm tis _ erest nin)
+
+-- Re-encoding the decoded input memory reproduces the raw input stream.
+-- Inductive on the declared inputs; `decode-inputs` consumes
+-- `encoded-len t` elements per input, so `take ‖ drop` rebuilds `raw`.
+-- The sub-map hypothesis `m ⊑ assign w` lets each named cell resolve to
+-- its decoded value; `NoDup` of the input names lets that hypothesis
+-- descend to the tail (the head name is unbound in the tail's map).
+decode-reencode : ∀ {w} tis raw m
+  → decode-inputs tis raw ≡ just m
+  → NoDup (map TypedIdentifier.name tis)
+  → (∀ {id v} → m id ≡ just v → CircuitWitness.assign w id ≡ just v)
+  → resolve-encode w (input-operands tis) ≡ just raw
+decode-reencode []         []        m ieq nd m⊑ = refl
+decode-reencode []         (_ ∷ _)   m ieq nd m⊑ = case ieq of λ ()
+decode-reencode {w} (ti ∷ tis) raw m ieq (nin , ndup) m⊑
+  with decode (TypedIdentifier.val-t ti)
+              (take (encoded-len (TypedIdentifier.val-t ti)) raw) in ed
+... | just v
+  with decode-inputs tis (drop (encoded-len (TypedIdentifier.val-t ti)) raw)
+         in erest
+...   | just m' with refl ← ieq =
+        let n  = encoded-len (TypedIdentifier.val-t ti)
+            nm = TypedIdentifier.name ti
+            -- the head cell resolves to its decoded value
+            head-≡ : CircuitWitness.assign w nm ≡ just v
+            head-≡ = m⊑ (ins-here nm v m')
+            -- the tail map survives: `nm` is unbound in `m'`, so every
+            -- binding of `m'` is a binding of `ins nm v m'`.
+            nm-fresh : m' nm ≡ nothing
+            nm-fresh = decode-inputs-fresh nm tis _ erest nin
+            m'⊑ : ∀ {id u} → m' id ≡ just u
+                → CircuitWitness.assign w id ≡ just u
+            m'⊑ {id} {u} p = m⊑ (ins-⊑ {nm} {v} {m'} nm-fresh {id} p)
+            tail-≡ : resolve-encode w (input-operands tis)
+                       ≡ just (drop n raw)
+            tail-≡ = decode-reencode tis (drop n raw) m' erest ndup m'⊑
+        in reencode-step {w} {nm} {v} tis raw n
+             head-≡ tail-≡
+             (decode-encode-chunk (TypedIdentifier.val-t ti) (take n raw) ed)
+  where
+  -- `resolve-encode w (var nm ∷ ops)` resolves the head cell to `v`,
+  -- flattens it to `encodeᵉ v = take n raw`, and prepends it to the tail
+  -- (the rest of `raw`); `take ‖ drop` rebuilds `raw`.
+  reencode-step : ∀ {w} {nm : Identifier} {v} tis raw n
+    → CircuitWitness.assign w nm ≡ just v
+    → resolve-encode w (input-operands tis) ≡ just (drop n raw)
+    → encodeᵉ v ≡ take n raw
+    → resolve-encode w (var nm ∷ input-operands tis) ≡ just raw
+  reencode-step {w} {nm} {v} tis raw n h t c
+    rewrite h | t | c = cong just (take++drop≡id n raw)
+
+-- `resolve-encode` distributes over operand-list concatenation.
+resolve-encode-++ : ∀ w xs ys {rx ry}
+  → resolve-encode w xs ≡ just rx
+  → resolve-encode w ys ≡ just ry
+  → resolve-encode w (xs ++ ys) ≡ just (rx ++ ry)
+resolve-encode-++ w []         ys {rx} {ry} ex ey with refl ← ex = ey
+resolve-encode-++ w (op ∷ ops) ys ex ey
+  with resolveᶜ w op in eqop
+... | just v
+  with resolve-encode w ops in eqrest
+...   | just rest with refl ← ex
+        rewrite resolve-encode-++ w ops ys eqrest ey =
+          cong just (sym (++-assoc (encodeᵉ v) rest _))
+
+-- The terminal `Output` operands resolve (at the final witness) to the
+-- raw encodings of exactly the values `collectOutputs` recorded into
+-- `outs`: `collectOutputs` resolves each operand at `m` and only
+-- type-checks it (it does not alter the value), and those resolutions are
+-- preserved to `mem s` by the rest of the run (`m ⊑ mem s`).
+re-cons : ∀ {w} op {v} ops vrest
+  → resolveᶜ w op ≡ just v
+  → resolve-encode w ops ≡ just (concatMap encodeᵉ vrest)
+  → resolve-encode w (op ∷ ops) ≡ just (concatMap encodeᵉ (v ∷ vrest))
+re-cons op ops vrest h t rewrite h | t = refl
+
+collect-resolve-encode : ∀ {P s} m ts ops {vs}
+  → collectOutputs m ts ops ≡ just vs
+  → m ⊑ State.mem s
+  → resolve-encode (witness-of P s) ops ≡ just (concatMap encodeᵉ vs)
+collect-resolve-encode m []       []         refl sub = refl
+collect-resolve-encode m []       (_ ∷ _)    ce   sub = case ce of λ ()
+collect-resolve-encode m (_ ∷ _)  []         ce   sub = case ce of λ ()
+collect-resolve-encode {P} {s} m (t ∷ ts) (op ∷ ops) ce sub
+  with resolve m op in eqop
+... | just v with typeof v ≟T t
+...   | yes _ with collectOutputs m ts ops in eqrest
+...     | just vrest with refl ← ce =
+          re-cons {witness-of P s} op ops vrest
+            (trans (resolve-agree P s op) (resolve-mono op sub eqop))
+            (collect-resolve-encode {P} {s} m ts ops eqrest sub)
+
+-- Every instruction except `circuit-output` leaves the output stream
+-- untouched.  This is the `outs` projection of `step-pi-outs`; the synth
+-- cursor is irrelevant to the output stream, so a dummy `mk-synth`
+-- (whose `next-pi` matches `length (State.pis st)`, discharging the
+-- cursor hypothesis by `refl`) suffices.
+step-outs-≡ : ∀ {P S st st'} (i : Instruction)
+  → ¬ (∃ λ vals → i ≡ circuit-output vals)
+  → step P S st i ≡ just st' → State.outs st' ≡ State.outs st
+step-outs-≡ {st = st} i ¬co e =
+  proj₂ (step-pi-outs i (mk-synth [] (length (State.pis st)) []) e refl) ¬co
+
+-- Synthesis of every instruction except `circuit-output` leaves the
+-- recorded `Output` operands untouched (it only pushes constraints and/or
+-- advances the PI cursor).  `circuit-output` is the sole producer of
+-- output operands.
+synth-oo-≡ : ∀ (i : Instruction) ss
+  → ¬ (∃ λ vals → i ≡ circuit-output vals)
+  → SynthState.output-ops (synth-instr i ss) ≡ SynthState.output-ops ss
+synth-oo-≡ (encode input outputs) ss _ = refl
+synth-oo-≡ (assert cond) ss _ = refl
+synth-oo-≡ (cond-select bit a b output) ss _ = refl
+synth-oo-≡ (constrain-bits val bits) ss _ = refl
+synth-oo-≡ (constrain-eq a b) ss _ = refl
+synth-oo-≡ (constrain-to-boolean val) ss _ = refl
+synth-oo-≡ (copy val output) ss _ = refl
+synth-oo-≡ (impact guard inputs) ss _ = refl
+synth-oo-≡ (ec-mul a scalar output) ss _ = refl
+synth-oo-≡ (ec-mul-generator scalar output) ss _ = refl
+synth-oo-≡ (hash-to-curve inputs output) ss _ = refl
+synth-oo-≡ (into-coordinates point (xo , yo)) ss _ = refl
+synth-oo-≡ (from-coordinates (x , y) output) ss _ = refl
+synth-oo-≡ (into-bytes32 input output) ss _ = refl
+synth-oo-≡ (from-bytes32 bytes val-t output) ss _ = refl
+synth-oo-≡ (reverse-bytes bytes output) ss _ = refl
+synth-oo-≡ (bytes32-into-low-high bytes (lo , hi)) ss _ = refl
+synth-oo-≡ (bytes32-from-low-high (lo , hi) output) ss _ = refl
+synth-oo-≡ (div-mod-power-of-two val bits []) ss _ = refl
+synth-oo-≡ (div-mod-power-of-two val bits (o ∷ [])) ss _ = refl
+synth-oo-≡ (div-mod-power-of-two val bits (q ∷ r ∷ [])) ss _ = refl
+synth-oo-≡ (div-mod-power-of-two val bits (q ∷ r ∷ o ∷ outs)) ss _ = refl
+synth-oo-≡ (reconstitute-field divisor modulus bits output) ss _ = refl
+synth-oo-≡ (transient-hash inputs output) ss _ = refl
+synth-oo-≡ (persistent-hash alignment inputs output) ss _ = refl
+synth-oo-≡ (keccak256 alignment inputs output) ss _ = refl
+synth-oo-≡ (test-eq a b output) ss _ = refl
+synth-oo-≡ (add a b output) ss _ = refl
+synth-oo-≡ (mul a b output) ss _ = refl
+synth-oo-≡ (neg a output) ss _ = refl
+synth-oo-≡ (inv a output) ss _ = refl
+synth-oo-≡ (not a output) ss _ = refl
+synth-oo-≡ (less-than a b bits output) ss _ = refl
+synth-oo-≡ (jubjub-scalar-from-native a output) ss _ = refl
+synth-oo-≡ (public-input guard val-t output) ss _ = refl
+synth-oo-≡ (private-input guard val-t output) ss _ = refl
+synth-oo-≡ (circuit-output vals) ss ¬co = case ¬co (vals , refl) of λ ()
+
+------------------------------------------------------------------------
+-- Output coupling: the synthesised `Output` operands resolve, at the
+-- run's final witness, to the raw encodings of the values the run
+-- collected into `State.outs`.  Threads the seed
+--   resolve-encode w (output-ops ss) ≡ just (concatMap encode (outs st))
+-- across the run.  Every instruction but `circuit-output` leaves both
+-- sides untouched (`synth-oo-≡`, `step-outs-≡`); `circuit-output vals`
+-- grows `output-ops` by `vals` and `outs` by `collectOutputs … vals`,
+-- and the two grow in lock-step (`collect-resolve-encode`,
+-- `resolve-encode-++`, `concatMap-++`).
+------------------------------------------------------------------------
+
+-- Transport the output-coupling seed across one non-`circuit-output`
+-- step: both the synthesised operands (`synth-oo-≡`) and the collected
+-- outputs (`step-outs-≡`) are unchanged, so the seed carries over to the
+-- state and synth-state after the step.
+keep-seed : ∀ {P S s} i st st-mid ss
+  → ¬ (∃ λ vals → i ≡ circuit-output vals)
+  → step P S st i ≡ just st-mid
+  → resolve-encode (witness-of P s) (SynthState.output-ops ss)
+      ≡ just (concatMap encodeᵉ (State.outs st))
+  → resolve-encode (witness-of P s)
+      (SynthState.output-ops (synth-instr i ss))
+      ≡ just (concatMap encodeᵉ (State.outs st-mid))
+keep-seed {P} {S} {s} i st st-mid ss ¬co step-eq seed =
+  trans (cong (resolve-encode (witness-of P s)) (synth-oo-≡ i ss ¬co))
+    (trans seed
+      (cong (λ os → just (concatMap encodeᵉ os))
+            (sym (step-outs-≡ i ¬co step-eq))))
+
+-- Decide whether an instruction is a `circuit-output` (the only producer
+-- of `Output` operands / `outs` entries).  Enumerated per constructor so
+-- the mismatch is structural in each negative case.
+circuit-output? : ∀ i → Dec (∃ λ vals → i ≡ circuit-output vals)
+circuit-output? (encode _ _)                = no λ { (_ , ()) }
+circuit-output? (assert _)                  = no λ { (_ , ()) }
+circuit-output? (cond-select _ _ _ _)       = no λ { (_ , ()) }
+circuit-output? (constrain-bits _ _)        = no λ { (_ , ()) }
+circuit-output? (constrain-eq _ _)          = no λ { (_ , ()) }
+circuit-output? (constrain-to-boolean _)    = no λ { (_ , ()) }
+circuit-output? (copy _ _)                  = no λ { (_ , ()) }
+circuit-output? (impact _ _)                = no λ { (_ , ()) }
+circuit-output? (ec-mul _ _ _)              = no λ { (_ , ()) }
+circuit-output? (ec-mul-generator _ _)      = no λ { (_ , ()) }
+circuit-output? (hash-to-curve _ _)         = no λ { (_ , ()) }
+circuit-output? (into-coordinates _ _)      = no λ { (_ , ()) }
+circuit-output? (from-coordinates _ _)      = no λ { (_ , ()) }
+circuit-output? (into-bytes32 _ _)          = no λ { (_ , ()) }
+circuit-output? (from-bytes32 _ _ _)        = no λ { (_ , ()) }
+circuit-output? (reverse-bytes _ _)         = no λ { (_ , ()) }
+circuit-output? (bytes32-into-low-high _ _) = no λ { (_ , ()) }
+circuit-output? (bytes32-from-low-high _ _) = no λ { (_ , ()) }
+circuit-output? (div-mod-power-of-two _ _ _) = no λ { (_ , ()) }
+circuit-output? (reconstitute-field _ _ _ _) = no λ { (_ , ()) }
+circuit-output? (transient-hash _ _)        = no λ { (_ , ()) }
+circuit-output? (persistent-hash _ _ _)     = no λ { (_ , ()) }
+circuit-output? (keccak256 _ _ _)           = no λ { (_ , ()) }
+circuit-output? (test-eq _ _ _)             = no λ { (_ , ()) }
+circuit-output? (add _ _ _)                 = no λ { (_ , ()) }
+circuit-output? (mul _ _ _)                 = no λ { (_ , ()) }
+circuit-output? (neg _ _)                   = no λ { (_ , ()) }
+circuit-output? (inv _ _)                   = no λ { (_ , ()) }
+circuit-output? (not _ _)                   = no λ { (_ , ()) }
+circuit-output? (less-than _ _ _ _)         = no λ { (_ , ()) }
+circuit-output? (jubjub-scalar-from-native _ _) = no λ { (_ , ()) }
+circuit-output? (public-input _ _ _)        = no λ { (_ , ()) }
+circuit-output? (private-input _ _ _)       = no λ { (_ , ()) }
+circuit-output? (circuit-output vals)       = yes (vals , refl)
+
+out-go : ∀ {P S s} is st ss
+  → run P S st is ≡ just s → WF-run P S is st
+  → resolve-encode (witness-of P s) (SynthState.output-ops ss)
+      ≡ just (concatMap encodeᵉ (State.outs st))
+  → resolve-encode (witness-of P s) (SynthState.output-ops (synth-instrs is ss))
+      ≡ just (concatMap encodeᵉ (State.outs s))
+out-go {P} {S} {s} [] st ss run-eq wf seed
+  rewrite just-injective run-eq = seed
+out-go {P} {S} {s} (i ∷ is) st ss run-eq (_ , wf) seed
+  with circuit-output? i
+... | no ¬co =
+      let (sm , se , rr) = run-inv i is st run-eq in
+      out-go is sm (synth-instr i ss) rr (wf se)
+        (keep-seed {P} {S} {s} i st sm ss ¬co se seed)
+... | yes (vals , refl) =
+      let (st-mid , step-eq , run-rest) =
+            run-inv (circuit-output vals) is st run-eq
+      in out-go is st-mid (synth-instr (circuit-output vals) ss)
+           run-rest (wf step-eq)
+           (out-step-output st st-mid step-eq run-rest (wf step-eq) seed)
+  where
+  -- The `circuit-output` step appends `collectOutputs (mem st) (outputs
+  -- S) vals` to `outs`; synth appends `vals` to `output-ops`.  The
+  -- appended operands resolve (at the final witness) to the encodings of
+  -- the appended values, so the seed grows consistently.
+  out-step-output : ∀ st st-mid
+    → step P S st (circuit-output vals) ≡ just st-mid
+    → run P S st-mid is ≡ just s → WF-run P S is st-mid
+    → resolve-encode (witness-of P s) (SynthState.output-ops ss)
+        ≡ just (concatMap encodeᵉ (State.outs st))
+    → resolve-encode (witness-of P s)
+        (SynthState.output-ops ss ++ vals)
+        ≡ just (concatMap encodeᵉ (State.outs st-mid))
+  out-step-output st st-mid step-eq run-rest wf-rest seed
+    with collectOutputs (State.mem st) (IrSource.outputs S) vals in eqc
+  ... | just vs with refl ← step-eq =
+        let (m⊑ , _) = run-extends {P} {S} {s} is st-mid run-rest wf-rest
+            vals-≡ : resolve-encode (witness-of P s) vals
+                       ≡ just (concatMap encodeᵉ vs)
+            vals-≡ = collect-resolve-encode {P} {s}
+                       (State.mem st) (IrSource.outputs S) vals eqc m⊑
+        in trans
+             (resolve-encode-++ (witness-of P s)
+               (SynthState.output-ops ss) vals seed vals-≡)
+             (cong just (sym (concatMap-++ encodeᵉ (State.outs st) vs)))
+
+------------------------------------------------------------------------
+-- The communications-commitment case.
+--
+-- When `do-communications-commitment S = true`, `init` seeds the PI
+-- vector with `binding ∷ c ∷ []` (where `comm-commitment P = just (c ,
+-- r)`), and `preprocess` enforces the terminal check TC2:
+--   c ≡ transient-commit (inputs P ++ concatMap encode (outs s)) r.
+-- The synthesised `comm` constraint asks exactly this, with its preimage
+-- the in-circuit re-encodings: `decode-reencode` reproduces `inputs P`
+-- from the named input cells, `out-go` reproduces `concatMap encode (outs
+-- s)` from the terminal `Output` operands, and π[1] = c carries the
+-- commitment.
+------------------------------------------------------------------------
+
+-- The second PI entry of a comm-commitment init state is the commitment.
+init-pi1 : ∀ {S P st0 c r}
+  → IrSource.do-communications-commitment S ≡ true
+  → ProofPreimage.comm-commitment P ≡ just (c , r)
+  → init S P ≡ just st0
+  → pi-lookup (State.pis st0) 1 ≡ just c
+init-pi1 {S} {P} {st0} {c} {r} hc cc ieq
+  with decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P)
+... | nothing = case ieq of λ ()
+init-pi1 {S} {P} {st0} {c} {r} hc cc ieq
+  | just m
+  with IrSource.do-communications-commitment S | hc
+...   | true | refl with ProofPreimage.comm-commitment P | cc
+...     | just (c , r) | refl rewrite sym (just-injective ieq) = refl
+
+open import zkir-v3.Semantics ⋯ using (preprocess)
+open import Data.Nat using () renaming (_≟_ to _≟ℕ_)
+
+-- Invert `preprocess`: it begins with the very `init` it was given and
+-- runs all instructions to the state it returns; the terminal checks
+-- (TC1, TC2) only gate the result.  A single walk of the guard tower
+-- yields both the run and TC2 — under a communications commitment, the
+-- recorded value equals the transient commitment of the inputs and the
+-- encoded outputs.
+preprocess-inv : ∀ {S P s st0}
+  → init S P ≡ just st0
+  → preprocess S P ≡ just s
+  → run P S st0 (IrSource.instructions S) ≡ just s
+  × (∀ {c r} → IrSource.do-communications-commitment S ≡ true
+       → ProofPreimage.comm-commitment P ≡ just (c , r)
+       → c ≡ transient-commit
+               (ProofPreimage.inputs P ++ concatMap encodeᵉ (State.outs s)) r)
+preprocess-inv {S} {P} {s} {st0} ieq peq
+  with init S P | ieq
+... | just st0' | refl
+  with run P S st0' (IrSource.instructions S)
+...   | just stf
+  with State.pti-idx stf ≟ℕ length (ProofPreimage.pub-transcript-inputs P)
+...     | yes _
+  with State.pto-rem stf
+...       | (_ ∷ _) = case peq of λ ()
+...       | []
+  with State.priv-rem stf
+...         | (_ ∷ _) = case peq of λ ()
+...         | []
+  with IrSource.do-communications-commitment S
+...           | false with refl ← peq =
+                refl , λ ht _ → case ht of λ ()
+preprocess-inv {S} {P} {s} {st0} ieq peq
+  | just st0' | refl | just stf | yes _ | [] | [] | true
+  with ProofPreimage.comm-commitment P
+...             | just (cₚ , rₚ)
+  with cₚ ≟ᶠ transient-commit
+              (ProofPreimage.inputs P ++ concatMap encodeᵉ (State.outs stf)) rₚ
+...               | yes c≡ with refl ← peq =
+                    refl
+                  , λ _ cc′ → case just-injective cc′ of
+                                λ where refl → c≡
+
+-- The communications-commitment constraint holds at the run's final
+-- witness.  Its preimage components are reconstructed in-circuit:
+-- `decode-reencode` rebuilds the raw inputs from the named input cells,
+-- `out-go` rebuilds the encoded outputs from the terminal `Output`
+-- operands (seeded by the empty initial output stream), the commitment
+-- randomness is `r`, and π[1] carries `c`; the final equation is TC2.
+comm-fwd : ∀ {S P s st0 c r}
+  → IrSource.do-communications-commitment S ≡ true
+  → ProofPreimage.comm-commitment P ≡ just (c , r)
+  → init S P ≡ just st0
+  → preprocess S P ≡ just s
+  → WF-run P S (IrSource.instructions S) st0
+  → NoDup (map TypedIdentifier.name (IrSource.inputs S))
+  → holds (witness-of P s)
+      (comm (input-operands (IrSource.inputs S))
+        (SynthState.output-ops
+          (synth-instrs (IrSource.instructions S)
+            (mk-synth (pi-binding 0 ∷ []) 2 []))))
+comm-fwd {S} {P} {s} {st0} {c} {r} hc cc ieq peq wf nd =
+    ProofPreimage.inputs P
+  , concatMap encodeᵉ (State.outs s)
+  , r
+  , c
+  , ivs-≡
+  , ovs-≡
+  , rand-≡
+  , pi1-≡
+  , proj₂ pre hc cc
+  where
+  pre = preprocess-inv {S} {P} {s} {st0} ieq peq
+
+  run-eq : run P S st0 (IrSource.instructions S) ≡ just s
+  run-eq = proj₁ pre
+
+  m⊑ : State.mem st0 ⊑ State.mem s
+  m⊑ = proj₁ (run-extends {P} {S} {s} (IrSource.instructions S) st0 run-eq wf)
+
+  pis≼ : State.pis st0 ≼ State.pis s
+  pis≼ = proj₂ (run-extends {P} {S} {s} (IrSource.instructions S) st0 run-eq wf)
+
+  -- inputs: re-encode the decoded input cells
+  ivs-≡ : resolve-encode (witness-of P s)
+            (input-operands (IrSource.inputs S))
+            ≡ just (ProofPreimage.inputs P)
+  ivs-≡ = decode-reencode {witness-of P s} (IrSource.inputs S)
+            (ProofPreimage.inputs P) (State.mem st0)
+            (init-decode {S} {P} {st0} ieq) nd m⊑
+
+  -- outputs: the terminal `Output` operands resolve to the encoded outs
+  ovs-≡ : resolve-encode (witness-of P s)
+            (SynthState.output-ops
+              (synth-instrs (IrSource.instructions S)
+                (mk-synth (pi-binding 0 ∷ []) 2 [])))
+            ≡ just (concatMap encodeᵉ (State.outs s))
+  ovs-≡ = out-go {P} {S} {s} (IrSource.instructions S) st0
+            (mk-synth (pi-binding 0 ∷ []) 2 []) run-eq wf
+            seed₀
+    where
+    -- the initial output stream is empty, and the seeded `output-ops` is
+    -- empty, so both sides start at `just []`.
+    seed₀ : resolve-encode (witness-of P s) []
+              ≡ just (concatMap encodeᵉ (State.outs st0))
+    seed₀ rewrite init-outs {S} {P} {st0} ieq = refl
+
+  rand-≡ : CircuitWitness.comm-rand (witness-of P s) ≡ just r
+  rand-≡ rewrite cc = refl
+
+  pi1-≡ : pi-lookup (CircuitWitness.pis (witness-of P s)) 1 ≡ just c
+  pi1-≡ = pi-lookup-mono pis≼ (init-pi1 {S} {P} {st0} {c} {r} hc cc ieq)
+
+------------------------------------------------------------------------
+-- Top-level forward faithfulness.
+--
+-- A successful preprocess run, under single-assignment well-formedness
+-- and distinctness of the declared input names, yields a witness that
+-- satisfies the synthesised circuit.  Splitting on the comm-commitment
+-- flag selects either the commitment-free assembly (`forward-no-comm`,
+-- reusing `fwd-go`) or the commitment case (appending `comm-fwd` to the
+-- per-instruction constraints via the `∷ʳ` that `synth` emits).
+------------------------------------------------------------------------
+
+-- Package the comm-commitment circuit's facts (stated for the two-entry
+-- preamble fold) into `satisfies (synth S)`.  The `do-comm = true`
+-- case-split makes `synth S` reduce; its arguments carry no `do-comm S`,
+-- so the split entangles nothing.
+satisfies-synth-true : ∀ {S P s c r w}
+  → IrSource.do-communications-commitment S ≡ true
+  → ProofPreimage.comm-commitment P ≡ just (c , r)
+  → w ≡ witness-of P s
+  → satisfies-constraints
+      (SynthState.constraints
+        (synth-instrs (IrSource.instructions S)
+          (mk-synth (pi-binding 0 ∷ []) 2 []))) w
+  → holds w
+      (comm (input-operands (IrSource.inputs S))
+        (SynthState.output-ops
+          (synth-instrs (IrSource.instructions S)
+            (mk-synth (pi-binding 0 ∷ []) 2 []))))
+  → length (CircuitWitness.pis w)
+      ≡ SynthState.next-pi
+          (synth-instrs (IrSource.instructions S)
+            (mk-synth (pi-binding 0 ∷ []) 2 []))
+  → satisfies (synth S) w
+satisfies-synth-true {S} {P} {s} {c} {r} {w} hc cc w≡ cok comm-ok pil
+  with IrSource.do-communications-commitment S | hc
+... | true | refl =
+  record
+    { pi-length = pil
+    ; rand-shape = rand-shape′
+    ; constraint-ok =
+        sat-++ (SynthState.constraints
+                 (synth-instrs (IrSource.instructions S)
+                   (mk-synth (pi-binding 0 ∷ []) 2 [])))
+               (comm (input-operands (IrSource.inputs S))
+                 (SynthState.output-ops
+                   (synth-instrs (IrSource.instructions S)
+                     (mk-synth (pi-binding 0 ∷ []) 2 []))) ∷ [])
+               w cok (comm-ok , tt)
+    }
+  where
+  -- `comm-rand w = just r`, so the comm-commitment randomness shape holds.
+  rand-shape′ : Maybe-shape true (CircuitWitness.comm-rand w)
+  rand-shape′ rewrite w≡ | cc = tt
+
+forward : ∀ {S P s st0}
+  → init S P ≡ just st0
+  → preprocess S P ≡ just s
+  → WF-run P S (IrSource.instructions S) st0
+  → NoDup (map TypedIdentifier.name (IrSource.inputs S))
+  → satisfies (synth S) (witness-of P s)
+forward {S} {P} {s} {st0} ieq peq wf nd = aux (do-comm S) refl
+  where
+  do-comm = IrSource.do-communications-commitment
+  run-eq = proj₁ (preprocess-inv {S} {P} {s} {st0} ieq peq)
+
+  -- The comm-commitment branch.  Carried out under `cc`, where the
+  -- commitment is present; `satisfies-synth-true` reassembles
+  -- `satisfies (synth S)` (it re-splits on the flag itself).
+  with-comm : ∀ {c r}
+    → do-comm S ≡ true
+    → ProofPreimage.comm-commitment P ≡ just (c , r)
+    → satisfies (synth S) (witness-of P s)
+  with-comm {c} {r} hc cc =
+    satisfies-synth-true {S} {P} {s} {c} {r} {witness-of P s}
+      hc cc refl (proj₁ result)
+      (comm-fwd {S} {P} {s} {st0} {c} {r} hc cc ieq peq wf nd)
+      (sym (proj₂ result))
+    where
+    ss₀ : SynthState
+    ss₀ = mk-synth (pi-binding 0 ∷ []) 2 []
+
+    pi-inv₀ : SynthState.next-pi ss₀ ≡ length (State.pis st0)
+    pi-inv₀ = sym (trans (init-pis-len {S} {P} {st0} ieq)
+                         (cong preamble-pi-count hc))
+
+    prev₀ : satisfies-constraints (SynthState.constraints ss₀) (witness-of P s)
+    prev₀ = (ProofPreimage.binding-input P
+            , pi-lookup-mono
+                (proj₂ (run-extends {P} {S} {s} (IrSource.instructions S)
+                          st0 run-eq wf))
+                (init-pi0 {S} {P} {st0} ieq))
+          , tt
+
+    result : satisfies-constraints
+               (SynthState.constraints (synth-instrs (IrSource.instructions S) ss₀))
+               (witness-of P s)
+           × (SynthState.next-pi (synth-instrs (IrSource.instructions S) ss₀)
+               ≡ length (State.pis s))
+    result = fwd-go (IrSource.instructions S) st0 ss₀ run-eq wf pi-inv₀ prev₀
+
+  -- With `do-comm S = true` but no commitment, `init` would have failed.
+  init-no-comm : do-comm S ≡ true
+    → ProofPreimage.comm-commitment P ≡ nothing → init S P ≡ nothing
+  init-no-comm hc cc
+    with decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P)
+  ... | nothing = refl
+  ... | just m
+    with IrSource.do-communications-commitment S | hc
+  ...   | true | refl
+    with ProofPreimage.comm-commitment P | cc
+  ...     | nothing | refl = refl
+
+  -- Dispatch on the commitment, keeping the goal's `synth S` /
+  -- `witness-of P s` abstract (the fresh `mc` is the scrutinee, not
+  -- `comm-commitment P`), so the branch results unify with the goal.
+  aux-cc : do-comm S ≡ true → (mc : Maybe (Fr × Fr))
+    → ProofPreimage.comm-commitment P ≡ mc
+    → satisfies (synth S) (witness-of P s)
+  aux-cc hc (just (c , r)) cc = with-comm {c} {r} hc cc
+  aux-cc hc nothing        cc = case trans (sym (init-no-comm hc cc)) ieq of λ ()
+
+  aux : (b : Bool) → do-comm S ≡ b → satisfies (synth S) (witness-of P s)
+  aux false e = forward-no-comm {S} {P} {s} {st0} e ieq run-eq wf
+  aux true  e = aux-cc e (ProofPreimage.comm-commitment P) refl

--- a/formal/src/zkir-v3/CircuitProof.agda
+++ b/formal/src/zkir-v3/CircuitProof.agda
@@ -1,0 +1,1718 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Program-level assembly of the circuit-faithfulness results.
+--
+-- This module ties the static well-formedness passes (`Obligations`), the
+-- forward per-instruction lemmas (`CircuitFaithfulness`), and the
+-- constraint-extraction interface (`CircuitBridge`) into the headline
+-- theorems:
+--
+--   • `forward-sa`   — forward faithfulness from the decidable static
+--     single-assignment check alone;
+--   • `backward`     — the spine-driven converse of `forward` (a run is
+--     reconstructed from the backward spine and `satisfies`);
+--   • `circuit-faithful` — an ⇔ at the canonical witness `witness-of P s`;
+--   • `preprocess→BwdWalk` — the spine and `Consumed` hypotheses of
+--     `circuit-faithful`, projected from a successful `preprocess` (via
+--     the per-instruction `step→bwd` inversions and `run→BwdWalk`).
+--
+-- The `defd-*` family builds the `Defd` side-conditions `holds-lower`
+-- consumes; the backward spine (`BwdStep`/`BwdWalk`/`spine-⊑`) and the
+-- `mutual` fold (`bwd-go`/`bwd-cont`) reconstruct the run; the commitment
+-- reconstruction (`comm-from-sat`/`comm-tc2`/`run→preprocess`) closes the
+-- preprocessing forward-composition.
+------------------------------------------------------------------------
+
+module zkir-v3.CircuitProof (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Semantics ⋯
+  using ( Mem; State; ProofPreimage; ins; step; init; out1; run
+        ; insertMany; decode-inputs; resolve; resolveᶠ
+        ; resolve-all-Fr; eval-guard; collectOutputs
+        ; default-val; to𝔹; preprocess; valEq?; _≟LFr_ )
+open import zkir-v3.SemanticsProperties ⋯
+  using ( NoDup; WF-run
+        ; _⊑_; _≼_; ⊑-refl; ⊑-trans; ≼-refl; ≼-trans
+        ; run-cons; run-shaped; mk-run-shaped; Consumed
+        ; run-extends; init-outs; init-decode
+        ; run-inv; step-extends; preprocess-walk-consumed )
+open import zkir-v3.Circuit ⋯ using (satisfies; synth; satisfies-constraints
+  ; holds; resolve-encode; pi-lookup
+  ; gate-copy; gate-add; gate-mul; gate-neg; gate-inv; eq; boolean
+  ; in-range; select; test-eq; is-not; less-than; reconstitute
+  ; scalar-from-native; poseidon; sha256; keccak; ec-mul; ec-gen; h2c
+  ; into-coords; from-coords; into-bytes; from-bytes; reverse-bytes
+  ; bytes-into-low-high; bytes-from-low-high; div-mod
+  ; Constraint; encode-eq; pi-binding; comm; impact-constraints
+  ; input-operands; SynthState; synth-instr; synth-instrs; mk-synth)
+open import zkir-v3.CircuitFaithfulness ⋯
+  using ( forward
+        -- commitment reconstruction ingredients (reused from `forward`)
+        ; decode-reencode; out-go; init-pi1 )
+open import zkir-v3.CircuitBackward ⋯
+  using ( copy-bwd; constrain-eq-bwd; add-bwd; mul-bwd; neg-bwd; inv-bwd
+        ; test-eq-bwd; assert-bwd; constrain-to-boolean-bwd; not-bwd
+        ; cond-select-bwd; constrain-bits-bwd; less-than-bwd
+        ; reconstitute-field-bwd; jubjub-scalar-from-native-bwd
+        ; ec-mul-bwd; ec-mul-generator-bwd; hash-to-curve-bwd
+        ; transient-hash-bwd; into-bytes32-bwd
+        ; from-bytes32-native-bwd; from-bytes32-secp-base-bwd
+        ; from-bytes32-secp-scalar-bwd
+        ; reverse-bytes-bwd
+        ; from-coordinates-bwd; bytes32-from-low-high-bwd
+        ; into-coordinates-bwd; bytes32-into-low-high-bwd
+        ; div-mod-power-of-two-bwd; persistent-hash-bwd; keccak256-bwd
+        ; encode-bwd
+        ; impact-true-bwd; impact-false-bwd
+        ; public-input-active-bwd; public-input-inactive-bwd
+        ; private-input-active-bwd; private-input-inactive-bwd
+        ; circuit-output-bwd
+        ; ⊢-back; out-val )
+open import zkir-v3.CircuitBridge ⋯
+open import zkir-v3.Obligations ⋯
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+
+open import Data.Bool    using (Bool; true; false; if_then_else_)
+open import Data.List    using (List; []; _∷_; _++_; _∷ʳ_; map; take; drop; length; concatMap)
+open import Data.List.Properties using (++-identityʳ; ++-assoc)
+open import Data.Maybe   using (Maybe; just; nothing)
+open import Data.Nat     using (ℕ; _^_; _+_; _*_; _∸_; _<_; _<?_)
+open import Data.Nat     using () renaming (_≟_ to _≟ℕ_)
+open import Data.Product using (_×_; _,_; ∃; ∃₂; proj₁; proj₂)
+open import Function.Bundles using (_⇔_; mk⇔)
+open import Data.Unit    using (⊤; tt)
+open import Function     using (case_of_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; cong₂; subst)
+open import Relation.Nullary using (¬_; yes; no; Dec)
+open import Data.String using () renaming (_≟_ to _≟str_)
+
+open import Data.List.Relation.Unary.All using (All; []; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Data.Empty using (⊥)
+open import Data.Maybe using () renaming (map to mapᵐ)
+open import Data.Maybe.Properties using (just-injective; ≡-dec)
+
+------------------------------------------------------------------------
+-- Forward faithfulness, from the static check alone.
+--
+-- Combining `producer-safe→WF` (discharging the semantic `WF-run`
+-- hypothesis) with the input-name distinctness carried by `producer-SA`,
+-- `forward` reduces to a check that scans the source once.
+------------------------------------------------------------------------
+
+forward-sa : ∀ {S P s st0}
+  → producer-SA S
+  → init S P ≡ just st0
+  → preprocess S P ≡ just s
+  → satisfies (synth S) (witness-of P s)
+forward-sa {S} {P} {s} {st0} sa ieq peq =
+  forward ieq peq
+    (producer-safe→WF {S} {P} {st0} sa ieq)
+    (proj₁ sa)
+
+------------------------------------------------------------------------
+-- Definedness of the emitted constraint at the post-step witness.
+--
+-- For each instruction whose backward lemma inverts a `holds` premise,
+-- `defd-<i>` builds the `Defd` side-condition `holds-lower`
+-- needs: every operand the constraint reads resolves at the post-step
+-- witness (its resolution at the pre-step memory, shifted across the fresh
+-- output binding by `⊢-pres`/`⊢ᶠ-pres`/`⊢all-pres` and their two-output
+-- variants) and every output cell is the just-written value
+-- (`assign-here`/`assign-inner`/`assign-outer`).  The pre-step operand
+-- resolutions come from `optype-resolve`/`optype-resolveᶠ`/`allNat-resolve`
+-- (i.e. from `TyEq` + `OpTy`).  Instructions with no `holds` premise
+-- (`encode`, `impact`, `public-input`, `private-input`, `circuit-output`)
+-- need no `Defd`.
+------------------------------------------------------------------------
+
+-- Single-output (post-state `out1 st output v`).
+
+defd-copy : ∀ {P st output val v w}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) val ≡ just w
+  → Defd (witness-of P (out1 st output v)) (gate-copy output val)
+defd-copy {P} {st} {output} {val} {v} {w} fresh rv =
+    (w , ⊢-pres P st output v val fresh rv)
+  , (v , assign-here P st output v)
+
+defd-add : ∀ {P st output a b v av bv}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) a ≡ just av → resolve (State.mem st) b ≡ just bv
+  → Defd (witness-of P (out1 st output v)) (gate-add output a b)
+defd-add {P} {st} {output} {a} {b} {v} {av} {bv} fresh ra rb =
+    (av , ⊢-pres P st output v a fresh ra)
+  , (bv , ⊢-pres P st output v b fresh rb)
+  , (v  , assign-here P st output v)
+
+defd-mul : ∀ {P st output a b v av bv}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) a ≡ just av → resolve (State.mem st) b ≡ just bv
+  → Defd (witness-of P (out1 st output v)) (gate-mul output a b)
+defd-mul {P} {st} {output} {a} {b} {v} {av} {bv} fresh ra rb =
+    (av , ⊢-pres P st output v a fresh ra)
+  , (bv , ⊢-pres P st output v b fresh rb)
+  , (v  , assign-here P st output v)
+
+defd-neg : ∀ {P st output a v av}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) a ≡ just av
+  → Defd (witness-of P (out1 st output v)) (gate-neg output a)
+defd-neg {P} {st} {output} {a} {v} {av} fresh ra =
+    (av , ⊢-pres P st output v a fresh ra)
+  , (v  , assign-here P st output v)
+
+defd-inv : ∀ {P st output a v av}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) a ≡ just av
+  → Defd (witness-of P (out1 st output v)) (gate-inv output a)
+defd-inv {P} {st} {output} {a} {v} {av} fresh ra =
+    (av , ⊢-pres P st output v a fresh ra)
+  , (v  , assign-here P st output v)
+
+defd-test-eq : ∀ {P st output a b v av bv}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) a ≡ just av → resolve (State.mem st) b ≡ just bv
+  → Defd (witness-of P (out1 st output v)) (test-eq output a b)
+defd-test-eq {P} {st} {output} {a} {b} {v} {av} {bv} fresh ra rb =
+    (av , ⊢-pres P st output v a fresh ra)
+  , (bv , ⊢-pres P st output v b fresh rb)
+  , (v  , assign-here P st output v)
+
+defd-scalar-from-native : ∀ {P st output a v x}
+  → State.mem st output ≡ nothing
+  → resolveᶠ (State.mem st) a ≡ just x
+  → Defd (witness-of P (out1 st output v)) (scalar-from-native output a)
+defd-scalar-from-native {P} {st} {output} {a} {v} {x} fresh ra =
+    (x , ⊢ᶠ-pres P st output v a fresh ra)
+  , (v , assign-here P st output v)
+
+defd-ec-mul : ∀ {P st output a scalar v av sv}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) a ≡ just av
+  → resolve (State.mem st) scalar ≡ just sv
+  → Defd (witness-of P (out1 st output v)) (ec-mul output a scalar)
+defd-ec-mul {P} {st} {output} {a} {scalar} {v} {av} {sv} fresh ra rs =
+    (av , ⊢-pres P st output v a fresh ra)
+  , (sv , ⊢-pres P st output v scalar fresh rs)
+  , (v  , assign-here P st output v)
+
+defd-ec-gen : ∀ {P st output scalar v sv}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) scalar ≡ just sv
+  → Defd (witness-of P (out1 st output v)) (ec-gen output scalar)
+defd-ec-gen {P} {st} {output} {scalar} {v} {sv} fresh rs =
+    (sv , ⊢-pres P st output v scalar fresh rs)
+  , (v  , assign-here P st output v)
+
+defd-h2c : ∀ {P st output inputs v frs}
+  → State.mem st output ≡ nothing
+  → resolve-all-Fr (State.mem st) inputs ≡ just frs
+  → Defd (witness-of P (out1 st output v)) (h2c output inputs)
+defd-h2c {P} {st} {output} {inputs} {v} {frs} fresh ri =
+    (frs , ⊢all-pres P st output v inputs fresh ri)
+  , (v   , assign-here P st output v)
+
+defd-poseidon : ∀ {P st output inputs v frs}
+  → State.mem st output ≡ nothing
+  → resolve-all-Fr (State.mem st) inputs ≡ just frs
+  → Defd (witness-of P (out1 st output v)) (poseidon output inputs)
+defd-poseidon {P} {st} {output} {inputs} {v} {frs} fresh ri =
+    (frs , ⊢all-pres P st output v inputs fresh ri)
+  , (v   , assign-here P st output v)
+
+defd-into-bytes : ∀ {P st output input v av}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) input ≡ just av
+  → Defd (witness-of P (out1 st output v)) (into-bytes output input)
+defd-into-bytes {P} {st} {output} {input} {v} {av} fresh ri =
+    (av , ⊢-pres P st output v input fresh ri)
+  , (v  , assign-here P st output v)
+
+defd-from-bytes : ∀ {P st output bytes v bv}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) bytes ≡ just bv
+  → Defd (witness-of P (out1 st output v)) (from-bytes output bytes)
+defd-from-bytes {P} {st} {output} {bytes} {v} {bv} fresh rb =
+    (bv , ⊢-pres P st output v bytes fresh rb)
+  , (v  , assign-here P st output v)
+
+defd-reverse-bytes : ∀ {P st output bytes v bv}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) bytes ≡ just bv
+  → Defd (witness-of P (out1 st output v)) (reverse-bytes output bytes)
+defd-reverse-bytes {P} {st} {output} {bytes} {v} {bv} fresh rb =
+    (bv , ⊢-pres P st output v bytes fresh rb)
+  , (v  , assign-here P st output v)
+
+defd-from-coords : ∀ {P st output x y v xv yv}
+  → State.mem st output ≡ nothing
+  → resolve (State.mem st) x ≡ just xv → resolve (State.mem st) y ≡ just yv
+  → Defd (witness-of P (out1 st output v)) (from-coords output x y)
+defd-from-coords {P} {st} {output} {x} {y} {v} {xv} {yv} fresh rx ry =
+    (xv , ⊢-pres P st output v x fresh rx)
+  , (yv , ⊢-pres P st output v y fresh ry)
+  , (v  , assign-here P st output v)
+
+defd-bytes-from-low-high : ∀ {P st output lo hi v l h}
+  → State.mem st output ≡ nothing
+  → resolveᶠ (State.mem st) lo ≡ just l → resolveᶠ (State.mem st) hi ≡ just h
+  → Defd (witness-of P (out1 st output v)) (bytes-from-low-high output lo hi)
+defd-bytes-from-low-high {P} {st} {output} {lo} {hi} {v} {l} {h} fresh rl rh =
+    (l , ⊢ᶠ-pres P st output v lo fresh rl)
+  , (h , ⊢ᶠ-pres P st output v hi fresh rh)
+  , (v , assign-here P st output v)
+
+defd-less-than : ∀ {P st output a b bits v x y}
+  → State.mem st output ≡ nothing
+  → resolveᶠ (State.mem st) a ≡ just x → resolveᶠ (State.mem st) b ≡ just y
+  → Defd (witness-of P (out1 st output v)) (less-than output a b bits)
+defd-less-than {P} {st} {output} {a} {b} {bits} {v} {x} {y} fresh ra rb =
+    (x , ⊢ᶠ-pres P st output v a fresh ra)
+  , (y , ⊢ᶠ-pres P st output v b fresh rb)
+  , (v , assign-here P st output v)
+
+defd-is-not : ∀ {P st output a v x}
+  → State.mem st output ≡ nothing
+  → resolveᶠ (State.mem st) a ≡ just x
+  → Defd (witness-of P (out1 st output v)) (is-not output a)
+defd-is-not {P} {st} {output} {a} {v} {x} fresh ra =
+    (x , ⊢ᶠ-pres P st output v a fresh ra)
+  , (v , assign-here P st output v)
+
+defd-select : ∀ {P st output bit a b v bf av bv}
+  → State.mem st output ≡ nothing
+  → resolveᶠ (State.mem st) bit ≡ just bf
+  → resolve (State.mem st) a ≡ just av → resolve (State.mem st) b ≡ just bv
+  → Defd (witness-of P (out1 st output v)) (select output bit a b)
+defd-select {P} {st} {output} {bit} {a} {b} {v} {bf} {av} {bv} fresh rbit ra rb =
+    (bf , ⊢ᶠ-pres P st output v bit fresh rbit)
+  , (av , ⊢-pres  P st output v a   fresh ra)
+  , (bv , ⊢-pres  P st output v b   fresh rb)
+  , (v  , assign-here P st output v)
+
+defd-reconstitute : ∀ {P st output d m bits v dv mv}
+  → State.mem st output ≡ nothing
+  → resolveᶠ (State.mem st) d ≡ just dv → resolveᶠ (State.mem st) m ≡ just mv
+  → Defd (witness-of P (out1 st output v)) (reconstitute output d m bits)
+defd-reconstitute {P} {st} {output} {d} {m} {bits} {v} {dv} {mv} fresh rd rm =
+    (dv , ⊢ᶠ-pres P st output v d fresh rd)
+  , (mv , ⊢ᶠ-pres P st output v m fresh rm)
+  , (v  , assign-here P st output v)
+
+-- No output (post-state `st`).
+
+defd-eq : ∀ {P st a b av bv}
+  → resolve (State.mem st) a ≡ just av → resolve (State.mem st) b ≡ just bv
+  → Defd (witness-of P st) (eq a b)
+defd-eq {P} {st} {a} {b} {av} {bv} ra rb =
+    (av , trans (resolve-agree P st a) ra)
+  , (bv , trans (resolve-agree P st b) rb)
+
+defd-boolean : ∀ {P st val x}
+  → resolveᶠ (State.mem st) val ≡ just x
+  → Defd (witness-of P st) (boolean val)
+defd-boolean {P} {st} {val} {x} rv = x , trans (resolveᶜ-Fr-agree P st val) rv
+
+defd-in-range : ∀ {P st val bits x}
+  → resolveᶠ (State.mem st) val ≡ just x
+  → Defd (witness-of P st) (in-range val bits)
+defd-in-range {P} {st} {val} {bits} {x} rv =
+  x , trans (resolveᶜ-Fr-agree P st val) rv
+
+-- Two distinct outputs (post-state `out1 (out1 st id₁ v₁) id₂ v₂`).
+
+defd-into-coords : ∀ {P st point xo yo v₁ v₂ pv}
+  → State.mem st xo ≡ nothing → State.mem st yo ≡ nothing → ¬ (xo ≡ yo)
+  → resolve (State.mem st) point ≡ just pv
+  → Defd (witness-of P (out1 (out1 st xo v₁) yo v₂)) (into-coords xo yo point)
+defd-into-coords {P} {st} {point} {xo} {yo} {v₁} {v₂} {pv} fx fy xo≢yo rp =
+    (pv , ⊢-pres2 P st xo v₁ yo v₂ point fx fy (λ y≡x → xo≢yo (sym y≡x)) rp)
+  , (v₁ , assign-inner P st xo v₁ yo v₂ xo≢yo)
+  , (v₂ , assign-outer P st xo v₁ yo v₂)
+
+defd-bytes-into-low-high : ∀ {P st bytes lo hi v₁ v₂ bv}
+  → State.mem st lo ≡ nothing → State.mem st hi ≡ nothing → ¬ (lo ≡ hi)
+  → resolve (State.mem st) bytes ≡ just bv
+  → Defd (witness-of P (out1 (out1 st lo v₁) hi v₂)) (bytes-into-low-high lo hi bytes)
+defd-bytes-into-low-high {P} {st} {bytes} {lo} {hi} {v₁} {v₂} {bv} fl fh lo≢hi rb =
+    (bv , ⊢-pres2 P st lo v₁ hi v₂ bytes fl fh (λ h≡l → lo≢hi (sym h≡l)) rb)
+  , (v₁ , assign-inner P st lo v₁ hi v₂ lo≢hi)
+  , (v₂ , assign-outer P st lo v₁ hi v₂)
+
+defd-div-mod : ∀ {P st q r val bits v₁ v₂ x}
+  → State.mem st q ≡ nothing → State.mem st r ≡ nothing → ¬ (q ≡ r)
+  → resolveᶠ (State.mem st) val ≡ just x
+  → Defd (witness-of P (out1 (out1 st q v₁) r v₂)) (div-mod q r val bits)
+defd-div-mod {P} {st} {q} {r} {val} {bits} {v₁} {v₂} {x} fq fr q≢r rv =
+    (x  , ⊢ᶠ-pres2 P st q v₁ r v₂ val fq fr (λ r≡q → q≢r (sym r≡q)) rv)
+  , (v₁ , assign-inner P st q v₁ r v₂ q≢r)
+  , (v₂ , assign-outer P st q v₁ r v₂)
+
+defd-sha256 : ∀ {P st alignment inputs output v frs}
+  → State.mem st output ≡ nothing
+  → resolve-all-Fr (State.mem st) inputs ≡ just frs
+  → Defd (witness-of P (out1 st output v)) (sha256 output alignment inputs)
+defd-sha256 {P} {st} {alignment} {inputs} {output} {v} {frs} fresh ri =
+    (frs , ⊢all-pres P st output v inputs fresh ri)
+  , (v   , assign-here P st output v)
+
+defd-keccak : ∀ {P st alignment inputs output v frs}
+  → State.mem st output ≡ nothing
+  → resolve-all-Fr (State.mem st) inputs ≡ just frs
+  → Defd (witness-of P (out1 st output v)) (keccak output alignment inputs)
+defd-keccak {P} {st} {alignment} {inputs} {output} {v} {frs} fresh ri =
+    (frs , ⊢all-pres P st output v inputs fresh ri)
+  , (v   , assign-here P st output v)
+
+------------------------------------------------------------------------
+-- The backward spine.
+--
+-- An endpoint-indexed reconstruction of the run from side data: per step
+-- the post-state (pinned by the output value(s), or the transcript/output
+-- record update) plus the semantic facts the corresponding `*-bwd` lemma
+-- needs beyond freshness, operand resolutions/types, and `holds` (guard
+-- readings, booleanity, the field-inverse, the no-overflow bound, the
+-- transcript slice/decode, the output collection).  Each `bw-cons` also
+-- carries the per-step store/PI monotonicity, so `spine-⊑` recovers
+-- `mem st ⊑ mem s` / `pis st ≼ pis s` structurally, with no run.
+------------------------------------------------------------------------
+
+-- Post-state pinning for one / two fresh output cells.
+O¹ : State → Identifier → State → Set
+O¹ st o st' = ∃ λ v → st' ≡ out1 st o v
+
+O² : State → Identifier → Identifier → State → Set
+O² st o₁ o₂ st' = ∃ λ v₁ → ∃ λ v₂ → st' ≡ out1 (out1 st o₁ v₁) o₂ v₂
+
+BwdStep : ProofPreimage → IrSource → State → Instruction → State → Set
+BwdStep P S st (encode input outputs) st' =
+  ∃ λ v → resolve (State.mem st) input ≡ just v
+        × insertMany st outputs (map val-native (encodeᵉ v)) ≡ just st'
+BwdStep P S st (assert cond) st' =
+  st' ≡ st
+  × (∃ λ x → resolveᶠ (State.mem st) cond ≡ just x × to𝔹 x ≡ just true)
+BwdStep P S st (cond-select bit a b o) st' =
+  O¹ st o st'
+  × (∃ λ x → resolveᶠ (State.mem st) bit ≡ just x)
+BwdStep P S st (constrain-bits val bits) st' = st' ≡ st
+BwdStep P S st (constrain-eq a b) st' = st' ≡ st
+BwdStep P S st (constrain-to-boolean val) st' = st' ≡ st
+BwdStep P S st (copy val o) st' = O¹ st o st'
+BwdStep P S st (impact guard inputs) st' =
+  ∃ λ vals → ∃ λ gᶠ →
+    resolve-all-Fr (State.mem st) inputs ≡ just vals
+  × resolveᶠ (State.mem st) guard ≡ just gᶠ
+  × ( (to𝔹 gᶠ ≡ just true
+       × take (length vals)
+           (drop (State.pti-idx st)
+             (ProofPreimage.pub-transcript-inputs P)) ≡ vals
+       × st' ≡ record st
+                 { pis      = State.pis st ++ vals
+                 ; pi-skips = State.pi-skips st ++ (nothing ∷ [])
+                 ; pti-idx  = State.pti-idx st + length vals })
+    ⊎ (to𝔹 gᶠ ≡ just false
+       × st' ≡ record st
+                 { pis      = State.pis st ++ map (λ _ → 0ᶠ) vals
+                 ; pi-skips = State.pi-skips st ++ (just (length vals) ∷ []) }))
+BwdStep P S st (ec-mul a scalar o) st' = O¹ st o st'
+BwdStep P S st (ec-mul-generator scalar o) st' = O¹ st o st'
+BwdStep P S st (hash-to-curve inputs o) st' = O¹ st o st'
+BwdStep P S st (into-coordinates point (xo , yo)) st' = O² st xo yo st'
+BwdStep P S st (from-coordinates (x , y) o) st' = O¹ st o st'
+BwdStep P S st (into-bytes32 input o) st' = O¹ st o st'
+-- The emitted `from-bytes` constraint leaves the output *type* a
+-- disjunction, so the side data pins the output constructor selected by
+-- `val-t` (the payload is recovered from `holds` and the concrete lemma).
+BwdStep P S st (from-bytes32 bytes val-t o) st' =
+  case val-t of λ { native      → ∃ λ n → st' ≡ out1 st o (val-native n)
+                  ; secp-base   → ∃ λ x → st' ≡ out1 st o (val-secp-base x)
+                  ; secp-scalar → ∃ λ x → st' ≡ out1 st o (val-secp-scalar x)
+                  ; _           → ⊥ }
+BwdStep P S st (reverse-bytes bytes o) st' = O¹ st o st'
+BwdStep P S st (bytes32-into-low-high bytes (lo , hi)) st' = O² st lo hi st'
+BwdStep P S st (bytes32-from-low-high (lo , hi) o) st' = O¹ st o st'
+BwdStep P S st (div-mod-power-of-two val bits outs) st' =
+  case outs of λ { (q ∷ r ∷ []) → O² st q r st' ; _ → ⊥ }
+BwdStep P S st (reconstitute-field d m bits o) st' =
+  O¹ st o st'
+  × (∃ λ dv → resolveᶠ (State.mem st) d ≡ just dv
+     × ∃ λ mo → resolveᶠ (State.mem st) m ≡ just mo
+                     × (valFr mo + 2 ^ bits * valFr dv < FR-ORDER))
+BwdStep P S st (transient-hash inputs o) st' = O¹ st o st'
+BwdStep P S st (persistent-hash al inputs o) st' = O¹ st o st'
+BwdStep P S st (keccak256 al inputs o) st' = O¹ st o st'
+BwdStep P S st (test-eq a b o) st' = O¹ st o st'
+BwdStep P S st (add a b o) st' = O¹ st o st'
+BwdStep P S st (mul a b o) st' = O¹ st o st'
+BwdStep P S st (neg a o) st' = O¹ st o st'
+BwdStep P S st (inv a o) st' = O¹ st o st'
+BwdStep P S st (not a o) st' =
+  O¹ st o st'
+  × (∃ λ x → resolveᶠ (State.mem st) a ≡ just x)
+-- The `less-than` constraint pins only the chip's evened bound
+-- (`< 2 ^ even4 bits`); the exact off-circuit `2 ^ bits` bounds are
+-- side data.
+BwdStep P S st (less-than a b bits o) st' =
+  O¹ st o st'
+  × (∃ λ x → resolveᶠ (State.mem st) a ≡ just x × valFr x < 2 ^ bits)
+  × (∃ λ y → resolveᶠ (State.mem st) b ≡ just y × valFr y < 2 ^ bits)
+BwdStep P S st (jubjub-scalar-from-native a o) st' = O¹ st o st'
+BwdStep P S st (public-input guard val-t o) st' =
+    (eval-guard (State.mem st) guard ≡ just true
+     × ∃ λ v → decode val-t (take (encoded-len val-t) (State.pto-rem st)) ≡ just v
+               × st' ≡ record st
+                         { mem     = ins o v (State.mem st)
+                         ; pto-rem = drop (encoded-len val-t) (State.pto-rem st) })
+  ⊎ (eval-guard (State.mem st) guard ≡ just false
+     × st' ≡ out1 st o (default-val val-t))
+BwdStep P S st (private-input guard val-t o) st' =
+    (eval-guard (State.mem st) guard ≡ just true
+     × ∃ λ v → decode val-t (take (encoded-len val-t) (State.priv-rem st)) ≡ just v
+               × st' ≡ record st
+                         { mem      = ins o v (State.mem st)
+                         ; priv-rem = drop (encoded-len val-t) (State.priv-rem st) })
+  ⊎ (eval-guard (State.mem st) guard ≡ just false
+     × st' ≡ out1 st o (default-val val-t))
+BwdStep P S st (circuit-output vals) st' =
+  ∃ λ vs → collectOutputs (State.mem st) (IrSource.outputs S) vals ≡ just vs
+         × st' ≡ record st { outs = State.outs st ++ vs }
+
+data BwdWalk (P : ProofPreimage) (S : IrSource)
+     : State → List Instruction → State → Set where
+  bw-nil  : ∀ {st} → BwdWalk P S st [] st
+  bw-cons : ∀ {st st′ s} i is
+          → State.mem st ⊑ State.mem st′ → State.pis st ≼ State.pis st′
+          → BwdStep P S st i st′
+          → BwdWalk P S st′ is s
+          → BwdWalk P S st (i ∷ is) s
+
+spine-⊑ : ∀ {P S st is s} → BwdWalk P S st is s
+  → (State.mem st ⊑ State.mem s) × (State.pis st ≼ State.pis s)
+spine-⊑ {st = st} bw-nil = ⊑-refl {State.mem st} , ≼-refl
+spine-⊑ {st = st} {s = s} (bw-cons {st′ = st′} i is m⊑ p≼ _ tail) =
+  let (m⊑′ , p≼′) = spine-⊑ tail
+  in ⊑-trans {State.mem st} {State.mem st′} {State.mem s} m⊑ m⊑′
+   , ≼-trans p≼ p≼′
+
+------------------------------------------------------------------------
+-- The spine of a genuine run (the v2 `R⇒preprocess-shaped` analogue).
+--
+-- A successful `step` determines its own `BwdStep` side data: one
+-- inversion per instruction reads the resolutions, guard values, bounds,
+-- and post-state shape off the step's success (`step→bwd`), and
+-- `run→BwdWalk` folds them — with `step-extends` supplying the per-step
+-- monotonicity — into a `BwdWalk`.  `preprocess→BwdWalk` packages the
+-- projection at the `preprocess` level, so callers can discharge
+-- `circuit-faithful`'s spine and `Consumed` hypotheses from a successful
+-- `preprocess` and the static single-assignment check alone.
+------------------------------------------------------------------------
+
+step→bwd : ∀ {P S st st'} (i : Instruction)
+  → step P S st i ≡ just st'
+  → BwdStep P S st i st'
+step→bwd {st = st} (encode input outputs) e
+  with resolve (State.mem st) input
+... | just v = v , refl , e
+step→bwd {st = st} (assert cond) e
+  with resolveᶠ (State.mem st) cond
+... | just x with to𝔹 x in eqb
+...   | just true with refl ← e = refl , x , refl , eqb
+step→bwd {st = st} (cond-select bit a b output) e
+  with resolveᶠ (State.mem st) bit
+... | just x with to𝔹 x
+...   | just bv with resolve (State.mem st) a | resolve (State.mem st) b
+...     | just av | just bvl with typeof av ≟T typeof bvl
+...       | yes _ with refl ← e = (_ , refl) , x , refl
+step→bwd {st = st} (constrain-bits val bits) e
+  with resolveᶠ (State.mem st) val
+... | just x with valFr x <? 2 ^ bits
+...   | yes _ with refl ← e = refl
+step→bwd {st = st} (constrain-eq a b) e
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just true with refl ← e = refl
+step→bwd {st = st} (constrain-to-boolean val) e
+  with resolveᶠ (State.mem st) val
+... | just x with to𝔹 x
+...   | just _ with refl ← e = refl
+step→bwd {st = st} (copy val output) e
+  with resolve (State.mem st) val
+... | just v with refl ← e = v , refl
+step→bwd {P = P} {st = st} (impact guard inputs) e
+  with resolve-all-Fr (State.mem st) inputs
+... | just vals with resolveᶠ (State.mem st) guard
+...   | just gᶠ with to𝔹 gᶠ in eqb
+...     | just true
+          with take (length vals)
+                 (drop (State.pti-idx st)
+                   (ProofPreimage.pub-transcript-inputs P))
+               ≟LFr vals
+...       | yes teq with refl ← e =
+            vals , gᶠ , refl , refl , inj₁ (eqb , teq , refl)
+step→bwd {P = P} {st = st} (impact guard inputs) e
+    | just vals | just gᶠ | just false with refl ← e =
+      vals , gᶠ , refl , refl , inj₂ (eqb , refl)
+step→bwd {st = st} (ec-mul a scalar output) e
+  with resolve (State.mem st) a | resolve (State.mem st) scalar
+... | just (val-jubjub-point p) | just (val-jubjub-scalar s)
+        with refl ← e = _ , refl
+... | just (val-secp-point p) | just (val-secp-scalar s)
+        with refl ← e = _ , refl
+step→bwd {st = st} (ec-mul-generator scalar output) e
+  with resolve (State.mem st) scalar
+... | just (val-jubjub-scalar s) with refl ← e = _ , refl
+... | just (val-secp-scalar s)   with refl ← e = _ , refl
+step→bwd {st = st} (hash-to-curve inputs output) e
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e = _ , refl
+step→bwd {st = st} (into-coordinates point (xid , yid)) e
+  with resolve (State.mem st) point
+... | just (val-jubjub-point p) with coordsJ p
+...   | (x , y) with refl ← e = _ , _ , refl
+step→bwd {st = st} (into-coordinates point (xid , yid)) e
+    | just (val-secp-point p) with coordsK p
+...   | just (x , y) with refl ← e = _ , _ , refl
+step→bwd {st = st} (from-coordinates (xop , yop) output) e
+  with resolve (State.mem st) xop | resolve (State.mem st) yop
+... | just (val-native x) | just (val-native y) with fromCoordsJ x y
+...   | just p with refl ← e = _ , refl
+step→bwd {st = st} (from-coordinates (xop , yop) output) e
+    | just (val-secp-base x) | just (val-secp-base y) with fromCoordsK x y
+...   | just p with refl ← e = _ , refl
+step→bwd {st = st} (into-bytes32 input output) e
+  with resolve (State.mem st) input
+... | just (val-native x)      with refl ← e = _ , refl
+... | just (val-secp-base x)   with refl ← e = _ , refl
+... | just (val-secp-scalar s) with refl ← e = _ , refl
+step→bwd {st = st} (from-bytes32 bytes native output) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = _ , refl
+step→bwd {st = st} (from-bytes32 bytes bytes32 output) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step→bwd {st = st} (from-bytes32 bytes jubjub-point output) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step→bwd {st = st} (from-bytes32 bytes jubjub-scalar output) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step→bwd {st = st} (from-bytes32 bytes secp-point output) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step→bwd {st = st} (from-bytes32 bytes secp-base output) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = _ , refl
+step→bwd {st = st} (from-bytes32 bytes secp-scalar output) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = _ , refl
+step→bwd {st = st} (reverse-bytes bytes output) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = _ , refl
+step→bwd {st = st} (bytes32-into-low-high bytes (loid , hiid)) e
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with bytes32→low-high b
+...   | (lo , hi) with refl ← e = _ , _ , refl
+step→bwd {st = st} (bytes32-from-low-high (loop , hiop) output) e
+  with resolveᶠ (State.mem st) loop | resolveᶠ (State.mem st) hiop
+... | just lo | just hi with low-high→bytes32 lo hi
+...   | just b with refl ← e = _ , refl
+step→bwd {st = st} (div-mod-power-of-two val bits []) e
+  with resolveᶠ (State.mem st) val
+... | just x = case e of λ ()
+step→bwd {st = st} (div-mod-power-of-two val bits (q ∷ [])) e
+  with resolveᶠ (State.mem st) val
+... | just x = case e of λ ()
+step→bwd {st = st} (div-mod-power-of-two val bits (q ∷ r ∷ [])) e
+  with resolveᶠ (State.mem st) val
+... | just x with refl ← e = _ , _ , refl
+step→bwd {st = st} (div-mod-power-of-two val bits (q ∷ r ∷ z ∷ zs)) e
+  with resolveᶠ (State.mem st) val
+... | just x = case e of λ ()
+step→bwd {st = st} (reconstitute-field divisor modulus bits output) e
+  with resolveᶠ (State.mem st) divisor
+     | resolveᶠ (State.mem st) modulus
+... | just d | just mo with valFr mo <? 2 ^ bits
+...   | yes _ with valFr d <? 2 ^ (FR-BITS ∸ bits)
+...     | yes _ with valFr mo + 2 ^ bits * valFr d <? FR-ORDER
+...       | yes novf with refl ← e =
+            (_ , refl) , d , refl , mo , refl , novf
+step→bwd {st = st} (transient-hash inputs output) e
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e = _ , refl
+step→bwd {st = st} (persistent-hash alignment inputs output) e
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with persistent-hash-fn alignment frs
+...   | just h with refl ← e = _ , refl
+step→bwd {st = st} (keccak256 alignment inputs output) e
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with keccak-fn alignment frs
+...   | just h with refl ← e = _ , refl
+step→bwd {st = st} (test-eq a b output) e
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just eqv with refl ← e = _ , refl
+step→bwd {st = st} (add a b output) e
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just (val-native x) | just (val-native y)
+        with refl ← e = _ , refl
+... | just (val-jubjub-point p) | just (val-jubjub-point q)
+        with refl ← e = _ , refl
+... | just (val-secp-point p) | just (val-secp-point q)
+        with refl ← e = _ , refl
+... | just (val-secp-base x) | just (val-secp-base y)
+        with refl ← e = _ , refl
+... | just (val-secp-scalar x) | just (val-secp-scalar y)
+        with refl ← e = _ , refl
+step→bwd {st = st} (mul a b output) e
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just (val-native x) | just (val-native y)
+        with refl ← e = _ , refl
+... | just (val-secp-base x) | just (val-secp-base y)
+        with refl ← e = _ , refl
+... | just (val-secp-scalar x) | just (val-secp-scalar y)
+        with refl ← e = _ , refl
+step→bwd {st = st} (neg a output) e
+  with resolve (State.mem st) a
+... | just (val-native x)       with refl ← e = _ , refl
+... | just (val-jubjub-point p) with refl ← e = _ , refl
+... | just (val-secp-point p)   with refl ← e = _ , refl
+... | just (val-secp-base x)    with refl ← e = _ , refl
+... | just (val-secp-scalar x)  with refl ← e = _ , refl
+step→bwd {st = st} (inv a output) e
+  with resolve (State.mem st) a
+... | just (val-native x) with invᶠ x
+...   | just xi with refl ← e = _ , refl
+step→bwd {st = st} (inv a output) e
+    | just (val-secp-base x) with invᵇ x
+...   | just xi with refl ← e = _ , refl
+step→bwd {st = st} (inv a output) e
+    | just (val-secp-scalar x) with invˢ x
+...   | just xi with refl ← e = _ , refl
+step→bwd {st = st} (not a output) e
+  with resolveᶠ (State.mem st) a
+... | just x with to𝔹 x
+...   | just b with refl ← e = (_ , refl) , x , refl
+step→bwd {st = st} (less-than a b bits output) e
+  with resolveᶠ (State.mem st) a | resolveᶠ (State.mem st) b
+... | just x | just y with valFr x <? 2 ^ bits
+...   | yes px with valFr y <? 2 ^ bits
+...     | yes py with refl ← e =
+          (_ , refl) , (x , refl , px) , (y , refl , py)
+step→bwd {st = st} (jubjub-scalar-from-native a output) e
+  with resolveᶠ (State.mem st) a
+... | just x with refl ← e = _ , refl
+step→bwd {st = st} (public-input guard val-t output) e
+  with eval-guard (State.mem st) guard
+... | just true
+      with decode val-t (take (encoded-len val-t) (State.pto-rem st))
+...   | just v with refl ← e = inj₁ (refl , v , refl , refl)
+step→bwd {st = st} (public-input guard val-t output) e | just false
+  with refl ← e = inj₂ (refl , refl)
+step→bwd {st = st} (private-input guard val-t output) e
+  with eval-guard (State.mem st) guard
+... | just true
+      with decode val-t (take (encoded-len val-t) (State.priv-rem st))
+...   | just v with refl ← e = inj₁ (refl , v , refl , refl)
+step→bwd {st = st} (private-input guard val-t output) e | just false
+  with refl ← e = inj₂ (refl , refl)
+step→bwd {S = S} {st = st} (circuit-output vals) e
+  with collectOutputs (State.mem st) (IrSource.outputs S) vals
+... | just vs with refl ← e = vs , refl , refl
+
+-- Fold the per-step inversions over a well-formed run.
+run→BwdWalk : ∀ {P S st s} is
+  → WF-run P S is st
+  → run P S st is ≡ just s
+  → BwdWalk P S st is s
+run→BwdWalk []       _              req with refl ← req = bw-nil
+run→BwdWalk {P} {S} {st} (i ∷ is) (of , wf-rest) req =
+  let (st-mid , step-eq , run-rest) = run-inv i is st req
+      (p≼ , m⊑) = step-extends i step-eq of
+  in bw-cons i is m⊑ p≼ (step→bwd i step-eq)
+       (run→BwdWalk is (wf-rest step-eq) run-rest)
+
+-- The `preprocess`-level projection: spine and terminal consumption from
+-- a successful preprocess and the static single-assignment check.
+preprocess→BwdWalk : ∀ {S P s st0}
+  → producer-SA S
+  → init S P ≡ just st0
+  → preprocess S P ≡ just s
+  → BwdWalk P S st0 (IrSource.instructions S) s × Consumed P s
+preprocess→BwdWalk {S} {P} {s} {st0} sa ieq peq =
+  let (walk , cons) = preprocess-walk-consumed {S} {P} {s} {st0} ieq peq
+  in run→BwdWalk (IrSource.instructions S)
+       (producer-safe→WF {S} {P} {st0} sa ieq) walk
+   , cons
+
+------------------------------------------------------------------------
+-- The backward driver: reassemble the run bottom-up from the spine.
+--
+-- `bwd-go` folds the spine, deriving each step operationally from the
+-- per-instruction `*-bwd` lemma (fed by `spine-⊑`+`holds-lower`+`defd-*`
+-- and the `*-support` discharges) and chaining with `run-cons`.
+------------------------------------------------------------------------
+
+mapᵐ-inv : ∀ {A B : Set} {f : A → B} {x : Maybe A} {y}
+  → mapᵐ f x ≡ just y → ∃ λ z → x ≡ just z
+mapᵐ-inv {x = just z} refl = z , refl
+
+typeof-scalar : ∀ {v} → typeof v ≡ jubjub-scalar
+  → ∃ λ s → v ≡ val-jubjub-scalar s
+typeof-scalar {val-jubjub-scalar s} refl = s , refl
+
+point-support : ∀ {m Γ a av}
+  → TyEq m Γ → optype Γ a ≡ just jubjub-point → resolve m a ≡ just av
+  → ∃ λ p → resolve m a ≡ just (val-jubjub-point p)
+point-support {a = a} teq oa ra
+  with typeof-point (tyEq-optype {op = a} teq oa ra)
+... | (p , refl) = p , ra
+
+scalar-support : ∀ {m Γ a av}
+  → TyEq m Γ → optype Γ a ≡ just jubjub-scalar → resolve m a ≡ just av
+  → ∃ λ s → resolve m a ≡ just (val-jubjub-scalar s)
+scalar-support {a = a} teq oa ra
+  with typeof-scalar (tyEq-optype {op = a} teq oa ra)
+... | (s , refl) = s , ra
+
+bytes32-support : ∀ {m Γ a av}
+  → TyEq m Γ → optype Γ a ≡ just bytes32 → resolve m a ≡ just av
+  → ∃ λ b → resolve m a ≡ just (val-bytes32 b)
+bytes32-support {a = a} teq oa ra
+  with typeof-bytes32 (tyEq-optype {op = a} teq oa ra)
+... | (b , refl) = b , ra
+
+secp-base-support : ∀ {m Γ a av}
+  → TyEq m Γ → optype Γ a ≡ just secp-base → resolve m a ≡ just av
+  → ∃ λ x → resolve m a ≡ just (val-secp-base x)
+secp-base-support {a = a} teq oa ra
+  with typeof-secp-base (tyEq-optype {op = a} teq oa ra)
+... | (x , refl) = x , ra
+
+secp-point-support : ∀ {m Γ a av}
+  → TyEq m Γ → optype Γ a ≡ just secp-point → resolve m a ≡ just av
+  → ∃ λ p → resolve m a ≡ just (val-secp-point p)
+secp-point-support {a = a} teq oa ra
+  with typeof-secp-point (tyEq-optype {op = a} teq oa ra)
+... | (p , refl) = p , ra
+
+secp-scalar-support : ∀ {m Γ a av}
+  → TyEq m Γ → optype Γ a ≡ just secp-scalar → resolve m a ≡ just av
+  → ∃ λ s → resolve m a ≡ just (val-secp-scalar s)
+secp-scalar-support {a = a} teq oa ra
+  with typeof-secp-scalar (tyEq-optype {op = a} teq oa ra)
+... | (s , refl) = s , ra
+
+mutual
+  -- The backward driver: reassemble the run bottom-up from the spine.
+  bwd-go : ∀ {P S s} (is : List Instruction) st Γ bound ss
+    → dom-ty Γ ≡ bound
+    → SA bound is → WT Γ is
+    → TyEq (State.mem st) Γ → DomEq (State.mem st) bound
+    → BwdWalk P S st is s
+    → satisfies-constraints (csOf is ss) (witness-of P s)
+    → run P S st is ≡ just s
+  bwd-go [] st Γ bound ss _ _ _ _ _ bw-nil _ = refl
+
+  bwd-go {P} {S} (mul a b output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , (t , oa , ob , fm) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (mul a b output) dom af nd
+        (av , ra) = optype-resolve {op = a} teq oa
+        (bv , rb) = optype-resolve {op = b} teq ob
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (mul a b output) is ss csat
+        hst = holds-lower (gate-mul output a b) m⊑ p≼
+                (defd-mul {P} {st} {output} {a} {b} {v} {av} {bv} fresh ra rb)
+                (proj₁ hc)
+        steq = mul-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+                 (mul-support {a = a} {b = b} teq oa ob fm ra rb) hst
+    in bwd-cont (mul a b output) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (add a b output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , (t , ota , otb , fp) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (add a b output) dom af nd
+        (av , ra) = optype-resolve {op = a} teq ota
+        (bv , rb) = optype-resolve {op = b} teq otb
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (add a b output) is ss csat
+        hst = holds-lower (gate-add output a b) m⊑ p≼
+                (defd-add {P} {st} {output} {a} {b} {v} {av} {bv} fresh ra rb)
+                (proj₁ hc)
+        steq = add-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+                 (add-support {a = a} {b = b} teq ota otb fp ra rb) hst
+    in bwd-cont (add a b output) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (copy val output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , (t , ov) , wt') teq dom (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (copy val output) dom af nd
+        (av , rv) = optype-resolve {op = val} teq ov
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (copy val output) is ss csat
+        hst = holds-lower (gate-copy output val) m⊑ p≼
+                (defd-copy {P} {st} {output} {val} {v} {av} fresh rv) (proj₁ hc)
+        steq = copy-bwd {P} {S} {st} {output} {val} {v} {av} fresh rv hst
+    in bwd-cont (copy val output) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (constrain-eq a b ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , ((t , ota , tsup) , (tb , otb)) , wt') teq dom
+    (bw-cons _ _ _ _ refl tail) csat =
+    let (av , ra) = optype-resolve {op = a} teq ota
+        (bv , rb) = optype-resolve {op = b} teq otb
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (constrain-eq a b) is ss csat
+        hst = holds-lower (eq a b) m⊑ p≼
+                (defd-eq {P} {st} {a} {b} {av} {bv} ra rb) (proj₁ hc)
+        steq = constrain-eq-bwd {P} {S} {st} {a} {b}
+                 (av , constrain-eq-support {a = a} teq ota tsup ra) hst
+    in bwd-cont (constrain-eq a b) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (assert cond ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , _ , wt') teq dom (bw-cons _ _ _ _ (refl , (x , rf , tb)) tail)
+    csat =
+    let (_ , tc) = csOf-peel (assert cond) is ss csat
+        steq = assert-bwd {P} {S} {st} {cond} (x , rf , tb)
+    in bwd-cont (assert cond) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (encode input outputs ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , _ , wt') teq dom (bw-cons _ _ _ _ (v , ri , im) tail) csat =
+    let (_ , tc) = csOf-peel (encode input outputs) is ss csat
+        steq = encode-bwd {P} {S} {st} {input} {outputs} {v} ri im
+    in bwd-cont (encode input outputs) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (neg a output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , (t , ota , fp) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (neg a output) dom af nd
+        (av , ra) = optype-resolve {op = a} teq ota
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (neg a output) is ss csat
+        hst = holds-lower (gate-neg output a) m⊑ p≼
+                (defd-neg {P} {st} {output} {a} {v} {av} fresh ra) (proj₁ hc)
+        steq = neg-bwd {P} {S} {st} {a} {output} {v} fresh
+                 (neg-support {a = a} teq ota fp ra) hst
+    in bwd-cont (neg a output) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (inv a output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , (t , oa , fm) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (inv a output) dom af nd
+        (av , ra) = optype-resolve {op = a} teq oa
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (inv a output) is ss csat
+        hst = holds-lower (gate-inv output a) m⊑ p≼
+                (defd-inv {P} {st} {output} {a} {v} {av} fresh ra) (proj₁ hc)
+        steq = inv-bwd {P} {S} {st} {a} {output} {v} fresh
+                 (inv-support {a = a} teq oa fm ra) hst
+    in bwd-cont (inv a output) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (not a output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , _ , wt') teq dom
+    (bw-cons _ _ _ _ ((v , refl) , (x , rf)) tail) csat =
+    let fresh    = out-fresh-of (not a output) dom af nd
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (not a output) is ss csat
+        hst = holds-lower (is-not output a) m⊑ p≼
+                (defd-is-not {P} {st} {output} {a} {v} {x} fresh rf) (proj₁ hc)
+        steq = not-bwd {P} {S} {st} {a} {output} {v} fresh (x , rf) hst
+    in bwd-cont (not a output) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (test-eq a b output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , ((_ , ota) , (_ , otb)) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (test-eq a b output) dom af nd
+        (av , ra) = optype-resolve {op = a} teq ota
+        (bv , rb) = optype-resolve {op = b} teq otb
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (test-eq a b output) is ss csat
+        hst = holds-lower (test-eq output a b) m⊑ p≼
+                (defd-test-eq {P} {st} {output} {a} {b} {v} {av} {bv} fresh ra rb)
+                (proj₁ hc)
+        steq = test-eq-bwd {P} {S} {st} {a} {b} {output} {v} fresh
+                 (av , ra) (bv , rb) hst
+    in bwd-cont (test-eq a b output) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (jubjub-scalar-from-native a output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , oa , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (jubjub-scalar-from-native a output) dom af nd
+        (x , rf) = optype-resolveᶠ {op = a} teq oa
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (jubjub-scalar-from-native a output) is ss csat
+        hst = holds-lower (scalar-from-native output a) m⊑ p≼
+                (defd-scalar-from-native {P} {st} {output} {a} {v} {x} fresh rf)
+                (proj₁ hc)
+        steq = jubjub-scalar-from-native-bwd {P} {S} {st} {a} {output} {v} fresh
+                 (x , rf) hst
+    in bwd-cont (jubjub-scalar-from-native a output) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+
+  bwd-go {P} {S} (ec-mul a scalar output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , inj₁ (oa , osc) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (ec-mul a scalar output) dom af nd
+        (av , ra) = optype-resolve {op = a} teq oa
+        (sv , rs) = optype-resolve {op = scalar} teq osc
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (ec-mul a scalar output) is ss csat
+        hst = holds-lower (ec-mul output a scalar) m⊑ p≼
+                (defd-ec-mul {P} {st} {output} {a} {scalar} {v} {av} {sv}
+                  fresh ra rs) (proj₁ hc)
+        steq = ec-mul-bwd {P} {S} {st} {a} {scalar} {output} {v} fresh
+                 (inj₁ ( point-support {a = a} teq oa ra
+                       , scalar-support {a = scalar} teq osc rs )) hst
+    in bwd-cont (ec-mul a scalar output) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+  bwd-go {P} {S} (ec-mul a scalar output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , inj₂ (oa , osc) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (ec-mul a scalar output) dom af nd
+        (av , ra) = optype-resolve {op = a} teq oa
+        (sv , rs) = optype-resolve {op = scalar} teq osc
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (ec-mul a scalar output) is ss csat
+        hst = holds-lower (ec-mul output a scalar) m⊑ p≼
+                (defd-ec-mul {P} {st} {output} {a} {scalar} {v} {av} {sv}
+                  fresh ra rs) (proj₁ hc)
+        steq = ec-mul-bwd {P} {S} {st} {a} {scalar} {output} {v} fresh
+                 (inj₂ ( secp-point-support {a = a} teq oa ra
+                       , secp-scalar-support {a = scalar} teq osc rs )) hst
+    in bwd-cont (ec-mul a scalar output) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (ec-mul-generator scalar output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , inj₁ osc , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (ec-mul-generator scalar output) dom af nd
+        (sv , rs) = optype-resolve {op = scalar} teq osc
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (ec-mul-generator scalar output) is ss csat
+        hst = holds-lower (ec-gen output scalar) m⊑ p≼
+                (defd-ec-gen {P} {st} {output} {scalar} {v} {sv} fresh rs)
+                (proj₁ hc)
+        steq = ec-mul-generator-bwd {P} {S} {st} {scalar} {output} {v} fresh
+                 (inj₁ (scalar-support {a = scalar} teq osc rs)) hst
+    in bwd-cont (ec-mul-generator scalar output) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+  bwd-go {P} {S} (ec-mul-generator scalar output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , inj₂ osc , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (ec-mul-generator scalar output) dom af nd
+        (sv , rs) = optype-resolve {op = scalar} teq osc
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (ec-mul-generator scalar output) is ss csat
+        hst = holds-lower (ec-gen output scalar) m⊑ p≼
+                (defd-ec-gen {P} {st} {output} {scalar} {v} {sv} fresh rs)
+                (proj₁ hc)
+        steq = ec-mul-generator-bwd {P} {S} {st} {scalar} {output} {v} fresh
+                 (inj₂ (secp-scalar-support {a = scalar} teq osc rs)) hst
+    in bwd-cont (ec-mul-generator scalar output) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+
+  bwd-go {P} {S} (hash-to-curve inputs output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , an , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (hash-to-curve inputs output) dom af nd
+        (frs , ri) = allNat-resolve inputs teq an
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (hash-to-curve inputs output) is ss csat
+        hst = holds-lower (h2c output inputs) m⊑ p≼
+                (defd-h2c {P} {st} {output} {inputs} {v} {frs} fresh ri)
+                (proj₁ hc)
+        steq = hash-to-curve-bwd {P} {S} {st} {inputs} {output} {v} fresh
+                 (frs , ri) hst
+    in bwd-cont (hash-to-curve inputs output) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (transient-hash inputs output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , an , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (transient-hash inputs output) dom af nd
+        (frs , ri) = allNat-resolve inputs teq an
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (transient-hash inputs output) is ss csat
+        hst = holds-lower (poseidon output inputs) m⊑ p≼
+                (defd-poseidon {P} {st} {output} {inputs} {v} {frs} fresh ri)
+                (proj₁ hc)
+        steq = transient-hash-bwd {P} {S} {st} {inputs} {output} {v} fresh
+                 (frs , ri) hst
+    in bwd-cont (transient-hash inputs output) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (into-bytes32 input output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , (t , oin , fm) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (into-bytes32 input output) dom af nd
+        (av , rv) = optype-resolve {op = input} teq oin
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (into-bytes32 input output) is ss csat
+        hst = holds-lower (into-bytes output input) m⊑ p≼
+                (defd-into-bytes {P} {st} {output} {input} {v} {av} fresh rv)
+                (proj₁ hc)
+        steq = into-bytes32-bwd {P} {S} {st} {input} {output} {v} fresh
+                 (inv-support {a = input} teq oin fm rv) hst
+    in bwd-cont (into-bytes32 input output) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (from-bytes32 bytes native output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , ob , wt') teq dom
+    (bw-cons _ _ _ _ (n , refl) tail) csat =
+    bwd-cont (from-bytes32 bytes native output) is dΓ oty af nd sa' wt'
+      teq dom steq tail tc
+    where
+    fresh = out-fresh-of (from-bytes32 bytes native output) dom af nd
+    b   = proj₁ (bytes32-support {a = bytes} teq ob
+                  (proj₂ (optype-resolve {op = bytes} teq ob)))
+    rb  = proj₂ (bytes32-support {a = bytes} teq ob
+                  (proj₂ (optype-resolve {op = bytes} teq ob)))
+    tc  = proj₂ (csOf-peel (from-bytes32 bytes native output) is ss csat)
+    hst = holds-lower (from-bytes output bytes)
+            (proj₁ (spine-⊑ tail)) (proj₂ (spine-⊑ tail))
+            (defd-from-bytes {P} {st} {output} {bytes} {val-native n}
+              {val-bytes32 b} fresh rb)
+            (proj₁ (proj₁ (csOf-peel (from-bytes32 bytes native output) is ss
+                             csat)))
+    steq : step P S st (from-bytes32 bytes native output)
+             ≡ just (out1 st output (val-native n))
+    steq with hst
+    ... | (bs , ⊢bytes , disj)
+          with ⊢-back P st output (val-native n) bytes fresh rb ⊢bytes
+    ...     | refl with disj
+    ...       | inj₁ dn =
+                trans (from-bytes32-native-bwd {P} {S} {st} {bytes} {output} {b}
+                        rb)
+                  (cong (λ z → just (out1 st output z))
+                    (sym (out-val P st output (val-native n) dn)))
+    ...       | inj₂ (inj₁ db) =
+                case out-val P st output (val-native n) db of λ ()
+    ...       | inj₂ (inj₂ ds) =
+                case out-val P st output (val-native n) ds of λ ()
+  bwd-go {P} {S} (from-bytes32 bytes secp-base output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , ob , wt') teq dom
+    (bw-cons _ _ _ _ (x , refl) tail) csat =
+    bwd-cont (from-bytes32 bytes secp-base output) is dΓ oty af nd sa' wt'
+      teq dom steq tail tc
+    where
+    fresh = out-fresh-of (from-bytes32 bytes secp-base output) dom af nd
+    b   = proj₁ (bytes32-support {a = bytes} teq ob
+                  (proj₂ (optype-resolve {op = bytes} teq ob)))
+    rb  = proj₂ (bytes32-support {a = bytes} teq ob
+                  (proj₂ (optype-resolve {op = bytes} teq ob)))
+    tc  = proj₂ (csOf-peel (from-bytes32 bytes secp-base output) is ss csat)
+    hst = holds-lower (from-bytes output bytes)
+            (proj₁ (spine-⊑ tail)) (proj₂ (spine-⊑ tail))
+            (defd-from-bytes {P} {st} {output} {bytes} {val-secp-base x}
+              {val-bytes32 b} fresh rb)
+            (proj₁ (proj₁ (csOf-peel (from-bytes32 bytes secp-base output) is ss
+                             csat)))
+    steq : step P S st (from-bytes32 bytes secp-base output)
+             ≡ just (out1 st output (val-secp-base x))
+    steq with hst
+    ... | (bs , ⊢bytes , disj)
+          with ⊢-back P st output (val-secp-base x) bytes fresh rb ⊢bytes
+    ...     | refl with disj
+    ...       | inj₂ (inj₁ db) =
+                trans (from-bytes32-secp-base-bwd {P} {S} {st} {bytes} {output}
+                        {b} rb)
+                  (cong (λ z → just (out1 st output z))
+                    (sym (out-val P st output (val-secp-base x) db)))
+    ...       | inj₁ dn =
+                case out-val P st output (val-secp-base x) dn of λ ()
+    ...       | inj₂ (inj₂ ds) =
+                case out-val P st output (val-secp-base x) ds of λ ()
+  bwd-go {P} {S} (from-bytes32 bytes secp-scalar output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , ob , wt') teq dom
+    (bw-cons _ _ _ _ (x , refl) tail) csat =
+    bwd-cont (from-bytes32 bytes secp-scalar output) is dΓ oty af nd sa' wt'
+      teq dom steq tail tc
+    where
+    fresh = out-fresh-of (from-bytes32 bytes secp-scalar output) dom af nd
+    b   = proj₁ (bytes32-support {a = bytes} teq ob
+                  (proj₂ (optype-resolve {op = bytes} teq ob)))
+    rb  = proj₂ (bytes32-support {a = bytes} teq ob
+                  (proj₂ (optype-resolve {op = bytes} teq ob)))
+    tc  = proj₂ (csOf-peel (from-bytes32 bytes secp-scalar output) is ss csat)
+    hst = holds-lower (from-bytes output bytes)
+            (proj₁ (spine-⊑ tail)) (proj₂ (spine-⊑ tail))
+            (defd-from-bytes {P} {st} {output} {bytes} {val-secp-scalar x}
+              {val-bytes32 b} fresh rb)
+            (proj₁ (proj₁ (csOf-peel (from-bytes32 bytes secp-scalar output) is
+                             ss csat)))
+    steq : step P S st (from-bytes32 bytes secp-scalar output)
+             ≡ just (out1 st output (val-secp-scalar x))
+    steq with hst
+    ... | (bs , ⊢bytes , disj)
+          with ⊢-back P st output (val-secp-scalar x) bytes fresh rb ⊢bytes
+    ...     | refl with disj
+    ...       | inj₂ (inj₂ ds) =
+                trans (from-bytes32-secp-scalar-bwd {P} {S} {st} {bytes} {output}
+                        {b} rb)
+                  (cong (λ z → just (out1 st output z))
+                    (sym (out-val P st output (val-secp-scalar x) ds)))
+    ...       | inj₁ dn =
+                case out-val P st output (val-secp-scalar x) dn of λ ()
+    ...       | inj₂ (inj₁ db) =
+                case out-val P st output (val-secp-scalar x) db of λ ()
+  bwd-go (from-bytes32 bytes bytes32 output ∷ is) st Γ bound ss dΓ sa wt teq
+    dom (bw-cons _ _ _ _ () _) csat
+  bwd-go (from-bytes32 bytes jubjub-point output ∷ is) st Γ bound ss dΓ sa wt
+    teq dom (bw-cons _ _ _ _ () _) csat
+  bwd-go (from-bytes32 bytes jubjub-scalar output ∷ is) st Γ bound ss dΓ sa wt
+    teq dom (bw-cons _ _ _ _ () _) csat
+  bwd-go (from-bytes32 bytes secp-point output ∷ is) st Γ bound ss dΓ sa wt
+    teq dom (bw-cons _ _ _ _ () _) csat
+
+  bwd-go {P} {S} (reverse-bytes bytes output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , ob , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (reverse-bytes bytes output) dom af nd
+        (av , rv) = optype-resolve {op = bytes} teq ob
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (reverse-bytes bytes output) is ss csat
+        hst = holds-lower (reverse-bytes output bytes) m⊑ p≼
+                (defd-reverse-bytes {P} {st} {output} {bytes} {v} {av} fresh rv)
+                (proj₁ hc)
+        steq = reverse-bytes-bwd {P} {S} {st} {bytes} {output} {v} fresh
+                 (bytes32-support {a = bytes} teq ob rv) hst
+    in bwd-cont (reverse-bytes bytes output) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+
+  bwd-go {P} {S} (from-coordinates (xop , yop) output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , inj₁ (ox , oy) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (from-coordinates (xop , yop) output) dom af nd
+        (xa , rxa) = optype-resolve {op = xop} teq ox
+        (ya , rya) = optype-resolve {op = yop} teq oy
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (from-coordinates (xop , yop) output) is ss csat
+        hst = holds-lower (from-coords output xop yop) m⊑ p≼
+                (defd-from-coords {P} {st} {output} {xop} {yop} {v} {xa} {ya}
+                  fresh rxa rya) (proj₁ hc)
+        steq = from-coordinates-bwd {P} {S} {st} {xop} {yop} {output} {v} fresh
+                 (inj₁ ( mul-support-l {a = xop} teq ox rxa
+                       , mul-support-l {a = yop} teq oy rya )) hst
+    in bwd-cont (from-coordinates (xop , yop) output) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+  bwd-go {P} {S} (from-coordinates (xop , yop) output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , inj₂ (ox , oy) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (from-coordinates (xop , yop) output) dom af nd
+        (xa , rxa) = optype-resolve {op = xop} teq ox
+        (ya , rya) = optype-resolve {op = yop} teq oy
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (from-coordinates (xop , yop) output) is ss csat
+        hst = holds-lower (from-coords output xop yop) m⊑ p≼
+                (defd-from-coords {P} {st} {output} {xop} {yop} {v} {xa} {ya}
+                  fresh rxa rya) (proj₁ hc)
+        steq = from-coordinates-bwd {P} {S} {st} {xop} {yop} {output} {v} fresh
+                 (inj₂ ( secp-base-support {a = xop} teq ox rxa
+                       , secp-base-support {a = yop} teq oy rya )) hst
+    in bwd-cont (from-coordinates (xop , yop) output) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+
+  bwd-go {P} {S} (bytes32-from-low-high (loop , hiop) output ∷ is) st Γ bound ss
+    dΓ (af , nd , sa') (Γ' , oty , (olo , ohi) , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (bytes32-from-low-high (loop , hiop) output)
+                     dom af nd
+        (lo , rl) = optype-resolveᶠ {op = loop} teq olo
+        (hi , rh) = optype-resolveᶠ {op = hiop} teq ohi
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (bytes32-from-low-high (loop , hiop) output)
+                      is ss csat
+        hst = holds-lower (bytes-from-low-high output loop hiop) m⊑ p≼
+                (defd-bytes-from-low-high {P} {st} {output} {loop} {hiop} {v}
+                  {lo} {hi} fresh rl rh) (proj₁ hc)
+        steq = bytes32-from-low-high-bwd {P} {S} {st} {loop} {hiop} {output} {v}
+                 fresh (lo , rl) (hi , rh) hst
+    in bwd-cont (bytes32-from-low-high (loop , hiop) output) is dΓ oty af nd
+         sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (less-than a b bits output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , (oa , ob) , wt') teq dom
+    (bw-cons _ _ _ _ ((v , refl) , (x , ra , px) , (y , rb , py)) tail) csat =
+    let fresh    = out-fresh-of (less-than a b bits output) dom af nd
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (less-than a b bits output) is ss csat
+        hst = holds-lower (less-than output a b bits) m⊑ p≼
+                (defd-less-than {P} {st} {output} {a} {b} {bits} {v} {x} {y}
+                  fresh ra rb) (proj₁ hc)
+        steq = less-than-bwd {P} {S} {st} {a} {b} {bits} {output} {v} fresh
+                 (x , ra , px) (y , rb , py) hst
+    in bwd-cont (less-than a b bits output) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (cond-select bit a b output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , obit , wt') teq dom
+    (bw-cons _ _ _ _ ((v , refl) , (xb , rbit)) tail) csat =
+    let (t , sty) = mapᵐ-inv oty
+        fresh    = out-fresh-of (cond-select bit a b output) dom af nd
+        (av , ra) = optype-resolve {op = a} teq (same-ty-l {Γ} {a} {b} sty)
+        (bv , rb) = optype-resolve {op = b} teq (same-ty-r {Γ} {a} {b} sty)
+        tmatch   = cond-select-support {a = a} {b = b} teq
+                     (same-ty-l {Γ} {a} {b} sty) (same-ty-r {Γ} {a} {b} sty)
+                     ra rb
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (cond-select bit a b output) is ss csat
+        hst = holds-lower (select output bit a b) m⊑ p≼
+                (defd-select {P} {st} {output} {bit} {a} {b} {v} {xb} {av} {bv}
+                  fresh rbit ra rb) (proj₁ hc)
+        steq = cond-select-bwd {P} {S} {st} {bit} {a} {b} {output} {v} fresh
+                 (xb , rbit) (av , ra , bv , rb , tmatch) hst
+    in bwd-cont (cond-select bit a b output) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (reconstitute-field divisor modulus bits output ∷ is) st Γ
+    bound ss dΓ (af , nd , sa') (Γ' , oty , _ , wt') teq dom
+    (bw-cons _ _ _ _ ((v , refl) , (d , rd , mo , rm , novf)) tail) csat =
+    let fresh    = out-fresh-of (reconstitute-field divisor modulus bits output)
+                     dom af nd
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (reconstitute-field divisor modulus bits output)
+                      is ss csat
+        hst = holds-lower (reconstitute output divisor modulus bits) m⊑ p≼
+                (defd-reconstitute {P} {st} {output} {divisor} {modulus} {bits}
+                  {v} {d} {mo} fresh rd rm) (proj₁ hc)
+        steq = reconstitute-field-bwd {P} {S} {st} {divisor} {modulus} {bits}
+                 {output} {v} fresh (d , rd , mo , rm , novf) hst
+    in bwd-cont (reconstitute-field divisor modulus bits output) is dΓ oty af
+         nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (constrain-bits val bits ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , ov , wt') teq dom (bw-cons _ _ _ _ refl tail) csat =
+    let (x , rf) = optype-resolveᶠ {op = val} teq ov
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (constrain-bits val bits) is ss csat
+        hst = holds-lower (in-range val bits) m⊑ p≼
+                (defd-in-range {P} {st} {val} {bits} {x} rf) (proj₁ hc)
+        steq = constrain-bits-bwd {P} {S} {st} {val} {bits} hst
+    in bwd-cont (constrain-bits val bits) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (constrain-to-boolean val ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , ov , wt') teq dom
+    (bw-cons _ _ _ _ refl tail) csat =
+    let (x , rf) = optype-resolveᶠ {op = val} teq ov
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (constrain-to-boolean val) is ss csat
+        hst = holds-lower (boolean val) m⊑ p≼
+                (defd-boolean {P} {st} {val} {x} rf) (proj₁ hc)
+        steq = constrain-to-boolean-bwd {P} {S} {st} {val} hst
+    in bwd-cont (constrain-to-boolean val) is dΓ oty af nd sa' wt' teq dom
+         steq tail tc
+
+  bwd-go {P} {S} (into-coordinates point (xo , yo) ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , inj₁ op , wt') teq dom
+    (bw-cons _ _ _ _ (v₁ , v₂ , refl) tail) csat =
+    let (fx , fy , x≢y) = out-fresh-of (into-coordinates point (xo , yo))
+                            dom af nd
+        (pv , rp) = optype-resolve {op = point} teq op
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (into-coordinates point (xo , yo)) is ss csat
+        hst = holds-lower (into-coords xo yo point) m⊑ p≼
+                (defd-into-coords {P} {st} {point} {xo} {yo} {v₁} {v₂} {pv}
+                  fx fy x≢y rp) (proj₁ hc)
+        steq = into-coordinates-bwd {P} {S} {st} {point} {xo} {yo} {v₁} {v₂}
+                 fx fy x≢y (inj₁ (point-support {a = point} teq op rp)) hst
+    in bwd-cont (into-coordinates point (xo , yo)) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+  bwd-go {P} {S} (into-coordinates point (xo , yo) ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , inj₂ op , wt') teq dom
+    (bw-cons _ _ _ _ (v₁ , v₂ , refl) tail) csat =
+    let (fx , fy , x≢y) = out-fresh-of (into-coordinates point (xo , yo))
+                            dom af nd
+        (pv , rp) = optype-resolve {op = point} teq op
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (into-coordinates point (xo , yo)) is ss csat
+        hst = holds-lower (into-coords xo yo point) m⊑ p≼
+                (defd-into-coords {P} {st} {point} {xo} {yo} {v₁} {v₂} {pv}
+                  fx fy x≢y rp) (proj₁ hc)
+        steq = into-coordinates-bwd {P} {S} {st} {point} {xo} {yo} {v₁} {v₂}
+                 fx fy x≢y (inj₂ (secp-point-support {a = point} teq op rp)) hst
+    in bwd-cont (into-coordinates point (xo , yo)) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+
+  bwd-go {P} {S} (bytes32-into-low-high bytes (lo , hi) ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , ob , wt') teq dom
+    (bw-cons _ _ _ _ (v₁ , v₂ , refl) tail) csat =
+    let (fl , fh , l≢h) = out-fresh-of (bytes32-into-low-high bytes (lo , hi))
+                            dom af nd
+        (bv , rb) = optype-resolve {op = bytes} teq ob
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (bytes32-into-low-high bytes (lo , hi)) is ss csat
+        hst = holds-lower (bytes-into-low-high lo hi bytes) m⊑ p≼
+                (defd-bytes-into-low-high {P} {st} {bytes} {lo} {hi} {v₁} {v₂}
+                  {bv} fl fh l≢h rb) (proj₁ hc)
+        steq = bytes32-into-low-high-bwd {P} {S} {st} {bytes} {lo} {hi} {v₁} {v₂}
+                 fl fh l≢h (bytes32-support {a = bytes} teq ob rb) hst
+    in bwd-cont (bytes32-into-low-high bytes (lo , hi)) is dΓ oty af nd sa' wt'
+         teq dom steq tail tc
+
+  bwd-go {P} {S} (div-mod-power-of-two val bits (q ∷ r ∷ []) ∷ is) st Γ bound ss
+    dΓ (af , nd , sa') (Γ' , oty , ov , wt') teq dom
+    (bw-cons _ _ _ _ (v₁ , v₂ , refl) tail) csat =
+    let ((fq , fr , _) , ((q≢r , _) , _)) =
+          out-fresh-of (div-mod-power-of-two val bits (q ∷ r ∷ [])) dom af nd
+        (x , rf) = optype-resolveᶠ {op = val} teq ov
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (div-mod-power-of-two val bits (q ∷ r ∷ []))
+                      is ss csat
+        hst = holds-lower (div-mod q r val bits) m⊑ p≼
+                (defd-div-mod {P} {st} {q} {r} {val} {bits} {v₁} {v₂} {x}
+                  fq fr q≢r rf) (proj₁ hc)
+        steq = div-mod-power-of-two-bwd {P} {S} {st} {val} {bits} {q} {r}
+                 {v₁} {v₂} fq fr q≢r (x , rf) hst
+    in bwd-cont (div-mod-power-of-two val bits (q ∷ r ∷ [])) is dΓ oty af nd
+         sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (persistent-hash al inputs output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , an , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (persistent-hash al inputs output) dom af nd
+        (frs , ri) = allNat-resolve inputs teq an
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (persistent-hash al inputs output) is ss csat
+        hst = holds-lower (sha256 output al inputs) m⊑ p≼
+                (defd-sha256 {P} {st} {al} {inputs} {output} {v} {frs} fresh ri)
+                (proj₁ hc)
+        steq = persistent-hash-bwd {P} {S} {st} {al} {inputs} {output} {v} fresh
+                 (frs , ri) hst
+    in bwd-cont (persistent-hash al inputs output) is dΓ oty af nd sa' wt' teq
+         dom steq tail tc
+
+  bwd-go {P} {S} (keccak256 al inputs output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , an , wt') teq dom
+    (bw-cons _ _ _ _ (v , refl) tail) csat =
+    let fresh    = out-fresh-of (keccak256 al inputs output) dom af nd
+        (frs , ri) = allNat-resolve inputs teq an
+        (m⊑ , p≼) = spine-⊑ tail
+        (hc , tc) = csOf-peel (keccak256 al inputs output) is ss csat
+        hst = holds-lower (keccak output al inputs) m⊑ p≼
+                (defd-keccak {P} {st} {al} {inputs} {output} {v} {frs} fresh ri)
+                (proj₁ hc)
+        steq = keccak256-bwd {P} {S} {st} {al} {inputs} {output} {v} fresh
+                 (frs , ri) hst
+    in bwd-cont (keccak256 al inputs output) is dΓ oty af nd sa' wt' teq
+         dom steq tail tc
+
+  bwd-go {P} {S} (impact guard inputs ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , _ , wt') teq dom
+    (bw-cons _ _ _ _ (vals , gᶠ , ri , rg , inj₁ (tb , tm , refl)) tail) csat =
+    let (_ , tc) = csOf-peel (impact guard inputs) is ss csat
+        steq = impact-true-bwd {P} {S} {st} {guard} {inputs} {gᶠ} {vals}
+                 ri rg tb tm
+    in bwd-cont (impact guard inputs) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (impact guard inputs ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , _ , wt') teq dom
+    (bw-cons _ _ _ _ (vals , gᶠ , ri , rg , inj₂ (tb , refl)) tail) csat =
+    let (_ , tc) = csOf-peel (impact guard inputs) is ss csat
+        steq = impact-false-bwd {P} {S} {st} {guard} {inputs} {gᶠ} {vals}
+                 ri rg tb
+    in bwd-cont (impact guard inputs) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  bwd-go {P} {S} (public-input guard val-t output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , _ , wt') teq dom
+    (bw-cons _ _ _ _ (inj₁ (eg , v , dv , refl)) tail) csat =
+    let (_ , tc) = csOf-peel (public-input guard val-t output) is ss csat
+        steq = public-input-active-bwd {P} {S} {st} {guard} {val-t} {output} {v}
+                 eg dv
+    in bwd-cont (public-input guard val-t output) is dΓ oty af nd sa' wt' teq
+         dom steq tail tc
+
+  bwd-go {P} {S} (public-input guard val-t output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , _ , wt') teq dom
+    (bw-cons _ _ _ _ (inj₂ (eg , refl)) tail) csat =
+    let (_ , tc) = csOf-peel (public-input guard val-t output) is ss csat
+        steq = public-input-inactive-bwd {P} {S} {st} {guard} {val-t} {output} eg
+    in bwd-cont (public-input guard val-t output) is dΓ oty af nd sa' wt' teq
+         dom steq tail tc
+
+  bwd-go {P} {S} (private-input guard val-t output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , _ , wt') teq dom
+    (bw-cons _ _ _ _ (inj₁ (eg , v , dv , refl)) tail) csat =
+    let (_ , tc) = csOf-peel (private-input guard val-t output) is ss csat
+        steq = private-input-active-bwd {P} {S} {st} {guard} {val-t} {output} {v}
+                 eg dv
+    in bwd-cont (private-input guard val-t output) is dΓ oty af nd sa' wt' teq
+         dom steq tail tc
+
+  bwd-go {P} {S} (private-input guard val-t output ∷ is) st Γ bound ss dΓ
+    (af , nd , sa') (Γ' , oty , _ , wt') teq dom
+    (bw-cons _ _ _ _ (inj₂ (eg , refl)) tail) csat =
+    let (_ , tc) = csOf-peel (private-input guard val-t output) is ss csat
+        steq = private-input-inactive-bwd {P} {S} {st} {guard} {val-t} {output} eg
+    in bwd-cont (private-input guard val-t output) is dΓ oty af nd sa' wt' teq
+         dom steq tail tc
+
+  bwd-go {P} {S} (circuit-output vals ∷ is) st Γ bound ss dΓ (af , nd , sa')
+    (Γ' , oty , _ , wt') teq dom (bw-cons _ _ _ _ (vs , co , refl) tail) csat =
+    let (_ , tc) = csOf-peel (circuit-output vals) is ss csat
+        steq = circuit-output-bwd {P} {S} {st} {vals} {vs} co
+    in bwd-cont (circuit-output vals) is dΓ oty af nd sa' wt' teq dom steq tail tc
+
+  -- Mis-arity div-mod: `step` fails, so the spine side-data is `⊥`.
+  bwd-go (div-mod-power-of-two val bits [] ∷ is) st Γ bound ss dΓ sa wt teq
+    dom (bw-cons _ _ _ _ () _) csat
+  bwd-go (div-mod-power-of-two val bits (_ ∷ []) ∷ is) st Γ bound ss dΓ sa wt
+    teq dom (bw-cons _ _ _ _ () _) csat
+  bwd-go (div-mod-power-of-two val bits (_ ∷ _ ∷ _ ∷ _) ∷ is) st Γ bound ss dΓ
+    sa wt teq dom (bw-cons _ _ _ _ () _) csat
+
+  -- The uniform tail: advance the invariants past `i` and recurse.
+  bwd-cont : ∀ {P S s} i is {st st′ Γ Γ' bound ss}
+    → dom-ty Γ ≡ bound
+    → outtys Γ i ≡ just Γ'
+    → All (λ o → ¬ (o ∈ bound)) (outs-of i) → NoDup (outs-of i)
+    → SA (bound ++ outs-of i) is → WT Γ' is
+    → TyEq (State.mem st) Γ → DomEq (State.mem st) bound
+    → step P S st i ≡ just st′
+    → BwdWalk P S st′ is s
+    → satisfies-constraints (csOf is (synth-instr i ss)) (witness-of P s)
+    → run P S st (i ∷ is) ≡ just s
+  bwd-cont i is {st} {st′} {Γ} {Γ'} {bound} {ss} dΓ oty af nd sa' wt' teq dom
+    steq tail tc =
+    run-cons i is steq
+      (bwd-go is st′ Γ' (bound ++ outs-of i) (synth-instr i ss)
+        (trans (outtys-dom Γ i oty) (cong (_++ outs-of i) dΓ))
+        sa' wt' (step-ty i oty steq teq (all∉-cast (outs-of i) dΓ af) nd)
+        (step-dom i steq dom) tail tc)
+
+------------------------------------------------------------------------
+-- Backward faithfulness: the converse of `forward`.
+--
+-- `preprocess` enforces the terminal transcript-consumption conditions
+-- (`Consumed`); `backward` reconstructs — from a well-typed producer, the
+-- initial state, that terminal consumption, and the backward spine — the
+-- run of a satisfying witness, assembling the `run-shaped` record.
+------------------------------------------------------------------------
+
+backward : ∀ {S P s st0}
+  → producer-WT S
+  → init S P ≡ just st0
+  → Consumed P s
+  → BwdWalk P S st0 (IrSource.instructions S) s
+  → satisfies (synth S) (witness-of P s)
+  → run-shaped S P s
+backward {S} {P} {s} {st0} ((ndup , sa) , wt) ieq cons spine sat =
+  mk-run-shaped st0 ieq (walk (IrSource.do-communications-commitment S) refl)
+    cons
+  where
+  walk : (b : Bool) → IrSource.do-communications-commitment S ≡ b
+       → run P S st0 (IrSource.instructions S) ≡ just s
+  walk false hc =
+    bwd-go {P} {S} {s} (IrSource.instructions S) st0
+      (input-ctx (IrSource.inputs S))
+      (map TypedIdentifier.name (IrSource.inputs S)) ss₁
+      (dom-ty-input-ctx (IrSource.inputs S)) sa wt
+      (init-ty {S} {P} {st0} ieq) (init-dom {S} {P} {st0} ieq) spine
+      (csOf-from-sat-false {S} {witness-of P s} hc sat)
+  walk true hc =
+    bwd-go {P} {S} {s} (IrSource.instructions S) st0
+      (input-ctx (IrSource.inputs S))
+      (map TypedIdentifier.name (IrSource.inputs S)) ss₂
+      (dom-ty-input-ctx (IrSource.inputs S)) sa wt
+      (init-ty {S} {P} {st0} ieq) (init-dom {S} {P} {st0} ieq) spine
+      (csOf-from-sat-true {S} {witness-of P s} hc sat)
+
+------------------------------------------------------------------------
+-- From a genuine run back to `preprocess`.
+--
+-- `preprocess` is `init >>= run >>=` the terminal checks TC1 (transcripts
+-- consumed) and TC2 (the commitment binds the inputs and outputs).  Given
+-- the run and the terminal facts, those checks all pass, so `preprocess`
+-- returns exactly the run's final state.  `Consumed` supplies TC1; the
+-- final argument supplies TC2 in the has-comm case (vacuous otherwise).
+------------------------------------------------------------------------
+
+run→preprocess : ∀ {S P s st0}
+  → init S P ≡ just st0
+  → run P S st0 (IrSource.instructions S) ≡ just s
+  → Consumed P s
+  → (IrSource.do-communications-commitment S ≡ true
+       → ∃₂ λ c r
+         → ProofPreimage.comm-commitment P ≡ just (c , r)
+         × c ≡ transient-commit
+                 (ProofPreimage.inputs P
+                   ++ concatMap encodeᵉ (State.outs s)) r)
+  → preprocess S P ≡ just s
+run→preprocess {S} {P} {s} {st0} ieq req (pti≡ , pto≡ , priv≡) tc2
+  rewrite ieq | req
+  with State.pti-idx s ≟ℕ length (ProofPreimage.pub-transcript-inputs P)
+... | no ¬p = case ¬p pti≡ of λ ()
+... | yes _
+  rewrite pto≡ | priv≡
+  with IrSource.do-communications-commitment S
+...   | false = refl
+...   | true with tc2 refl
+...     | (c , r , cceq , tc2eq) rewrite cceq
+  with c ≟ᶠ transient-commit
+             (ProofPreimage.inputs P ++ concatMap encodeᵉ (State.outs s)) r
+...       | yes _ = refl
+...       | no ¬q = case ¬q tc2eq of λ ()
+
+------------------------------------------------------------------------
+-- The terminal commitment check (TC2), inverted from `satisfies`.
+--
+-- This is the converse use of `comm-fwd`'s machinery: rather than deriving
+-- the `comm` constraint from TC2, we start from the `comm` constraint that
+-- `satisfies` provides (`comm-from-sat`) and recover TC2.  The commitment
+-- preimage is pinned against the genuine run just as in `comm-fwd`: the
+-- inputs re-encode to `ProofPreimage.inputs P` (`decode-reencode`), the
+-- outputs to `concatMap encode (outs s)` (`out-go`), the randomness to `r`,
+-- and π[1] to `c` (`init-pi1`, monotone along the run).
+------------------------------------------------------------------------
+
+-- Under the commitment flag, a missing commitment makes `init` fail.
+init-nothing-no-comm : ∀ {S P}
+  → IrSource.do-communications-commitment S ≡ true
+  → ProofPreimage.comm-commitment P ≡ nothing
+  → init S P ≡ nothing
+init-nothing-no-comm {S} {P} hc cc
+  with decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P)
+... | nothing = refl
+... | just m
+  with IrSource.do-communications-commitment S | hc
+...   | true | refl
+  with ProofPreimage.comm-commitment P | cc
+...     | nothing | refl = refl
+
+-- Under the commitment flag, a successful `init` exposes the commitment.
+-- Matching the commitment as a helper *argument* (not by `with` on the
+-- projection) keeps `comm-commitment P` out of the abstracted goal, so the
+-- present-case equation can be returned directly.
+init-comm : ∀ {S P st0}
+  → IrSource.do-communications-commitment S ≡ true
+  → init S P ≡ just st0
+  → ∃₂ λ c r → ProofPreimage.comm-commitment P ≡ just (c , r)
+init-comm {S} {P} {st0} hc ieq = go (ProofPreimage.comm-commitment P) refl
+  where
+  go : (mc : _) → ProofPreimage.comm-commitment P ≡ mc
+     → ∃₂ λ c r → ProofPreimage.comm-commitment P ≡ just (c , r)
+  go (just (c , r)) cc = c , r , cc
+  go nothing        cc =
+    case trans (sym (init-nothing-no-comm {S} {P} hc cc)) ieq of λ ()
+
+-- The `comm` constraint holds at the run's witness, extracted from
+-- `satisfies` by peeling the trailing commitment constraint that `synth`
+-- appends (the mirror of `csOf-from-sat-true`, which discards it).
+comm-from-sat : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ true
+  → satisfies (synth S) w
+  → holds w
+      (comm (input-operands (IrSource.inputs S))
+        (SynthState.output-ops
+          (synth-instrs (IrSource.instructions S) ss₂)))
+comm-from-sat {S} {w} hc sat =
+  proj₂ (proj₂ (synth-true-split {S} {w} hc sat))
+
+comm-tc2 : ∀ {S P s st0}
+  → IrSource.do-communications-commitment S ≡ true
+  → NoDup (map TypedIdentifier.name (IrSource.inputs S))
+  → init S P ≡ just st0
+  → run P S st0 (IrSource.instructions S) ≡ just s
+  → WF-run P S (IrSource.instructions S) st0
+  → satisfies (synth S) (witness-of P s)
+  → ∃₂ λ c r → ProofPreimage.comm-commitment P ≡ just (c , r)
+       × c ≡ transient-commit
+               (ProofPreimage.inputs P
+                 ++ concatMap encodeᵉ (State.outs s)) r
+comm-tc2 {S} {P} {s} {st0} hc nd ieq req wf sat
+  with init-comm {S} {P} {st0} hc ieq
+... | (c , r , cceq) = c , r , cceq , tc2eq
+  where
+  w : _
+  w = witness-of P s
+
+  ext : (State.mem st0 ⊑ State.mem s) × (State.pis st0 ≼ State.pis s)
+  ext = run-extends {P} {S} {s} (IrSource.instructions S) st0 req wf
+
+  ivs-≡ : resolve-encode w (input-operands (IrSource.inputs S))
+            ≡ just (ProofPreimage.inputs P)
+  ivs-≡ = decode-reencode {w} (IrSource.inputs S)
+            (ProofPreimage.inputs P) (State.mem st0)
+            (init-decode {S} {P} {st0} ieq) nd (proj₁ ext)
+
+  ovs-≡ : resolve-encode w
+            (SynthState.output-ops
+              (synth-instrs (IrSource.instructions S) ss₂))
+            ≡ just (concatMap encodeᵉ (State.outs s))
+  ovs-≡ = out-go {P} {S} {s} (IrSource.instructions S) st0 ss₂ req wf seed₀
+    where
+    seed₀ : resolve-encode w []
+              ≡ just (concatMap encodeᵉ (State.outs st0))
+    seed₀ rewrite init-outs {S} {P} {st0} ieq = refl
+
+  rand-≡ : comm-rand-of (ProofPreimage.comm-commitment P) ≡ just r
+  rand-≡ rewrite cceq = refl
+
+  pi1-≡ : pi-lookup (State.pis s) 1 ≡ just c
+  pi1-≡ = pi-lookup-mono (proj₂ ext)
+            (init-pi1 {S} {P} {st0} {c} {r} hc cceq ieq)
+
+  tc2eq : c ≡ transient-commit
+                (ProofPreimage.inputs P
+                  ++ concatMap encodeᵉ (State.outs s)) r
+  tc2eq with comm-from-sat {S} {w} hc sat
+  ... | (ivs , ovs , rv , pv , ri , ro , rr , rp , eqn) =
+    trans (sym (just-injective (trans (sym rp) pi1-≡)))
+      (trans eqn
+        (cong₂ transient-commit
+          (cong₂ _++_ (just-injective (trans (sym ri) ivs-≡))
+                      (just-injective (trans (sym ro) ovs-≡)))
+          (just-injective (trans (sym rr) rand-≡))))
+
+------------------------------------------------------------------------
+-- Canonical-witness circuit faithfulness (the v3 analogue of v2's P5
+-- `circuit-faithful`).
+--
+-- For a well-typed producer whose backward spine and terminal consumption
+-- are given, a successful `preprocess` and satisfaction of the synthesised
+-- circuit at the run's canonical witness `witness-of P s` are equivalent.
+--
+--   ⇒  is `forward-sa` (its `producer-SA` premise is the first component
+--      of `producer-WT`);
+--   ⇐  runs `backward` to reconstruct the run (`init` is deterministic, so
+--      the reconstructed start coincides with `st0`), then `run→preprocess`
+--      re-runs the terminal checks, with `comm-tc2` supplying TC2 in the
+--      has-comm case.
+--
+-- The spine and `Consumed` play the role of v2's `preprocess-shaped`
+-- hypothesis: they are the shape data `satisfies` alone does not
+-- determine.  From a successful run they are projected by
+-- `preprocess→BwdWalk` (the v2 `R⇒preprocess-shaped` analogue), so a
+-- caller holding a run needs no hand-built spine.  As in v2 the result
+-- is a logical
+-- equivalence (`_⇔_`), not a type isomorphism: the two directions are
+-- proofs of distinct `Set`-valued relations, so no round-trip identity is
+-- asserted.  Because `P` and `s` are fixed on both sides, this is a genuine
+-- iff at a single witness — unlike the `statement-sound`/`forward-sa` pair,
+-- whose witnesses differ and share only their public inputs.
+------------------------------------------------------------------------
+
+circuit-faithful : ∀ {S P s st0}
+  → producer-WT S
+  → init S P ≡ just st0
+  → BwdWalk P S st0 (IrSource.instructions S) s
+  → Consumed P s
+  → (preprocess S P ≡ just s) ⇔ (satisfies (synth S) (witness-of P s))
+circuit-faithful {S} {P} {s} {st0} wt ieq spine cons =
+  mk⇔ (λ peq → forward-sa (proj₁ wt) ieq peq)
+      (λ sat → ⇐ sat)
+  where
+  ⇐ : satisfies (synth S) (witness-of P s) → preprocess S P ≡ just s
+  ⇐ sat =
+    let rs   = backward wt ieq cons spine sat
+        run≡ : run P S st0 (IrSource.instructions S) ≡ just s
+        run≡ = run-shaped.walk rs
+    in run→preprocess {S} {P} {s} {st0} ieq run≡ cons
+         (λ hc → comm-tc2 {S} {P} {s} {st0} hc (proj₁ (proj₁ wt)) ieq run≡
+                   (producer-safe→WF {S} {P} {st0} (proj₁ wt) ieq) sat)

--- a/formal/src/zkir-v3/Encoding.agda
+++ b/formal/src/zkir-v3/Encoding.agda
@@ -1,0 +1,50 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Encoding of typed values to raw Fr  (ir_instructions/encode.rs)
+--
+-- `encode`/`decode` are the wire format crossing every circuit boundary
+-- (inputs, transcripts, outputs, commitment).  They are *derived* from
+-- the per-type trust-base primitives rather than assumed, keeping them
+-- out of the trusted surface; only the primitives they call are trusted.
+------------------------------------------------------------------------
+
+module zkir-v3.Encoding (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+
+open import Data.List    using (List; []; _∷_)
+open import Data.Maybe   using (Maybe; just; nothing; map)
+open import Data.Product using (_,_)
+
+------------------------------------------------------------------------
+-- encode : flatten a typed value into raw field elements.
+------------------------------------------------------------------------
+
+encode : IrValue → List Fr
+encode (val-native x)        = x ∷ []
+encode (val-jubjub-scalar s) = jubjubScalarToFr s ∷ []
+encode (val-bytes32 b)       = let (lo , hi) = bytes32→low-high b in lo ∷ hi ∷ []
+encode (val-jubjub-point p)  = let (x , y)   = coordsJ p          in x  ∷ y  ∷ []
+encode (val-secp-base x)     = let (l , h) = secpBase→limbs x   in l ∷ h ∷ []
+encode (val-secp-scalar s)   = let (l , h) = secpScalar→limbs s in l ∷ h ∷ []
+encode (val-secp-point p)    =
+  let (a , b , c , d , e) = secpPoint→limbs p in a ∷ b ∷ c ∷ d ∷ e ∷ []
+
+------------------------------------------------------------------------
+-- decode : read raw field elements as a value of the given type.
+-- Partial: the wrong number of elements, or an invalid encoding (a
+-- non-subgroup point, a non-canonical Bytes32/scalar), yields `nothing`.
+------------------------------------------------------------------------
+
+decode : IrType → List Fr → Maybe IrValue
+decode native        (x ∷ [])       = just (val-native x)
+decode jubjub-scalar (s ∷ [])       = map val-jubjub-scalar (jubjubScalarFromFr s)
+decode bytes32       (lo ∷ hi ∷ []) = map val-bytes32       (low-high→bytes32 lo hi)
+decode jubjub-point  (x ∷ y ∷ [])   = map val-jubjub-point  (fromCoordsJ x y)
+decode secp-base     (l ∷ h ∷ [])   = map val-secp-base     (limbs→secpBase l h)
+decode secp-scalar   (l ∷ h ∷ [])   = map val-secp-scalar   (limbs→secpScalar l h)
+decode secp-point    (a ∷ b ∷ c ∷ d ∷ e ∷ []) =
+  map val-secp-point (limbs→secpPoint a b c d e)
+decode _             _              = nothing

--- a/formal/src/zkir-v3/Main.agda
+++ b/formal/src/zkir-v3/Main.agda
@@ -1,0 +1,26 @@
+-- Top-level module for the zkir-v3 formalization.
+--
+-- Importing this module type-checks the entire zkir-v3 development.  As
+-- in zkir-v2, the development is abstract over the trust base: it takes
+-- an `Assumptions` value as a module parameter rather than postulating
+-- the field/curve/hash primitives, so the whole development typechecks
+-- under `--safe` with no `postulate`s.
+--
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+module zkir-v3.Main (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Encoding ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Semantics ⋯
+open import zkir-v3.SemanticsProperties ⋯
+open import zkir-v3.Circuit ⋯
+open import zkir-v3.CircuitBridge ⋯
+open import zkir-v3.CircuitFaithfulness ⋯
+open import zkir-v3.CircuitBackward ⋯
+open import zkir-v3.Obligations ⋯
+open import zkir-v3.CircuitProof ⋯
+open import zkir-v3.StatementSoundness ⋯
+open import zkir-v3.StatementUniqueness ⋯

--- a/formal/src/zkir-v3/Obligations.agda
+++ b/formal/src/zkir-v3/Obligations.agda
@@ -1,0 +1,1999 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Static single-assignment well-formedness for a zkir-v3 `IrSource`.
+--
+-- The forward faithfulness theorem `forward` (in `CircuitFaithfulness`)
+-- has two producer-side hypotheses that are not intrinsic to a run:
+--
+--   • `WF-run P S (instructions S) st0`  — at every step the outputs the
+--     instruction binds are fresh (unbound in the memory it sees) and, for
+--     multi-output instructions, pairwise distinct; and
+--   • `NoDup (map name (inputs S))`      — the declared input names are
+--     distinct.
+--
+-- Both are consequences of a purely static property of the source: it is
+-- in single-assignment form.  This module states that property as a
+-- decidable predicate `producer-SA` — a linear scan tracking the set of
+-- already-bound names — and proves `producer-safe→WF`, discharging the
+-- semantic `WF-run` hypothesis from it.  The clean corollary `forward-sa`
+-- then depends only on the static check (and the run's success).
+--
+-- The invariant that connects the static "bound name set" to the dynamic
+-- memory is `DomEq m bound`: the memory's domain is exactly `bound`.  It
+-- is seeded from `init` (`init-dom`: the initial memory binds exactly the
+-- input names) and maintained across each step (`step-dom`: a step extends
+-- the domain by exactly the names `outs-of i`).
+------------------------------------------------------------------------
+
+module zkir-v3.Obligations (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Semantics ⋯
+  using ( Mem; State; ProofPreimage; ins; step; init; out1; run
+        ; insertMany; decode-inputs; resolve; resolveᶠ; resolve𝔹
+        ; resolve-all-Fr; eval-guard; collectOutputs; valEq?; _≟LFr_
+        ; default-val; _≟B_; to𝔹; preprocess; guardD )
+open import zkir-v3.SemanticsProperties ⋯
+  using ( AllFresh; NotIn; NoDup; out-fresh; WF-run
+        ; ins-here; ins-other; resolveᶠ-intro
+        ; _⊑_; _≼_; ⊑-refl; ⊑-trans; ≼-refl; ≼-trans
+        ; run-cons; run-shaped; mk-run-shaped; Consumed
+        ; run-extends; init-outs; init-decode )
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+
+open import Data.Bool    using (Bool; true; false; if_then_else_; T)
+open import Data.Bool.Properties using (T?)
+open import Data.List    using (List; []; _∷_; _++_; _∷ʳ_; map; take; drop; length; concatMap)
+open import Data.List.Properties using (++-identityʳ)
+open import Data.Maybe   using (Maybe; just; nothing; _>>=_)
+open import Data.Nat     using (ℕ; _^_; _+_; _*_; _∸_; _<_; _<?_; _<ᵇ_; _≤ᵇ_)
+open import Data.Nat     using () renaming (_≟_ to _≟ℕ_)
+open import Data.Product using (_×_; _,_; ∃; ∃₂; proj₁; proj₂)
+open import Function.Bundles using (_⇔_; mk⇔)
+open import Data.Unit    using (⊤; tt)
+open import Function     using (case_of_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; cong₂; subst)
+open import Relation.Nullary using (¬_; yes; no; Dec)
+open import Relation.Nullary.Decidable
+  using (¬?; _×-dec_; _⊎-dec_; map′; isYes≗does; dec-true)
+open import Data.String using () renaming (_≟_ to _≟str_)
+
+open import Data.List.Relation.Unary.All using (All; []; _∷_; all?)
+open import Data.List.Membership.DecPropositional _≟str_ using (_∈?_)
+open import Data.List.Relation.Unary.Any using (Any; here; there)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Membership.Propositional.Properties
+  using (∈-++⁻; ∈-++⁺ˡ; ∈-++⁺ʳ)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Data.Empty using (⊥)
+open import Data.Maybe using () renaming (map to mapᵐ)
+open import Data.Maybe.Properties using (just-injective; ≡-dec)
+
+------------------------------------------------------------------------
+-- The output identifiers each instruction binds.
+--
+-- Exactly the names appearing as memory-write targets in `step`; mirrors
+-- the shape of `out-fresh`.  No-output instructions bind nothing.
+------------------------------------------------------------------------
+
+outs-of : Instruction → List Identifier
+outs-of (encode _ outputs)                 = outputs
+outs-of (assert _)                         = []
+outs-of (cond-select _ _ _ o)              = o ∷ []
+outs-of (constrain-bits _ _)               = []
+outs-of (constrain-eq _ _)                 = []
+outs-of (constrain-to-boolean _)           = []
+outs-of (copy _ o)                         = o ∷ []
+outs-of (impact _ _)                       = []
+outs-of (ec-mul _ _ o)                     = o ∷ []
+outs-of (ec-mul-generator _ o)             = o ∷ []
+outs-of (hash-to-curve _ o)                = o ∷ []
+outs-of (into-coordinates _ (xo , yo))     = xo ∷ yo ∷ []
+outs-of (from-coordinates _ o)             = o ∷ []
+outs-of (into-bytes32 _ o)                 = o ∷ []
+outs-of (from-bytes32 _ _ o)               = o ∷ []
+outs-of (reverse-bytes _ o)                = o ∷ []
+outs-of (bytes32-into-low-high _ (lo , hi)) = lo ∷ hi ∷ []
+outs-of (bytes32-from-low-high _ o)        = o ∷ []
+outs-of (div-mod-power-of-two _ _ outs)    = outs
+outs-of (reconstitute-field _ _ _ o)       = o ∷ []
+outs-of (transient-hash _ o)               = o ∷ []
+outs-of (persistent-hash _ _ o)            = o ∷ []
+outs-of (keccak256 _ _ o)                  = o ∷ []
+outs-of (test-eq _ _ o)                    = o ∷ []
+outs-of (add _ _ o)                        = o ∷ []
+outs-of (mul _ _ o)                        = o ∷ []
+outs-of (neg _ o)                          = o ∷ []
+outs-of (inv _ o)                          = o ∷ []
+outs-of (not _ o)                          = o ∷ []
+outs-of (less-than _ _ _ o)                = o ∷ []
+outs-of (jubjub-scalar-from-native _ o)    = o ∷ []
+outs-of (public-input _ _ o)               = o ∷ []
+outs-of (private-input _ _ o)              = o ∷ []
+outs-of (circuit-output _)                 = []
+
+------------------------------------------------------------------------
+-- Domain-tracking invariant: the memory's domain is exactly `bound`.
+------------------------------------------------------------------------
+
+-- The memory's domain is contained in `bound`: every identifier outside
+-- `bound` is unbound.  Only this "off" direction is consumed downstream
+-- (`out-fresh-of`/`allFresh-of` turn "not bound ⇒ unbound in memory" into
+-- freshness); it is self-contained (needs no key-freshness to maintain).
+DomEq : Mem → List Identifier → Set
+DomEq m bound = ∀ {id} → ¬ (id ∈ bound) → m id ≡ nothing
+
+-- A member of a singleton is the element.
+∈-[x] : ∀ {id o : Identifier} → id ∈ (o ∷ []) → id ≡ o
+∈-[x] (here p) = p
+
+-- The empty domain matches the empty memory.
+domEq-∅ : ∀ {m} → (∀ id → m id ≡ nothing) → DomEq m []
+domEq-∅ empty {id} _ = empty id
+
+------------------------------------------------------------------------
+-- Extending the domain by one fresh binding.
+------------------------------------------------------------------------
+
+domEq-ins : ∀ {m bound} (o : Identifier) v
+  → DomEq m bound → DomEq (ins o v m) (bound ++ (o ∷ []))
+domEq-ins {m} {bound} o v d {id} id∉ =
+  let id∉bound = λ p → id∉ (∈-++⁺ˡ p)
+      id≢o     = λ id≡o → id∉ (∈-++⁺ʳ bound (here id≡o))
+  in trans (ins-other v m id≢o) (d id∉bound)
+
+-- Transport a `DomEq` along an equality of the bound-name list.
+domEq-cast : ∀ {m bs cs} → bs ≡ cs → DomEq m bs → DomEq m cs
+domEq-cast refl d = d
+
+-- Prepending one binding to the domain.  Unlike `domEq-ins` (which
+-- appends), this frames the fresh cell at the *front* of the name list —
+-- the shape `decode-inputs` produces.  No freshness is required: binding
+-- `o` covers it whether or not `o` was already in the tail's domain.
+domEq-cons : ∀ {m bound} (o : Identifier) v
+  → DomEq m bound → DomEq (ins o v m) (o ∷ bound)
+domEq-cons {m} {bound} o v d {id} id∉ =
+  let id≢o     = λ id≡o → id∉ (here id≡o)
+      id∉bound = λ p → id∉ (there p)
+  in trans (ins-other v m id≢o) (d id∉bound)
+
+-- `NotIn` read as plain non-membership.
+notIn-∉ : ∀ {id} ks → NotIn id ks → ¬ (id ∈ ks)
+notIn-∉ (k ∷ ks) (id≢k , nin) (here id≡k) = id≢k id≡k
+notIn-∉ (k ∷ ks) (id≢k , nin) (there p)   = notIn-∉ ks nin p
+
+open import Data.List.Properties using (++-assoc)
+
+-- Extending the domain by a whole `insertMany`.  Mirrors `insertMany`
+-- (and `insertMany-⊑`); the "off" direction needs no key-freshness (an
+-- id outside `bound ++ ids` avoids every inserted key and stays unbound).
+domEq-insertMany : ∀ {bound} st ids vs {st'}
+  → insertMany st ids vs ≡ just st'
+  → DomEq (State.mem st) bound
+  → DomEq (State.mem st') (bound ++ ids)
+domEq-insertMany {bound} st []         []         refl d =
+  domEq-cast (sym (++-identityʳ bound)) d
+domEq-insertMany {bound} st (id ∷ ids) (v ∷ vs)   e    d =
+  domEq-cast (++-assoc bound (id ∷ []) ids)
+    (domEq-insertMany {bound ++ (id ∷ [])} (out1 st id v) ids vs e
+      (domEq-ins id v d))
+domEq-insertMany st []        (_ ∷ _)  ()  _
+domEq-insertMany st (_ ∷ _)   []       ()  _
+
+-- Extending the domain by two bindings (the `out1 ∘ out1` shape of the
+-- two-output instructions).  A specialisation of `domEq-insertMany` at a
+-- two-element list (the states coincide definitionally).
+domEq-ins2 : ∀ {bound} st (i₁ : Identifier) v₁ (i₂ : Identifier) v₂
+  → DomEq (State.mem st) bound
+  → DomEq (State.mem (out1 (out1 st i₁ v₁) i₂ v₂)) (bound ++ (i₁ ∷ i₂ ∷ []))
+domEq-ins2 {bound} st i₁ v₁ i₂ v₂ d =
+  domEq-insertMany st (i₁ ∷ i₂ ∷ []) (v₁ ∷ v₂ ∷ []) refl d
+
+------------------------------------------------------------------------
+-- Seeding the invariant from `init`.
+--
+-- `decode-inputs` binds exactly the declared input names, so the initial
+-- memory's domain is `map name (inputs S)`.  `init-decode` (from
+-- `SemanticsProperties`) says the initial memory is that decoding.
+------------------------------------------------------------------------
+
+decode-inputs-dom : ∀ tis raw {m}
+  → decode-inputs tis raw ≡ just m
+  → DomEq m (map TypedIdentifier.name tis)
+decode-inputs-dom []         []      refl = domEq-∅ (λ _ → refl)
+decode-inputs-dom []         (_ ∷ _) ()
+decode-inputs-dom (ti ∷ tis) raw ieq
+  with decode (TypedIdentifier.val-t ti)
+              (take (encoded-len (TypedIdentifier.val-t ti)) raw)
+... | just v
+  with decode-inputs tis (drop (encoded-len (TypedIdentifier.val-t ti)) raw)
+         in erest
+...   | just m' with refl ← ieq =
+        domEq-cons (TypedIdentifier.name ti) v
+          (decode-inputs-dom tis _ erest)
+
+init-dom : ∀ {S P st0}
+  → init S P ≡ just st0
+  → DomEq (State.mem st0) (map TypedIdentifier.name (IrSource.inputs S))
+init-dom {S} {P} {st0} ieq =
+  decode-inputs-dom (IrSource.inputs S) (ProofPreimage.inputs P)
+    (init-decode {S} {P} {st0} ieq)
+
+------------------------------------------------------------------------
+-- Converting static output freshness (w.r.t. `bound`) into the semantic
+-- `out-fresh` (freshness w.r.t. the memory).
+--
+-- The `DomEq`'s second component turns "not in the bound set" into
+-- "unbound in memory"; the static `NoDup (outs-of i)` supplies the
+-- within-instruction distinctness the multi-output cases ask for.
+------------------------------------------------------------------------
+
+-- Every statically-fresh name is unbound in a domain-matching memory.
+allFresh-of : ∀ {m bound} ids
+  → DomEq m bound → All (λ o → ¬ (o ∈ bound)) ids → AllFresh ids m
+allFresh-of []         _ _          = tt
+allFresh-of (o ∷ ids)  d (o∉ ∷ frs) = d o∉ , allFresh-of ids d frs
+
+out-fresh-of : ∀ {m bound} (i : Instruction)
+  → DomEq m bound
+  → All (λ o → ¬ (o ∈ bound)) (outs-of i)
+  → NoDup (outs-of i)
+  → out-fresh i m
+out-fresh-of (encode _ outputs)  d af nd = allFresh-of outputs d af , nd
+out-fresh-of (assert _)                    d af nd = tt
+out-fresh-of (cond-select _ _ _ o)         d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (constrain-bits _ _)          d af nd = tt
+out-fresh-of (constrain-eq _ _)            d af nd = tt
+out-fresh-of (constrain-to-boolean _)      d af nd = tt
+out-fresh-of (copy _ o)                    d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (impact _ _)                  d af nd = tt
+out-fresh-of (ec-mul _ _ o)                d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (ec-mul-generator _ o)        d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (hash-to-curve _ o)           d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (into-coordinates _ (xo , yo)) d
+  (xo∉ ∷ yo∉ ∷ []) ((xo≢yo , _) , _) = d xo∉ , d yo∉ , xo≢yo
+out-fresh-of (from-coordinates _ o)        d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (into-bytes32 _ o)            d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (from-bytes32 _ _ o)          d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (reverse-bytes _ o)           d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (bytes32-into-low-high _ (lo , hi)) d
+  (lo∉ ∷ hi∉ ∷ []) ((lo≢hi , _) , _) = d lo∉ , d hi∉ , lo≢hi
+out-fresh-of (bytes32-from-low-high _ o)   d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (div-mod-power-of-two _ _ outs) d af nd = allFresh-of outs d af , nd
+out-fresh-of (reconstitute-field _ _ _ o)  d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (transient-hash _ o)          d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (persistent-hash _ _ o)       d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (keccak256 _ _ o)             d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (test-eq _ _ o)               d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (add _ _ o)                   d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (mul _ _ o)                   d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (neg _ o)                     d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (inv _ o)                     d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (not _ o)                     d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (less-than _ _ _ o)           d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (jubjub-scalar-from-native _ o) d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (public-input _ _ o)          d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (private-input _ _ o)         d        (o∉ ∷ _) _ = d o∉
+out-fresh-of (circuit-output _)            d af nd = tt
+
+------------------------------------------------------------------------
+-- Domain maintenance across one step.
+--
+-- Inverting `step` per instruction (mirroring `step-mem-⊑`), the memory
+-- grows by exactly the names `outs-of i`: no-output instructions leave it
+-- unchanged (`bound ++ [] = bound`), single-output instructions bind one
+-- fresh cell (`domEq-ins`), two-output ones two (`domEq-ins2`), and the
+-- `insertMany` instructions a whole fresh, distinct list
+-- (`domEq-insertMany`).
+------------------------------------------------------------------------
+
+-- The no-output shape: memory and domain both unchanged.
+domEq-nop : ∀ {m bound} → DomEq m bound → DomEq m (bound ++ [])
+domEq-nop {bound = bound} d = domEq-cast (sym (++-identityʳ bound)) d
+
+step-dom : ∀ {P S st st' bound} (i : Instruction)
+  → step P S st i ≡ just st'
+  → DomEq (State.mem st) bound
+  → DomEq (State.mem st') (bound ++ outs-of i)
+step-dom {st = st} (encode input outputs) e d
+  with resolve (State.mem st) input
+... | just v = domEq-insertMany st outputs (map val-native (encodeᵉ v)) e d
+step-dom {st = st} (assert cond) e d
+  with resolve𝔹 (State.mem st) cond
+... | just true with refl ← e = domEq-nop d
+step-dom {st = st} (cond-select bit a b output) e d
+  with resolve𝔹 (State.mem st) bit
+... | just bv with resolve (State.mem st) a | resolve (State.mem st) b
+...   | just av | just bvl with typeof av ≟T typeof bvl
+...     | yes _ with refl ← e = domEq-ins output _ d
+step-dom {st = st} (constrain-bits val bits) e d
+  with resolveᶠ (State.mem st) val
+... | just x with valFr x <? 2 ^ bits
+...   | yes _ with refl ← e = domEq-nop d
+step-dom {st = st} (constrain-eq a b) e d
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just true with refl ← e = domEq-nop d
+step-dom {st = st} (constrain-to-boolean val) e d
+  with resolve𝔹 (State.mem st) val
+... | just _ with refl ← e = domEq-nop d
+step-dom {st = st} (copy val output) e d
+  with resolve (State.mem st) val
+... | just v with refl ← e = domEq-ins output _ d
+step-dom {P = P} {st = st} (impact guard inputs) e d
+  with resolve-all-Fr (State.mem st) inputs
+... | just vals with resolve𝔹 (State.mem st) guard
+...   | just g with g
+...     | true
+          with take (length vals)
+                 (drop (State.pti-idx st)
+                   (ProofPreimage.pub-transcript-inputs P))
+               ≟LFr vals
+...       | yes _ with refl ← e = domEq-nop d
+step-dom {st = st} (impact guard inputs) e d | just vals | just g | false
+  with refl ← e = domEq-nop d
+step-dom {st = st} (ec-mul a scalar output) e d
+  with resolve (State.mem st) a | resolve (State.mem st) scalar
+... | just (val-jubjub-point p) | just (val-jubjub-scalar s)
+        with refl ← e = domEq-ins output _ d
+step-dom {st = st} (ec-mul a scalar output) e d
+  | just (val-secp-point p) | just (val-secp-scalar s)
+        with refl ← e = domEq-ins output _ d
+step-dom {st = st} (ec-mul-generator scalar output) e d
+  with resolve (State.mem st) scalar
+... | just (val-jubjub-scalar s) with refl ← e = domEq-ins output _ d
+step-dom {st = st} (ec-mul-generator scalar output) e d
+  | just (val-secp-scalar s) with refl ← e = domEq-ins output _ d
+step-dom {st = st} (hash-to-curve inputs output) e d
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e = domEq-ins output _ d
+step-dom {st = st} (into-coordinates point (xid , yid)) e d
+  with resolve (State.mem st) point
+... | just (val-jubjub-point p) with coordsJ p
+...   | (x , y) with refl ← e =
+          domEq-ins2 st xid (val-native x) yid (val-native y) d
+step-dom {st = st} (into-coordinates point (xid , yid)) e d
+  | just (val-secp-point p) with coordsK p
+...   | just (x , y) with refl ← e =
+          domEq-ins2 st xid (val-secp-base x) yid (val-secp-base y) d
+step-dom {st = st} (from-coordinates (xop , yop) output) e d
+  with resolve (State.mem st) xop | resolve (State.mem st) yop
+... | just (val-native x) | just (val-native y) with fromCoordsJ x y
+...   | just p with refl ← e = domEq-ins output _ d
+step-dom {st = st} (from-coordinates (xop , yop) output) e d
+  | just (val-secp-base x) | just (val-secp-base y) with fromCoordsK x y
+...   | just p with refl ← e = domEq-ins output _ d
+step-dom {st = st} (into-bytes32 input output) e d
+  with resolve (State.mem st) input
+... | just (val-native x) with refl ← e = domEq-ins output _ d
+... | just (val-secp-base x) with refl ← e = domEq-ins output _ d
+... | just (val-secp-scalar s) with refl ← e = domEq-ins output _ d
+step-dom {st = st} (from-bytes32 bytes native output) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = domEq-ins output _ d
+step-dom {st = st} (from-bytes32 bytes secp-base output) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = domEq-ins output _ d
+step-dom {st = st} (from-bytes32 bytes secp-scalar output) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = domEq-ins output _ d
+step-dom {st = st} (from-bytes32 bytes bytes32 output) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-dom {st = st} (from-bytes32 bytes jubjub-point output) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-dom {st = st} (from-bytes32 bytes jubjub-scalar output) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-dom {st = st} (from-bytes32 bytes secp-point output) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-dom {st = st} (reverse-bytes bytes output) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = domEq-ins output _ d
+step-dom {st = st} (bytes32-into-low-high bytes (loid , hiid)) e d
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with bytes32→low-high b
+...   | (lo , hi) with refl ← e =
+          domEq-ins2 st loid (val-native lo) hiid (val-native hi) d
+step-dom {st = st} (bytes32-from-low-high (loop , hiop) output) e d
+  with resolveᶠ (State.mem st) loop | resolveᶠ (State.mem st) hiop
+... | just lo | just hi with low-high→bytes32 lo hi
+...   | just b with refl ← e = domEq-ins output _ d
+step-dom {st = st} (div-mod-power-of-two val bits outs) e d
+  with resolveᶠ (State.mem st) val
+... | just x =
+        domEq-insertMany st outs
+          ( val-native (from-le-bits (drop bits (to-le-bits x)))
+          ∷ val-native (from-le-bits (take bits (to-le-bits x))) ∷ [])
+          e d
+step-dom {st = st} (reconstitute-field divisor modulus bits output) e d
+  with resolveᶠ (State.mem st) divisor | resolveᶠ (State.mem st) modulus
+... | just dd | just mo with valFr mo <? 2 ^ bits
+...   | yes _ with valFr dd <? 2 ^ (FR-BITS ∸ bits)
+...     | yes _ with valFr mo + 2 ^ bits * valFr dd <? FR-ORDER
+...       | yes _ with refl ← e = domEq-ins output _ d
+step-dom {st = st} (transient-hash inputs output) e d
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e = domEq-ins output _ d
+step-dom {st = st} (persistent-hash alignment inputs output) e d
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with persistent-hash-fn alignment frs
+...   | just h with refl ← e = domEq-ins output _ d
+step-dom {st = st} (keccak256 alignment inputs output) e d
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with keccak-fn alignment frs
+...   | just h with refl ← e = domEq-ins output _ d
+step-dom {st = st} (test-eq a b output) e d
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just eqv with refl ← e = domEq-ins output _ d
+step-dom {st = st} (add a b output) e d
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just (val-native x) | just (val-native y)
+        with refl ← e = domEq-ins output _ d
+... | just (val-jubjub-point p) | just (val-jubjub-point q)
+        with refl ← e = domEq-ins output _ d
+... | just (val-secp-point p) | just (val-secp-point q)
+        with refl ← e = domEq-ins output _ d
+... | just (val-secp-base x) | just (val-secp-base y)
+        with refl ← e = domEq-ins output _ d
+... | just (val-secp-scalar x) | just (val-secp-scalar y)
+        with refl ← e = domEq-ins output _ d
+step-dom {st = st} (mul a b output) e d
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just (val-native x) | just (val-native y)
+        with refl ← e = domEq-ins output _ d
+... | just (val-secp-base x) | just (val-secp-base y)
+        with refl ← e = domEq-ins output _ d
+... | just (val-secp-scalar x) | just (val-secp-scalar y)
+        with refl ← e = domEq-ins output _ d
+step-dom {st = st} (neg a output) e d
+  with resolve (State.mem st) a
+... | just (val-native x) with refl ← e = domEq-ins output _ d
+... | just (val-jubjub-point p) with refl ← e = domEq-ins output _ d
+... | just (val-secp-point p) with refl ← e = domEq-ins output _ d
+... | just (val-secp-base x) with refl ← e = domEq-ins output _ d
+... | just (val-secp-scalar x) with refl ← e = domEq-ins output _ d
+step-dom {st = st} (inv a output) e d
+  with resolve (State.mem st) a
+... | just (val-native x) with invᶠ x
+...   | just xi with refl ← e = domEq-ins output _ d
+step-dom {st = st} (inv a output) e d
+  | just (val-secp-base x) with invᵇ x
+...   | just xi with refl ← e = domEq-ins output _ d
+step-dom {st = st} (inv a output) e d
+  | just (val-secp-scalar x) with invˢ x
+...   | just xi with refl ← e = domEq-ins output _ d
+step-dom {st = st} (not a output) e d
+  with resolve𝔹 (State.mem st) a
+... | just b with refl ← e = domEq-ins output _ d
+step-dom {st = st} (less-than a b bits output) e d
+  with resolveᶠ (State.mem st) a | resolveᶠ (State.mem st) b
+... | just x | just y with valFr x <? 2 ^ bits
+...   | yes _ with valFr y <? 2 ^ bits
+...     | yes _ with refl ← e = domEq-ins output _ d
+step-dom {st = st} (jubjub-scalar-from-native a output) e d
+  with resolveᶠ (State.mem st) a
+... | just x with refl ← e = domEq-ins output _ d
+step-dom {st = st} (public-input guard val-t output) e d
+  with eval-guard (State.mem st) guard
+... | just g with g
+...   | true with decode val-t
+                    (take (encoded-len val-t) (State.pto-rem st))
+...     | just v with refl ← e = domEq-ins output _ d
+step-dom {st = st} (public-input guard val-t output) e d
+    | just g | false with refl ← e = domEq-ins output _ d
+step-dom {st = st} (private-input guard val-t output) e d
+  with eval-guard (State.mem st) guard
+... | just g with g
+...   | true with decode val-t
+                    (take (encoded-len val-t) (State.priv-rem st))
+...     | just v with refl ← e = domEq-ins output _ d
+step-dom {st = st} (private-input guard val-t output) e d
+    | just g | false with refl ← e = domEq-ins output _ d
+step-dom {S = S} {st = st} (circuit-output vals) e d
+  with collectOutputs (State.mem st) (IrSource.outputs S) vals
+... | just vs with refl ← e = domEq-nop d
+
+------------------------------------------------------------------------
+-- The static single-assignment predicate and its soundness.
+--
+-- `SA bound is` scans `is` from an already-bound name set `bound`: each
+-- instruction's outputs must be fresh against `bound` and pairwise
+-- distinct, and the scan continues with `bound` extended by those
+-- outputs.  It is decidable (a nesting of `_∈?_`/`all?` decisions), though
+-- only the `Set` form is needed downstream.
+------------------------------------------------------------------------
+
+SA : List Identifier → List Instruction → Set
+SA bound []       = ⊤
+SA bound (i ∷ is) = All (λ o → ¬ (o ∈ bound)) (outs-of i)
+                  × NoDup (outs-of i)
+                  × SA (bound ++ outs-of i) is
+
+producer-SA : IrSource → Set
+producer-SA S = NoDup (map TypedIdentifier.name (IrSource.inputs S))
+              × SA (map TypedIdentifier.name (IrSource.inputs S))
+                   (IrSource.instructions S)
+
+-- The domain invariant + `SA` imply `WF-run`: at the head, `out-fresh-of`
+-- turns the static freshness into the semantic one; along the tail,
+-- `step-dom` re-establishes the invariant at the enlarged bound.
+sa-wf : ∀ {P S} is st bound
+  → SA bound is → DomEq (State.mem st) bound → WF-run P S is st
+sa-wf []       st bound _              _ = tt
+sa-wf {P} {S} (i ∷ is) st bound (af , nd , sa-rest) d =
+    out-fresh-of i d af nd
+  , λ {st'} step-eq →
+      sa-wf {P} {S} is st' (bound ++ outs-of i) sa-rest
+        (step-dom {P} {S} i step-eq d)
+
+producer-safe→WF : ∀ {S P st0}
+  → producer-SA S
+  → init S P ≡ just st0
+  → WF-run P S (IrSource.instructions S) st0
+producer-safe→WF {S} {P} {st0} (_ , sa) ieq =
+  sa-wf (IrSource.instructions S) st0
+    (map TypedIdentifier.name (IrSource.inputs S)) sa
+    (init-dom {S} {P} {st0} ieq)
+
+------------------------------------------------------------------------
+-- The single-assignment check is decidable: `producer-SA` is a runnable
+-- static well-formedness check.
+------------------------------------------------------------------------
+
+NotIn? : (id : Identifier) (ks : List Identifier) → Dec (NotIn id ks)
+NotIn? id []       = yes tt
+NotIn? id (k ∷ ks) = ¬? (id ≟str k) ×-dec NotIn? id ks
+
+NoDup? : (ids : List Identifier) → Dec (NoDup ids)
+NoDup? []         = yes tt
+NoDup? (id ∷ ids) = NotIn? id ids ×-dec NoDup? ids
+
+SA? : (bound : List Identifier) (is : List Instruction) → Dec (SA bound is)
+SA? bound []       = yes tt
+SA? bound (i ∷ is) =
+      all? (λ o → ¬? (o ∈? bound)) (outs-of i)
+  ×-dec NoDup? (outs-of i)
+  ×-dec SA? (bound ++ outs-of i) is
+
+producer-SA? : (S : IrSource) → Dec (producer-SA S)
+producer-SA? S =
+      NoDup? (map TypedIdentifier.name (IrSource.inputs S))
+  ×-dec SA? (map TypedIdentifier.name (IrSource.inputs S))
+            (IrSource.instructions S)
+
+------------------------------------------------------------------------
+-- WF2 — the structural bit-count bounds (spec §5.3).
+--
+-- The Rust preprocess rejects these dynamically ("Excessive bit
+-- bound" / "Excessive bit count", ir_vm.rs); the mechanized `step`
+-- deliberately does not re-check them (Semantics, header note).  The
+-- transfer theorem below (`preprocessʳ-agree`) makes the fidelity claim
+-- precise: on every WF2-conforming source the Rust-faithful semantics
+-- `preprocessʳ` — whose step re-checks the bounds — agrees with
+-- `preprocess`, so the development's theorems apply verbatim.
+-- 248 = FR_BYTES_STORED · 8.
+------------------------------------------------------------------------
+
+wf2-ok : Instruction → Bool
+wf2-ok (constrain-bits _ bits)         = bits <ᵇ FR-BITS
+wf2-ok (less-than _ _ bits _)          = bits <ᵇ FR-BITS
+wf2-ok (div-mod-power-of-two _ bits _) = bits ≤ᵇ 248
+wf2-ok (reconstitute-field _ _ bits _) = bits ≤ᵇ 248
+wf2-ok _                               = true
+
+producer-WF2 : IrSource → Set
+producer-WF2 S = All (λ i → T (wf2-ok i)) (IrSource.instructions S)
+
+producer-WF2? : (S : IrSource) → Dec (producer-WF2 S)
+producer-WF2? S = all? (λ i → T? (wf2-ok i)) (IrSource.instructions S)
+
+------------------------------------------------------------------------
+-- The Rust-faithful semantics and the WF2 transfer theorem.
+--
+-- `stepʳ` guards each instruction with the WF2 bit-count check the Rust
+-- preprocess performs dynamically; `runʳ`/`preprocessʳ` are the
+-- corresponding Rust-faithful run and preprocess (the terminal side
+-- conditions are those of `preprocess`, unchanged).  On a
+-- WF2-conforming source every guard passes, so the two semantics agree
+-- outright.
+------------------------------------------------------------------------
+
+stepʳ : ProofPreimage → IrSource → State → Instruction → Maybe State
+stepʳ P S st i = if wf2-ok i then step P S st i else nothing
+
+runʳ : ProofPreimage → IrSource → State → List Instruction → Maybe State
+runʳ P S st []       = just st
+runʳ P S st (i ∷ is) = stepʳ P S st i >>= λ st′ → runʳ P S st′ is
+
+preprocessʳ : IrSource → ProofPreimage → Maybe State
+preprocessʳ S P =
+  init S P >>= λ st0 →
+  runʳ P S st0 (IrSource.instructions S) >>= λ stf →
+  guardD (State.pti-idx stf
+           ≟ℕ length (ProofPreimage.pub-transcript-inputs P))
+   (case State.pto-rem stf of λ
+     { (_ ∷ _) → nothing
+     ; []      → case State.priv-rem stf of λ
+       { (_ ∷ _) → nothing
+       ; []      →
+           if IrSource.do-communications-commitment S
+           then (case ProofPreimage.comm-commitment P of λ
+                  { (just (c , r)) →
+                      guardD (c ≟ᶠ transient-commit
+                                    (ProofPreimage.inputs P
+                                      ++ concatMap encodeᵉ (State.outs stf)) r)
+                        (just stf)
+                  ; nothing → nothing })
+           else just stf } })
+
+-- On WF2-conforming instructions the guarded run is the plain run.
+runʳ-agree : ∀ {P S st} is → All (λ i → T (wf2-ok i)) is
+  → runʳ P S st is ≡ run P S st is
+runʳ-agree []       _          = refl
+runʳ-agree {P} {S} {st} (i ∷ is) (px ∷ pxs) with wf2-ok i
+... | false = case px of λ ()
+... | true with step P S st i
+...   | nothing  = refl
+...   | just st′ = runʳ-agree {P} {S} {st′} is pxs
+
+-- The transfer theorem: for a WF2-conforming source the Rust-faithful
+-- preprocess is the mechanized one.
+preprocessʳ-agree : ∀ S P → producer-WF2 S
+  → preprocessʳ S P ≡ preprocess S P
+preprocessʳ-agree S P wf2
+  with init S P
+... | nothing  = refl
+... | just st0
+  rewrite runʳ-agree {P} {S} {st0} (IrSource.instructions S) wf2
+  with run P S st0 (IrSource.instructions S)
+...   | nothing  = refl
+...   | just stf
+  with State.pti-idx stf ≟ℕ length (ProofPreimage.pub-transcript-inputs P)
+...     | no _  = refl
+...     | yes _
+  with State.pto-rem stf
+...       | (_ ∷ _) = refl
+...       | []
+  with State.priv-rem stf
+...         | (_ ∷ _) = refl
+...         | []
+  with IrSource.do-communications-commitment S
+...           | false = refl
+...           | true
+  with ProofPreimage.comm-commitment P
+...             | nothing = refl
+...             | just (c , r)
+  with c ≟ᶠ transient-commit
+             (ProofPreimage.inputs P ++ concatMap encodeᵉ (State.outs stf)) r
+...               | yes _ = refl
+...               | no _  = refl
+
+------------------------------------------------------------------------
+-- Static well-typedness for a zkir-v3 `IrSource`.
+--
+-- The backward per-instruction lemmas (`*-bwd` in `CircuitBackward`)
+-- ask for *type-directed* facts about their operands — that `add`'s
+-- operands are both Native or both JubjubPoint, that `cond-select`'s two
+-- branches share a type, etc.  Off-circuit these hold because a
+-- well-typed producer never feeds an operand the wrong type; zkir-v3 is
+-- untyped at the wire level, so we recover them from a static typing
+-- pass, exactly parallel to the single-assignment pass above.
+--
+-- The type context `TyCtx` assigns each bound identifier an `IrType`.
+-- The value-typing invariant `TyEq m Γ` says every entry of `Γ` names a
+-- cell of `m` holding a value of that type.  It is seeded from `init`
+-- (declared input types) and maintained by `step` (each instruction's
+-- output type rule, `outtys`).  The decidable `producer-WT` scans the
+-- source, computing the output types and checking each instruction's
+-- operand types against what its off-circuit `step` demands.
+------------------------------------------------------------------------
+
+TyCtx : Set
+TyCtx = List (Identifier × IrType)
+
+-- The identifiers a context binds.
+dom-ty : TyCtx → List Identifier
+dom-ty = map proj₁
+
+-- Look up an identifier's declared type (first match).
+lookup-ty : TyCtx → Identifier → Maybe IrType
+lookup-ty []             _  = nothing
+lookup-ty ((k , t) ∷ Γ) id  =
+  case id ≟str k of λ { (yes _) → just t ; (no _) → lookup-ty Γ id }
+
+-- Operand type: an immediate is Native; a variable's is its context type.
+optype : TyCtx → Operand → Maybe IrType
+optype Γ (imm _)  = just native
+optype Γ (var id) = lookup-ty Γ id
+
+------------------------------------------------------------------------
+-- The value-typing invariant.
+------------------------------------------------------------------------
+
+-- Each identifier the context types names a cell holding a value of that
+-- type.  Stated via `lookup-ty` (first-match), so a fresh append never
+-- perturbs an earlier entry.  Wrapped in a record (not a bare Π) so the
+-- combinators' Π-typed results are not eagerly instantiated at call
+-- sites (a bare `∀{id t}→…` result stalls the unifier with fresh `{id}`
+-- metas, exactly the `_⊑_` issue from `holds-lower`).
+record TyEq (m : Mem) (Γ : TyCtx) : Set where
+  constructor tyEq
+  field
+    at : ∀ {id t} → lookup-ty Γ id ≡ just t
+       → ∃ λ v → m id ≡ just v × typeof v ≡ t
+open TyEq public
+
+-- `decode` yields a value of the type it was asked to read.
+decode-typeof : ∀ t raw {v} → decode t raw ≡ just v → typeof v ≡ t
+decode-typeof native (x ∷ []) refl = refl
+decode-typeof jubjub-scalar (s ∷ []) e
+  with jubjubScalarFromFr s
+... | just _ with refl ← e = refl
+decode-typeof bytes32 (lo ∷ hi ∷ []) e
+  with low-high→bytes32 lo hi
+... | just _ with refl ← e = refl
+decode-typeof jubjub-point (x ∷ y ∷ []) e
+  with fromCoordsJ x y
+... | just _ with refl ← e = refl
+decode-typeof secp-base (l ∷ h ∷ []) e
+  with limbs→secpBase l h
+... | just _ with refl ← e = refl
+decode-typeof secp-scalar (l ∷ h ∷ []) e
+  with limbs→secpScalar l h
+... | just _ with refl ← e = refl
+decode-typeof secp-point (a ∷ b ∷ c ∷ d ∷ f ∷ []) e
+  with limbs→secpPoint a b c d f
+... | just _ with refl ← e = refl
+
+-- The default value of a type has that type.
+default-typeof : ∀ t → typeof (default-val t) ≡ t
+default-typeof native        = refl
+default-typeof bytes32       = refl
+default-typeof jubjub-point  = refl
+default-typeof jubjub-scalar = refl
+default-typeof secp-point    = refl
+default-typeof secp-base     = refl
+default-typeof secp-scalar   = refl
+
+------------------------------------------------------------------------
+-- Lookup lemmas for context extension.
+------------------------------------------------------------------------
+
+-- A lookup found in a prefix is unchanged by appending a suffix.
+lookup-ty-++ˡ : ∀ Γ Δ {id t}
+  → lookup-ty Γ id ≡ just t → lookup-ty (Γ ++ Δ) id ≡ just t
+lookup-ty-++ˡ ((k , s) ∷ Γ) Δ {id} e with id ≟str k
+... | yes _ = e
+... | no  _ = lookup-ty-++ˡ Γ Δ e
+
+-- Looking up in `Γ ++ Δ` an id absent from `Γ` falls through to `Δ`.
+lookup-ty-++ʳ : ∀ Γ Δ {id}
+  → ¬ (id ∈ dom-ty Γ)
+  → lookup-ty (Γ ++ Δ) id ≡ lookup-ty Δ id
+lookup-ty-++ʳ []            Δ _   = refl
+lookup-ty-++ʳ ((k , s) ∷ Γ) Δ {id} id∉ with id ≟str k
+... | yes id≡k = case id∉ (here id≡k) of λ ()
+... | no  _    = lookup-ty-++ʳ Γ Δ (λ p → id∉ (there p))
+
+-- The head of a context is found under its own key.
+lookup-ty-here : ∀ {Γ} (o : Identifier) t → lookup-ty ((o , t) ∷ Γ) o ≡ just t
+lookup-ty-here {Γ} o t with o ≟str o
+... | yes _  = refl
+... | no ¬p  = case ¬p refl of λ ()
+
+-- A successful lookup in `Γ ++ Δ` either came from `Γ` or (if `Γ` misses)
+-- from `Δ`.  Splits an append lookup for the reverse (`step`) direction.
+lookup-ty-++⁻ : ∀ Γ Δ {id t}
+  → lookup-ty (Γ ++ Δ) id ≡ just t
+  → (lookup-ty Γ id ≡ just t) ⊎ (lookup-ty Δ id ≡ just t)
+lookup-ty-++⁻ []            Δ e = inj₂ e
+lookup-ty-++⁻ ((k , s) ∷ Γ) Δ {id} e with id ≟str k
+... | yes _ = inj₁ e
+... | no  _ = lookup-ty-++⁻ Γ Δ e
+
+-- The singleton context resolves only its own key.
+lookup-ty-[x]≢ : ∀ {id o t s} → ¬ (id ≡ o)
+  → lookup-ty ((o , t) ∷ []) id ≡ just s → ⊥
+lookup-ty-[x]≢ {id} {o} id≢o e with id ≟str o
+... | yes id≡o = id≢o id≡o
+... | no  _    = case e of λ ()
+
+------------------------------------------------------------------------
+-- Seeding and maintaining `TyEq`.
+------------------------------------------------------------------------
+
+-- The empty context is satisfied by any memory (no lookups succeed).
+tyEq-∅ : ∀ {m} → TyEq m []
+tyEq-∅ = tyEq λ ()
+
+-- Prepend a fresh binding whose value has the declared type.  The shape
+-- `decode-inputs` produces (front-extension); `lookup-ty` sees the new
+-- head first, and earlier keys are untouched.
+tyEq-cons : ∀ (m : Mem) (Γ : TyCtx) (o : Identifier) v t
+  → typeof v ≡ t → TyEq m Γ → TyEq (ins o v m) ((o , t) ∷ Γ)
+tyEq-cons m Γ o v t tv teq = tyEq λ {id} {s} e → go id s e
+  where
+  go : ∀ id s → lookup-ty ((o , t) ∷ Γ) id ≡ just s
+     → ∃ λ w → ins o v m id ≡ just w × typeof w ≡ s
+  go id s e with id ≟str o
+  ... | yes refl with refl ← just-injective e = v , refl , tv
+  ... | no id≢o = let (w , mw , tw) = at teq e in w , mw , tw
+
+-- Append a fresh binding at the end (step's single-output shape).  The
+-- new key `o` must be absent from `dom-ty Γ` so the append does not
+-- shadow it; earlier lookups fall through the append unchanged.
+tyEq-ins : ∀ (m : Mem) (Γ : TyCtx) (o : Identifier) v t
+  → typeof v ≡ t → ¬ (o ∈ dom-ty Γ)
+  → TyEq m Γ → TyEq (ins o v m) (Γ ++ (o , t) ∷ [])
+tyEq-ins m Γ o v t tv o∉ teq = tyEq λ {id} {s} e → go id s e
+  where
+  go : ∀ id s → lookup-ty (Γ ++ (o , t) ∷ []) id ≡ just s
+     → ∃ λ w → ins o v m id ≡ just w × typeof w ≡ s
+  go id s e with id ≟str o
+  ... | yes refl
+        with refl ← just-injective
+               (trans (sym (trans (lookup-ty-++ʳ Γ ((o , t) ∷ []) o∉)
+                                  (lookup-ty-here o t))) e) =
+          v , refl , tv
+  ... | no id≢o =
+        let (w , mw , tw) = at teq (from-Γ (lookup-ty-++⁻ Γ ((o , t) ∷ []) e))
+        in w , mw , tw
+    where
+    -- The lookup came from `Γ` (the singleton only resolves `o`, id≢o).
+    from-Γ : (lookup-ty Γ id ≡ just s) ⊎ (lookup-ty ((o , t) ∷ []) id ≡ just s)
+           → lookup-ty Γ id ≡ just s
+    from-Γ (inj₁ p) = p
+    from-Γ (inj₂ q) = case lookup-ty-[x]≢ id≢o q of λ ()
+
+------------------------------------------------------------------------
+-- Seeding `TyEq` from `init`.
+--
+-- `decode-inputs` binds each declared input to a value of its declared
+-- type (`decode-typeof`), so the initial memory satisfies the input
+-- context `input-ctx S` (the declared `(name , type)` pairs).
+------------------------------------------------------------------------
+
+input-ctx : List TypedIdentifier → TyCtx
+input-ctx = map (λ ti → TypedIdentifier.name ti , TypedIdentifier.val-t ti)
+
+decode-inputs-ty : ∀ tis raw {m}
+  → decode-inputs tis raw ≡ just m
+  → TyEq m (input-ctx tis)
+decode-inputs-ty []         []      refl = tyEq-∅
+decode-inputs-ty []         (_ ∷ _) ()
+decode-inputs-ty (ti ∷ tis) raw ieq
+  with decode (TypedIdentifier.val-t ti)
+              (take (encoded-len (TypedIdentifier.val-t ti)) raw)
+         in edec
+... | just v
+  with decode-inputs tis (drop (encoded-len (TypedIdentifier.val-t ti)) raw)
+         in erest
+...   | just m' with refl ← ieq =
+        tyEq-cons m' (input-ctx tis)
+          (TypedIdentifier.name ti) v (TypedIdentifier.val-t ti)
+          (decode-typeof (TypedIdentifier.val-t ti) _ edec)
+          (decode-inputs-ty tis (drop (encoded-len (TypedIdentifier.val-t ti))
+                                   raw) erest)
+
+init-ty : ∀ {S P st0}
+  → init S P ≡ just st0
+  → TyEq (State.mem st0) (input-ctx (IrSource.inputs S))
+init-ty {S} {P} {st0} ieq =
+  decode-inputs-ty (IrSource.inputs S) (ProofPreimage.inputs P)
+    (init-decode {S} {P} {st0} ieq)
+
+------------------------------------------------------------------------
+-- Reading an operand's type off the invariant.
+--
+-- Under `TyEq m Γ`, an operand with a declared type `t` (`optype Γ`) that
+-- resolves to `av` in `m` has `typeof av ≡ t`.  This is the bridge the
+-- discharge lemmas use to turn a static operand type into a runtime one.
+------------------------------------------------------------------------
+
+tyEq-optype : ∀ {m Γ op t av}
+  → TyEq m Γ → optype Γ op ≡ just t → resolve m op ≡ just av
+  → typeof av ≡ t
+tyEq-optype {op = imm x} teq ot rv
+  with refl ← ot with refl ← rv = refl
+tyEq-optype {m} {Γ} {op = var id} {t} {av} teq ot rv
+  with at teq ot
+... | (w , mw , tw) with refl ← just-injective (trans (sym mw) rv) = tw
+
+-- A value whose type is `native` is a `val-native`.
+typeof-native : ∀ {v} → typeof v ≡ native → ∃ λ x → v ≡ val-native x
+typeof-native {val-native x} refl = x , refl
+
+-- A value whose type is `jubjub-point` is a `val-jubjub-point`.
+typeof-point : ∀ {v} → typeof v ≡ jubjub-point → ∃ λ p → v ≡ val-jubjub-point p
+typeof-point {val-jubjub-point p} refl = p , refl
+
+-- A value whose type is `bytes32` is a `val-bytes32`.
+typeof-bytes32 : ∀ {v} → typeof v ≡ bytes32 → ∃ λ b → v ≡ val-bytes32 b
+typeof-bytes32 {val-bytes32 b} refl = b , refl
+
+-- A value whose type is `secp-point` is a `val-secp-point`.
+typeof-secp-point : ∀ {v} → typeof v ≡ secp-point
+  → ∃ λ p → v ≡ val-secp-point p
+typeof-secp-point {val-secp-point p} refl = p , refl
+
+-- A value whose type is `secp-base` is a `val-secp-base`.
+typeof-secp-base : ∀ {v} → typeof v ≡ secp-base
+  → ∃ λ x → v ≡ val-secp-base x
+typeof-secp-base {val-secp-base x} refl = x , refl
+
+-- A value whose type is `secp-scalar` is a `val-secp-scalar`.
+typeof-secp-scalar : ∀ {v} → typeof v ≡ secp-scalar
+  → ∃ λ s → v ≡ val-secp-scalar s
+typeof-secp-scalar {val-secp-scalar s} refl = s , refl
+
+------------------------------------------------------------------------
+-- Discharging the type-directed `*-bwd` obligations.
+--
+-- Given the typing invariant at the pre-step context, the operands'
+-- static types (`optype`), and their runtime resolutions, produce exactly
+-- the type-support premise the corresponding backward lemma asks for.
+------------------------------------------------------------------------
+
+-- A field-or-group operand type: the five types `add`/`neg` accept
+-- (native, JubjubPoint, SecpPoint, SecpBase, SecpScalar).  The disjunct
+-- order matches `Circuit.holds`' `gate-add`/`gate-neg`.
+FN : IrType → Set
+FN t = (t ≡ native) ⊎ (t ≡ jubjub-point) ⊎ (t ≡ secp-point)
+     ⊎ (t ≡ secp-base) ⊎ (t ≡ secp-scalar)
+
+-- A field-multiplication operand type: the three types `mul`/`inv`
+-- accept (native, SecpBase, SecpScalar).  Order matches `Circuit.holds`'
+-- `gate-mul`/`gate-inv`.
+FM : IrType → Set
+FM t = (t ≡ native) ⊎ (t ≡ secp-base) ⊎ (t ≡ secp-scalar)
+
+-- `add-bwd`'s five-way disjunction, from a shared operand type that is one
+-- of the field/group types.  The disjunct order (native, JubjubPoint,
+-- SecpPoint, SecpBase, SecpScalar) matches `gate-add`.
+add-support : ∀ {m Γ a b t av bv}
+  → TyEq m Γ
+  → optype Γ a ≡ just t → optype Γ b ≡ just t
+  → FN t
+  → resolve m a ≡ just av → resolve m b ≡ just bv
+  → ( (∃ λ x → ∃ λ y →
+         resolve m a ≡ just (val-native x) × resolve m b ≡ just (val-native y))
+    ⊎ (∃ λ p → ∃ λ q →
+         resolve m a ≡ just (val-jubjub-point p)
+       × resolve m b ≡ just (val-jubjub-point q))
+    ⊎ (∃ λ p → ∃ λ q →
+         resolve m a ≡ just (val-secp-point p)
+       × resolve m b ≡ just (val-secp-point q))
+    ⊎ (∃ λ x → ∃ λ y →
+         resolve m a ≡ just (val-secp-base x)
+       × resolve m b ≡ just (val-secp-base y))
+    ⊎ (∃ λ x → ∃ λ y →
+         resolve m a ≡ just (val-secp-scalar x)
+       × resolve m b ≡ just (val-secp-scalar y)))
+add-support {a = a} {b} teq ota otb (inj₁ refl) ra rb
+  with typeof-native (tyEq-optype {op = a} teq ota ra)
+     | typeof-native (tyEq-optype {op = b} teq otb rb)
+... | (x , refl) | (y , refl) = inj₁ (x , y , ra , rb)
+add-support {a = a} {b} teq ota otb (inj₂ (inj₁ refl)) ra rb
+  with typeof-point (tyEq-optype {op = a} teq ota ra)
+     | typeof-point (tyEq-optype {op = b} teq otb rb)
+... | (p , refl) | (q , refl) = inj₂ (inj₁ (p , q , ra , rb))
+add-support {a = a} {b} teq ota otb (inj₂ (inj₂ (inj₁ refl))) ra rb
+  with typeof-secp-point (tyEq-optype {op = a} teq ota ra)
+     | typeof-secp-point (tyEq-optype {op = b} teq otb rb)
+... | (p , refl) | (q , refl) = inj₂ (inj₂ (inj₁ (p , q , ra , rb)))
+add-support {a = a} {b} teq ota otb (inj₂ (inj₂ (inj₂ (inj₁ refl)))) ra rb
+  with typeof-secp-base (tyEq-optype {op = a} teq ota ra)
+     | typeof-secp-base (tyEq-optype {op = b} teq otb rb)
+... | (x , refl) | (y , refl) = inj₂ (inj₂ (inj₂ (inj₁ (x , y , ra , rb))))
+add-support {a = a} {b} teq ota otb (inj₂ (inj₂ (inj₂ (inj₂ refl)))) ra rb
+  with typeof-secp-scalar (tyEq-optype {op = a} teq ota ra)
+     | typeof-secp-scalar (tyEq-optype {op = b} teq otb rb)
+... | (x , refl) | (y , refl) = inj₂ (inj₂ (inj₂ (inj₂ (x , y , ra , rb))))
+
+-- `cond-select-bwd`'s `typeof av ≡ typeof bvl`, from a shared operand type.
+cond-select-support : ∀ {m Γ a b t av bv}
+  → TyEq m Γ
+  → optype Γ a ≡ just t → optype Γ b ≡ just t
+  → resolve m a ≡ just av → resolve m b ≡ just bv
+  → typeof av ≡ typeof bv
+cond-select-support {a = a} {b} teq ota otb ra rb =
+  trans (tyEq-optype {op = a} teq ota ra)
+        (sym (tyEq-optype {op = b} teq otb rb))
+
+-- Extracts a `val-native` resolution from an operand statically typed
+-- Native.  Used wherever a backward lemma reads a Native operand
+-- (`into-bytes32`, the coordinate splits, the native `mul` arm, …).
+mul-support-l : ∀ {m Γ a av}
+  → TyEq m Γ → optype Γ a ≡ just native → resolve m a ≡ just av
+  → ∃ λ x → resolve m a ≡ just (val-native x)
+mul-support-l {a = a} {av} teq ota ra
+  with typeof-native (tyEq-optype {op = a} teq ota ra)
+... | (x , refl) = x , ra
+
+-- `mul-bwd`'s three-way disjunction, from a shared operand type that is
+-- one of the field-multiplication types.  Order matches `gate-mul`.
+mul-support : ∀ {m Γ a b t av bv}
+  → TyEq m Γ
+  → optype Γ a ≡ just t → optype Γ b ≡ just t
+  → FM t
+  → resolve m a ≡ just av → resolve m b ≡ just bv
+  → ( (∃ λ x → ∃ λ y →
+         resolve m a ≡ just (val-native x) × resolve m b ≡ just (val-native y))
+    ⊎ (∃ λ x → ∃ λ y →
+         resolve m a ≡ just (val-secp-base x)
+       × resolve m b ≡ just (val-secp-base y))
+    ⊎ (∃ λ x → ∃ λ y →
+         resolve m a ≡ just (val-secp-scalar x)
+       × resolve m b ≡ just (val-secp-scalar y)))
+mul-support {a = a} {b} teq ota otb (inj₁ refl) ra rb
+  with typeof-native (tyEq-optype {op = a} teq ota ra)
+     | typeof-native (tyEq-optype {op = b} teq otb rb)
+... | (x , refl) | (y , refl) = inj₁ (x , y , ra , rb)
+mul-support {a = a} {b} teq ota otb (inj₂ (inj₁ refl)) ra rb
+  with typeof-secp-base (tyEq-optype {op = a} teq ota ra)
+     | typeof-secp-base (tyEq-optype {op = b} teq otb rb)
+... | (x , refl) | (y , refl) = inj₂ (inj₁ (x , y , ra , rb))
+mul-support {a = a} {b} teq ota otb (inj₂ (inj₂ refl)) ra rb
+  with typeof-secp-scalar (tyEq-optype {op = a} teq ota ra)
+     | typeof-secp-scalar (tyEq-optype {op = b} teq otb rb)
+... | (x , refl) | (y , refl) = inj₂ (inj₂ (x , y , ra , rb))
+
+-- `inv-bwd`'s three-way disjunction (single operand).  Order matches
+-- `gate-inv`.
+inv-support : ∀ {m Γ a t av}
+  → TyEq m Γ → optype Γ a ≡ just t → FM t
+  → resolve m a ≡ just av
+  → (∃ λ x → resolve m a ≡ just (val-native x))
+  ⊎ (∃ λ x → resolve m a ≡ just (val-secp-base x))
+  ⊎ (∃ λ x → resolve m a ≡ just (val-secp-scalar x))
+inv-support {a = a} teq ota (inj₁ refl) ra
+  with typeof-native (tyEq-optype {op = a} teq ota ra)
+... | (x , refl) = inj₁ (x , ra)
+inv-support {a = a} teq ota (inj₂ (inj₁ refl)) ra
+  with typeof-secp-base (tyEq-optype {op = a} teq ota ra)
+... | (x , refl) = inj₂ (inj₁ (x , ra))
+inv-support {a = a} teq ota (inj₂ (inj₂ refl)) ra
+  with typeof-secp-scalar (tyEq-optype {op = a} teq ota ra)
+... | (x , refl) = inj₂ (inj₂ (x , ra))
+
+-- `neg-bwd`'s five-way disjunction (single operand).  Order matches
+-- `gate-neg`.
+neg-support : ∀ {m Γ a t av}
+  → TyEq m Γ → optype Γ a ≡ just t → FN t
+  → resolve m a ≡ just av
+  → (∃ λ x → resolve m a ≡ just (val-native x))
+  ⊎ (∃ λ p → resolve m a ≡ just (val-jubjub-point p))
+  ⊎ (∃ λ p → resolve m a ≡ just (val-secp-point p))
+  ⊎ (∃ λ x → resolve m a ≡ just (val-secp-base x))
+  ⊎ (∃ λ x → resolve m a ≡ just (val-secp-scalar x))
+neg-support {a = a} teq ota (inj₁ refl) ra
+  with typeof-native (tyEq-optype {op = a} teq ota ra)
+... | (x , refl) = inj₁ (x , ra)
+neg-support {a = a} teq ota (inj₂ (inj₁ refl)) ra
+  with typeof-point (tyEq-optype {op = a} teq ota ra)
+... | (p , refl) = inj₂ (inj₁ (p , ra))
+neg-support {a = a} teq ota (inj₂ (inj₂ (inj₁ refl))) ra
+  with typeof-secp-point (tyEq-optype {op = a} teq ota ra)
+... | (p , refl) = inj₂ (inj₂ (inj₁ (p , ra)))
+neg-support {a = a} teq ota (inj₂ (inj₂ (inj₂ (inj₁ refl)))) ra
+  with typeof-secp-base (tyEq-optype {op = a} teq ota ra)
+... | (x , refl) = inj₂ (inj₂ (inj₂ (inj₁ (x , ra))))
+neg-support {a = a} teq ota (inj₂ (inj₂ (inj₂ (inj₂ refl)))) ra
+  with typeof-secp-scalar (tyEq-optype {op = a} teq ota ra)
+... | (x , refl) = inj₂ (inj₂ (inj₂ (inj₂ (x , ra))))
+
+-- The reflexive equality reads `true` at every `valEq?`-supported type
+-- (Native / Bytes32 / JubjubPoint / the Secp256k1 triple; `valEq?` is
+-- `nothing` on JubjubScalar).
+valEq?-refl-native  : ∀ x → valEq? (val-native x) (val-native x) ≡ just true
+valEq?-refl-native  x =
+  cong just (trans (isYes≗does (x ≟ᶠ x)) (dec-true (x ≟ᶠ x) refl))
+
+valEq?-refl-bytes32 : ∀ b → valEq? (val-bytes32 b) (val-bytes32 b) ≡ just true
+valEq?-refl-bytes32 b =
+  cong just (trans (isYes≗does (b ≟B b)) (dec-true (b ≟B b) refl))
+
+valEq?-refl-point   : ∀ p
+  → valEq? (val-jubjub-point p) (val-jubjub-point p) ≡ just true
+valEq?-refl-point   p =
+  cong just (trans (isYes≗does (p ≟J p)) (dec-true (p ≟J p) refl))
+
+valEq?-refl-secp-point : ∀ p
+  → valEq? (val-secp-point p) (val-secp-point p) ≡ just true
+valEq?-refl-secp-point p =
+  cong just (trans (isYes≗does (p ≟K p)) (dec-true (p ≟K p) refl))
+
+valEq?-refl-secp-base : ∀ x
+  → valEq? (val-secp-base x) (val-secp-base x) ≡ just true
+valEq?-refl-secp-base x =
+  cong just (trans (isYes≗does (x ≟ᵇ x)) (dec-true (x ≟ᵇ x) refl))
+
+valEq?-refl-secp-scalar : ∀ s
+  → valEq? (val-secp-scalar s) (val-secp-scalar s) ≡ just true
+valEq?-refl-secp-scalar s =
+  cong just (trans (isYes≗does (s ≟ˢ s)) (dec-true (s ≟ˢ s) refl))
+
+-- The `valEq?`-supported operand types of `constrain-eq` (every type
+-- except JubjubScalar, whose `valEq?` is `nothing`).
+SuppEq : IrType → Set
+SuppEq t = (t ≡ native) ⊎ (t ≡ bytes32) ⊎ (t ≡ jubjub-point)
+         ⊎ (t ≡ secp-point) ⊎ (t ≡ secp-base) ⊎ (t ≡ secp-scalar)
+
+-- `constrain-eq-bwd`'s reflexive-`valEq?` support, given the operand's
+-- type is `valEq?`-supported.
+constrain-eq-support : ∀ {m Γ a t av}
+  → TyEq m Γ → optype Γ a ≡ just t
+  → SuppEq t
+  → resolve m a ≡ just av
+  → resolve m a ≡ just av × valEq? av av ≡ just true
+constrain-eq-support {a = a} {av = av} teq ota tsup ra = ra , goal tsup
+  where
+  goal : _ → valEq? av av ≡ just true
+  goal (inj₁ refl)
+    with x , eqx ← typeof-native (tyEq-optype {op = a} teq ota ra) =
+      trans (cong (λ w → valEq? w w) eqx) (valEq?-refl-native x)
+  goal (inj₂ (inj₁ refl))
+    with b , eqb ← typeof-bytes32 (tyEq-optype {op = a} teq ota ra) =
+      trans (cong (λ w → valEq? w w) eqb) (valEq?-refl-bytes32 b)
+  goal (inj₂ (inj₂ (inj₁ refl)))
+    with p , eqp ← typeof-point (tyEq-optype {op = a} teq ota ra) =
+      trans (cong (λ w → valEq? w w) eqp) (valEq?-refl-point p)
+  goal (inj₂ (inj₂ (inj₂ (inj₁ refl))))
+    with p , eqp ← typeof-secp-point (tyEq-optype {op = a} teq ota ra) =
+      trans (cong (λ w → valEq? w w) eqp) (valEq?-refl-secp-point p)
+  goal (inj₂ (inj₂ (inj₂ (inj₂ (inj₁ refl)))))
+    with x , eqx ← typeof-secp-base (tyEq-optype {op = a} teq ota ra) =
+      trans (cong (λ w → valEq? w w) eqx) (valEq?-refl-secp-base x)
+  goal (inj₂ (inj₂ (inj₂ (inj₂ (inj₂ refl)))))
+    with s , eqs ← typeof-secp-scalar (tyEq-optype {op = a} teq ota ra) =
+      trans (cong (λ w → valEq? w w) eqs) (valEq?-refl-secp-scalar s)
+
+------------------------------------------------------------------------
+-- Operand resolution from the typing invariant.
+--
+-- The backward driver must, at each step, *produce* the resolution of
+-- every operand the reconstructed `step`/constraint reads.  `TyEq` alone
+-- supplies it: a typed operand (`optype Γ op ≡ just t`) names a bound
+-- cell (immediates resolve to a `val-native` directly).  These are the
+-- witnesses `defd-of` shifts to the post-step witness (via `⊢-pres`) and
+-- the backward lemmas take as their operand premises.
+------------------------------------------------------------------------
+
+optype-resolve : ∀ {m Γ op t} → TyEq m Γ → optype Γ op ≡ just t
+  → ∃ λ v → resolve m op ≡ just v
+optype-resolve {op = imm x}  teq ot = val-native x , refl
+optype-resolve {op = var id} teq ot with at teq ot
+... | (v , mv , _) = v , mv
+
+optype-resolveᶠ : ∀ {m Γ op} → TyEq m Γ → optype Γ op ≡ just native
+  → ∃ λ x → resolveᶠ m op ≡ just x
+optype-resolveᶠ {m} {op = op} teq ot with optype-resolve {op = op} teq ot
+... | (v , rv) with typeof-native (tyEq-optype {op = op} teq ot rv)
+...   | (x , refl) = x , resolveᶠ-intro m op rv
+
+------------------------------------------------------------------------
+-- Static output-typing rules.
+--
+-- `outtys Γ i` extends the context `Γ` with the type of each output wire
+-- of `i`, or fails (`nothing`) when `i`'s operands are ill-typed for what
+-- its off-circuit `step` demands.  It parallels `outs-of` / `step-dom`:
+-- no-output instructions leave `Γ` unchanged; single-output ones append
+-- one typed entry; the two-/list-output ones append the corresponding
+-- entries.  Only the type-directed instructions (`add`/`mul`/`neg`/
+-- `cond-select`/`copy`) inspect operand types; the rest have a fixed
+-- output type.
+------------------------------------------------------------------------
+
+-- Same operand type on both sides, if defined and equal (`add`,
+-- `cond-select`).
+same-ty : TyCtx → Operand → Operand → Maybe IrType
+same-ty Γ a b with optype Γ a | optype Γ b
+... | just ta | just tb =
+      case ta ≟T tb of λ { (yes _) → just ta ; (no _) → nothing }
+... | _       | _       = nothing
+
+-- `same-ty` yields a type that both operands share.
+same-ty-l : ∀ {Γ a b t} → same-ty Γ a b ≡ just t → optype Γ a ≡ just t
+same-ty-l {Γ} {a} {b} e with optype Γ a | optype Γ b
+... | just ta | just tb with ta ≟T tb
+...   | yes _ with refl ← e = refl
+
+same-ty-r : ∀ {Γ a b t} → same-ty Γ a b ≡ just t → optype Γ b ≡ just t
+same-ty-r {Γ} {a} {b} e with optype Γ a | optype Γ b
+... | just ta | just tb with ta ≟T tb
+...   | yes ta≡tb with refl ← e = sym (cong just ta≡tb)
+
+-- Append one typed output.
+_◂_ : TyCtx → (Identifier × IrType) → TyCtx
+Γ ◂ e = Γ ++ e ∷ []
+
+-- Append a list of outputs all of the same type (`encode` → native;
+-- `div-mod`/`persistent`/`keccak` → native; two-output lists as well).
+extN : TyCtx → List Identifier → IrType → TyCtx
+extN Γ []         t = Γ
+extN Γ (o ∷ os)   t = extN (Γ ◂ (o , t)) os t
+
+-- The static output typing.  `nothing` = ill-typed (an operand's type is
+-- undefined or fails the instruction's demand).
+outtys : TyCtx → Instruction → Maybe TyCtx
+outtys Γ (encode input outputs)        = just (extN Γ outputs native)
+outtys Γ (assert _)                    = just Γ
+outtys Γ (cond-select bit a b o)       =
+  mapᵐ (λ t → Γ ◂ (o , t)) (same-ty Γ a b)
+outtys Γ (constrain-bits _ _)          = just Γ
+outtys Γ (constrain-eq _ _)            = just Γ
+outtys Γ (constrain-to-boolean _)      = just Γ
+outtys Γ (copy val o)                  = mapᵐ (λ t → Γ ◂ (o , t)) (optype Γ val)
+outtys Γ (impact _ _)                  = just Γ
+outtys Γ (ec-mul a _ o)                = mapᵐ (λ t → Γ ◂ (o , t)) (optype Γ a)
+outtys Γ (ec-mul-generator scalar o)   =
+  case optype Γ scalar of λ
+    { (just jubjub-scalar) → just (Γ ◂ (o , jubjub-point))
+    ; (just secp-scalar)   → just (Γ ◂ (o , secp-point))
+    ; _                    → nothing }
+outtys Γ (hash-to-curve _ o)           = just (Γ ◂ (o , jubjub-point))
+outtys Γ (into-coordinates point (xo , yo)) =
+  case optype Γ point of λ
+    { (just jubjub-point) → just (extN Γ (xo ∷ yo ∷ []) native)
+    ; (just secp-point)   → just (extN Γ (xo ∷ yo ∷ []) secp-base)
+    ; _                   → nothing }
+outtys Γ (from-coordinates (xop , yop) o) =
+  case optype Γ xop of λ
+    { (just native)    → just (Γ ◂ (o , jubjub-point))
+    ; (just secp-base) → just (Γ ◂ (o , secp-point))
+    ; _                → nothing }
+outtys Γ (into-bytes32 _ o)            = just (Γ ◂ (o , bytes32))
+outtys Γ (from-bytes32 _ val-t o)      = just (Γ ◂ (o , val-t))
+outtys Γ (reverse-bytes _ o)           = just (Γ ◂ (o , bytes32))
+outtys Γ (bytes32-into-low-high _ (lo , hi)) =
+  just (extN Γ (lo ∷ hi ∷ []) native)
+outtys Γ (bytes32-from-low-high _ o)   = just (Γ ◂ (o , bytes32))
+outtys Γ (div-mod-power-of-two _ _ outs) = just (extN Γ outs native)
+outtys Γ (reconstitute-field _ _ _ o)  = just (Γ ◂ (o , native))
+outtys Γ (transient-hash _ o)          = just (Γ ◂ (o , native))
+outtys Γ (persistent-hash _ _ o)       = just (Γ ◂ (o , bytes32))
+outtys Γ (keccak256 _ _ o)             = just (Γ ◂ (o , bytes32))
+outtys Γ (test-eq _ _ o)               = just (Γ ◂ (o , native))
+outtys Γ (add a b o)                   = mapᵐ (λ t → Γ ◂ (o , t)) (same-ty Γ a b)
+outtys Γ (mul a b o)                   = mapᵐ (λ t → Γ ◂ (o , t)) (same-ty Γ a b)
+outtys Γ (neg a o)                     = mapᵐ (λ t → Γ ◂ (o , t)) (optype Γ a)
+outtys Γ (inv a o)                     = mapᵐ (λ t → Γ ◂ (o , t)) (optype Γ a)
+outtys Γ (not _ o)                     = just (Γ ◂ (o , native))
+outtys Γ (less-than _ _ _ o)           = just (Γ ◂ (o , native))
+outtys Γ (jubjub-scalar-from-native _ o) = just (Γ ◂ (o , jubjub-scalar))
+outtys Γ (public-input _ val-t o)      = just (Γ ◂ (o , val-t))
+outtys Γ (private-input _ val-t o)     = just (Γ ◂ (o , val-t))
+outtys Γ (circuit-output _)            = just Γ
+
+------------------------------------------------------------------------
+-- `dom-ty` of an extended context (mirrors `outs-of`).
+------------------------------------------------------------------------
+
+-- Appending one entry appends its key.
+dom-ty-◂ : ∀ Γ o t → dom-ty (Γ ◂ (o , t)) ≡ dom-ty Γ ++ (o ∷ [])
+dom-ty-◂ Γ o t = map-++ proj₁ Γ ((o , t) ∷ [])
+  where open import Data.List.Properties using (map-++)
+
+-- Appending a same-typed list appends the list of keys.
+dom-ty-extN : ∀ Γ ids t → dom-ty (extN Γ ids t) ≡ dom-ty Γ ++ ids
+dom-ty-extN Γ []         t = sym (++-identityʳ (dom-ty Γ))
+dom-ty-extN Γ (o ∷ ids)  t =
+  trans (dom-ty-extN (Γ ◂ (o , t)) ids t)
+    (trans (cong (_++ ids) (dom-ty-◂ Γ o t)) (++-assoc (dom-ty Γ) (o ∷ []) ids))
+
+------------------------------------------------------------------------
+-- Two-output and list `TyEq` extension (native values).
+------------------------------------------------------------------------
+
+-- Not a member of `Γ`'s extended domain: absent from `Γ` and ≠ the new key.
+∉-◂ : ∀ {Γ o t id} → ¬ (id ∈ dom-ty Γ) → ¬ (id ≡ o)
+  → ¬ (id ∈ dom-ty (Γ ◂ (o , t)))
+∉-◂ {Γ} {o} {t} {id} id∉ id≢o id∈
+  with ∈-++⁻ (dom-ty Γ) (subst (id ∈_) (dom-ty-◂ Γ o t) id∈)
+... | inj₁ p = id∉ p
+... | inj₂ q = id≢o (∈-[x] q)
+
+-- Two distinct fresh native outputs.
+tyEq-ins2 : ∀ (m : Mem) (Γ : TyCtx) (i₁ : Identifier) v₁ t₁
+              (i₂ : Identifier) v₂ t₂
+  → typeof v₁ ≡ t₁ → typeof v₂ ≡ t₂
+  → ¬ (i₁ ∈ dom-ty Γ) → ¬ (i₂ ∈ dom-ty Γ) → ¬ (i₂ ≡ i₁)
+  → TyEq m Γ
+  → TyEq (ins i₂ v₂ (ins i₁ v₁ m)) ((Γ ◂ (i₁ , t₁)) ◂ (i₂ , t₂))
+tyEq-ins2 m Γ i₁ v₁ t₁ i₂ v₂ t₂ tv₁ tv₂ i₁∉ i₂∉ i₂≢i₁ teq =
+  tyEq-ins (ins i₁ v₁ m) (Γ ◂ (i₁ , t₁)) i₂ v₂ t₂ tv₂
+    (∉-◂ i₂∉ i₂≢i₁)
+    (tyEq-ins m Γ i₁ v₁ t₁ tv₁ i₁∉ teq)
+
+-- A list of fresh, distinct native outputs (`insertMany`).  Mirrors
+-- `domEq-insertMany`: the context grows by the keys (`extN … native`),
+-- each cell holding a `val-native` (so `typeof ≡ native` by `refl`).
+tyEq-insertManyⁿ : ∀ {Γ} st ids frs {st'}
+  → insertMany st ids (map val-native frs) ≡ just st'
+  → TyEq (State.mem st) Γ
+  → All (λ o → ¬ (o ∈ dom-ty Γ)) ids → NoDup ids
+  → TyEq (State.mem st') (extN Γ ids native)
+tyEq-insertManyⁿ {Γ} st []         []         refl teq _          _ = teq
+tyEq-insertManyⁿ {Γ} st (id ∷ ids) (fr ∷ frs) e    teq (o∉ ∷ afr) (nin , ndup) =
+  tyEq-insertManyⁿ {Γ ◂ (id , native)} (out1 st id (val-native fr)) ids frs e
+    (tyEq-ins (State.mem st) Γ id (val-native fr) native refl o∉ teq)
+    (all-shift ids afr nin) ndup
+  where
+  all-shift : ∀ ids → All (λ o → ¬ (o ∈ dom-ty Γ)) ids → NotIn id ids
+    → All (λ o → ¬ (o ∈ dom-ty (Γ ◂ (id , native)))) ids
+  all-shift []         []          _            = []
+  all-shift (k ∷ ids)  (k∉ ∷ afr') (id≢k , nin') =
+    ∉-◂ k∉ (λ k≡id → id≢k (sym k≡id)) ∷ all-shift ids afr' nin'
+tyEq-insertManyⁿ st []        (_ ∷ _)  () _ _ _
+tyEq-insertManyⁿ st (_ ∷ _)   []       () _ _ _
+
+------------------------------------------------------------------------
+-- Type maintenance across one step.
+--
+-- Inverting `step` per instruction (mirroring `step-dom`), the memory's
+-- typing extends from `Γ` to `Γ'` (the `outtys` result): no-output
+-- instructions leave `Γ` unchanged; each output cell holds a value of the
+-- statically-predicted type.  For fixed-type outputs (`mul`, hashes, the
+-- byte/coordinate splits, …) the value is a literal `val-native`/
+-- `val-bytes32`/… so its `typeof` is `refl`; for the type-directed ones
+-- (`add`/`neg`/`cond-select`/`copy`) the output type is read off the
+-- operands via `tyEq-optype`/`same-ty`.
+------------------------------------------------------------------------
+
+-- A no-output step leaves the typing unchanged.
+tyEq-nop : ∀ {m Γ Γ'} → just Γ ≡ just Γ' → TyEq m Γ → TyEq m Γ'
+tyEq-nop refl teq = teq
+
+step-ty : ∀ {P S st st' Γ Γ'} (i : Instruction)
+  → outtys Γ i ≡ just Γ'
+  → step P S st i ≡ just st'
+  → TyEq (State.mem st) Γ
+  → All (λ o → ¬ (o ∈ dom-ty Γ)) (outs-of i)
+  → NoDup (outs-of i)
+  → TyEq (State.mem st') Γ'
+step-ty {st = st} (assert cond) oty e teq _ _
+  with resolve𝔹 (State.mem st) cond
+... | just true with refl ← e = tyEq-nop oty teq
+step-ty {st = st} (constrain-bits val bits) oty e teq _ _
+  with resolveᶠ (State.mem st) val
+... | just x with valFr x <? 2 ^ bits
+...   | yes _ with refl ← e = tyEq-nop oty teq
+step-ty {st = st} (constrain-eq a b) oty e teq _ _
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just true with refl ← e = tyEq-nop oty teq
+step-ty {st = st} (constrain-to-boolean val) oty e teq _ _
+  with resolve𝔹 (State.mem st) val
+... | just _ with refl ← e = tyEq-nop oty teq
+step-ty {P = P} {st = st} (impact guard inputs) oty e teq _ _
+  with resolve-all-Fr (State.mem st) inputs
+... | just vals with resolve𝔹 (State.mem st) guard
+...   | just g with g
+...     | true
+          with take (length vals)
+                 (drop (State.pti-idx st)
+                   (ProofPreimage.pub-transcript-inputs P))
+               ≟LFr vals
+...       | yes _ with refl ← e = tyEq-nop oty teq
+step-ty {st = st} (impact guard inputs) oty e teq _ _
+  | just vals | just g | false with refl ← e = tyEq-nop oty teq
+step-ty {S = S} {st = st} (circuit-output vals) oty e teq _ _
+  with collectOutputs (State.mem st) (IrSource.outputs S) vals
+... | just vs with refl ← e = tyEq-nop oty teq
+-- `ec-mul`'s output shares the operand point's type (like `add`/`neg`).
+step-ty {st = st} {Γ = Γ} (ec-mul a scalar output) oty e teq (o∉ ∷ _) _
+  with optype Γ a in oat
+... | just t with refl ← oty
+  with resolve (State.mem st) a in ra | resolve (State.mem st) scalar
+...   | just (val-jubjub-point p) | just (val-jubjub-scalar s) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+...   | just (val-secp-point p) | just (val-secp-scalar s) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+-- `ec-mul-generator`'s output is the point type matching the scalar's
+-- curve; the crossed resolution is ruled out by the operand's static type.
+step-ty {st = st} {Γ = Γ} (ec-mul-generator scalar output) oty e teq (o∉ ∷ _) _
+  with resolve (State.mem st) scalar in rs
+... | just (val-jubjub-scalar s) with optype Γ scalar in ost
+...   | just jubjub-scalar with refl ← oty with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ jubjub-point refl o∉ teq
+...   | just secp-scalar =
+          case tyEq-optype {op = scalar} teq ost rs of λ ()
+step-ty {st = st} {Γ = Γ} (ec-mul-generator scalar output) oty e teq (o∉ ∷ _) _
+  | just (val-secp-scalar s) with optype Γ scalar in ost
+...   | just secp-scalar with refl ← oty with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ secp-point refl o∉ teq
+...   | just jubjub-scalar =
+          case tyEq-optype {op = scalar} teq ost rs of λ ()
+step-ty {st = st} (hash-to-curve inputs output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e =
+        tyEq-ins (State.mem st) _ output _ jubjub-point refl o∉ teq
+step-ty {st = st} {Γ = Γ} (from-coordinates (xop , yop) output) oty e teq
+  (o∉ ∷ _) _
+  with resolve (State.mem st) xop in rx | resolve (State.mem st) yop
+... | just (val-native x) | just (val-native y) with fromCoordsJ x y
+...   | just p with optype Γ xop in oxt
+...     | just native with refl ← oty with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ jubjub-point refl o∉ teq
+...     | just secp-base = case tyEq-optype {op = xop} teq oxt rx of λ ()
+step-ty {st = st} {Γ = Γ} (from-coordinates (xop , yop) output) oty e teq
+  (o∉ ∷ _) _
+  | just (val-secp-base x) | just (val-secp-base y) with fromCoordsK x y
+...   | just p with optype Γ xop in oxt
+...     | just secp-base with refl ← oty with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ secp-point refl o∉ teq
+...     | just native = case tyEq-optype {op = xop} teq oxt rx of λ ()
+step-ty {st = st} (into-bytes32 input output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve (State.mem st) input
+... | just (val-native x) with refl ← e =
+        tyEq-ins (State.mem st) _ output _ bytes32 refl o∉ teq
+... | just (val-secp-base x) with refl ← e =
+        tyEq-ins (State.mem st) _ output _ bytes32 refl o∉ teq
+... | just (val-secp-scalar s) with refl ← e =
+        tyEq-ins (State.mem st) _ output _ bytes32 refl o∉ teq
+step-ty {st = st} (bytes32-from-low-high (loop , hiop) output) oty e teq (o∉ ∷ _) _
+  with refl ← oty
+  with resolveᶠ (State.mem st) loop | resolveᶠ (State.mem st) hiop
+... | just lo | just hi with low-high→bytes32 lo hi
+...   | just b with refl ← e =
+        tyEq-ins (State.mem st) _ output _ bytes32 refl o∉ teq
+step-ty {st = st} (reconstitute-field divisor modulus bits output) oty e teq
+  (o∉ ∷ _) _
+  with refl ← oty
+  with resolveᶠ (State.mem st) divisor | resolveᶠ (State.mem st) modulus
+... | just dd | just mo with valFr mo <? 2 ^ bits
+...   | yes _ with valFr dd <? 2 ^ (FR-BITS ∸ bits)
+...     | yes _ with valFr mo + 2 ^ bits * valFr dd <? FR-ORDER
+...       | yes _ with refl ← e =
+            tyEq-ins (State.mem st) _ output _ native refl o∉ teq
+step-ty {st = st} (transient-hash inputs output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e =
+        tyEq-ins (State.mem st) _ output _ native refl o∉ teq
+step-ty {st = st} (test-eq a b output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just eqv with refl ← e =
+        tyEq-ins (State.mem st) _ output _ native refl o∉ teq
+step-ty {st = st} {Γ = Γ} (mul a b output) oty e teq (o∉ ∷ _) _
+  with same-ty Γ a b in sty
+... | just t with refl ← oty
+  with resolve (State.mem st) a in ra | resolve (State.mem st) b in rb
+...   | just (val-native x) | just (val-native y) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra) o∉ teq
+...   | just (val-secp-base x) | just (val-secp-base y) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra) o∉ teq
+...   | just (val-secp-scalar x) | just (val-secp-scalar y) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra) o∉ teq
+step-ty {st = st} {Γ = Γ} (inv a output) oty e teq (o∉ ∷ _) _
+  with resolve (State.mem st) a in ra
+... | just (val-native x) with invᶠ x
+...   | just xi with optype Γ a in oat
+...     | just t with refl ← oty with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+step-ty {st = st} {Γ = Γ} (inv a output) oty e teq (o∉ ∷ _) _
+  | just (val-secp-base x) with invᵇ x
+...   | just xi with optype Γ a in oat
+...     | just t with refl ← oty with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+step-ty {st = st} {Γ = Γ} (inv a output) oty e teq (o∉ ∷ _) _
+  | just (val-secp-scalar x) with invˢ x
+...   | just xi with optype Γ a in oat
+...     | just t with refl ← oty with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+step-ty {st = st} (not a output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve𝔹 (State.mem st) a
+... | just b with refl ← e =
+        tyEq-ins (State.mem st) _ output _ native refl o∉ teq
+step-ty {st = st} (less-than a b bits output) oty e teq (o∉ ∷ _) _
+  with refl ← oty
+  with resolveᶠ (State.mem st) a | resolveᶠ (State.mem st) b
+... | just x | just y with valFr x <? 2 ^ bits
+...   | yes _ with valFr y <? 2 ^ bits
+...     | yes _ with refl ← e =
+          tyEq-ins (State.mem st) _ output _ native refl o∉ teq
+step-ty {st = st} (jubjub-scalar-from-native a output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolveᶠ (State.mem st) a
+... | just x with refl ← e =
+        tyEq-ins (State.mem st) _ output _ jubjub-scalar refl o∉ teq
+step-ty {st = st} (from-bytes32 bytes native output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e =
+        tyEq-ins (State.mem st) _ output _ native refl o∉ teq
+step-ty {st = st} (from-bytes32 bytes secp-base output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e =
+        tyEq-ins (State.mem st) _ output _ secp-base refl o∉ teq
+step-ty {st = st} (from-bytes32 bytes secp-scalar output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e =
+        tyEq-ins (State.mem st) _ output _ secp-scalar refl o∉ teq
+step-ty {st = st} (from-bytes32 bytes secp-point output) oty e teq _ _
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-ty {st = st} (from-bytes32 bytes bytes32 output) oty e teq _ _
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-ty {st = st} (from-bytes32 bytes jubjub-point output) oty e teq _ _
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-ty {st = st} (from-bytes32 bytes jubjub-scalar output) oty e teq _ _
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-ty {st = st} (reverse-bytes bytes output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e =
+        tyEq-ins (State.mem st) _ output _ bytes32 refl o∉ teq
+-- Transcript inputs: the bound value has the declared type `val-t` by
+-- `decode-typeof` (active) or `default-typeof` (inactive).
+step-ty {st = st} (public-input guard val-t output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with eval-guard (State.mem st) guard
+... | just true with decode val-t (take (encoded-len val-t) (State.pto-rem st))
+                     in edec
+...   | just v with refl ← e =
+        tyEq-ins (State.mem st) _ output v val-t
+          (decode-typeof val-t _ edec) o∉ teq
+step-ty {st = st} (public-input guard val-t output) oty e teq (o∉ ∷ _) _
+    | just false with refl ← e =
+        tyEq-ins (State.mem st) _ output _ val-t (default-typeof val-t) o∉ teq
+step-ty {st = st} (private-input guard val-t output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with eval-guard (State.mem st) guard
+... | just true with decode val-t (take (encoded-len val-t) (State.priv-rem st))
+                     in edec
+...   | just v with refl ← e =
+        tyEq-ins (State.mem st) _ output v val-t
+          (decode-typeof val-t _ edec) o∉ teq
+step-ty {st = st} (private-input guard val-t output) oty e teq (o∉ ∷ _) _
+    | just false with refl ← e =
+        tyEq-ins (State.mem st) _ output _ val-t (default-typeof val-t) o∉ teq
+-- Type-directed single outputs: read the output type off the operands.
+step-ty {st = st} {Γ = Γ} (copy val output) oty e teq (o∉ ∷ _) _
+  with optype Γ val in ovt
+... | just t with refl ← oty with resolve (State.mem st) val in rv
+...   | just v with refl ← e =
+        tyEq-ins (State.mem st) Γ output v t
+          (tyEq-optype {op = val} teq ovt rv) o∉ teq
+step-ty {st = st} {Γ = Γ} (add a b output) oty e teq (o∉ ∷ _) _
+  with same-ty Γ a b in sty
+... | just t with refl ← oty
+  with resolve (State.mem st) a in ra | resolve (State.mem st) b in rb
+...   | just (val-native x) | just (val-native y) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra) o∉ teq
+...   | just (val-jubjub-point p) | just (val-jubjub-point q) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra) o∉ teq
+...   | just (val-secp-point p) | just (val-secp-point q) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra) o∉ teq
+...   | just (val-secp-base x) | just (val-secp-base y) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra) o∉ teq
+...   | just (val-secp-scalar x) | just (val-secp-scalar y) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra) o∉ teq
+step-ty {st = st} {Γ = Γ} (neg a output) oty e teq (o∉ ∷ _) _
+  with optype Γ a in oat
+... | just t with refl ← oty with resolve (State.mem st) a in ra
+...   | just (val-native x) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+...   | just (val-jubjub-point p) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+...   | just (val-secp-point p) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+...   | just (val-secp-base x) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+...   | just (val-secp-scalar x) with refl ← e =
+          tyEq-ins (State.mem st) Γ output _ t
+            (tyEq-optype {op = a} teq oat ra) o∉ teq
+step-ty {st = st} {Γ = Γ} (cond-select bit a b output) oty e teq (o∉ ∷ _) _
+  with same-ty Γ a b in sty
+... | just t with refl ← oty with resolve𝔹 (State.mem st) bit
+...   | just bv with resolve (State.mem st) a in ra
+                   | resolve (State.mem st) b in rb
+...     | just av | just bvl with typeof av ≟T typeof bvl
+...       | yes _ with refl ← e =
+            tyEq-ins (State.mem st) Γ output _ t (tyof-if bv) o∉ teq
+  where
+  -- The selected value has type `t` whichever branch is taken (both `a`
+  -- and `b` share the type `t`).
+  tyof-if : ∀ bv → typeof (if bv then av else bvl) ≡ t
+  tyof-if true  = tyEq-optype {op = a} teq (same-ty-l {Γ} {a} {b} sty) ra
+  tyof-if false = tyEq-optype {op = b} teq (same-ty-r {Γ} {a} {b} sty) rb
+-- Two distinct outputs whose type is fixed by the point operand's curve.
+step-ty {st = st} {Γ = Γ} (into-coordinates point (xid , yid)) oty e teq
+  (x∉ ∷ y∉ ∷ []) ((x≢y , _) , _)
+  with resolve (State.mem st) point in rp
+... | just (val-jubjub-point p) with coordsJ p
+...   | (x , y) with optype Γ point in opt
+...     | just jubjub-point with refl ← oty with refl ← e =
+          tyEq-ins2 (State.mem st) Γ xid (val-native x) native
+            yid (val-native y) native refl refl x∉ y∉
+            (λ y≡x → x≢y (sym y≡x)) teq
+...     | just secp-point = case tyEq-optype {op = point} teq opt rp of λ ()
+step-ty {st = st} {Γ = Γ} (into-coordinates point (xid , yid)) oty e teq
+  (x∉ ∷ y∉ ∷ []) ((x≢y , _) , _)
+  | just (val-secp-point p) with coordsK p
+...   | just (x , y) with optype Γ point in opt
+...     | just secp-point with refl ← oty with refl ← e =
+          tyEq-ins2 (State.mem st) Γ xid (val-secp-base x) secp-base
+            yid (val-secp-base y) secp-base refl refl x∉ y∉
+            (λ y≡x → x≢y (sym y≡x)) teq
+...     | just jubjub-point = case tyEq-optype {op = point} teq opt rp of λ ()
+step-ty {st = st} (bytes32-into-low-high bytes (loid , hiid)) oty e teq
+  (l∉ ∷ h∉ ∷ []) ((l≢h , _) , _)
+  with refl ← oty with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with bytes32→low-high b
+...   | (lo , hi) with refl ← e =
+          tyEq-ins2 (State.mem st) _ loid (val-native lo) native
+            hiid (val-native hi) native refl refl l∉ h∉
+            (λ h≡l → l≢h (sym h≡l)) teq
+-- List native outputs (`insertMany`).
+step-ty {st = st} (encode input outputs) oty e teq af nd
+  with refl ← oty with resolve (State.mem st) input
+... | just v =
+      tyEq-insertManyⁿ st outputs (encodeᵉ v) e teq af nd
+step-ty {st = st} (div-mod-power-of-two val bits outs) oty e teq af nd
+  with refl ← oty with resolveᶠ (State.mem st) val
+... | just x =
+      tyEq-insertManyⁿ st outs
+        ( from-le-bits (drop bits (to-le-bits x))
+        ∷ from-le-bits (take bits (to-le-bits x)) ∷ [])
+        e teq af nd
+step-ty {st = st} (persistent-hash alignment inputs output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve-all-Fr (State.mem st) inputs
+... | just frs with persistent-hash-fn alignment frs
+...   | just h with refl ← e =
+        tyEq-ins (State.mem st) _ output _ bytes32 refl o∉ teq
+step-ty {st = st} (keccak256 alignment inputs output) oty e teq (o∉ ∷ _) _
+  with refl ← oty with resolve-all-Fr (State.mem st) inputs
+... | just frs with keccak-fn alignment frs
+...   | just h with refl ← e =
+        tyEq-ins (State.mem st) _ output _ bytes32 refl o∉ teq
+
+------------------------------------------------------------------------
+-- `outtys` grows the typed domain by exactly `outs-of i`.
+--
+-- So the single-assignment freshness (`¬∈ bound`, over the SA name set)
+-- and the typing freshness (`¬∈ dom-ty Γ`) stay in lock-step: whenever
+-- `dom-ty Γ ≡ bound`, the successor context's domain is `bound ++
+-- outs-of i` — exactly the SA scan's next bound.
+------------------------------------------------------------------------
+
+outtys-dom : ∀ Γ (i : Instruction) {Γ'}
+  → outtys Γ i ≡ just Γ'
+  → dom-ty Γ' ≡ dom-ty Γ ++ outs-of i
+outtys-dom Γ (encode input outputs)  refl = dom-ty-extN Γ outputs native
+outtys-dom Γ (assert _)              refl = sym (++-identityʳ (dom-ty Γ))
+outtys-dom Γ (cond-select bit a b o) oty with same-ty Γ a b
+... | just t with refl ← oty = dom-ty-◂ Γ o t
+outtys-dom Γ (constrain-bits _ _)    refl = sym (++-identityʳ (dom-ty Γ))
+outtys-dom Γ (constrain-eq _ _)      refl = sym (++-identityʳ (dom-ty Γ))
+outtys-dom Γ (constrain-to-boolean _) refl = sym (++-identityʳ (dom-ty Γ))
+outtys-dom Γ (copy val o)            oty with optype Γ val
+... | just t with refl ← oty = dom-ty-◂ Γ o t
+outtys-dom Γ (impact _ _)            refl = sym (++-identityʳ (dom-ty Γ))
+outtys-dom Γ (ec-mul a _ o)          oty with optype Γ a
+... | just t with refl ← oty = dom-ty-◂ Γ o t
+outtys-dom Γ (ec-mul-generator scalar o) oty with optype Γ scalar
+... | just jubjub-scalar with refl ← oty = dom-ty-◂ Γ o jubjub-point
+... | just secp-scalar   with refl ← oty = dom-ty-◂ Γ o secp-point
+... | just native        = case oty of λ ()
+... | just bytes32       = case oty of λ ()
+... | just jubjub-point  = case oty of λ ()
+... | just secp-point    = case oty of λ ()
+... | just secp-base     = case oty of λ ()
+... | nothing            = case oty of λ ()
+outtys-dom Γ (hash-to-curve _ o)     refl = dom-ty-◂ Γ o jubjub-point
+outtys-dom Γ (into-coordinates point (xo , yo)) oty with optype Γ point
+... | just jubjub-point with refl ← oty = dom-ty-extN Γ (xo ∷ yo ∷ []) native
+... | just secp-point with refl ← oty = dom-ty-extN Γ (xo ∷ yo ∷ []) secp-base
+... | just native        = case oty of λ ()
+... | just bytes32       = case oty of λ ()
+... | just jubjub-scalar = case oty of λ ()
+... | just secp-base     = case oty of λ ()
+... | just secp-scalar   = case oty of λ ()
+... | nothing            = case oty of λ ()
+outtys-dom Γ (from-coordinates (xop , yop) o) oty with optype Γ xop
+... | just native    with refl ← oty = dom-ty-◂ Γ o jubjub-point
+... | just secp-base with refl ← oty = dom-ty-◂ Γ o secp-point
+... | just bytes32       = case oty of λ ()
+... | just jubjub-point  = case oty of λ ()
+... | just jubjub-scalar = case oty of λ ()
+... | just secp-point    = case oty of λ ()
+... | just secp-scalar   = case oty of λ ()
+... | nothing            = case oty of λ ()
+outtys-dom Γ (into-bytes32 _ o)      refl = dom-ty-◂ Γ o bytes32
+outtys-dom Γ (from-bytes32 _ vt o)   refl = dom-ty-◂ Γ o vt
+outtys-dom Γ (reverse-bytes _ o)     refl = dom-ty-◂ Γ o bytes32
+outtys-dom Γ (bytes32-into-low-high _ (lo , hi)) refl =
+  dom-ty-extN Γ (lo ∷ hi ∷ []) native
+outtys-dom Γ (bytes32-from-low-high _ o) refl = dom-ty-◂ Γ o bytes32
+outtys-dom Γ (div-mod-power-of-two _ _ outs) refl = dom-ty-extN Γ outs native
+outtys-dom Γ (reconstitute-field _ _ _ o) refl = dom-ty-◂ Γ o native
+outtys-dom Γ (transient-hash _ o)    refl = dom-ty-◂ Γ o native
+outtys-dom Γ (persistent-hash _ _ o) refl = dom-ty-◂ Γ o bytes32
+outtys-dom Γ (keccak256 _ _ o)       refl = dom-ty-◂ Γ o bytes32
+outtys-dom Γ (test-eq _ _ o)         refl = dom-ty-◂ Γ o native
+outtys-dom Γ (add a b o)             oty with same-ty Γ a b
+... | just t with refl ← oty = dom-ty-◂ Γ o t
+outtys-dom Γ (mul a b o)             oty with same-ty Γ a b
+... | just t with refl ← oty = dom-ty-◂ Γ o t
+outtys-dom Γ (neg a o)               oty with optype Γ a
+... | just t with refl ← oty = dom-ty-◂ Γ o t
+outtys-dom Γ (inv a o)               oty with optype Γ a
+... | just t with refl ← oty = dom-ty-◂ Γ o t
+outtys-dom Γ (not _ o)               refl = dom-ty-◂ Γ o native
+outtys-dom Γ (less-than _ _ _ o)     refl = dom-ty-◂ Γ o native
+outtys-dom Γ (jubjub-scalar-from-native _ o) refl = dom-ty-◂ Γ o jubjub-scalar
+outtys-dom Γ (public-input _ vt o)   refl = dom-ty-◂ Γ o vt
+outtys-dom Γ (private-input _ vt o)  refl = dom-ty-◂ Γ o vt
+outtys-dom Γ (circuit-output _)      refl = sym (++-identityʳ (dom-ty Γ))
+
+------------------------------------------------------------------------
+-- Operand typing precondition.
+--
+-- `outtys` fixes each instruction's OUTPUT types but, for the fixed-type
+-- instructions, does not constrain the operands.  `OpTy Γ i` records the
+-- operand types the off-circuit `step` and the backward lemma of `i`
+-- demand: which operands must be Native, which carry a specific type,
+-- and — for `add`/`neg` — that the shared operand type is a field or a
+-- point, or — for `constrain-eq` — that the compared operand's type
+-- supports the reflexive equality test (Native / Bytes32 / JubjubPoint,
+-- never JubjubScalar).  Bundled with `WT`, it makes `producer-WT`
+-- guarantee every operand reference is bound to a value of the required
+-- type — the fact the backward driver needs to resolve each operand at
+-- the pre-step memory.
+------------------------------------------------------------------------
+
+-- An operand carries type `t` under `Γ`.
+Opᵗ : TyCtx → Operand → IrType → Set
+Opᵗ Γ op t = optype Γ op ≡ just t
+
+-- An operand is typed (bound) under `Γ`.
+OpDefd : TyCtx → Operand → Set
+OpDefd Γ op = ∃ λ t → optype Γ op ≡ just t
+
+-- Every operand of a list is Native.
+AllNatᵒ : TyCtx → List Operand → Set
+AllNatᵒ Γ = All (λ op → Opᵗ Γ op native)
+
+-- Every operand of a list is defined (typed at some type).  Used for
+-- `circuit-output`, whose operands carry no other constraint but must be
+-- bound so the off-circuit `collectOutputs` resolves them.
+AllDefdᵒ : TyCtx → List Operand → Set
+AllDefdᵒ Γ = All (OpDefd Γ)
+
+-- An all-Native operand list resolves to a field-element list.
+allNat-resolve : ∀ {m Γ} ops → TyEq m Γ → AllNatᵒ Γ ops
+  → ∃ λ frs → resolve-all-Fr m ops ≡ just frs
+allNat-resolve []         teq []         = [] , refl
+allNat-resolve {m} (op ∷ ops) teq (oN ∷ aN)
+  with optype-resolveᶠ {op = op} teq oN | allNat-resolve ops teq aN
+... | (x , rx) | (frs , rfrs) = x ∷ frs , cons
+  where
+  cons : resolve-all-Fr m (op ∷ ops) ≡ just (x ∷ frs)
+  cons rewrite rx | rfrs = refl
+
+-- An optional guard, if present, is Native.
+GuardNat : TyCtx → Maybe Operand → Set
+GuardNat Γ nothing   = ⊤
+GuardNat Γ (just op) = Opᵗ Γ op native
+
+OpTy : TyCtx → Instruction → Set
+OpTy Γ (encode input _)              = OpDefd Γ input
+OpTy Γ (assert cond)                 = Opᵗ Γ cond native
+OpTy Γ (cond-select bit _ _ _)       = Opᵗ Γ bit native
+OpTy Γ (constrain-bits val _)        = Opᵗ Γ val native
+OpTy Γ (constrain-eq a b)            =
+  (∃ λ t → Opᵗ Γ a t × SuppEq t) × OpDefd Γ b
+OpTy Γ (constrain-to-boolean val)    = Opᵗ Γ val native
+OpTy Γ (copy val _)                  = OpDefd Γ val
+OpTy Γ (impact guard inputs)         = Opᵗ Γ guard native × AllNatᵒ Γ inputs
+OpTy Γ (ec-mul a scalar _)           =
+    (Opᵗ Γ a jubjub-point × Opᵗ Γ scalar jubjub-scalar)
+  ⊎ (Opᵗ Γ a secp-point × Opᵗ Γ scalar secp-scalar)
+OpTy Γ (ec-mul-generator scalar _)   =
+  Opᵗ Γ scalar jubjub-scalar ⊎ Opᵗ Γ scalar secp-scalar
+OpTy Γ (hash-to-curve inputs _)      = AllNatᵒ Γ inputs
+OpTy Γ (into-coordinates point _)    =
+  Opᵗ Γ point jubjub-point ⊎ Opᵗ Γ point secp-point
+OpTy Γ (from-coordinates (x , y) _)  =
+    (Opᵗ Γ x native × Opᵗ Γ y native)
+  ⊎ (Opᵗ Γ x secp-base × Opᵗ Γ y secp-base)
+OpTy Γ (into-bytes32 input _)        = ∃ λ t → Opᵗ Γ input t × FM t
+OpTy Γ (from-bytes32 bytes _ _)      = Opᵗ Γ bytes bytes32
+OpTy Γ (reverse-bytes bytes _)       = Opᵗ Γ bytes bytes32
+OpTy Γ (bytes32-into-low-high b _)   = Opᵗ Γ b bytes32
+OpTy Γ (bytes32-from-low-high (lo , hi) _) =
+  Opᵗ Γ lo native × Opᵗ Γ hi native
+OpTy Γ (div-mod-power-of-two val _ _) = Opᵗ Γ val native
+OpTy Γ (reconstitute-field d m _ _)  = Opᵗ Γ d native × Opᵗ Γ m native
+OpTy Γ (transient-hash inputs _)     = AllNatᵒ Γ inputs
+OpTy Γ (persistent-hash _ inputs _)  = AllNatᵒ Γ inputs
+OpTy Γ (keccak256 _ inputs _)        = AllNatᵒ Γ inputs
+OpTy Γ (test-eq a b _)               = OpDefd Γ a × OpDefd Γ b
+OpTy Γ (add a b _)                   =
+  ∃ λ t → Opᵗ Γ a t × Opᵗ Γ b t × FN t
+OpTy Γ (mul a b _)                   =
+  ∃ λ t → Opᵗ Γ a t × Opᵗ Γ b t × FM t
+OpTy Γ (neg a _)                     = ∃ λ t → Opᵗ Γ a t × FN t
+OpTy Γ (inv a _)                     = ∃ λ t → Opᵗ Γ a t × FM t
+OpTy Γ (not a _)                     = Opᵗ Γ a native
+OpTy Γ (less-than a b _ _)           = Opᵗ Γ a native × Opᵗ Γ b native
+OpTy Γ (jubjub-scalar-from-native a _) = Opᵗ Γ a native
+OpTy Γ (public-input guard _ _)      = GuardNat Γ guard
+OpTy Γ (private-input guard _ _)     = GuardNat Γ guard
+OpTy Γ (circuit-output vals)         = AllDefdᵒ Γ vals
+
+------------------------------------------------------------------------
+-- `OpTy` is decidable (a runnable operand-typing check).
+------------------------------------------------------------------------
+
+opᵗ? : ∀ Γ op t → Dec (Opᵗ Γ op t)
+opᵗ? Γ op t = ≡-dec _≟T_ (optype Γ op) (just t)
+
+opDefd? : ∀ Γ op → Dec (OpDefd Γ op)
+opDefd? Γ op with optype Γ op
+... | just t  = yes (t , refl)
+... | nothing = no λ { (_ , ()) }
+
+allNatᵒ? : ∀ Γ ops → Dec (AllNatᵒ Γ ops)
+allNatᵒ? Γ = all? (λ op → opᵗ? Γ op native)
+
+allDefdᵒ? : ∀ Γ ops → Dec (AllDefdᵒ Γ ops)
+allDefdᵒ? Γ = all? (opDefd? Γ)
+
+FN? : ∀ t → Dec (FN t)
+FN? t = (t ≟T native) ⊎-dec ((t ≟T jubjub-point) ⊎-dec ((t ≟T secp-point)
+      ⊎-dec ((t ≟T secp-base) ⊎-dec (t ≟T secp-scalar))))
+
+FM? : ∀ t → Dec (FM t)
+FM? t = (t ≟T native) ⊎-dec ((t ≟T secp-base) ⊎-dec (t ≟T secp-scalar))
+
+SuppEq? : ∀ t → Dec (SuppEq t)
+SuppEq? t = (t ≟T native) ⊎-dec ((t ≟T bytes32) ⊎-dec ((t ≟T jubjub-point)
+        ⊎-dec ((t ≟T secp-point) ⊎-dec ((t ≟T secp-base)
+        ⊎-dec (t ≟T secp-scalar)))))
+
+guardNat? : ∀ Γ g → Dec (GuardNat Γ g)
+guardNat? Γ nothing   = yes tt
+guardNat? Γ (just op) = opᵗ? Γ op native
+
+-- Single-operand refinement (`neg`, `inv`, `constrain-eq`, `into-bytes32`):
+-- an operand carrying a type in a decidable predicate.
+opp? : ∀ {P : IrType → Set} → (∀ t → Dec (P t)) → ∀ Γ a
+  → Dec (∃ λ t → Opᵗ Γ a t × P t)
+opp? P? Γ a with optype Γ a
+... | just t  = map′ (λ p → t , refl , p) (λ { (_ , refl , p) → p }) (P? t)
+... | nothing = no λ { (_ , () , _) }
+
+-- Two-operand refinement (`add`, `mul`): both operands share a type in a
+-- decidable predicate.
+opp2? : ∀ {P : IrType → Set} → (∀ t → Dec (P t)) → ∀ Γ a b
+  → Dec (∃ λ t → Opᵗ Γ a t × Opᵗ Γ b t × P t)
+opp2? P? Γ a b with optype Γ a | optype Γ b
+... | nothing | _       = no λ { (_ , () , _ , _) }
+... | just _  | nothing = no λ { (_ , _ , () , _) }
+... | just ta | just tb with ta ≟T tb
+...   | no ta≢tb = no λ { (_ , refl , e2 , _) → ta≢tb (sym (just-injective e2)) }
+...   | yes refl = map′ (λ p → ta , refl , refl , p)
+                        (λ { (_ , refl , refl , p) → p }) (P? ta)
+
+OpTy? : ∀ Γ i → Dec (OpTy Γ i)
+OpTy? Γ (encode input _)              = opDefd? Γ input
+OpTy? Γ (assert cond)                 = opᵗ? Γ cond native
+OpTy? Γ (cond-select bit _ _ _)       = opᵗ? Γ bit native
+OpTy? Γ (constrain-bits val _)        = opᵗ? Γ val native
+OpTy? Γ (constrain-eq a b)            = opp? SuppEq? Γ a ×-dec opDefd? Γ b
+OpTy? Γ (constrain-to-boolean val)    = opᵗ? Γ val native
+OpTy? Γ (copy val _)                  = opDefd? Γ val
+OpTy? Γ (impact guard inputs)         =
+  opᵗ? Γ guard native ×-dec allNatᵒ? Γ inputs
+OpTy? Γ (ec-mul a scalar _)           =
+      (opᵗ? Γ a jubjub-point ×-dec opᵗ? Γ scalar jubjub-scalar)
+  ⊎-dec (opᵗ? Γ a secp-point ×-dec opᵗ? Γ scalar secp-scalar)
+OpTy? Γ (ec-mul-generator scalar _)   =
+  opᵗ? Γ scalar jubjub-scalar ⊎-dec opᵗ? Γ scalar secp-scalar
+OpTy? Γ (hash-to-curve inputs _)      = allNatᵒ? Γ inputs
+OpTy? Γ (into-coordinates point _)    =
+  opᵗ? Γ point jubjub-point ⊎-dec opᵗ? Γ point secp-point
+OpTy? Γ (from-coordinates (x , y) _)  =
+      (opᵗ? Γ x native ×-dec opᵗ? Γ y native)
+  ⊎-dec (opᵗ? Γ x secp-base ×-dec opᵗ? Γ y secp-base)
+OpTy? Γ (into-bytes32 input _)        = opp? FM? Γ input
+OpTy? Γ (from-bytes32 bytes _ _)      = opᵗ? Γ bytes bytes32
+OpTy? Γ (reverse-bytes bytes _)       = opᵗ? Γ bytes bytes32
+OpTy? Γ (bytes32-into-low-high b _)   = opᵗ? Γ b bytes32
+OpTy? Γ (bytes32-from-low-high (lo , hi) _) =
+  opᵗ? Γ lo native ×-dec opᵗ? Γ hi native
+OpTy? Γ (div-mod-power-of-two val _ _) = opᵗ? Γ val native
+OpTy? Γ (reconstitute-field d m _ _)  = opᵗ? Γ d native ×-dec opᵗ? Γ m native
+OpTy? Γ (transient-hash inputs _)     = allNatᵒ? Γ inputs
+OpTy? Γ (persistent-hash _ inputs _)  = allNatᵒ? Γ inputs
+OpTy? Γ (keccak256 _ inputs _)        = allNatᵒ? Γ inputs
+OpTy? Γ (test-eq a b _)               = opDefd? Γ a ×-dec opDefd? Γ b
+OpTy? Γ (add a b _)                   = opp2? FN? Γ a b
+OpTy? Γ (mul a b _)                   = opp2? FM? Γ a b
+OpTy? Γ (neg a _)                     = opp? FN? Γ a
+OpTy? Γ (inv a _)                     = opp? FM? Γ a
+OpTy? Γ (not a _)                     = opᵗ? Γ a native
+OpTy? Γ (less-than a b _ _)           = opᵗ? Γ a native ×-dec opᵗ? Γ b native
+OpTy? Γ (jubjub-scalar-from-native a _) = opᵗ? Γ a native
+OpTy? Γ (public-input guard _ _)      = guardNat? Γ guard
+OpTy? Γ (private-input guard _ _)     = guardNat? Γ guard
+OpTy? Γ (circuit-output vals)         = allDefdᵒ? Γ vals
+
+------------------------------------------------------------------------
+-- The static well-typedness predicate and its soundness.
+--
+-- `WT Γ is` threads `outtys` through the instruction list: each
+-- instruction is well-typed at the current context (its outputs typed by
+-- `outtys`, its operands typed by `OpTy`), yielding the next context.
+-- `producer-WT` adds it to `producer-SA` (which already gives freshness
+-- and input-name distinctness).  Its soundness is consumed per-step by
+-- the backward driver (`bwd-go`) and the build fold, via `step-ty`.
+------------------------------------------------------------------------
+
+WT : TyCtx → List Instruction → Set
+WT Γ []       = ⊤
+WT Γ (i ∷ is) = ∃ λ Γ' → outtys Γ i ≡ just Γ' × OpTy Γ i × WT Γ' is
+
+producer-WT : IrSource → Set
+producer-WT S = producer-SA S
+              × WT (input-ctx (IrSource.inputs S)) (IrSource.instructions S)
+
+-- Freshness transport: an `SA`-fresh output list (over `bound`) is fresh
+-- over `dom-ty Γ` when the two coincide.
+all∉-cast : ∀ {Γ bound} ids → dom-ty Γ ≡ bound
+  → All (λ o → ¬ (o ∈ bound)) ids → All (λ o → ¬ (o ∈ dom-ty Γ)) ids
+all∉-cast ids refl af = af
+
+-- The typed domain of the input context is the SA input-name set.
+dom-ty-input-ctx : ∀ tis
+  → dom-ty (input-ctx tis) ≡ map TypedIdentifier.name tis
+dom-ty-input-ctx []         = refl
+dom-ty-input-ctx (ti ∷ tis) = cong (TypedIdentifier.name ti ∷_)
+                                (dom-ty-input-ctx tis)
+
+------------------------------------------------------------------------
+-- `producer-WT` is decidable: a runnable static well-typedness check.
+------------------------------------------------------------------------
+
+WT? : (Γ : TyCtx) (is : List Instruction) → Dec (WT Γ is)
+WT? Γ []       = yes tt
+WT? Γ (i ∷ is) with outtys Γ i in oty
+... | nothing = no λ { (_ , () , _ , _) }
+... | just Γ' =
+      map′ (λ { (op , wt) → Γ' , refl , op , wt })
+           (λ { (_ , refl , op , wt) → op , wt })
+           (OpTy? Γ i ×-dec WT? Γ' is)
+
+producer-WT? : (S : IrSource) → Dec (producer-WT S)
+producer-WT? S =
+      producer-SA? S
+  ×-dec WT? (input-ctx (IrSource.inputs S)) (IrSource.instructions S)
+
+
+
+

--- a/formal/src/zkir-v3/README.md
+++ b/formal/src/zkir-v3/README.md
@@ -1,0 +1,181 @@
+# ZKIR v3 — Agda formalization
+
+This directory contains the Agda mechanization of **ZKIR major version 3**,
+tracking the Rust `zkir-v3` crate in `midnight-ledger` (pinned at commit
+`a1d1611c`, `midnight-zkir-v3 3.0.0-rc.2`; byte-identical to the earlier
+pin `b17df9d1`). It covers the **full
+seven-type surface** — Native, Bytes32, Jubjub point/scalar, and the
+Secp256k1 point/base/scalar triple — with all 34 instructions over those
+types.
+
+Companion documents: the textual spec
+[`docs/zkir-v3-spec.md`](../../docs/zkir-v3-spec.md) and the
+implementer-facing divergence review
+[`docs/zkir-v3-divergence-review.md`](../../docs/zkir-v3-divergence-review.md).
+The ultimate source of truth is the Rust implementation.
+
+## Headline results
+
+The development relates the off-circuit interpreter (`preprocess`, a
+deterministic function) to the synthesized constraint system (`synth`) at
+two levels. All results are `--safe` with **no `postulate`s**; the trust
+base is the [`Assumptions`](Assumptions.agda) record, threaded through
+every module as a parameter.
+
+**Canonical-witness faithfulness** (`circuit-faithful` in
+[`CircuitProof.agda`](CircuitProof.agda)) — the v3 analogue of v2's P5.
+For a well-typed producer, given the run-shape data (`BwdWalk` spine and
+terminal `Consumed` facts — the analogue of v2's `preprocess-shaped`):
+
+```
+preprocess S P ≡ just s  ⇔  satisfies (synth S) (witness-of P s)
+```
+
+The shape data is projected from a successful run by
+`preprocess→BwdWalk` (the v2 `R⇒preprocess-shaped` analogue): 34
+per-instruction step inversions (`step→bwd`) folded by `run→BwdWalk`,
+so a caller holding a run needs no hand-built spine.
+
+**Statement soundness, pis-form** (`statement-sound` in
+[`StatementSoundness.agda`](StatementSoundness.agda)). From an *arbitrary*
+satisfying witness `w` of shape `WShape S w`, a preimage and run are
+constructed whose canonical witness agrees with `w` on the public inputs,
+whose memory is a sub-assignment of `w` (exact agreement on the run's
+domain), and — under the commitment flag — whose commitment randomness
+matches `w`'s:
+
+```
+producer-WT S → satisfies (synth S) w → WShape S w → SubRealizer S w
+```
+
+where a `SubRealizer S w` bundles a preimage `P'` and a final state `s`
+with `run-shaped S P' s` and outright `preprocess S P' ≡ just s`,
+`pis (witness-of P' s) ≡ pis w`, `mem s ⊑ᵂ w`, the
+commitment-randomness agreement under the flag, and a `CommWF`
+component (`do-comm S ≡ false → comm-commitment P' ≡ nothing`, excluding
+vestigial commitment pairs when the flag is off).
+
+An exact-equality extraction form (`witness-of P' s ≡ w`) is **false** for
+v3: the Rust deliberately leaves transcript-input cells and their guards
+unconstrained in-circuit, so `w` is free off the run's domain. The `⊑ᵂ`
+component is the honest strengthening available.
+
+**Extraction uniqueness** (`statement-unique` and
+`statement-sound-unique` in
+[`StatementUniqueness.agda`](StatementUniqueness.agda)). Any two
+sub-realizers of the same witness have equal preimages and equal states,
+and combined with `statement-sound`: **exactly one** `SubRealizer` per
+satisfying `WShape` witness — the extractor is a function of the witness.
+
+**Extractor completeness** (`extractor-complete` in
+[`StatementSoundness.agda`](StatementSoundness.agda)). The extracted
+preimage actually proves: the canonical witness of a `SubRealizer`'s
+preimage/state pair itself satisfies the synthesized circuit
+(`forward-sa` through the realizer's `preproc-ok` field).
+
+**`WShape` non-vacuity** (`preprocess→WShape` in
+[`StatementSoundness.agda`](StatementSoundness.agda)). The canonical
+witness of every successful run is in the extraction class: each
+`WSteps` conjunct is forced by its step's success (via the `step→bwd`
+inversions), so `statement-sound` applies to every honestly-provable
+statement.
+
+Four producer checks are decidable and runnable: `producer-SA?`
+(single-assignment well-formedness, [`Obligations.agda`](Obligations.agda)),
+`producer-WT?` (adds the value-typing pass), `producer-WF2?` (the spec §5.3
+bit-count bounds, which the Rust preprocess checks dynamically but the
+mechanized `step` deliberately omits), and `WShape?` (witness shape,
+[`StatementSoundness.agda`](StatementSoundness.agda)). The WF2 transfer
+is itself a theorem (`preprocessʳ-agree`, Obligations): the Rust-faithful
+`preprocessʳ`, whose step re-checks the bounds, agrees with `preprocess`
+on every WF2-conforming source.
+
+## Modules
+
+Import [`Main.agda`](Main.agda) to type-check the entire development. The
+dependency chain:
+
+```
+Assumptions → Types → Encoding → Syntax → Semantics → SemanticsProperties
+  → Circuit → CircuitBridge → CircuitFaithfulness → CircuitBackward
+  → Obligations → CircuitProof → StatementSoundness
+  → StatementUniqueness → Main
+```
+
+| Module | Contents |
+| --- | --- |
+| [`Assumptions.agda`](Assumptions.agda) | The trust base: carriers (`Fr`, `Alignment`, `JubjubPoint`, `JubjubScalar`, `SecpPoint`, `SecpBase`, `SecpScalar`; concrete `Byte`/`Bytes32`), field/curve/byte/hash/commitment operations (incl. the Secp256k1 foreign-field and foreign-ECC chip contracts), the non-triviality law `1ᶠ≢0ᶠ`, the typed-encoding round-trip laws (Group C), and the derived valuation `valFr`. |
+| [`Types.agda`](Types.agda) | `IrType` (7 constructors), `IrValue`, `encoded-len`, `typeof`, decidable type equality — mirrors `ir_types.rs`. |
+| [`Encoding.agda`](Encoding.agda) | `encode`/`decode` between `IrValue` and `List Fr`, derived from the per-type trust-base primitives. |
+| [`Syntax.agda`](Syntax.agda) | `Identifier`, `Operand`, the 34-variant `Instruction`, `IrSource` — mirrors `ir.rs`. |
+| [`Semantics.agda`](Semantics.agda) | The off-circuit interpreter: `step`/`run`/`init`/`preprocess` over the typed named-register state; `ProofPreimage`. |
+| [`SemanticsProperties.agda`](SemanticsProperties.agda) | Circuit-free consequences: store orders `_⊑_`/`_≼_`, freshness and domain lemmas, run inversion/extension, `Consumed`/`run-shaped`, and the `preprocess` inversions. |
+| [`Circuit.agda`](Circuit.agda) | The constraint vocabulary and its semantics (`holds`), witness model (`CircuitWitness`), `satisfies`, and the total synthesis function `synth`. Chips are modeled at contract level (spec §7.0). |
+| [`CircuitBridge.agda`](CircuitBridge.agda) | The witness/constraint bridge shared by both proof directions: `witness-of`, resolution transports, constraint monotonicity (`holds-mono`) and lowering (`Defd`/`holds-lower`), and the constraint-extraction family (`csOf`). |
+| [`CircuitFaithfulness.agda`](CircuitFaithfulness.agda) | The forward direction: per-instruction `*-fwd` lemmas and the program-level induction `forward`. |
+| [`CircuitBackward.agda`](CircuitBackward.agda) | The backward per-instruction layer: 39 `*-bwd` step-reconstruction lemmas (`from-bytes32` contributes three). Independent of the forward module. |
+| [`Obligations.agda`](Obligations.agda) | Static producer checks, circuit-free: the single-assignment scan (`producer-SA`/`producer-SA?`), the value-typing pass (`producer-WT`/`producer-WT?`), the WF2 bit-bound check (`producer-WF2`/`producer-WF2?`), and the Rust-faithful semantics with its transfer theorem (`stepʳ`/`preprocessʳ`/`preprocessʳ-agree`). |
+| [`CircuitProof.agda`](CircuitProof.agda) | Program-level assembly: the backward spine (`BwdWalk`) and fold (`bwd-go`), the run→spine projection (`step→bwd`/`run→BwdWalk`/`preprocess→BwdWalk`), `backward`, `forward-sa`, and the headline `circuit-faithful`. |
+| [`StatementSoundness.agda`](StatementSoundness.agda) | Pis-form statement soundness: the witness-shape predicate `WShape`/`WShape?`, the w-only preimage pre-passes, the 34-clause `build` run-realizer, the `CommWF`/`SubRealizer` conclusion record, `statement-sound`, `extractor-complete`, and the `WShape` non-vacuity `preprocess→WShape`. |
+| [`StatementUniqueness.agda`](StatementUniqueness.agda) | Extraction uniqueness: the transcript-pinning walk, `statement-unique`, `statement-sound-unique`. |
+| [`Main.agda`](Main.agda) | Aggregator; type-checking it verifies the whole development. |
+
+## Trust base and modeling level
+
+The mechanization is parametric in the cryptography: the `Assumptions`
+record collects the carriers and the functional contracts of the
+`midnight-circuits` chips. Chips — including the range/decomposition
+family (`div-mod`, `less-than`, `in-range`, `reconstitute`) — are modeled
+at **contract level**: each constraint's `holds` clause states the
+canonical semantic answer and trusts the chip that implements it (see the
+decision record in spec §7.0). Faithfulness therefore catches
+orchestration errors and off-/in-circuit divergences, but is sound only
+insofar as `midnight-circuits` is. The Jubjub `from-coordinates`
+subgroup contract was verified faithful against the chip source (the
+chip enforces membership by in-circuit cofactor-clearing; see the note
+in [`Assumptions.agda`](Assumptions.agda)). The `less-than` contract
+states the chip's evened operand bound (`max(bits + bits%2, 4)` —
+`even4` in [`Circuit.agda`](Circuit.agda)), matching the deployed
+circuit; the exact `2^bits` bound the off-circuit run checks is carried
+as a `WShape` conjunct and `BwdStep` side data instead — see spec §9
+("Contract strength"). The Secp256k1 limb *decoders* are modeled as the
+canonical partial inverses, which is stricter than the deployed
+off-circuit `from_public_input` (audited 2026-07-24: it silently reduces
+non-canonical encodings) — theorems transfer to the deployed decoder on
+canonically-encoded data; see spec §9 ("Secp256k1 decode canonicity")
+and the TRUST NOTE in [`Assumptions.agda`](Assumptions.agda).
+
+## Type-checking
+
+See [`../README.md`](../README.md) for the toolchain; checking
+[`Main.agda`](Main.agda) verifies the entire `--safe` development:
+
+```sh
+agda --safe -i src src/zkir-v3/Main.agda
+```
+
+A cold check takes a few minutes (CircuitFaithfulness and
+StatementSoundness dominate).
+
+## Proof idioms / gotchas (learned the hard way)
+
+- A local variable named `eq` clashes with the `Constraint` constructor
+  `eq` (from `constrain-eq`). Name equality variables `ieq` / `e`.
+- Implicits don't infer through the non-injective `init` / `synth` /
+  `run` / `step` / `out1` — **pin them explicitly** (e.g.
+  `init-pi0 {S}{P}{st0}`, `run-extends {P}{S}{s}`).
+- To make `do-communications-commitment S` *definitionally* `false`/`true`
+  where `synth`/`init` must reduce, use a helper whose arguments contain no
+  `do-comm S` (a top-level `with do-comm S` orphans a `where`-block's
+  implicits).
+- `_⊑_` is a Π over functions `{id v}`; the unifier stalls on
+  `⊑-refl`/`⊑-trans` implicits — give them explicitly or η-expand
+  (`λ {id}{v} p → g (f p)`).
+- The `*-fwd`/`*-bwd` lemmas are stated at the **immediate post-step
+  witness** `witness-of P (out1 st out v)`; the program-level lift to the
+  final witness is `holds-mono` + `run-extends` (forward) and
+  `holds-lower` + the spine's monotonicity data (backward).
+- Multi-instruction inductions must **enumerate all 34 instructions**; a
+  catch-all leaves `i` opaque and blocks the needed reductions.
+- `grep` for lemma names with `[a-zA-Z-]*` misses `bytes32`/`keccak256`
+  names (digits) — include `0-9`.

--- a/formal/src/zkir-v3/Semantics.agda
+++ b/formal/src/zkir-v3/Semantics.agda
@@ -1,0 +1,522 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Off-circuit (preprocess) semantics of zkir-v3  (ir_vm.rs: preprocess)
+--
+-- A big-step functional interpreter, faithful to `IrSource::preprocess`:
+-- a forward run over the instruction list, threading the named value
+-- store and the public-input / transcript / commitment channels, that
+-- either produces the preprocessed witness or fails (`nothing`).
+--
+-- Per-instruction type dispatch matches the supported types of
+-- the corresponding `*_offcircuit` functions; unsupported combinations
+-- fail.  The purely-structural WF2 bit-count bounds (bits < FR-BITS,
+-- bits ≤ 248) are treated as a well-formedness layer (as in zkir-v2) and
+-- are NOT re-checked in the step (the Rust preprocess does check them
+-- dynamically); value-dependent premises are.  The runnable static check
+-- is `producer-WF2?` (Obligations) — theorems transfer to the Rust
+-- exactly for WF2-conforming sources.
+------------------------------------------------------------------------
+
+module zkir-v3.Semantics (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+
+open import Data.Bool using (Bool; true; false; if_then_else_)
+  renaming (not to bnot)
+open import Data.Nat  using (ℕ; zero; suc; _+_; _*_; _^_; _∸_; _<?_; _≟_)
+open import Data.List using (List; []; _∷_; _++_; length; take; drop; map;
+                             concatMap)
+open import Data.Maybe using (Maybe; just; nothing; _>>=_)
+open import Data.Product using (_×_; _,_)
+open import Data.String using () renaming (_≟_ to _≟str_)
+import Data.Fin as F
+import Data.Fin.Properties  as FinP
+import Data.Vec.Properties  as VecP
+import Data.List.Properties as ListP
+open import Data.Vec using (tabulate; reverse)
+open import Function using (case_of_)
+open import Relation.Binary.Definitions using (DecidableEquality)
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Nullary.Decidable using (isYes)
+
+------------------------------------------------------------------------
+-- Numeric / decision helpers.
+------------------------------------------------------------------------
+
+-- A decision used as a guard: keep the continuation iff it holds.
+guardD : {P A : Set} → Dec P → Maybe A → Maybe A
+guardD (yes _) k = k
+guardD (no  _) _ = nothing
+
+-- `bits-to-ℕ` and `valFr` come from the trust base (`Assumptions`).
+
+-- 2^n as a field element.
+pow2ᶠ : ℕ → Fr
+pow2ᶠ zero    = 1ᶠ
+pow2ᶠ (suc n) = (1ᶠ +ᶠ 1ᶠ) *ᶠ pow2ᶠ n
+
+-- Boolean → field embedding.
+χ : Bool → Fr
+χ true  = 1ᶠ
+χ false = 0ᶠ
+
+-- Decidable equality on Bytes32 (a vector of bytes).
+_≟B_ : DecidableEquality Bytes32
+_≟B_ = VecP.≡-dec FinP._≟_
+
+-- Decidable equality on raw field-element lists (for the active-Impact
+-- transcript-match check).
+_≟LFr_ : DecidableEquality (List Fr)
+_≟LFr_ = ListP.≡-dec _≟ᶠ_
+
+-- Read a field element as a boolean: 0 ↦ false, 1 ↦ true, else fail.
+to𝔹 : Fr → Maybe Bool
+to𝔹 x with x ≟ᶠ 0ᶠ
+... | yes _ = just false
+... | no  _ with x ≟ᶠ 1ᶠ
+...   | yes _ = just true
+...   | no  _ = nothing
+
+-- The default value of each type (guarded transcript reads).  The secp
+-- field defaults are the Rust `Fp::default()` / `Fq::default()` = 0,
+-- obtained here as the reduction of the all-zero byte string (keeping
+-- zero out of the trust base); `K256::default()` is the identity.
+default-val : IrType → IrValue
+default-val native        = val-native 0ᶠ
+default-val bytes32       = val-bytes32 (tabulate (λ _ → F.zero))
+default-val jubjub-point  = val-jubjub-point idJ
+default-val jubjub-scalar = val-jubjub-scalar (native→jubjubScalar 0ᶠ)
+default-val secp-point    = val-secp-point idK
+default-val secp-base     =
+  val-secp-base (secpBaseFromBytes (tabulate (λ _ → F.zero)))
+default-val secp-scalar   =
+  val-secp-scalar (secpScalarFromBytes (tabulate (λ _ → F.zero)))
+
+------------------------------------------------------------------------
+-- The named value store.
+------------------------------------------------------------------------
+
+Mem : Set
+Mem = Identifier → Maybe IrValue
+
+∅ : Mem
+∅ _ = nothing
+
+ins : Identifier → IrValue → Mem → Mem
+ins id v m i = case (i ≟str id) of λ { (yes _) → just v ; (no _) → m i }
+
+------------------------------------------------------------------------
+-- Operand resolution.
+------------------------------------------------------------------------
+
+resolve : Mem → Operand → Maybe IrValue
+resolve m (var id) = m id
+resolve m (imm x)  = just (val-native x)
+
+-- Resolve, expecting a Native value (an immediate, or a Native variable).
+resolveᶠ : Mem → Operand → Maybe Fr
+resolveᶠ m op = resolve m op >>= λ { (val-native x) → just x ; _ → nothing }
+
+resolve𝔹 : Mem → Operand → Maybe Bool
+resolve𝔹 m op = resolveᶠ m op >>= to𝔹
+
+eval-guard : Mem → Maybe Operand → Maybe Bool
+eval-guard m nothing   = just true
+eval-guard m (just op) = resolve𝔹 m op
+
+resolve-all-Fr : Mem → List Operand → Maybe (List Fr)
+resolve-all-Fr m []         = just []
+resolve-all-Fr m (op ∷ ops) =
+  resolveᶠ m op        >>= λ x  →
+  resolve-all-Fr m ops >>= λ xs →
+  just (x ∷ xs)
+
+------------------------------------------------------------------------
+-- Proof preimage and preprocess state.
+------------------------------------------------------------------------
+
+record ProofPreimage : Set where
+  field
+    inputs                 : List Fr
+    binding-input          : Fr
+    comm-commitment        : Maybe (Fr × Fr)
+    pub-transcript-inputs  : List Fr
+    pub-transcript-outputs : List Fr
+    priv-transcript        : List Fr
+
+record State : Set where
+  field
+    mem      : Mem
+    pis      : List Fr
+    pi-skips : List (Maybe ℕ)
+    pti-idx  : ℕ            -- cursor into pub-transcript-inputs
+    pto-rem  : List Fr      -- remaining pub-transcript-outputs
+    priv-rem : List Fr      -- remaining private-transcript
+    outs     : List IrValue
+
+------------------------------------------------------------------------
+-- Small state combinators.
+------------------------------------------------------------------------
+
+out1 : State → Identifier → IrValue → State
+out1 st id v = record st { mem = ins id v (State.mem st) }
+
+-- Bind a list of identifiers to a list of values; lengths must match.
+insertMany : State → List Identifier → List IrValue → Maybe State
+insertMany st []         []       = just st
+insertMany st (id ∷ ids) (v ∷ vs) = insertMany (out1 st id v) ids vs
+insertMany st _          _        = nothing
+
+-- Equality of two values at a supported type (Native / Bytes32 /
+-- JubjubPoint / the Secp256k1 triple), or `nothing` if the type
+-- combination is unsupported.
+valEq? : IrValue → IrValue → Maybe Bool
+valEq? (val-native x)       (val-native y)       = just (isYes (x ≟ᶠ y))
+valEq? (val-bytes32 a)      (val-bytes32 b)      = just (isYes (a ≟B b))
+valEq? (val-jubjub-point p) (val-jubjub-point q) = just (isYes (p ≟J q))
+valEq? (val-secp-point p)   (val-secp-point q)   = just (isYes (p ≟K q))
+valEq? (val-secp-base x)    (val-secp-base y)    = just (isYes (x ≟ᵇ y))
+valEq? (val-secp-scalar x)  (val-secp-scalar y)  = just (isYes (x ≟ˢ y))
+valEq? _                    _                    = nothing
+
+-- Resolve and type-check the `output` operands against a type signature.
+collectOutputs : Mem → List IrType → List Operand → Maybe (List IrValue)
+collectOutputs m []       []         = just []
+collectOutputs m (t ∷ ts) (op ∷ ops) =
+  resolve m op >>= λ v →
+  guardD (typeof v ≟T t)
+    (collectOutputs m ts ops >>= λ vs → just (v ∷ vs))
+collectOutputs m _        _          = nothing
+
+-- Decode the declared inputs from the raw input stream, consuming
+-- `encoded-len` elements per input; the stream must be fully consumed.
+decode-inputs : List TypedIdentifier → List Fr → Maybe Mem
+decode-inputs []         []        = just ∅
+decode-inputs []         (_ ∷ _)   = nothing
+decode-inputs (ti ∷ tis) raw       =
+  let t = TypedIdentifier.val-t ti in
+  decode t (take (encoded-len t) raw)        >>= λ v →
+  decode-inputs tis (drop (encoded-len t) raw) >>= λ m →
+  just (ins (TypedIdentifier.name ti) v m)
+
+------------------------------------------------------------------------
+-- The per-instruction step  (ir_vm.rs: the `preprocess` match).
+------------------------------------------------------------------------
+
+step : ProofPreimage → IrSource → State → Instruction → Maybe State
+step P S st i = go i
+  where
+  m : Mem
+  m = State.mem st
+  go : Instruction → Maybe State
+  go (encode input outs) =
+    resolve m input >>= λ v →
+    insertMany st outs (map val-native (encodeᵉ v))
+
+  go (assert cond) =
+    resolve𝔹 m cond >>= λ b → if b then just st else nothing
+
+  go (cond-select bit a b output) =
+    resolve𝔹 m bit >>= λ bv →
+    resolve m a    >>= λ av →
+    resolve m b    >>= λ bvl →
+    guardD (typeof av ≟T typeof bvl)
+      (just (out1 st output (if bv then av else bvl)))
+
+  go (constrain-bits val bits) =
+    resolveᶠ m val >>= λ x →
+    guardD (valFr x <? 2 ^ bits) (just st)
+
+  go (constrain-eq a b) =
+    resolve m a >>= λ av →
+    resolve m b >>= λ bv →
+    valEq? av bv >>= λ eq → if eq then just st else nothing
+
+  go (constrain-to-boolean val) =
+    resolve𝔹 m val >>= λ _ → just st
+
+  go (copy val output) =
+    resolve m val >>= λ v → just (out1 st output v)
+
+  -- Public inputs are pushed guarded, exactly as the Rust preprocess
+  -- does (ir_vm.rs, I::Impact): an active group (guard = true) pushes
+  -- the resolved `vals` — also matched against the public transcript —
+  -- and advances the cursor; a skipped group pushes zeros, mirroring the
+  -- in-circuit `select(guard, x, 0)` (`Circuit.pi-impact`), and leaves
+  -- the cursor unmoved.
+  go (impact guard inputs) =
+    resolve-all-Fr m inputs >>= λ vals →
+    resolve𝔹 m guard        >>= λ g    →
+    let n = length vals in
+    if g
+    then guardD (take n (drop (State.pti-idx st)
+                           (ProofPreimage.pub-transcript-inputs P))
+                  ≟LFr vals)
+           (just (record st { pis      = State.pis st ++ vals
+                            ; pi-skips = State.pi-skips st ++ (nothing ∷ [])
+                            ; pti-idx  = State.pti-idx st + n }))
+    else just (record st { pis      = State.pis st ++ map (λ _ → 0ᶠ) vals
+                         ; pi-skips = State.pi-skips st ++ (just n ∷ []) })
+
+  go (ec-mul a scalar output) =
+    resolve m a      >>= λ pv →
+    resolve m scalar >>= λ sv →
+    case (pv , sv) of λ
+      { (val-jubjub-point p , val-jubjub-scalar s) →
+          just (out1 st output (val-jubjub-point (s ·J p)))
+      ; (val-secp-point p , val-secp-scalar s) →
+          just (out1 st output (val-secp-point (s ·K p)))
+      ; _ → nothing }
+
+  go (ec-mul-generator scalar output) =
+    resolve m scalar >>= λ sv →
+    case sv of λ
+      { (val-jubjub-scalar s) →
+          just (out1 st output (val-jubjub-point (s ·J genJ)))
+      ; (val-secp-scalar s) →
+          just (out1 st output (val-secp-point (s ·K genK)))
+      ; _ → nothing }
+
+  go (hash-to-curve inputs output) =
+    resolve-all-Fr m inputs >>= λ frs →
+    just (out1 st output (val-jubjub-point (hash-to-curve-fn frs)))
+
+  go (into-coordinates point (xid , yid)) =
+    resolve m point >>= λ pv →
+    case pv of λ
+      { (val-jubjub-point p) →
+          let (x , y) = coordsJ p in
+          just (out1 (out1 st xid (val-native x)) yid (val-native y))
+      ; (val-secp-point p) →
+          -- Errors on the Weierstrass identity (`coordsK` is `nothing`
+          -- exactly there).
+          coordsK p >>= λ (x , y) →
+          just (out1 (out1 st xid (val-secp-base x)) yid (val-secp-base y))
+      ; _ → nothing }
+
+  go (from-coordinates (xop , yop) output) =
+    resolve m xop >>= λ xv →
+    resolve m yop >>= λ yv →
+    case (xv , yv) of λ
+      { (val-native x , val-native y) →
+          fromCoordsJ x y >>= λ p →
+          just (out1 st output (val-jubjub-point p))
+      ; (val-secp-base x , val-secp-base y) →
+          fromCoordsK x y >>= λ p →
+          just (out1 st output (val-secp-point p))
+      ; _ → nothing }
+
+  go (into-bytes32 input output) =
+    resolve m input >>= λ v →
+    case v of λ
+      { (val-native x)      → just (out1 st output (val-bytes32 (nativeToBytes x)))
+      ; (val-secp-base x)   → just (out1 st output (val-bytes32 (secpBaseToBytes x)))
+      ; (val-secp-scalar s) → just (out1 st output (val-bytes32 (secpScalarToBytes s)))
+      ; _ → nothing }
+
+  go (from-bytes32 bytes val-t output) =
+    resolve m bytes >>= λ v →
+    case v of λ
+      { (val-bytes32 b) →
+          -- On the foreign fields the conversion is total: non-canonical
+          -- bytes reduce mod the field order
+          -- (from_le_bytes_with_reduction).
+          case val-t of λ
+            { native      → just (out1 st output (val-native (nativeFromBytes b)))
+            ; secp-base   → just (out1 st output (val-secp-base (secpBaseFromBytes b)))
+            ; secp-scalar → just (out1 st output (val-secp-scalar (secpScalarFromBytes b)))
+            ; _           → nothing }
+      ; _ → nothing }
+
+  go (reverse-bytes bytes output) =
+    resolve m bytes >>= λ v →
+    case v of λ
+      { (val-bytes32 b) → just (out1 st output (val-bytes32 (reverse b)))
+      ; _ → nothing }
+
+  go (bytes32-into-low-high bytes (loid , hiid)) =
+    resolve m bytes >>= λ v →
+    case v of λ
+      { (val-bytes32 b) →
+          let (lo , hi) = bytes32→low-high b in
+          just (out1 (out1 st loid (val-native lo)) hiid (val-native hi))
+      ; _ → nothing }
+
+  go (bytes32-from-low-high (loop , hiop) output) =
+    resolveᶠ m loop >>= λ lo →
+    resolveᶠ m hiop >>= λ hi →
+    low-high→bytes32 lo hi >>= λ b →
+    just (out1 st output (val-bytes32 b))
+
+  go (div-mod-power-of-two val bits outs) =
+    resolveᶠ m val >>= λ x →
+    let L = to-le-bits x in
+    insertMany st outs
+      ( val-native (from-le-bits (drop bits L))
+      ∷ val-native (from-le-bits (take bits L)) ∷ [])
+
+  go (reconstitute-field divisor modulus bits output) =
+    resolveᶠ m divisor >>= λ d  →
+    resolveᶠ m modulus >>= λ mo →
+    guardD (valFr mo <? 2 ^ bits)
+      (guardD (valFr d <? 2 ^ (FR-BITS ∸ bits))
+        (guardD (valFr mo + 2 ^ bits * valFr d <? FR-ORDER)
+          (just (out1 st output (val-native ((pow2ᶠ bits *ᶠ d) +ᶠ mo))))))
+
+  go (transient-hash inputs output) =
+    resolve-all-Fr m inputs >>= λ frs →
+    just (out1 st output (val-native (transient-hash-fn frs)))
+
+  go (persistent-hash alignment inputs output) =
+    resolve-all-Fr m inputs >>= λ frs →
+    persistent-hash-fn alignment frs >>= λ h →
+    just (out1 st output (val-bytes32 h))
+
+  go (keccak256 alignment inputs output) =
+    resolve-all-Fr m inputs >>= λ frs →
+    keccak-fn alignment frs >>= λ h →
+    just (out1 st output (val-bytes32 h))
+
+  go (test-eq a b output) =
+    resolve m a  >>= λ av →
+    resolve m b  >>= λ bv →
+    valEq? av bv >>= λ eq →
+    just (out1 st output (val-native (χ eq)))
+
+  go (add a b output) =
+    resolve m a >>= λ av →
+    resolve m b >>= λ bv →
+    case (av , bv) of λ
+      { (val-native x , val-native y) →
+          just (out1 st output (val-native (x +ᶠ y)))
+      ; (val-jubjub-point p , val-jubjub-point q) →
+          just (out1 st output (val-jubjub-point (p +J q)))
+      ; (val-secp-point p , val-secp-point q) →
+          just (out1 st output (val-secp-point (p +K q)))
+      ; (val-secp-base x , val-secp-base y) →
+          just (out1 st output (val-secp-base (x +ᵇ y)))
+      ; (val-secp-scalar x , val-secp-scalar y) →
+          just (out1 st output (val-secp-scalar (x +ˢ y)))
+      ; _ → nothing }
+
+  go (mul a b output) =
+    resolve m a >>= λ av →
+    resolve m b >>= λ bv →
+    case (av , bv) of λ
+      { (val-native x , val-native y) →
+          just (out1 st output (val-native (x *ᶠ y)))
+      ; (val-secp-base x , val-secp-base y) →
+          just (out1 st output (val-secp-base (x *ᵇ y)))
+      ; (val-secp-scalar x , val-secp-scalar y) →
+          just (out1 st output (val-secp-scalar (x *ˢ y)))
+      ; _ → nothing }
+
+  go (neg a output) =
+    resolve m a >>= λ av →
+    case av of λ
+      { (val-native x)       → just (out1 st output (val-native (-ᶠ x)))
+      ; (val-jubjub-point p) → just (out1 st output (val-jubjub-point (negJ p)))
+      ; (val-secp-point p)   → just (out1 st output (val-secp-point (negK p)))
+      ; (val-secp-base x)    → just (out1 st output (val-secp-base (-ᵇ x)))
+      ; (val-secp-scalar x)  → just (out1 st output (val-secp-scalar (-ˢ x)))
+      ; _ → nothing }
+
+  go (inv a output) =
+    resolve m a >>= λ av →
+    case av of λ
+      { (val-native x) →
+          invᶠ x >>= λ xi → just (out1 st output (val-native xi))
+      ; (val-secp-base x) →
+          invᵇ x >>= λ xi → just (out1 st output (val-secp-base xi))
+      ; (val-secp-scalar x) →
+          invˢ x >>= λ xi → just (out1 st output (val-secp-scalar xi))
+      ; _ → nothing }
+
+  go (not a output) =
+    resolve𝔹 m a >>= λ b →
+    just (out1 st output (val-native (χ (bnot b))))
+
+  go (less-than a b bits output) =
+    resolveᶠ m a >>= λ x →
+    resolveᶠ m b >>= λ y →
+    guardD (valFr x <? 2 ^ bits)
+      (guardD (valFr y <? 2 ^ bits)
+        (just (out1 st output (val-native (χ (isYes (valFr x <? valFr y)))))))
+
+  go (jubjub-scalar-from-native a output) =
+    resolveᶠ m a >>= λ x →
+    just (out1 st output (val-jubjub-scalar (native→jubjubScalar x)))
+
+  go (public-input guard val-t output) =
+    eval-guard m guard >>= λ g →
+    if g
+    then (let n = encoded-len val-t in
+          decode val-t (take n (State.pto-rem st)) >>= λ v →
+          just (record st { mem     = ins output v (State.mem st)
+                          ; pto-rem = drop n (State.pto-rem st) }))
+    else just (out1 st output (default-val val-t))
+
+  go (private-input guard val-t output) =
+    eval-guard m guard >>= λ g →
+    if g
+    then (let n = encoded-len val-t in
+          decode val-t (take n (State.priv-rem st)) >>= λ v →
+          just (record st { mem      = ins output v (State.mem st)
+                          ; priv-rem = drop n (State.priv-rem st) }))
+    else just (out1 st output (default-val val-t))
+
+  go (circuit-output vals) =
+    collectOutputs m (IrSource.outputs S) vals >>= λ vs →
+    just (record st { outs = State.outs st ++ vs })
+
+------------------------------------------------------------------------
+-- Running a program and the acceptance conditions.
+------------------------------------------------------------------------
+
+run : ProofPreimage → IrSource → State → List Instruction → Maybe State
+run P S st []       = just st
+run P S st (i ∷ is) = step P S st i >>= λ st′ → run P S st′ is
+
+-- Initialisation  (ir_vm.rs: input decoding + seeding the PI vector).
+init : IrSource → ProofPreimage → Maybe State
+init S P =
+  decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P) >>= λ m →
+  let mk = λ pis → record { mem      = m
+                          ; pis      = pis
+                          ; pi-skips = []
+                          ; pti-idx  = 0
+                          ; pto-rem  = ProofPreimage.pub-transcript-outputs P
+                          ; priv-rem = ProofPreimage.priv-transcript P
+                          ; outs     = [] }
+  in if IrSource.do-communications-commitment S
+     then (case ProofPreimage.comm-commitment P of λ
+            { (just (c , _)) →
+                just (mk (ProofPreimage.binding-input P ∷ c ∷ []))
+            ; nothing → nothing })
+     else just (mk (ProofPreimage.binding-input P ∷ []))
+
+-- The preprocess function: run, then check the terminal side conditions
+-- TC1 (transcripts fully consumed) and TC2 (communications commitment).
+preprocess : IrSource → ProofPreimage → Maybe State
+preprocess S P =
+  init S P >>= λ st0 →
+  run P S st0 (IrSource.instructions S) >>= λ stf →
+  guardD (State.pti-idx stf ≟ length (ProofPreimage.pub-transcript-inputs P))
+   (case State.pto-rem stf of λ
+     { (_ ∷ _) → nothing
+     ; []      → case State.priv-rem stf of λ
+       { (_ ∷ _) → nothing
+       ; []      →
+           if IrSource.do-communications-commitment S
+           then (case ProofPreimage.comm-commitment P of λ
+                  { (just (c , r)) →
+                      guardD (c ≟ᶠ transient-commit
+                                    (ProofPreimage.inputs P
+                                      ++ concatMap encodeᵉ (State.outs stf)) r)
+                        (just stf)
+                  ; nothing → nothing })
+           else just stf } })

--- a/formal/src/zkir-v3/SemanticsProperties.agda
+++ b/formal/src/zkir-v3/SemanticsProperties.agda
@@ -1,0 +1,723 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Pure properties of the off-circuit (preprocess) semantics of zkir-v3.
+--
+-- Structural facts about the named store, operand resolution, the
+-- single-assignment freshness discipline, and monotonicity of a run —
+-- none of which mention the in-circuit constraint layer.  These are the
+-- semantics-level lemmas shared by the faithfulness bridge, the backward
+-- driver, and the static well-formedness / typing passes.
+------------------------------------------------------------------------
+
+module zkir-v3.SemanticsProperties (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+open import zkir-v3.Semantics ⋯
+
+open import Data.Bool using (Bool; true; false)
+open import Data.Nat using (ℕ; zero; suc; _+_; _*_; _^_; _∸_; _<?_)
+open import Data.Nat using () renaming (_≟_ to _≟ℕ_)
+open import Data.List using (List; []; _∷_; _++_; map; length; take; drop;
+                            concatMap)
+open import Data.List.Properties using (++-identityʳ; ++-assoc)
+open import Data.Maybe using (Maybe; just; nothing)
+open import Data.Maybe.Properties using (just-injective)
+open import Data.Product using (_×_; _,_; ∃)
+open import Data.Unit using (⊤; tt)
+open import Data.String using () renaming (_≟_ to _≟str_)
+open import Function using (case_of_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong)
+open import Relation.Nullary using (yes; no; ¬_)
+open import Relation.Nullary.Decidable using (isYes)
+
+------------------------------------------------------------------------
+-- Memory / resolution helpers under a single output binding.
+------------------------------------------------------------------------
+
+-- After binding `out` to `v`, the cell `out` holds exactly `v`.
+ins-here : ∀ (out : Identifier) v (m : Mem)
+  → ins out v m out ≡ just v
+ins-here out v m with out ≟str out
+... | yes _ = refl
+... | no ¬p = case ¬p refl of λ ()
+
+-- Looking up a key other than the one just bound sees through the bind.
+ins-other : ∀ {id k : Identifier} v (m : Mem)
+  → ¬ (id ≡ k)
+  → ins k v m id ≡ m id
+ins-other {id} {k} v m id≢k with id ≟str k
+... | yes p = case id≢k p of λ ()
+... | no  _ = refl
+
+-- After binding `out` to `v`, any operand that resolved in the original
+-- memory still resolves to the same value — given freshness of `out`
+-- (an immediate is unaffected; a variable equal to `out` could not have
+-- resolved before the binding, so it is impossible here).
+resolve-pres : ∀ (out : Identifier) v (m : Mem) op {w}
+  → m out ≡ nothing
+  → resolve m op ≡ just w
+  → resolve (ins out v m) op ≡ just w
+resolve-pres out v m (imm x) _ r = r
+resolve-pres out v m (var id) {w} fresh r with id ≟str out
+... | no  _  = r
+... | yes refl rewrite fresh = case r of λ ()
+
+-- Invert `resolveᶠ`: a Native resolution comes from a Native value.
+resolveᶠ-inv : ∀ (m : Mem) op {x}
+  → resolveᶠ m op ≡ just x
+  → resolve m op ≡ just (val-native x)
+resolveᶠ-inv m op r with resolve m op
+... | just (val-native _) with refl ← r = refl
+
+-- And the converse: a Native value resolution is a Native resolution.
+resolveᶠ-intro : ∀ (m : Mem) op {x}
+  → resolve m op ≡ just (val-native x)
+  → resolveᶠ m op ≡ just x
+resolveᶠ-intro m op r rewrite r = refl
+
+-- The Native-resolution analogue of `resolve-pres`.
+resolveᶠ-pres : ∀ (out : Identifier) v (m : Mem) op {x}
+  → m out ≡ nothing
+  → resolveᶠ m op ≡ just x
+  → resolveᶠ (ins out v m) op ≡ just x
+resolveᶠ-pres out v m op {x} fresh r
+  rewrite resolve-pres out v m op fresh (resolveᶠ-inv m op r) = refl
+
+------------------------------------------------------------------------
+-- Store extension and public-input prefix orders.
+--
+-- A single step only *extends* the named store (inserting fresh keys)
+-- and *appends* to the public-input vector.
+------------------------------------------------------------------------
+
+-- Sub-map: m′ preserves every binding of m.
+_⊑_ : Mem → Mem → Set
+m ⊑ m′ = ∀ {id v} → m id ≡ just v → m′ id ≡ just v
+
+⊑-refl : ∀ {m} → m ⊑ m
+⊑-refl p = p
+
+⊑-trans : ∀ {m m′ m″} → m ⊑ m′ → m′ ⊑ m″ → m ⊑ m″
+⊑-trans f g p = g (f p)
+
+-- Inserting a fresh key extends the store.
+ins-⊑ : ∀ {out v m} → m out ≡ nothing → m ⊑ ins out v m
+ins-⊑ {out} fresh {id} p with id ≟str out
+... | yes refl = case trans (sym fresh) p of λ ()
+... | no  _    = p
+
+-- Prefix order on the public-input vector.
+_≼_ : List Fr → List Fr → Set
+xs ≼ ys = ∃ λ zs → ys ≡ xs ++ zs
+
+≼-refl : ∀ {xs} → xs ≼ xs
+≼-refl {xs} = [] , sym (++-identityʳ xs)
+
+≼-trans : ∀ {xs ys zs} → xs ≼ ys → ys ≼ zs → xs ≼ zs
+≼-trans {xs} (as , refl) (bs , refl) = (as ++ bs) , ++-assoc xs as bs
+
+≼-append : ∀ xs ys → xs ≼ (xs ++ ys)
+≼-append xs ys = ys , refl
+
+------------------------------------------------------------------------
+-- Single-assignment freshness predicates.
+--
+-- `out-fresh i m` is the freshness/distinctness precondition the
+-- per-instruction lemma of `i` needs: every output identifier is unbound
+-- in `m`, and (for multi-output instructions) the outputs are pairwise
+-- distinct.  It is what the program-level proofs thread through a run as
+-- their single-assignment invariant.
+------------------------------------------------------------------------
+
+AllFresh : List Identifier → Mem → Set
+AllFresh []         m = ⊤
+AllFresh (id ∷ ids) m = (m id ≡ nothing) × AllFresh ids m
+
+NotIn : Identifier → List Identifier → Set
+NotIn id []         = ⊤
+NotIn id (k ∷ ks)   = ¬ (id ≡ k) × NotIn id ks
+
+NoDup : List Identifier → Set
+NoDup []         = ⊤
+NoDup (id ∷ ids) = NotIn id ids × NoDup ids
+
+out-fresh : Instruction → Mem → Set
+out-fresh (encode _ outputs)              m = AllFresh outputs m × NoDup outputs
+out-fresh (assert _)                      m = ⊤
+out-fresh (cond-select _ _ _ o)           m = m o ≡ nothing
+out-fresh (constrain-bits _ _)            m = ⊤
+out-fresh (constrain-eq _ _)              m = ⊤
+out-fresh (constrain-to-boolean _)        m = ⊤
+out-fresh (copy _ o)                      m = m o ≡ nothing
+out-fresh (impact _ _)                    m = ⊤
+out-fresh (ec-mul _ _ o)                  m = m o ≡ nothing
+out-fresh (ec-mul-generator _ o)          m = m o ≡ nothing
+out-fresh (hash-to-curve _ o)             m = m o ≡ nothing
+out-fresh (into-coordinates _ (xo , yo))  m =
+  (m xo ≡ nothing) × (m yo ≡ nothing) × ¬ (xo ≡ yo)
+out-fresh (from-coordinates _ o)          m = m o ≡ nothing
+out-fresh (into-bytes32 _ o)              m = m o ≡ nothing
+out-fresh (from-bytes32 _ _ o)            m = m o ≡ nothing
+out-fresh (reverse-bytes _ o)             m = m o ≡ nothing
+out-fresh (bytes32-into-low-high _ (lo , hi)) m =
+  (m lo ≡ nothing) × (m hi ≡ nothing) × ¬ (lo ≡ hi)
+out-fresh (bytes32-from-low-high _ o)     m = m o ≡ nothing
+out-fresh (div-mod-power-of-two _ _ outs) m = AllFresh outs m × NoDup outs
+out-fresh (reconstitute-field _ _ _ o)    m = m o ≡ nothing
+out-fresh (transient-hash _ o)            m = m o ≡ nothing
+out-fresh (persistent-hash _ _ o)         m = m o ≡ nothing
+out-fresh (keccak256 _ _ o)               m = m o ≡ nothing
+out-fresh (test-eq _ _ o)                 m = m o ≡ nothing
+out-fresh (add _ _ o)                     m = m o ≡ nothing
+out-fresh (mul _ _ o)                     m = m o ≡ nothing
+out-fresh (neg _ o)                       m = m o ≡ nothing
+out-fresh (inv _ o)                       m = m o ≡ nothing
+out-fresh (not _ o)                       m = m o ≡ nothing
+out-fresh (less-than _ _ _ o)             m = m o ≡ nothing
+out-fresh (jubjub-scalar-from-native _ o) m = m o ≡ nothing
+out-fresh (public-input _ _ o)            m = m o ≡ nothing
+out-fresh (private-input _ _ o)           m = m o ≡ nothing
+out-fresh (circuit-output _)              m = ⊤
+
+------------------------------------------------------------------------
+-- Single-step extension.
+--
+-- One step never shrinks the public-input vector nor drops a memory
+-- binding: most instructions leave `pis` untouched (the only one that
+-- touches it — `impact` — appends to it), and memory only grows by the
+-- fresh output cells the step writes.  `step-extends` establishes both
+-- `State.pis st ≼ State.pis st'` and `State.mem st ⊑ State.mem st'` from
+-- one inversion of the step.  The helpers below (`insertMany-pis`,
+-- `out1-⊑`, …) supply the two component facts per instruction shape.
+------------------------------------------------------------------------
+
+-- `insertMany` only ever rebinds memory cells (`out1`), so it leaves the
+-- public-input vector untouched.
+insertMany-pis : ∀ st ids vs {st'}
+  → insertMany st ids vs ≡ just st'
+  → State.pis st' ≡ State.pis st
+insertMany-pis st []         []         refl = refl
+insertMany-pis st (id ∷ ids) (v ∷ vs)   e    =
+  insertMany-pis (out1 st id v) ids vs e
+insertMany-pis st []         (_ ∷ _)    ()
+insertMany-pis st (_ ∷ _)    []         ()
+
+-- Transport a `pis`-equality to the prefix order.
+pis-≡→≼ : ∀ {xs ys : List Fr} → ys ≡ xs → xs ≼ ys
+pis-≡→≼ refl = ≼-refl
+
+------------------------------------------------------------------------
+-- Memory-extension helpers.
+--
+-- The memory component of `step-extends`: no-output instructions leave
+-- memory unchanged, single-output instructions insert one fresh cell,
+-- two-output instructions insert two, and the `insertMany` instructions
+-- bind a whole (fresh, duplicate-free) list.  Given the
+-- freshness/distinctness that `out-fresh` records, each shape yields
+-- `State.mem st ⊑ State.mem st'`.
+------------------------------------------------------------------------
+
+-- Binding a key keeps the others unbound, given the key is distinct from
+-- each of them.
+allfresh-ins : ∀ (id : Identifier) v ids m
+  → AllFresh ids m → NotIn id ids → AllFresh ids (ins id v m)
+allfresh-ins id v []         m _          _            = tt
+allfresh-ins id v (k ∷ ids)  m (fk , frs) (id≢k , nin) =
+    trans (ins-other v m (λ k≡id → id≢k (sym k≡id))) fk
+  , allfresh-ins id v ids m frs nin
+
+-- A single fresh output binding extends the store.  Keyed on `out1` so
+-- that the output identifier and value are read off the goal's state.
+out1-⊑ : ∀ st (o : Identifier) v
+  → State.mem st o ≡ nothing → State.mem st ⊑ State.mem (out1 st o v)
+out1-⊑ st o v fresh = ins-⊑ {o} {v} {State.mem st} fresh
+
+-- Two distinct fresh output bindings extend the store.  Keyed on the
+-- nested `out1` so the identifiers and values come from the goal's state.
+out2-⊑ : ∀ st (i₁ : Identifier) v₁ (i₂ : Identifier) v₂
+  → State.mem st i₁ ≡ nothing → State.mem st i₂ ≡ nothing → ¬ (i₁ ≡ i₂)
+  → State.mem st ⊑ State.mem (out1 (out1 st i₁ v₁) i₂ v₂)
+out2-⊑ st i₁ v₁ i₂ v₂ f₁ f₂ i₁≢i₂ {id} p =
+  ins-⊑ {i₂} {v₂} {ins i₁ v₁ (State.mem st)}
+    (trans (ins-other v₁ (State.mem st)
+             (λ i₂≡i₁ → i₁≢i₂ (sym i₂≡i₁))) f₂)
+    {id} (ins-⊑ {i₁} {v₁} {State.mem st} f₁ {id} p)
+
+-- `insertMany` over fresh, duplicate-free keys only extends the store.
+insertMany-⊑ : ∀ st ids vs {st'}
+  → insertMany st ids vs ≡ just st'
+  → AllFresh ids (State.mem st) → NoDup ids
+  → State.mem st ⊑ State.mem st'
+insertMany-⊑ st []         []         refl _            _            =
+  ⊑-refl {State.mem st}
+insertMany-⊑ st (id ∷ ids) (v ∷ vs)   e    (fid , frs)  (nin , ndup) {k} p =
+  insertMany-⊑ (out1 st id v) ids vs e
+    (allfresh-ins id v ids (State.mem st) frs nin) ndup
+    {k} (ins-⊑ {id} {v} {State.mem st} fid {k} p)
+insertMany-⊑ st []         (_ ∷ _)    ()   _            _
+insertMany-⊑ st (_ ∷ _)    []         ()   _            _
+
+step-extends : ∀ {P S st st'} (i : Instruction)
+  → step P S st i ≡ just st'
+  → out-fresh i (State.mem st)
+  → (State.pis st ≼ State.pis st') × (State.mem st ⊑ State.mem st')
+step-extends {st = st} (encode input outputs) e (af , nd)
+  with resolve (State.mem st) input
+... | just v = pis-≡→≼ (insertMany-pis st outputs
+                          (map val-native (encodeᵉ v)) e)
+             , insertMany-⊑ st outputs (map val-native (encodeᵉ v)) e af nd
+step-extends {st = st} (assert cond) e _
+  with resolve𝔹 (State.mem st) cond
+... | just true with refl ← e = ≼-refl , ⊑-refl {State.mem st}
+step-extends {st = st} (cond-select bit a b output) e fresh
+  with resolve𝔹 (State.mem st) bit
+... | just bv with resolve (State.mem st) a | resolve (State.mem st) b
+...   | just av | just bvl with typeof av ≟T typeof bvl
+...     | yes _ with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (constrain-bits val bits) e _
+  with resolveᶠ (State.mem st) val
+... | just x with valFr x <? 2 ^ bits
+...   | yes _ with refl ← e = ≼-refl , ⊑-refl {State.mem st}
+step-extends {st = st} (constrain-eq a b) e _
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just true with refl ← e = ≼-refl , ⊑-refl {State.mem st}
+step-extends {st = st} (constrain-to-boolean val) e _
+  with resolve𝔹 (State.mem st) val
+... | just _ with refl ← e = ≼-refl , ⊑-refl {State.mem st}
+step-extends {st = st} (copy val output) e fresh
+  with resolve (State.mem st) val
+... | just v with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {P = P} {st = st} (impact guard inputs) e _
+  with resolve-all-Fr (State.mem st) inputs
+... | just vals with resolve𝔹 (State.mem st) guard
+...   | just g with g
+...     | true
+          with take (length vals)
+                 (drop (State.pti-idx st)
+                   (ProofPreimage.pub-transcript-inputs P))
+               ≟LFr vals
+...       | yes _ with refl ← e =
+            ≼-append (State.pis st) vals , ⊑-refl {State.mem st}
+step-extends {st = st} (impact guard inputs) e _ | just vals | just g | false
+  with refl ← e =
+    ≼-append (State.pis st) (map (λ _ → 0ᶠ) vals) , ⊑-refl {State.mem st}
+step-extends {st = st} (ec-mul a scalar output) e fresh
+  with resolve (State.mem st) a | resolve (State.mem st) scalar
+... | just (val-jubjub-point p) | just (val-jubjub-scalar s)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (ec-mul a scalar output) e fresh
+    | just (val-secp-point p) | just (val-secp-scalar s)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (ec-mul-generator scalar output) e fresh
+  with resolve (State.mem st) scalar
+... | just (val-jubjub-scalar s) with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-scalar s)   with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (hash-to-curve inputs output) e fresh
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (into-coordinates point (xid , yid)) e
+  (freshx , freshy , xid≢yid)
+  with resolve (State.mem st) point
+... | just (val-jubjub-point p) with coordsJ p
+...   | (x , y) with refl ← e =
+          ≼-refl
+        , out2-⊑ st xid (val-native x) yid (val-native y)
+            freshx freshy xid≢yid
+step-extends {st = st} (into-coordinates point (xid , yid)) e
+  (freshx , freshy , xid≢yid)
+    | just (val-secp-point p) with coordsK p
+...   | just (x , y) with refl ← e =
+          ≼-refl
+        , out2-⊑ st xid (val-secp-base x) yid (val-secp-base y)
+            freshx freshy xid≢yid
+step-extends {st = st} (from-coordinates (xop , yop) output) e fresh
+  with resolve (State.mem st) xop | resolve (State.mem st) yop
+... | just (val-native x) | just (val-native y) with fromCoordsJ x y
+...   | just p with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (from-coordinates (xop , yop) output) e fresh
+    | just (val-secp-base x) | just (val-secp-base y) with fromCoordsK x y
+...   | just p with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (into-bytes32 input output) e fresh
+  with resolve (State.mem st) input
+... | just (val-native x)      with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-base x)   with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-scalar s) with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (from-bytes32 bytes native output) e fresh
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (from-bytes32 bytes bytes32 output) e _
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-extends {st = st} (from-bytes32 bytes jubjub-point output) e _
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-extends {st = st} (from-bytes32 bytes jubjub-scalar output) e _
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-extends {st = st} (from-bytes32 bytes secp-point output) e _
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) = case e of λ ()
+step-extends {st = st} (from-bytes32 bytes secp-base output) e fresh
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (from-bytes32 bytes secp-scalar output) e fresh
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (reverse-bytes bytes output) e fresh
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (bytes32-into-low-high bytes (loid , hiid)) e
+  (freshl , freshh , loid≢hiid)
+  with resolve (State.mem st) bytes
+... | just (val-bytes32 b) with bytes32→low-high b
+...   | (lo , hi) with refl ← e =
+          ≼-refl
+        , out2-⊑ st loid (val-native lo) hiid (val-native hi)
+            freshl freshh loid≢hiid
+step-extends {st = st} (bytes32-from-low-high (loop , hiop) output) e fresh
+  with resolveᶠ (State.mem st) loop | resolveᶠ (State.mem st) hiop
+... | just lo | just hi with low-high→bytes32 lo hi
+...   | just b with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (div-mod-power-of-two val bits outs) e (af , nd)
+  with resolveᶠ (State.mem st) val
+... | just x =
+        pis-≡→≼ (insertMany-pis st outs
+          ( val-native (from-le-bits (drop bits (to-le-bits x)))
+          ∷ val-native (from-le-bits (take bits (to-le-bits x))) ∷ []) e)
+      , insertMany-⊑ st outs
+          ( val-native (from-le-bits (drop bits (to-le-bits x)))
+          ∷ val-native (from-le-bits (take bits (to-le-bits x))) ∷ [])
+          e af nd
+step-extends {st = st} (reconstitute-field divisor modulus bits output) e fresh
+  with resolveᶠ (State.mem st) divisor | resolveᶠ (State.mem st) modulus
+... | just d | just mo with valFr mo <? 2 ^ bits
+...   | yes _ with valFr d <? 2 ^ (FR-BITS ∸ bits)
+...     | yes _ with valFr mo + 2 ^ bits * valFr d <? FR-ORDER
+...       | yes _ with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (transient-hash inputs output) e fresh
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (persistent-hash alignment inputs output) e fresh
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with persistent-hash-fn alignment frs
+...   | just h with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (keccak256 alignment inputs output) e fresh
+  with resolve-all-Fr (State.mem st) inputs
+... | just frs with keccak-fn alignment frs
+...   | just h with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (test-eq a b output) e fresh
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just av | just bv with valEq? av bv
+...   | just eqv with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (add a b output) e fresh
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just (val-native x) | just (val-native y)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+... | just (val-jubjub-point p) | just (val-jubjub-point q)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-point p) | just (val-secp-point q)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-base x) | just (val-secp-base y)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-scalar x) | just (val-secp-scalar y)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (mul a b output) e fresh
+  with resolve (State.mem st) a | resolve (State.mem st) b
+... | just (val-native x) | just (val-native y)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-base x) | just (val-secp-base y)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-scalar x) | just (val-secp-scalar y)
+        with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (neg a output) e fresh
+  with resolve (State.mem st) a
+... | just (val-native x) with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+... | just (val-jubjub-point p) with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-point p) with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-base x) with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+... | just (val-secp-scalar x) with refl ← e =
+        ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (inv a output) e fresh
+  with resolve (State.mem st) a
+... | just (val-native x) with invᶠ x
+...   | just xi with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (inv a output) e fresh
+    | just (val-secp-base x) with invᵇ x
+...   | just xi with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (inv a output) e fresh
+    | just (val-secp-scalar x) with invˢ x
+...   | just xi with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (not a output) e fresh
+  with resolve𝔹 (State.mem st) a
+... | just b with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (less-than a b bits output) e fresh
+  with resolveᶠ (State.mem st) a | resolveᶠ (State.mem st) b
+... | just x | just y with valFr x <? 2 ^ bits
+...   | yes _ with valFr y <? 2 ^ bits
+...     | yes _ with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (jubjub-scalar-from-native a output) e fresh
+  with resolveᶠ (State.mem st) a
+... | just x with refl ← e = ≼-refl , out1-⊑ st output _ fresh
+step-extends {st = st} (public-input guard val-t output) e fresh
+  with eval-guard (State.mem st) guard
+... | just g with g
+...   | true with decode val-t
+                    (take (encoded-len val-t) (State.pto-rem st))
+...     | just v with refl ← e =
+          ≼-refl , ins-⊑ {output} {v} {State.mem st} fresh
+step-extends {st = st} (public-input guard val-t output) e fresh
+    | just g | false with refl ← e =
+        ≼-refl , out1-⊑ st output (default-val val-t) fresh
+step-extends {st = st} (private-input guard val-t output) e fresh
+  with eval-guard (State.mem st) guard
+... | just g with g
+...   | true with decode val-t
+                    (take (encoded-len val-t) (State.priv-rem st))
+...     | just v with refl ← e =
+          ≼-refl , ins-⊑ {output} {v} {State.mem st} fresh
+step-extends {st = st} (private-input guard val-t output) e fresh
+    | just g | false with refl ← e =
+        ≼-refl , out1-⊑ st output (default-val val-t) fresh
+step-extends {S = S} {st = st} (circuit-output vals) e _
+  with collectOutputs (State.mem st) (IrSource.outputs S) vals
+... | just vs with refl ← e = ≼-refl , ⊑-refl {State.mem st}
+
+-- Operand resolution is monotone in the store.
+resolve-mono : ∀ {m m′} op {v} → m ⊑ m′
+  → resolve m op ≡ just v → resolve m′ op ≡ just v
+resolve-mono (var id) sub r = sub r
+resolve-mono (imm x)  sub r = r
+
+-- The Native-resolution, boolean-reading, guard-evaluation, and
+-- output-collection variants of `resolve-mono`.
+resolveᶠ-mono : ∀ {m m′} op {x} → m ⊑ m′
+  → resolveᶠ m op ≡ just x → resolveᶠ m′ op ≡ just x
+resolveᶠ-mono {m} {m′} op sub r =
+  resolveᶠ-intro m′ op (resolve-mono op sub (resolveᶠ-inv m op r))
+
+resolve𝔹-mono : ∀ {m m′} op {b} → m ⊑ m′
+  → resolve𝔹 m op ≡ just b → resolve𝔹 m′ op ≡ just b
+resolve𝔹-mono {m} {m′} op sub e
+  with resolveᶠ m op in eqx
+... | just x rewrite resolveᶠ-mono {m} {m′} op sub eqx = e
+
+eval-guard-mono : ∀ {m m′} g {b} → m ⊑ m′
+  → eval-guard m g ≡ just b → eval-guard m′ g ≡ just b
+eval-guard-mono nothing   sub e = e
+eval-guard-mono (just op) sub e = resolve𝔹-mono op sub e
+
+collectOutputs-mono : ∀ {m m′} tys ops {vs} → m ⊑ m′
+  → collectOutputs m tys ops ≡ just vs
+  → collectOutputs m′ tys ops ≡ just vs
+collectOutputs-mono          []       []         sub e = e
+collectOutputs-mono {m} {m′} (t ∷ ts) (op ∷ ops) sub e
+  with resolve m op in eqv
+... | just v rewrite resolve-mono op sub eqv
+  with typeof v ≟T t
+...   | yes _ with collectOutputs m ts ops in eqrest
+...     | just rest
+          rewrite collectOutputs-mono {m} {m′} ts ops sub eqrest = e
+collectOutputs-mono          []       (_ ∷ _)    sub ()
+collectOutputs-mono          (_ ∷ _)  []         sub ()
+
+------------------------------------------------------------------------
+-- Run-level single-assignment well-formedness, and run extension.
+--
+-- `WF-run P S is st` threads the per-step output freshness (`out-fresh`)
+-- through the deterministic run from `st`.  Under it, a whole run only
+-- *extends* the store and *appends* to the public inputs.
+------------------------------------------------------------------------
+
+WF-run : ProofPreimage → IrSource → List Instruction → State → Set
+WF-run P S []       st = ⊤
+WF-run P S (i ∷ is) st =
+  out-fresh i (State.mem st)
+  × (∀ {st′} → step P S st i ≡ just st′ → WF-run P S is st′)
+
+-- Invert one step of a run: a non-empty run splits into its first step
+-- and the run of the rest.
+run-inv : ∀ {P S s} i is st
+  → run P S st (i ∷ is) ≡ just s
+  → ∃ λ st-mid → (step P S st i ≡ just st-mid) × (run P S st-mid is ≡ just s)
+run-inv {P} {S} i is st run-eq with step P S st i
+... | just st-mid = st-mid , refl , run-eq
+... | nothing     = case run-eq of λ ()
+
+run-extends : ∀ {P S s} is st
+  → run P S st is ≡ just s
+  → WF-run P S is st
+  → (State.mem st ⊑ State.mem s) × (State.pis st ≼ State.pis s)
+run-extends {s = s} [] st run-eq wf rewrite just-injective run-eq =
+  ⊑-refl {State.mem s} , ≼-refl {State.pis s}
+run-extends (i ∷ is) st run-eq (of , wf-rest) =
+  let (st-mid , step-eq , run-rest) = run-inv i is st run-eq
+      (p≼₁ , m⊑₁) = step-extends i step-eq of
+      (m⊑ , p≼) = run-extends is st-mid run-rest (wf-rest step-eq)
+  in  ⊑-trans {State.mem st} {State.mem st-mid} m⊑₁ m⊑
+   ,  ≼-trans p≼₁ p≼
+
+------------------------------------------------------------------------
+-- Boolean reading of a field element.
+------------------------------------------------------------------------
+
+-- `to𝔹` reading `false` forces the field element to `0ᶠ`.
+to𝔹-false : ∀ {gᶠ} → to𝔹 gᶠ ≡ just false → gᶠ ≡ 0ᶠ
+to𝔹-false {gᶠ} e with gᶠ ≟ᶠ 0ᶠ
+... | yes gᶠ≡0 = gᶠ≡0
+... | no _ with gᶠ ≟ᶠ 1ᶠ
+...   | yes _ = case e of λ ()
+...   | no  _ = case e of λ ()
+
+-- `to𝔹` reading `true` forces the field element to `1ᶠ`.
+to𝔹-true : ∀ {gᶠ} → to𝔹 gᶠ ≡ just true → gᶠ ≡ 1ᶠ
+to𝔹-true {gᶠ} e with gᶠ ≟ᶠ 0ᶠ
+... | yes _ = case e of λ ()
+... | no _ with gᶠ ≟ᶠ 1ᶠ
+...   | yes gᶠ≡1 = gᶠ≡1
+...   | no  _    = case e of λ ()
+
+-- `to𝔹` / `isYes (_ ≟ᶠ 1ᶠ)` reading forced from the bit value.
+to𝔹-0 : ∀ {x} → x ≡ 0ᶠ → to𝔹 x ≡ just false
+to𝔹-0 x≡0 rewrite x≡0 with 0ᶠ ≟ᶠ 0ᶠ
+... | yes _ = refl
+... | no ¬p = case ¬p refl of λ ()
+
+to𝔹-1 : ∀ {x} → x ≡ 1ᶠ → to𝔹 x ≡ just true
+to𝔹-1 x≡1 rewrite x≡1 with 1ᶠ ≟ᶠ 0ᶠ
+... | yes 1≡0 = case 1ᶠ≢0ᶠ 1≡0 of λ ()
+... | no _ with 1ᶠ ≟ᶠ 1ᶠ
+...   | yes _ = refl
+...   | no ¬p = case ¬p refl of λ ()
+
+isYes1-0 : ∀ {x} → x ≡ 0ᶠ → isYes (x ≟ᶠ 1ᶠ) ≡ false
+isYes1-0 x≡0 rewrite x≡0 with 0ᶠ ≟ᶠ 1ᶠ
+... | yes 0≡1 = case 1ᶠ≢0ᶠ (sym 0≡1) of λ ()
+... | no _ = refl
+
+isYes1-1 : ∀ {x} → x ≡ 1ᶠ → isYes (x ≟ᶠ 1ᶠ) ≡ true
+isYes1-1 x≡1 rewrite x≡1 with 1ᶠ ≟ᶠ 1ᶠ
+... | yes _ = refl
+... | no ¬p = case ¬p refl of λ ()
+
+------------------------------------------------------------------------
+-- Miscellaneous run / initialisation facts.
+------------------------------------------------------------------------
+
+-- The number of resolved field elements equals the number of operands.
+resolve-all-Fr-length : ∀ m ops {vals}
+  → resolve-all-Fr m ops ≡ just vals → length vals ≡ length ops
+resolve-all-Fr-length m []         refl = refl
+resolve-all-Fr-length m (op ∷ ops) e
+  with resolveᶠ m op | resolve-all-Fr m ops in eqs
+... | just x | just xs with refl ← e =
+        cong suc (resolve-all-Fr-length m ops eqs)
+
+-- The init state's memory is exactly the decoding of the raw inputs.
+init-decode : ∀ {S P st0}
+  → init S P ≡ just st0
+  → decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P)
+      ≡ just (State.mem st0)
+init-decode {S} {P} {st0} ieq
+  with decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P)
+... | just m
+  with IrSource.do-communications-commitment S
+...   | false = cong (λ z → just (State.mem z)) (just-injective ieq)
+init-decode {S} {P} {st0} ieq | just m | true
+  with ProofPreimage.comm-commitment P
+...     | just (c , _) = cong (λ z → just (State.mem z)) (just-injective ieq)
+
+-- `init` always seeds an empty output stream.
+init-outs : ∀ {S P st0} → init S P ≡ just st0 → State.outs st0 ≡ []
+init-outs {S} {P} {st0} ieq
+  with decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P)
+... | just m
+  with IrSource.do-communications-commitment S
+...   | false = sym (cong State.outs (just-injective ieq))
+init-outs {S} {P} {st0} ieq | just m | true
+  with ProofPreimage.comm-commitment P
+...     | just (c , _) = sym (cong State.outs (just-injective ieq))
+
+------------------------------------------------------------------------
+-- The user-facing run shape.
+--
+-- `Consumed` records the terminal transcript-exhaustion side conditions;
+-- `run-shaped` packages an initial state and a run over the source's
+-- instructions ending EXACTLY at `s`, with the transcripts consumed.
+------------------------------------------------------------------------
+
+Consumed : ProofPreimage → State → Set
+Consumed P s =
+    (State.pti-idx s ≡ length (ProofPreimage.pub-transcript-inputs P))
+  × (State.pto-rem s ≡ [])
+  × (State.priv-rem s ≡ [])
+
+record run-shaped (S : IrSource) (P : ProofPreimage) (s : State) : Set where
+  constructor mk-run-shaped
+  field
+    start    : State
+    init≡    : init S P ≡ just start
+    walk     : run P S start (IrSource.instructions S) ≡ just s
+    consumed : Consumed P s
+
+-- Chaining one reconstructed step onto a tail run: the cons rule of `run`
+-- read as a builder.
+run-cons : ∀ {P S st st' s} i is
+  → step P S st i ≡ just st'
+  → run P S st' is ≡ just s
+  → run P S st (i ∷ is) ≡ just s
+run-cons {P} {S} {st} i is step-eq run-rest rewrite step-eq = run-rest
+
+------------------------------------------------------------------------
+-- `run-shaped` from a successful preprocess.
+------------------------------------------------------------------------
+
+-- Invert a successful `preprocess`: its inner `run` reaches `s` from the
+-- initial state, and the terminal transcript-exhaustion side conditions
+-- hold (the terminal guards only pass `stf` through).  A single walk of
+-- the 7-deep guard tower yields both facts.
+preprocess-walk-consumed : ∀ {S P s st0}
+  → init S P ≡ just st0 → preprocess S P ≡ just s
+  → run P S st0 (IrSource.instructions S) ≡ just s × Consumed P s
+preprocess-walk-consumed {S} {P} {s} {st0} ieq peq
+  with init S P | ieq
+... | just st0' | refl
+  with run P S st0' (IrSource.instructions S)
+...   | just stf
+  with State.pti-idx stf ≟ℕ length (ProofPreimage.pub-transcript-inputs P)
+...     | yes p
+  with State.pto-rem stf in ptoeq
+...       | []
+  with State.priv-rem stf in preq
+...         | []
+  with IrSource.do-communications-commitment S
+...           | false with refl ← peq = refl , p , ptoeq , preq
+preprocess-walk-consumed {S} {P} {s} {st0} ieq peq
+  | just st0' | refl | just stf | yes p | [] | [] | true
+  with ProofPreimage.comm-commitment P
+...             | just (c , r)
+  with c ≟ᶠ transient-commit
+              (ProofPreimage.inputs P ++ concatMap encodeᵉ (State.outs stf)) r
+...               | yes _ with refl ← peq = refl , p , ptoeq , preq
+
+-- `run-shaped` follows directly from a successful `init` + `preprocess`.
+-- This is the target the witness→run construction reduces to: build `P'`
+-- with a successful `preprocess`, and `run-shaped` is immediate.
+preprocess→run-shaped : ∀ {S P s st0}
+  → init S P ≡ just st0 → preprocess S P ≡ just s → run-shaped S P s
+preprocess→run-shaped {S} {P} {s} {st0} ieq peq =
+  let (walk , consumed) = preprocess-walk-consumed {S} {P} {s} {st0} ieq peq
+  in mk-run-shaped st0 ieq walk consumed

--- a/formal/src/zkir-v3/StatementSoundness.agda
+++ b/formal/src/zkir-v3/StatementSoundness.agda
@@ -1,0 +1,4056 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Constructive (pis-form) statement soundness for zkir-v3.
+--
+-- The backward faithfulness result `backward` (in `CircuitProof`) is the
+-- converse of `forward` for a GIVEN preprocess run and a GIVEN backward
+-- spine.  Statement soundness strengthens this: from an ARBITRARY
+-- satisfying witness `w` of `synth S` (with a well-typed producer and a
+-- minimal witness-shape side condition on the free public/private-input
+-- cells), one CONSTRUCTS a preimage `P'` and a final state `s` with
+-- `run-shaped S P' s` and three agreements against `w`, all packaged in a
+-- `SubRealizer S w` record:
+--   • `pis (witness-of P' s) ≡ pis w` — the pis-form, not the extraction
+--     form `witness-of P' s ≡ w`, which is false for the unconstrained
+--     public/private-input cells and guards;
+--   • `mem s ⊑ᵂ w` — the run's entire final memory is a sub-assignment of
+--     `w` (the honest v3 analogue of the extraction form, restricted to
+--     the run's domain);
+--   • when `do-comm S ≡ true`, `comm-rand (witness-of P' s) ≡ comm-rand w`;
+-- together with `CommWF`, which forces an absent commitment when the flag
+-- is off (`do-comm S ≡ false → comm-commitment P' ≡ nothing`).
+--
+-- The construction:
+--
+--   • It rests on `preprocess→run-shaped` (SemanticsProperties):
+--     `run-shaped` is exactly a successful `init` + `preprocess` (the walk
+--     is the `run` inside `preprocess`, and the terminal `Consumed` side
+--     conditions, both read off `preprocess-walk-consumed`).  So the
+--     construction reduces to building `P'` with `preprocess S P' ≡ just s`
+--     and `pis s ≡ pis w`.
+--
+--   • The memory-agreement invariant `m ⊑ᵂ w` (the run memory is a
+--     sub-assignment of the witness) and its resolution-transport lemmas.
+--     For every constraint-pinned instruction the witness's output cell is
+--     exactly what `step` computes (`agree-mul` is the representative), so
+--     the invariant is preserved as the run binds outputs; and on an
+--     active `impact` group the value the run appends to `pis` equals the
+--     witness's pinned pi entry (`impact-slice`) — the per-entry basis of
+--     the pis-form conclusion, driven entirely by `satisfies w`.
+--
+--   • The w-only pre-passes (`mkInputs`/`mkPTI`/`mkPTO`/`mkPRV`), the
+--     34-clause `build` run-realizer, the branch lemmas
+--     `statement-sound-false`/`-true`, and the combined `statement-sound`.
+------------------------------------------------------------------------
+
+module zkir-v3.StatementSoundness (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Semantics ⋯
+open import zkir-v3.SemanticsProperties ⋯
+open import zkir-v3.Circuit ⋯
+open import zkir-v3.CircuitBridge ⋯
+open import zkir-v3.CircuitFaithfulness ⋯
+open import zkir-v3.Obligations ⋯
+open import zkir-v3.CircuitProof ⋯
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+open import zkir-v3.Semantics ⋯ using () renaming (χ to χˢ; pow2ᶠ to pow2ᶠˢ)
+open import zkir-v3.Circuit ⋯ using () renaming (χ to χᶜ)
+
+open import Data.Bool    using (Bool; true; false; if_then_else_)
+                         renaming (not to bnot)
+open import Data.Bool.Properties using () renaming (_≟_ to _≟𝔹_)
+open import Data.List    using (List; []; _∷_; _++_; take; drop; length; map;
+                                concatMap)
+open import Data.Maybe   using (Maybe; just; nothing; _>>=_; maybe′)
+open import Data.Vec     using (reverse)
+open import Data.Sum     using (_⊎_; inj₁; inj₂)
+open import Data.Product using (_×_; _,_; ∃; ∃-syntax; uncurry; proj₁; proj₂)
+open import Data.Unit    using (⊤; tt)
+open import Data.String  using () renaming (_≟_ to _≟str_)
+open import Data.List.Properties using (drop-drop; length-++; length-map;
+                                        take-all; ++-assoc)
+open import Data.Nat.Properties using (+-identityʳ; +-assoc; ≤-reflexive)
+open import Data.List.Relation.Unary.All using (All; []; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Relation.Binary.PropositionalEquality
+open import Relation.Binary.Definitions using (DecidableEquality)
+open import Relation.Nullary using (¬_; yes; no; Dec)
+open import Relation.Nullary.Decidable using (isYes; map′; _×-dec_)
+open import Data.Maybe.Properties using (just-injective; ≡-dec)
+open import Function using (case_of_)
+open import Data.Nat using (ℕ; zero; suc; _+_; _*_; _^_; _∸_; _<_; _<?_)
+                     renaming (_≟_ to _≟ℕ_)
+
+------------------------------------------------------------------------
+-- The memory-agreement invariant and its resolution transport.
+------------------------------------------------------------------------
+
+-- The run's memory is a sub-assignment of the given witness `w`.
+_⊑ᵂ_ : Mem → CircuitWitness → Set
+m ⊑ᵂ w = m ⊑ CircuitWitness.assign w
+
+-- Transport an off-circuit resolution up to the witness under agreement.
+⊑-resolve : ∀ {m w} op {v}
+  → m ⊑ᵂ w → resolve m op ≡ just v → resolveᶜ w op ≡ just v
+⊑-resolve (imm x)  sub e = e
+⊑-resolve (var id) sub e = sub e
+
+⊑-resolveᶠ : ∀ {m w} op {x}
+  → m ⊑ᵂ w → resolveᶠ m op ≡ just x → resolveᶜ-Fr w op ≡ just x
+⊑-resolveᶠ (imm x)  sub e = e
+⊑-resolveᶠ {m} (var id) sub e with m id in re
+... | just (val-native v) rewrite sub {id} {val-native v} re = e
+
+-- The list companion of `⊑-resolve`, for the all-native input lists of
+-- `hash-to-curve`/`transient-hash`/`impact`.
+⊑-resolve-all : ∀ {m w} ops {frs}
+  → m ⊑ᵂ w → resolve-all-Fr m ops ≡ just frs
+  → resolveᶜ-all-Fr w ops ≡ just frs
+⊑-resolve-all []       sub refl = refl
+⊑-resolve-all {m} {w} (op ∷ ops) sub e
+  with resolveᶠ m op in eo | resolve-all-Fr m ops in eos | e
+... | just x | just xs | refl
+  with resolveᶜ-Fr w op | ⊑-resolveᶠ {w = w} op sub eo
+...   | .(just x) | refl
+  with resolveᶜ-all-Fr w ops | ⊑-resolve-all {w = w} ops sub eos
+...     | .(just xs) | refl = refl
+
+------------------------------------------------------------------------
+-- Agreement is preserved: the witness's output cell is exactly what
+-- `step` computes.  `agree-mul` is the representative for the whole
+-- constraint-pinned family (add/copy/neg/inv/ec-*/hash/bytes/coords/
+-- div-mod/less-than/…): the gate fixes the output from operands the
+-- invariant already agrees on, via `⊑-resolveᶠ`/`⊑-resolve`.
+------------------------------------------------------------------------
+
+agree-mul : ∀ {m w a b out x y}
+  → m ⊑ᵂ w
+  → resolveᶠ m a ≡ just x → resolveᶠ m b ≡ just y
+  → holds w (gate-mul out a b)
+  → CircuitWitness.assign w out ≡ just (val-native (x *ᶠ y))
+agree-mul {w = w} {a = a} {b} sub ra rb
+  (av , bv , ov , wa , wb , wout , disj)
+  with trans (sym (resolveᶜ-Fr-inv w a (⊑-resolveᶠ a sub ra))) wa
+     | trans (sym (resolveᶜ-Fr-inv w b (⊑-resolveᶠ b sub rb))) wb
+... | refl | refl with disj
+...   | inj₁ (x' , y' , refl , refl , refl) = wout
+...   | inj₂ (inj₁ (_ , _ , () , _))
+...   | inj₂ (inj₂ (_ , _ , () , _))
+
+-- The rest of the total-value family (output value = a total function of
+-- the resolved operands).  Each lifts the run's resolutions to `w` with
+-- `⊑-resolve*`, unifies them with the witness's pinned operands (`refl`),
+-- and returns the witness's output cell (bridging `χˢ`/`χ` where the
+-- value is a boolean reading, since `step` uses the Semantics copy and
+-- `holds` the Circuit copy).
+
+agree-add-n : ∀ {m w a b out x y}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-native x) → resolve m b ≡ just (val-native y)
+  → holds w (gate-add out a b)
+  → CircuitWitness.assign w out ≡ just (val-native (x +ᶠ y))
+agree-add-n {a = a} {b} sub ra rb (av , bv , ov , wa , wb , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve b sub rb)) wb
+... | refl | refl with disj
+...   | inj₁ (x , y , refl , refl , refl) = wout
+...   | inj₂ (inj₁ (p , q , () , _))
+...   | inj₂ (inj₂ (inj₁ (p , q , () , _)))
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , y , () , _))))
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , y , () , _))))
+
+agree-add-p : ∀ {m w a b out p q}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-jubjub-point p)
+  → resolve m b ≡ just (val-jubjub-point q)
+  → holds w (gate-add out a b)
+  → CircuitWitness.assign w out ≡ just (val-jubjub-point (p +J q))
+agree-add-p {a = a} {b} sub ra rb (av , bv , ov , wa , wb , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve b sub rb)) wb
+... | refl | refl with disj
+...   | inj₁ (x , y , () , _)
+...   | inj₂ (inj₁ (p , q , refl , refl , refl)) = wout
+...   | inj₂ (inj₂ (inj₁ (p , q , () , _)))
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , y , () , _))))
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , y , () , _))))
+
+agree-neg-n : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-native x)
+  → holds w (gate-neg out a)
+  → CircuitWitness.assign w out ≡ just (val-native (-ᶠ x))
+agree-neg-n {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (x , refl , refl) = wout
+...   | inj₂ (inj₁ (p , () , _))
+...   | inj₂ (inj₂ (inj₁ (p , () , _)))
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , () , _))))
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , () , _))))
+
+agree-neg-p : ∀ {m w a out p}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-jubjub-point p)
+  → holds w (gate-neg out a)
+  → CircuitWitness.assign w out ≡ just (val-jubjub-point (negJ p))
+agree-neg-p {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (x , () , _)
+...   | inj₂ (inj₁ (p , refl , refl)) = wout
+...   | inj₂ (inj₂ (inj₁ (p , () , _)))
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , () , _))))
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , () , _))))
+
+agree-copy : ∀ {m w a out v}
+  → m ⊑ᵂ w → resolve m a ≡ just v
+  → holds w (gate-copy out a)
+  → CircuitWitness.assign w out ≡ just v
+agree-copy {a = a} sub ra (av , wa , wout)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl = wout
+
+agree-test-eq : ∀ {m w a b out av bv e}
+  → m ⊑ᵂ w → resolve m a ≡ just av → resolve m b ≡ just bv
+  → valEq? av bv ≡ just e
+  → holds w (test-eq out a b)
+  → CircuitWitness.assign w out ≡ just (val-native (χˢ e))
+agree-test-eq {a = a} {b} {e = e} sub ra rb ve
+  (av , bv , eqb , wa , wb , wveq , wout)
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve b sub rb)) wb
+... | refl | refl with trans (sym ve) wveq
+...   | refl =
+  wout
+
+agree-scalar-from-native : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolveᶠ m a ≡ just x
+  → holds w (scalar-from-native out a)
+  → CircuitWitness.assign w out
+      ≡ just (val-jubjub-scalar (native→jubjubScalar x))
+agree-scalar-from-native {a = a} sub ra (x , wa , wout)
+  with trans (sym (⊑-resolveᶠ a sub ra)) wa
+... | refl = wout
+
+agree-ec-mul : ∀ {m w a scalar out p s}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-jubjub-point p)
+  → resolve m scalar ≡ just (val-jubjub-scalar s)
+  → holds w (ec-mul out a scalar)
+  → CircuitWitness.assign w out ≡ just (val-jubjub-point (s ·J p))
+agree-ec-mul {a = a} {scalar} sub ra rs (inj₁ (p , s , wa , ws , wout))
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve scalar sub rs)) ws
+... | refl | refl = wout
+agree-ec-mul {a = a} sub ra rs (inj₂ (p , s , wa , ws , wout))
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | ()
+
+agree-ec-gen : ∀ {m w scalar out s}
+  → m ⊑ᵂ w → resolve m scalar ≡ just (val-jubjub-scalar s)
+  → holds w (ec-gen out scalar)
+  → CircuitWitness.assign w out ≡ just (val-jubjub-point (s ·J genJ))
+agree-ec-gen {scalar = scalar} sub rs (inj₁ (s , ws , wout))
+  with trans (sym (⊑-resolve scalar sub rs)) ws
+... | refl = wout
+agree-ec-gen {scalar = scalar} sub rs (inj₂ (s , ws , wout))
+  with trans (sym (⊑-resolve scalar sub rs)) ws
+... | ()
+
+agree-h2c : ∀ {m w inputs out frs}
+  → m ⊑ᵂ w → resolve-all-Fr m inputs ≡ just frs
+  → holds w (h2c out inputs)
+  → CircuitWitness.assign w out
+      ≡ just (val-jubjub-point (hash-to-curve-fn frs))
+agree-h2c {inputs = inputs} sub rf (frs , wf , wout)
+  with trans (sym (⊑-resolve-all inputs sub rf)) wf
+... | refl = wout
+
+agree-transient-hash : ∀ {m w inputs out frs}
+  → m ⊑ᵂ w → resolve-all-Fr m inputs ≡ just frs
+  → holds w (poseidon out inputs)
+  → CircuitWitness.assign w out ≡ just (val-native (transient-hash-fn frs))
+agree-transient-hash {inputs = inputs} sub rf (frs , wf , wout)
+  with trans (sym (⊑-resolve-all inputs sub rf)) wf
+... | refl = wout
+
+agree-into-bytes : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolveᶠ m a ≡ just x
+  → holds w (into-bytes out a)
+  → CircuitWitness.assign w out ≡ just (val-bytes32 (nativeToBytes x))
+agree-into-bytes {w = w} {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (resolveᶜ-Fr-inv w a (⊑-resolveᶠ a sub ra))) wa
+... | refl with disj
+...   | inj₁ (x , refl , refl) = wout
+...   | inj₂ (inj₁ (_ , () , _))
+...   | inj₂ (inj₂ (_ , () , _))
+
+agree-less-than : ∀ {m w a b bits out x y}
+  → m ⊑ᵂ w → resolveᶠ m a ≡ just x → resolveᶠ m b ≡ just y
+  → holds w (less-than out a b bits)
+  → CircuitWitness.assign w out
+      ≡ just (val-native (χˢ (isYes (valFr x <? valFr y))))
+agree-less-than {a = a} {b} sub ra rb (x , y , wa , wb , bx , by , wout)
+  with trans (sym (⊑-resolveᶠ a sub ra)) wa
+     | trans (sym (⊑-resolveᶠ b sub rb)) wb
+... | refl | refl =
+  wout
+
+-- Partial-op / two-output instructions.  The output value depends on a
+-- partial operation or the instruction binds two cells, so `holds`
+-- carries the output cell(s) as witness existentials; each lemma unifies
+-- the run's operands with the witness's and returns the semantic success
+-- fact(s) (which feed the matching `*-step`) bundled with the output
+-- cell(s) (which feed `ins-⊑ᵂ`).
+
+agree-inv : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolveᶠ m a ≡ just x
+  → holds w (gate-inv out a)
+  → ∃ λ xi → invᶠ x ≡ just xi
+           × CircuitWitness.assign w out ≡ just (val-native xi)
+agree-inv {w = w} {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (resolveᶜ-Fr-inv w a (⊑-resolveᶠ a sub ra))) wa
+... | refl with disj
+...   | inj₁ (_ , xi , refl , invEq , refl) = xi , invEq , wout
+...   | inj₂ (inj₁ (_ , _ , () , _))
+...   | inj₂ (inj₂ (_ , _ , () , _))
+
+-- `from-bytes`'s constraint is a 3-way disjunction over the output value; it
+-- does NOT record the instruction's `val-t`.  The declared output cell value
+-- `v` (from `WCell`, with `typeof v ≡ val-t`) selects the matching disjunct:
+-- the two off-type disjuncts pin `v` to the other constructor, contradicting
+-- `typeof v ≡ val-t`.
+agree-from-bytes-native : ∀ {m w b out bs v}
+  → m ⊑ᵂ w → resolve m b ≡ just (val-bytes32 bs)
+  → holds w (from-bytes out b)
+  → CircuitWitness.assign w out ≡ just v → typeof v ≡ native
+  → CircuitWitness.assign w out ≡ just (val-native (nativeFromBytes bs))
+agree-from-bytes-native {b = b} sub rb (bs , wb , disj) wo tv
+  with trans (sym (⊑-resolve b sub rb)) wb
+... | refl with disj
+...   | inj₁ e = e
+...   | inj₂ (inj₁ e) with just-injective (trans (sym wo) e)
+...     | refl = case tv of λ ()
+agree-from-bytes-native {b = b} sub rb (bs , wb , disj) wo tv
+  | refl | inj₂ (inj₂ e) with just-injective (trans (sym wo) e)
+...   | refl = case tv of λ ()
+
+agree-from-bytes-secp-base : ∀ {m w b out bs v}
+  → m ⊑ᵂ w → resolve m b ≡ just (val-bytes32 bs)
+  → holds w (from-bytes out b)
+  → CircuitWitness.assign w out ≡ just v → typeof v ≡ secp-base
+  → CircuitWitness.assign w out ≡ just (val-secp-base (secpBaseFromBytes bs))
+agree-from-bytes-secp-base {b = b} sub rb (bs , wb , disj) wo tv
+  with trans (sym (⊑-resolve b sub rb)) wb
+... | refl with disj
+...   | inj₂ (inj₁ e) = e
+...   | inj₁ e with just-injective (trans (sym wo) e)
+...     | refl = case tv of λ ()
+agree-from-bytes-secp-base {b = b} sub rb (bs , wb , disj) wo tv
+  | refl | inj₂ (inj₂ e) with just-injective (trans (sym wo) e)
+...   | refl = case tv of λ ()
+
+agree-from-bytes-secp-scalar : ∀ {m w b out bs v}
+  → m ⊑ᵂ w → resolve m b ≡ just (val-bytes32 bs)
+  → holds w (from-bytes out b)
+  → CircuitWitness.assign w out ≡ just v → typeof v ≡ secp-scalar
+  → CircuitWitness.assign w out ≡ just (val-secp-scalar (secpScalarFromBytes bs))
+agree-from-bytes-secp-scalar {b = b} sub rb (bs , wb , disj) wo tv
+  with trans (sym (⊑-resolve b sub rb)) wb
+... | refl with disj
+...   | inj₂ (inj₂ e) = e
+...   | inj₁ e with just-injective (trans (sym wo) e)
+...     | refl = case tv of λ ()
+agree-from-bytes-secp-scalar {b = b} sub rb (bs , wb , disj) wo tv
+  | refl | inj₂ (inj₁ e) with just-injective (trans (sym wo) e)
+...   | refl = case tv of λ ()
+
+-- The `from-bytes` constraint pins the output cell to one of the three
+-- supported value constructors; so the value `w` binds there has a
+-- supported type.  Used to refute the unsupported declared `val-t`.
+from-bytes-out-typeof : ∀ {w o bytes v}
+  → holds w (from-bytes o bytes)
+  → CircuitWitness.assign w o ≡ just v
+  → (typeof v ≡ native) ⊎ (typeof v ≡ secp-base) ⊎ (typeof v ≡ secp-scalar)
+from-bytes-out-typeof (bs , wb , inj₁ e)        wo =
+  inj₁ (cong typeof (just-injective (trans (sym wo) e)))
+from-bytes-out-typeof (bs , wb , inj₂ (inj₁ e)) wo =
+  inj₂ (inj₁ (cong typeof (just-injective (trans (sym wo) e))))
+from-bytes-out-typeof (bs , wb , inj₂ (inj₂ e)) wo =
+  inj₂ (inj₂ (cong typeof (just-injective (trans (sym wo) e))))
+
+agree-reverse-bytes : ∀ {m w b out bs}
+  → m ⊑ᵂ w → resolve m b ≡ just (val-bytes32 bs)
+  → holds w (reverse-bytes out b)
+  → CircuitWitness.assign w out ≡ just (val-bytes32 (reverse bs))
+agree-reverse-bytes {b = b} sub rb (bs , wb , wout)
+  with trans (sym (⊑-resolve b sub rb)) wb
+... | refl = wout
+
+agree-from-coords : ∀ {m w xop yop out xv yv}
+  → m ⊑ᵂ w → resolveᶠ m xop ≡ just xv → resolveᶠ m yop ≡ just yv
+  → holds w (from-coords out xop yop)
+  → ∃ λ p → fromCoordsJ xv yv ≡ just p
+          × CircuitWitness.assign w out ≡ just (val-jubjub-point p)
+agree-from-coords {xop = xop} {yop} sub rx ry
+  (inj₁ (xv , yv , p , wx , wy , fcEq , wout))
+  with trans (sym (⊑-resolveᶠ xop sub rx)) wx
+     | trans (sym (⊑-resolveᶠ yop sub ry)) wy
+... | refl | refl = p , fcEq , wout
+agree-from-coords {w = w} {xop = xop} sub rx ry
+  (inj₂ (xv , yv , p , wx , wy , fcEq , wout))
+  with trans (sym (resolveᶜ-Fr-inv w xop (⊑-resolveᶠ xop sub rx))) wx
+... | ()
+
+agree-bytes-from-low-high : ∀ {m w lop hip out l h}
+  → m ⊑ᵂ w → resolveᶠ m lop ≡ just l → resolveᶠ m hip ≡ just h
+  → holds w (bytes-from-low-high out lop hip)
+  → ∃ λ bs → low-high→bytes32 l h ≡ just bs
+           × CircuitWitness.assign w out ≡ just (val-bytes32 bs)
+agree-bytes-from-low-high {lop = lop} {hip} sub rl rh
+  (l , h , bs , wlo , whi , lhEq , wout)
+  with trans (sym (⊑-resolveᶠ lop sub rl)) wlo
+     | trans (sym (⊑-resolveᶠ hip sub rh)) whi
+... | refl | refl = bs , lhEq , wout
+
+agree-reconstitute : ∀ {m w divisor modulus bits out d mo}
+  → m ⊑ᵂ w → resolveᶠ m divisor ≡ just d → resolveᶠ m modulus ≡ just mo
+  → holds w (reconstitute out divisor modulus bits)
+  → (valFr mo < 2 ^ bits) × (valFr d < 2 ^ (FR-BITS ∸ bits))
+  × CircuitWitness.assign w out
+      ≡ just (val-native ((pow2ᶠˢ bits *ᶠ d) +ᶠ mo))
+agree-reconstitute {divisor = divisor} {modulus} {bits = bits}
+  sub rd rmo (dv , mv , wd , wm , bd , bm , wout)
+  with trans (sym (⊑-resolveᶠ divisor sub rd)) wd
+     | trans (sym (⊑-resolveᶠ modulus sub rmo)) wm
+... | refl | refl =
+  bm , bd , wout
+
+agree-into-coords : ∀ {m w point xo yo p}
+  → m ⊑ᵂ w → resolve m point ≡ just (val-jubjub-point p)
+  → holds w (into-coords xo yo point)
+  → ∃ λ x → ∃ λ y → coordsJ p ≡ (x , y)
+          × CircuitWitness.assign w xo ≡ just (val-native x)
+          × CircuitWitness.assign w yo ≡ just (val-native y)
+agree-into-coords {point = point} sub rp
+  (inj₁ (p , x , y , wp , coordsEq , wxo , wyo))
+  with trans (sym (⊑-resolve point sub rp)) wp
+... | refl = x , y , coordsEq , wxo , wyo
+agree-into-coords {point = point} sub rp
+  (inj₂ (p , x , y , wp , coordsEq , wxo , wyo))
+  with trans (sym (⊑-resolve point sub rp)) wp
+... | ()
+
+agree-bytes-into-low-high : ∀ {m w bytes lo hi bs}
+  → m ⊑ᵂ w → resolve m bytes ≡ just (val-bytes32 bs)
+  → holds w (bytes-into-low-high lo hi bytes)
+  → ∃ λ l → ∃ λ h → bytes32→low-high bs ≡ (l , h)
+          × CircuitWitness.assign w lo ≡ just (val-native l)
+          × CircuitWitness.assign w hi ≡ just (val-native h)
+agree-bytes-into-low-high {bytes = bytes} sub rb
+  (bs , l , h , wb , splitEq , wlo , whi)
+  with trans (sym (⊑-resolve bytes sub rb)) wb
+... | refl = l , h , splitEq , wlo , whi
+
+agree-div-mod : ∀ {m w q r val bits x}
+  → m ⊑ᵂ w → resolveᶠ m val ≡ just x
+  → holds w (div-mod q r val bits)
+  → CircuitWitness.assign w q
+      ≡ just (val-native (from-le-bits (drop bits (to-le-bits x))))
+  × CircuitWitness.assign w r
+      ≡ just (val-native (from-le-bits (take bits (to-le-bits x))))
+agree-div-mod {val = val} sub rv (x , wv , wq , wr)
+  with trans (sym (⊑-resolveᶠ val sub rv)) wv
+... | refl = wq , wr
+
+agree-persistent-hash : ∀ {m w out al inputs frs}
+  → m ⊑ᵂ w → resolve-all-Fr m inputs ≡ just frs
+  → holds w (sha256 out al inputs)
+  → ∃ λ v → persistent-hash-fn al frs ≡ just v
+          × CircuitWitness.assign w out ≡ just (val-bytes32 v)
+agree-persistent-hash {inputs = inputs} sub rf
+  (frs , v , rall , phEq , wout)
+  with trans (sym (⊑-resolve-all inputs sub rf)) rall
+... | refl = v , phEq , wout
+
+agree-keccak : ∀ {m w out al inputs frs}
+  → m ⊑ᵂ w → resolve-all-Fr m inputs ≡ just frs
+  → holds w (keccak out al inputs)
+  → ∃ λ v → keccak-fn al frs ≡ just v
+          × CircuitWitness.assign w out ≡ just (val-bytes32 v)
+agree-keccak {inputs = inputs} sub rf
+  (frs , v , rall , kfEq , wout)
+  with trans (sym (⊑-resolve-all inputs sub rf)) rall
+... | refl = v , kfEq , wout
+
+------------------------------------------------------------------------
+-- The Secp256k1 companions of the total/partial-value agreements.  Each
+-- selects the constructor-matching `holds` disjunct (the off-type arms
+-- pin `av`/`ov` to the wrong constructor, killed by the resolution
+-- equalities); the top-level ⊎ instructions (ec-mul/ec-gen/coords) cross
+-- to the other arm via `⊑-resolve`/`resolveᶜ-Fr-inv`.
+------------------------------------------------------------------------
+
+agree-add-sp : ∀ {m w a b out p q}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-secp-point p)
+  → resolve m b ≡ just (val-secp-point q)
+  → holds w (gate-add out a b)
+  → CircuitWitness.assign w out ≡ just (val-secp-point (p +K q))
+agree-add-sp {a = a} {b} sub ra rb (av , bv , ov , wa , wb , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve b sub rb)) wb
+... | refl | refl with disj
+...   | inj₁ (x , y , () , _)
+...   | inj₂ (inj₁ (p , q , () , _))
+...   | inj₂ (inj₂ (inj₁ (p , q , refl , refl , refl))) = wout
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , y , () , _))))
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , y , () , _))))
+
+agree-add-sb : ∀ {m w a b out x y}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-secp-base x)
+  → resolve m b ≡ just (val-secp-base y)
+  → holds w (gate-add out a b)
+  → CircuitWitness.assign w out ≡ just (val-secp-base (x +ᵇ y))
+agree-add-sb {a = a} {b} sub ra rb (av , bv , ov , wa , wb , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve b sub rb)) wb
+... | refl | refl with disj
+...   | inj₁ (x , y , () , _)
+...   | inj₂ (inj₁ (p , q , () , _))
+...   | inj₂ (inj₂ (inj₁ (p , q , () , _)))
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , y , refl , refl , refl)))) = wout
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , y , () , _))))
+
+agree-add-ss : ∀ {m w a b out x y}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-secp-scalar x)
+  → resolve m b ≡ just (val-secp-scalar y)
+  → holds w (gate-add out a b)
+  → CircuitWitness.assign w out ≡ just (val-secp-scalar (x +ˢ y))
+agree-add-ss {a = a} {b} sub ra rb (av , bv , ov , wa , wb , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve b sub rb)) wb
+... | refl | refl with disj
+...   | inj₁ (x , y , () , _)
+...   | inj₂ (inj₁ (p , q , () , _))
+...   | inj₂ (inj₂ (inj₁ (p , q , () , _)))
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , y , () , _))))
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , y , refl , refl , refl)))) = wout
+
+agree-mul-sb : ∀ {m w a b out x y}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-secp-base x)
+  → resolve m b ≡ just (val-secp-base y)
+  → holds w (gate-mul out a b)
+  → CircuitWitness.assign w out ≡ just (val-secp-base (x *ᵇ y))
+agree-mul-sb {a = a} {b} sub ra rb (av , bv , ov , wa , wb , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve b sub rb)) wb
+... | refl | refl with disj
+...   | inj₁ (x , y , () , _)
+...   | inj₂ (inj₁ (x , y , refl , refl , refl)) = wout
+...   | inj₂ (inj₂ (x , y , () , _))
+
+agree-mul-ss : ∀ {m w a b out x y}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-secp-scalar x)
+  → resolve m b ≡ just (val-secp-scalar y)
+  → holds w (gate-mul out a b)
+  → CircuitWitness.assign w out ≡ just (val-secp-scalar (x *ˢ y))
+agree-mul-ss {a = a} {b} sub ra rb (av , bv , ov , wa , wb , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve b sub rb)) wb
+... | refl | refl with disj
+...   | inj₁ (x , y , () , _)
+...   | inj₂ (inj₁ (x , y , () , _))
+...   | inj₂ (inj₂ (x , y , refl , refl , refl)) = wout
+
+agree-neg-sp : ∀ {m w a out p}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-secp-point p)
+  → holds w (gate-neg out a)
+  → CircuitWitness.assign w out ≡ just (val-secp-point (negK p))
+agree-neg-sp {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (x , () , _)
+...   | inj₂ (inj₁ (p , () , _))
+...   | inj₂ (inj₂ (inj₁ (p , refl , refl))) = wout
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , () , _))))
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , () , _))))
+
+agree-neg-sb : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-secp-base x)
+  → holds w (gate-neg out a)
+  → CircuitWitness.assign w out ≡ just (val-secp-base (-ᵇ x))
+agree-neg-sb {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (x , () , _)
+...   | inj₂ (inj₁ (p , () , _))
+...   | inj₂ (inj₂ (inj₁ (p , () , _)))
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , refl , refl)))) = wout
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , () , _))))
+
+agree-neg-ss : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-secp-scalar x)
+  → holds w (gate-neg out a)
+  → CircuitWitness.assign w out ≡ just (val-secp-scalar (-ˢ x))
+agree-neg-ss {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (x , () , _)
+...   | inj₂ (inj₁ (p , () , _))
+...   | inj₂ (inj₂ (inj₁ (p , () , _)))
+...   | inj₂ (inj₂ (inj₂ (inj₁ (x , () , _))))
+...   | inj₂ (inj₂ (inj₂ (inj₂ (x , refl , refl)))) = wout
+
+agree-inv-sb : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-secp-base x)
+  → holds w (gate-inv out a)
+  → ∃ λ xi → invᵇ x ≡ just xi
+           × CircuitWitness.assign w out ≡ just (val-secp-base xi)
+agree-inv-sb {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (_ , _ , () , _)
+...   | inj₂ (inj₁ (_ , xi , refl , invEq , refl)) = xi , invEq , wout
+...   | inj₂ (inj₂ (_ , _ , () , _))
+
+agree-inv-ss : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-secp-scalar x)
+  → holds w (gate-inv out a)
+  → ∃ λ xi → invˢ x ≡ just xi
+           × CircuitWitness.assign w out ≡ just (val-secp-scalar xi)
+agree-inv-ss {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (_ , _ , () , _)
+...   | inj₂ (inj₁ (_ , _ , () , _))
+...   | inj₂ (inj₂ (_ , xi , refl , invEq , refl)) = xi , invEq , wout
+
+agree-ec-mul-secp : ∀ {m w a scalar out p s}
+  → m ⊑ᵂ w
+  → resolve m a ≡ just (val-secp-point p)
+  → resolve m scalar ≡ just (val-secp-scalar s)
+  → holds w (ec-mul out a scalar)
+  → CircuitWitness.assign w out ≡ just (val-secp-point (s ·K p))
+agree-ec-mul-secp {a = a} {scalar} sub ra rs (inj₂ (p , s , wa , ws , wout))
+  with trans (sym (⊑-resolve a sub ra)) wa
+     | trans (sym (⊑-resolve scalar sub rs)) ws
+... | refl | refl = wout
+agree-ec-mul-secp {a = a} sub ra rs (inj₁ (p , s , wa , ws , wout))
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | ()
+
+agree-ec-gen-secp : ∀ {m w scalar out s}
+  → m ⊑ᵂ w → resolve m scalar ≡ just (val-secp-scalar s)
+  → holds w (ec-gen out scalar)
+  → CircuitWitness.assign w out ≡ just (val-secp-point (s ·K genK))
+agree-ec-gen-secp {scalar = scalar} sub rs (inj₂ (s , ws , wout))
+  with trans (sym (⊑-resolve scalar sub rs)) ws
+... | refl = wout
+agree-ec-gen-secp {scalar = scalar} sub rs (inj₁ (s , ws , wout))
+  with trans (sym (⊑-resolve scalar sub rs)) ws
+... | ()
+
+agree-into-coords-secp : ∀ {m w point xo yo p}
+  → m ⊑ᵂ w → resolve m point ≡ just (val-secp-point p)
+  → holds w (into-coords xo yo point)
+  → ∃ λ x → ∃ λ y → coordsK p ≡ just (x , y)
+          × CircuitWitness.assign w xo ≡ just (val-secp-base x)
+          × CircuitWitness.assign w yo ≡ just (val-secp-base y)
+agree-into-coords-secp {point = point} sub rp
+  (inj₂ (p , x , y , wp , coordsEq , wxo , wyo))
+  with trans (sym (⊑-resolve point sub rp)) wp
+... | refl = x , y , coordsEq , wxo , wyo
+agree-into-coords-secp {point = point} sub rp
+  (inj₁ (p , x , y , wp , coordsEq , wxo , wyo))
+  with trans (sym (⊑-resolve point sub rp)) wp
+... | ()
+
+agree-from-coords-secp : ∀ {m w xop yop out xv yv}
+  → m ⊑ᵂ w
+  → resolve m xop ≡ just (val-secp-base xv)
+  → resolve m yop ≡ just (val-secp-base yv)
+  → holds w (from-coords out xop yop)
+  → ∃ λ p → fromCoordsK xv yv ≡ just p
+          × CircuitWitness.assign w out ≡ just (val-secp-point p)
+agree-from-coords-secp {xop = xop} {yop} sub rx ry
+  (inj₂ (xv , yv , p , wx , wy , fcEq , wout))
+  with trans (sym (⊑-resolve xop sub rx)) wx
+     | trans (sym (⊑-resolve yop sub ry)) wy
+... | refl | refl = p , fcEq , wout
+agree-from-coords-secp {w = w} {xop = xop} sub rx ry
+  (inj₁ (xv , yv , p , wx , wy , fcEq , wout))
+  with trans (sym (⊑-resolve xop sub rx)) (resolveᶜ-Fr-inv w xop wx)
+... | ()
+
+agree-into-bytes-sb : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-secp-base x)
+  → holds w (into-bytes out a)
+  → CircuitWitness.assign w out ≡ just (val-bytes32 (secpBaseToBytes x))
+agree-into-bytes-sb {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (x , () , _)
+...   | inj₂ (inj₁ (x , refl , refl)) = wout
+...   | inj₂ (inj₂ (x , () , _))
+
+agree-into-bytes-ss : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolve m a ≡ just (val-secp-scalar x)
+  → holds w (into-bytes out a)
+  → CircuitWitness.assign w out ≡ just (val-bytes32 (secpScalarToBytes x))
+agree-into-bytes-ss {a = a} sub ra (av , ov , wa , wout , disj)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl with disj
+...   | inj₁ (x , () , _)
+...   | inj₂ (inj₁ (x , () , _))
+...   | inj₂ (inj₂ (x , refl , refl)) = wout
+
+-- `not` / `cond-select`: the output value's boolean reading couples
+-- step-success and the witness output cell (the same `is-bit` split), so
+-- each returns the run's boolean reading (feeding `not-step`/
+-- `cond-select-step`) bundled with the witness output cell (feeding
+-- `ins-⊑ᵂ`).  `to𝔹`/`isYes (_ ≟ᶠ 1ᶠ)` are stuck on `_≟ᶠ_`; each is read
+-- off booleanity by casing the `≟ᶠ` decisions (impossible branch via the
+-- Group-A law `1ᶠ≢0ᶠ`).  `resolve𝔹 m op ≡ resolveᶠ m op >>= to𝔹`.
+
+agree-not : ∀ {m w a out x}
+  → m ⊑ᵂ w → resolveᶠ m a ≡ just x
+  → holds w (is-not out a)
+  → ∃ λ b → resolve𝔹 m a ≡ just b
+          × CircuitWitness.assign w out ≡ just (val-native (χˢ (bnot b)))
+agree-not {a = a} sub ra (x , wa , inj₁ x≡0 , wout)
+  with trans (sym (⊑-resolveᶠ a sub ra)) wa
+... | refl =
+  false , trans (cong (_>>= to𝔹) ra) (to𝔹-0 x≡0) ,
+  trans wout
+    (cong (λ z → just (val-native (χᶜ (bnot z)))) (isYes1-0 x≡0))
+agree-not {a = a} sub ra (x , wa , inj₂ x≡1 , wout)
+  with trans (sym (⊑-resolveᶠ a sub ra)) wa
+... | refl =
+  true , trans (cong (_>>= to𝔹) ra) (to𝔹-1 x≡1) ,
+  trans wout
+    (cong (λ z → just (val-native (χᶜ (bnot z)))) (isYes1-1 x≡1))
+
+agree-cond-select : ∀ {m w bit a b out xbit av bvl}
+  → m ⊑ᵂ w
+  → resolveᶠ m bit ≡ just xbit
+  → resolve m a ≡ just av → resolve m b ≡ just bvl
+  → holds w (select out bit a b)
+  → ∃ λ bb → resolve𝔹 m bit ≡ just bb
+           × CircuitWitness.assign w out ≡ just (if bb then av else bvl)
+agree-cond-select {bit = bit} {a} {b} sub rbit ra rb
+  (bv , av , bvl , ov , ⊢bit , ⊢a , ⊢b , wout , inj₁ bv≡0 , imp1 , imp0)
+  with trans (sym (⊑-resolveᶠ bit sub rbit)) ⊢bit
+     | trans (sym (⊑-resolve a sub ra)) ⊢a
+     | trans (sym (⊑-resolve b sub rb)) ⊢b
+... | refl | refl | refl =
+  false , trans (cong (_>>= to𝔹) rbit) (to𝔹-0 bv≡0) ,
+  trans wout (cong just (imp0 bv≡0))
+agree-cond-select {bit = bit} {a} {b} sub rbit ra rb
+  (bv , av , bvl , ov , ⊢bit , ⊢a , ⊢b , wout , inj₂ bv≡1 , imp1 , imp0)
+  with trans (sym (⊑-resolveᶠ bit sub rbit)) ⊢bit
+     | trans (sym (⊑-resolve a sub ra)) ⊢a
+     | trans (sym (⊑-resolve b sub rb)) ⊢b
+... | refl | refl | refl =
+  true , trans (cong (_>>= to𝔹) rbit) (to𝔹-1 bv≡1) ,
+  trans wout (cong just (imp1 bv≡1))
+
+------------------------------------------------------------------------
+-- The `*-step` family: deterministic forward step-success.
+--
+-- Once the operands resolve at the run memory (from TyEq/OpTy) and any
+-- partial semantic operation succeeds (from `holds w` via the `agree-*`
+-- kernels), `step` computes and lands on a CONCRETE post-state (pinned,
+-- mirroring the `*-bwd` conclusions, to sidestep the `out1`/`step`
+-- non-injectivity unification stall).  `mul-step` is the template.
+------------------------------------------------------------------------
+
+mul-step : ∀ {P S st a b output x y}
+  → resolve (State.mem st) a ≡ just (val-native x)
+  → resolve (State.mem st) b ≡ just (val-native y)
+  → step P S st (mul a b output)
+      ≡ just (out1 st output (val-native (x *ᶠ y)))
+mul-step ra rb rewrite ra | rb = refl
+
+add-step-n : ∀ {P S st a b out x y}
+  → resolve (State.mem st) a ≡ just (val-native x)
+  → resolve (State.mem st) b ≡ just (val-native y)
+  → step P S st (add a b out) ≡ just (out1 st out (val-native (x +ᶠ y)))
+add-step-n ra rb rewrite ra | rb = refl
+
+add-step-p : ∀ {P S st a b out p q}
+  → resolve (State.mem st) a ≡ just (val-jubjub-point p)
+  → resolve (State.mem st) b ≡ just (val-jubjub-point q)
+  → step P S st (add a b out)
+      ≡ just (out1 st out (val-jubjub-point (p +J q)))
+add-step-p ra rb rewrite ra | rb = refl
+
+neg-step-n : ∀ {P S st a out x}
+  → resolve (State.mem st) a ≡ just (val-native x)
+  → step P S st (neg a out) ≡ just (out1 st out (val-native (-ᶠ x)))
+neg-step-n ra rewrite ra = refl
+
+neg-step-p : ∀ {P S st a out p}
+  → resolve (State.mem st) a ≡ just (val-jubjub-point p)
+  → step P S st (neg a out) ≡ just (out1 st out (val-jubjub-point (negJ p)))
+neg-step-p ra rewrite ra = refl
+
+copy-step : ∀ {P S st a out v}
+  → resolve (State.mem st) a ≡ just v
+  → step P S st (copy a out) ≡ just (out1 st out v)
+copy-step ra rewrite ra = refl
+
+inv-step : ∀ {P S st a out x xi}
+  → resolve (State.mem st) a ≡ just (val-native x) → invᶠ x ≡ just xi
+  → step P S st (inv a out) ≡ just (out1 st out (val-native xi))
+inv-step ra ri rewrite ra | ri = refl
+
+inv-step-sb : ∀ {P S st a out x xi}
+  → resolve (State.mem st) a ≡ just (val-secp-base x) → invᵇ x ≡ just xi
+  → step P S st (inv a out) ≡ just (out1 st out (val-secp-base xi))
+inv-step-sb ra ri rewrite ra | ri = refl
+
+inv-step-ss : ∀ {P S st a out x xi}
+  → resolve (State.mem st) a ≡ just (val-secp-scalar x) → invˢ x ≡ just xi
+  → step P S st (inv a out) ≡ just (out1 st out (val-secp-scalar xi))
+inv-step-ss ra ri rewrite ra | ri = refl
+
+mul-step-sb : ∀ {P S st a b out x y}
+  → resolve (State.mem st) a ≡ just (val-secp-base x)
+  → resolve (State.mem st) b ≡ just (val-secp-base y)
+  → step P S st (mul a b out) ≡ just (out1 st out (val-secp-base (x *ᵇ y)))
+mul-step-sb ra rb rewrite ra | rb = refl
+
+mul-step-ss : ∀ {P S st a b out x y}
+  → resolve (State.mem st) a ≡ just (val-secp-scalar x)
+  → resolve (State.mem st) b ≡ just (val-secp-scalar y)
+  → step P S st (mul a b out) ≡ just (out1 st out (val-secp-scalar (x *ˢ y)))
+mul-step-ss ra rb rewrite ra | rb = refl
+
+add-step-sp : ∀ {P S st a b out p q}
+  → resolve (State.mem st) a ≡ just (val-secp-point p)
+  → resolve (State.mem st) b ≡ just (val-secp-point q)
+  → step P S st (add a b out) ≡ just (out1 st out (val-secp-point (p +K q)))
+add-step-sp ra rb rewrite ra | rb = refl
+
+add-step-sb : ∀ {P S st a b out x y}
+  → resolve (State.mem st) a ≡ just (val-secp-base x)
+  → resolve (State.mem st) b ≡ just (val-secp-base y)
+  → step P S st (add a b out) ≡ just (out1 st out (val-secp-base (x +ᵇ y)))
+add-step-sb ra rb rewrite ra | rb = refl
+
+add-step-ss : ∀ {P S st a b out x y}
+  → resolve (State.mem st) a ≡ just (val-secp-scalar x)
+  → resolve (State.mem st) b ≡ just (val-secp-scalar y)
+  → step P S st (add a b out) ≡ just (out1 st out (val-secp-scalar (x +ˢ y)))
+add-step-ss ra rb rewrite ra | rb = refl
+
+neg-step-sp : ∀ {P S st a out p}
+  → resolve (State.mem st) a ≡ just (val-secp-point p)
+  → step P S st (neg a out) ≡ just (out1 st out (val-secp-point (negK p)))
+neg-step-sp ra rewrite ra = refl
+
+neg-step-sb : ∀ {P S st a out x}
+  → resolve (State.mem st) a ≡ just (val-secp-base x)
+  → step P S st (neg a out) ≡ just (out1 st out (val-secp-base (-ᵇ x)))
+neg-step-sb ra rewrite ra = refl
+
+neg-step-ss : ∀ {P S st a out x}
+  → resolve (State.mem st) a ≡ just (val-secp-scalar x)
+  → step P S st (neg a out) ≡ just (out1 st out (val-secp-scalar (-ˢ x)))
+neg-step-ss ra rewrite ra = refl
+
+not-step : ∀ {P S st a out b}
+  → resolve𝔹 (State.mem st) a ≡ just b
+  → step P S st (not a out) ≡ just (out1 st out (val-native (χˢ (bnot b))))
+not-step ra rewrite ra = refl
+
+test-eq-step : ∀ {P S st a b out av bv e}
+  → resolve (State.mem st) a ≡ just av → resolve (State.mem st) b ≡ just bv
+  → valEq? av bv ≡ just e
+  → step P S st (test-eq a b out) ≡ just (out1 st out (val-native (χˢ e)))
+test-eq-step ra rb ve rewrite ra | rb | ve = refl
+
+jubjub-scalar-from-native-step : ∀ {P S st a out x}
+  → resolveᶠ (State.mem st) a ≡ just x
+  → step P S st (jubjub-scalar-from-native a out)
+      ≡ just (out1 st out (val-jubjub-scalar (native→jubjubScalar x)))
+jubjub-scalar-from-native-step ra rewrite ra = refl
+
+ec-mul-step : ∀ {P S st a scalar out p s}
+  → resolve (State.mem st) a ≡ just (val-jubjub-point p)
+  → resolve (State.mem st) scalar ≡ just (val-jubjub-scalar s)
+  → step P S st (ec-mul a scalar out)
+      ≡ just (out1 st out (val-jubjub-point (s ·J p)))
+ec-mul-step ra rs rewrite ra | rs = refl
+
+ec-mul-generator-step : ∀ {P S st scalar out s}
+  → resolve (State.mem st) scalar ≡ just (val-jubjub-scalar s)
+  → step P S st (ec-mul-generator scalar out)
+      ≡ just (out1 st out (val-jubjub-point (s ·J genJ)))
+ec-mul-generator-step rs rewrite rs = refl
+
+ec-mul-step-secp : ∀ {P S st a scalar out p s}
+  → resolve (State.mem st) a ≡ just (val-secp-point p)
+  → resolve (State.mem st) scalar ≡ just (val-secp-scalar s)
+  → step P S st (ec-mul a scalar out)
+      ≡ just (out1 st out (val-secp-point (s ·K p)))
+ec-mul-step-secp ra rs rewrite ra | rs = refl
+
+ec-mul-generator-step-secp : ∀ {P S st scalar out s}
+  → resolve (State.mem st) scalar ≡ just (val-secp-scalar s)
+  → step P S st (ec-mul-generator scalar out)
+      ≡ just (out1 st out (val-secp-point (s ·K genK)))
+ec-mul-generator-step-secp rs rewrite rs = refl
+
+hash-to-curve-step : ∀ {P S st inputs out frs}
+  → resolve-all-Fr (State.mem st) inputs ≡ just frs
+  → step P S st (hash-to-curve inputs out)
+      ≡ just (out1 st out (val-jubjub-point (hash-to-curve-fn frs)))
+hash-to-curve-step rf rewrite rf = refl
+
+transient-hash-step : ∀ {P S st inputs out frs}
+  → resolve-all-Fr (State.mem st) inputs ≡ just frs
+  → step P S st (transient-hash inputs out)
+      ≡ just (out1 st out (val-native (transient-hash-fn frs)))
+transient-hash-step rf rewrite rf = refl
+
+into-bytes32-step : ∀ {P S st a out x}
+  → resolve (State.mem st) a ≡ just (val-native x)
+  → step P S st (into-bytes32 a out)
+      ≡ just (out1 st out (val-bytes32 (nativeToBytes x)))
+into-bytes32-step ra rewrite ra = refl
+
+into-bytes32-step-sb : ∀ {P S st a out x}
+  → resolve (State.mem st) a ≡ just (val-secp-base x)
+  → step P S st (into-bytes32 a out)
+      ≡ just (out1 st out (val-bytes32 (secpBaseToBytes x)))
+into-bytes32-step-sb ra rewrite ra = refl
+
+into-bytes32-step-ss : ∀ {P S st a out x}
+  → resolve (State.mem st) a ≡ just (val-secp-scalar x)
+  → step P S st (into-bytes32 a out)
+      ≡ just (out1 st out (val-bytes32 (secpScalarToBytes x)))
+into-bytes32-step-ss ra rewrite ra = refl
+
+from-bytes32-step : ∀ {P S st a out b}
+  → resolve (State.mem st) a ≡ just (val-bytes32 b)
+  → step P S st (from-bytes32 a native out)
+      ≡ just (out1 st out (val-native (nativeFromBytes b)))
+from-bytes32-step ra rewrite ra = refl
+
+from-bytes32-secp-base-step : ∀ {P S st a out b}
+  → resolve (State.mem st) a ≡ just (val-bytes32 b)
+  → step P S st (from-bytes32 a secp-base out)
+      ≡ just (out1 st out (val-secp-base (secpBaseFromBytes b)))
+from-bytes32-secp-base-step ra rewrite ra = refl
+
+from-bytes32-secp-scalar-step : ∀ {P S st a out b}
+  → resolve (State.mem st) a ≡ just (val-bytes32 b)
+  → step P S st (from-bytes32 a secp-scalar out)
+      ≡ just (out1 st out (val-secp-scalar (secpScalarFromBytes b)))
+from-bytes32-secp-scalar-step ra rewrite ra = refl
+
+reverse-bytes-step : ∀ {P S st a out b}
+  → resolve (State.mem st) a ≡ just (val-bytes32 b)
+  → step P S st (reverse-bytes a out)
+      ≡ just (out1 st out (val-bytes32 (reverse b)))
+reverse-bytes-step ra rewrite ra = refl
+
+from-coordinates-step : ∀ {P S st xop yop out x y p}
+  → resolve (State.mem st) xop ≡ just (val-native x)
+  → resolve (State.mem st) yop ≡ just (val-native y)
+  → fromCoordsJ x y ≡ just p
+  → step P S st (from-coordinates (xop , yop) out)
+      ≡ just (out1 st out (val-jubjub-point p))
+from-coordinates-step rx ry fp rewrite rx | ry | fp = refl
+
+from-coordinates-step-secp : ∀ {P S st xop yop out x y p}
+  → resolve (State.mem st) xop ≡ just (val-secp-base x)
+  → resolve (State.mem st) yop ≡ just (val-secp-base y)
+  → fromCoordsK x y ≡ just p
+  → step P S st (from-coordinates (xop , yop) out)
+      ≡ just (out1 st out (val-secp-point p))
+from-coordinates-step-secp rx ry fp rewrite rx | ry | fp = refl
+
+into-coordinates-step : ∀ {P S st point xid yid p x y}
+  → resolve (State.mem st) point ≡ just (val-jubjub-point p)
+  → coordsJ p ≡ (x , y)
+  → step P S st (into-coordinates point (xid , yid))
+      ≡ just (out1 (out1 st xid (val-native x)) yid (val-native y))
+into-coordinates-step rp cp rewrite rp | cp = refl
+
+into-coordinates-step-secp : ∀ {P S st point xid yid p x y}
+  → resolve (State.mem st) point ≡ just (val-secp-point p)
+  → coordsK p ≡ just (x , y)
+  → step P S st (into-coordinates point (xid , yid))
+      ≡ just (out1 (out1 st xid (val-secp-base x)) yid (val-secp-base y))
+into-coordinates-step-secp rp cp rewrite rp | cp = refl
+
+bytes32-into-low-high-step : ∀ {P S st bytes loid hiid b lo hi}
+  → resolve (State.mem st) bytes ≡ just (val-bytes32 b)
+  → bytes32→low-high b ≡ (lo , hi)
+  → step P S st (bytes32-into-low-high bytes (loid , hiid))
+      ≡ just (out1 (out1 st loid (val-native lo)) hiid (val-native hi))
+bytes32-into-low-high-step rb bl rewrite rb | bl = refl
+
+bytes32-from-low-high-step : ∀ {P S st loop hiop out lo hi b}
+  → resolveᶠ (State.mem st) loop ≡ just lo
+  → resolveᶠ (State.mem st) hiop ≡ just hi
+  → low-high→bytes32 lo hi ≡ just b
+  → step P S st (bytes32-from-low-high (loop , hiop) out)
+      ≡ just (out1 st out (val-bytes32 b))
+bytes32-from-low-high-step rl rh lb rewrite rl | rh | lb = refl
+
+div-mod-step : ∀ {P S st val bits outs x st'}
+  → resolveᶠ (State.mem st) val ≡ just x
+  → insertMany st outs
+      ( val-native (from-le-bits (drop bits (to-le-bits x)))
+      ∷ val-native (from-le-bits (take bits (to-le-bits x))) ∷ []) ≡ just st'
+  → step P S st (div-mod-power-of-two val bits outs) ≡ just st'
+div-mod-step rv im rewrite rv | im = refl
+
+reconstitute-field-step : ∀ {P S st divisor modulus bits out d mo}
+  → resolveᶠ (State.mem st) divisor ≡ just d
+  → resolveᶠ (State.mem st) modulus ≡ just mo
+  → valFr mo < 2 ^ bits → valFr d < 2 ^ (FR-BITS ∸ bits)
+  → valFr mo + 2 ^ bits * valFr d < FR-ORDER
+  → step P S st (reconstitute-field divisor modulus bits out)
+      ≡ just (out1 st out (val-native ((pow2ᶠˢ bits *ᶠ d) +ᶠ mo)))
+reconstitute-field-step {bits = bits} {d = d} {mo} rd rmo bm dm om
+  rewrite rd | rmo with valFr mo <? 2 ^ bits
+... | no ¬bm = case ¬bm bm of λ ()
+... | yes _ with valFr d <? 2 ^ (FR-BITS ∸ bits)
+...   | no ¬dm = case ¬dm dm of λ ()
+...   | yes _ with valFr mo + 2 ^ bits * valFr d <? FR-ORDER
+...     | no ¬om = case ¬om om of λ ()
+...     | yes _ = refl
+
+less-than-step : ∀ {P S st a b bits out x y}
+  → resolveᶠ (State.mem st) a ≡ just x
+  → resolveᶠ (State.mem st) b ≡ just y
+  → valFr x < 2 ^ bits → valFr y < 2 ^ bits
+  → step P S st (less-than a b bits out)
+      ≡ just (out1 st out (val-native (χˢ (isYes (valFr x <? valFr y)))))
+less-than-step {bits = bits} {x = x} {y} ra rb bx by
+  rewrite ra | rb with valFr x <? 2 ^ bits
+... | no ¬bx = case ¬bx bx of λ ()
+... | yes _ with valFr y <? 2 ^ bits
+...   | no ¬by = case ¬by by of λ ()
+...   | yes _ = refl
+
+persistent-hash-step : ∀ {P S st al inputs out frs h}
+  → resolve-all-Fr (State.mem st) inputs ≡ just frs
+  → persistent-hash-fn al frs ≡ just h
+  → step P S st (persistent-hash al inputs out)
+      ≡ just (out1 st out (val-bytes32 h))
+persistent-hash-step rf ph rewrite rf | ph = refl
+
+keccak256-step : ∀ {P S st al inputs out frs h}
+  → resolve-all-Fr (State.mem st) inputs ≡ just frs
+  → keccak-fn al frs ≡ just h
+  → step P S st (keccak256 al inputs out)
+      ≡ just (out1 st out (val-bytes32 h))
+keccak256-step rf kf rewrite rf | kf = refl
+
+encode-step : ∀ {P S st a outs v st'}
+  → resolve (State.mem st) a ≡ just v
+  → insertMany st outs (map val-native (encodeᵉ v)) ≡ just st'
+  → step P S st (encode a outs) ≡ just st'
+encode-step ra im rewrite ra | im = refl
+
+cond-select-step : ∀ {P S st bit a b out bv av bvl}
+  → resolve𝔹 (State.mem st) bit ≡ just bv
+  → resolve (State.mem st) a ≡ just av
+  → resolve (State.mem st) b ≡ just bvl
+  → typeof av ≡ typeof bvl
+  → step P S st (cond-select bit a b out)
+      ≡ just (out1 st out (if bv then av else bvl))
+cond-select-step {av = av} {bvl} rbit ra rb ty
+  rewrite rbit | ra | rb with typeof av ≟T typeof bvl
+... | yes _ = refl
+... | no ¬p = case ¬p ty of λ ()
+
+assert-step : ∀ {P S st cond}
+  → resolve𝔹 (State.mem st) cond ≡ just true
+  → step P S st (assert cond) ≡ just st
+assert-step rc rewrite rc = refl
+
+constrain-bits-step : ∀ {P S st val bits x}
+  → resolveᶠ (State.mem st) val ≡ just x → valFr x < 2 ^ bits
+  → step P S st (constrain-bits val bits) ≡ just st
+constrain-bits-step {bits = bits} {x = x} rv bd
+  rewrite rv with valFr x <? 2 ^ bits
+... | no ¬bd = case ¬bd bd of λ ()
+... | yes _ = refl
+
+constrain-eq-step : ∀ {P S st a b av bv}
+  → resolve (State.mem st) a ≡ just av → resolve (State.mem st) b ≡ just bv
+  → valEq? av bv ≡ just true
+  → step P S st (constrain-eq a b) ≡ just st
+constrain-eq-step ra rb ve rewrite ra | rb | ve = refl
+
+constrain-to-boolean-step : ∀ {P S st val b}
+  → resolve𝔹 (State.mem st) val ≡ just b
+  → step P S st (constrain-to-boolean val) ≡ just st
+constrain-to-boolean-step rv rewrite rv = refl
+
+------------------------------------------------------------------------
+-- Encoding round-trip and width law.  The transcript pre-pass reproduces
+-- a witness cell `v` by placing `encode v` in the transcript; the run then
+-- `decode`s exactly `encode v` back to `v` (round-trip, from the Group-C
+-- laws), consuming `encoded-len (typeof v)` elements (width law).
+------------------------------------------------------------------------
+
+encode-len : ∀ v → length (encodeᵉ v) ≡ encoded-len (typeof v)
+encode-len (val-native _)        = refl
+encode-len (val-jubjub-scalar _) = refl
+encode-len (val-bytes32 b)       with bytes32→low-high b
+... | (_ , _) = refl
+encode-len (val-jubjub-point p)  with coordsJ p
+... | (_ , _) = refl
+encode-len (val-secp-base x)     with secpBase→limbs x
+... | (_ , _) = refl
+encode-len (val-secp-scalar s)   with secpScalar→limbs s
+... | (_ , _) = refl
+encode-len (val-secp-point p)    with secpPoint→limbs p
+... | (_ , _ , _ , _ , _) = refl
+
+encode-decode : ∀ v → decode (typeof v) (encodeᵉ v) ≡ just v
+encode-decode (val-native x)        = refl
+encode-decode (val-jubjub-scalar s) rewrite jubjubScalar-round s = refl
+encode-decode (val-bytes32 b)       with bytes32→low-high b in beq
+... | (lo , hi)
+  rewrite trans (cong (uncurry low-high→bytes32) (sym beq)) (bytes32-round b)
+  = refl
+encode-decode (val-jubjub-point p)  with coordsJ p in ceq
+... | (x , y)
+  rewrite trans (cong (uncurry fromCoordsJ) (sym ceq)) (coordsJ-fromCoordsJ p)
+  = refl
+encode-decode (val-secp-base x)     with secpBase→limbs x in beq
+... | (l , h)
+  rewrite trans (cong (uncurry limbs→secpBase) (sym beq)) (secpBase-round x)
+  = refl
+encode-decode (val-secp-scalar s)   with secpScalar→limbs s in seq
+... | (l , h)
+  rewrite trans (cong (uncurry limbs→secpScalar) (sym seq)) (secpScalar-round s)
+  = refl
+encode-decode (val-secp-point p)    with secpPoint→limbs p in peq
+... | (a , b , c , d , e)
+  rewrite secpPoint-round peq = refl
+
+------------------------------------------------------------------------
+-- Binding a cell whose value the witness already carries preserves
+-- agreement (no freshness needed).  This is how each `build` clause
+-- maintains `mem st ⊑ᵂ w` after `step` binds the output to the value the
+-- `agree-*` kernel pinned in `w`.
+------------------------------------------------------------------------
+
+ins-⊑ᵂ : ∀ {m w} out {v} → m ⊑ᵂ w → CircuitWitness.assign w out ≡ just v
+  → ins out v m ⊑ᵂ w
+ins-⊑ᵂ out sub wo {id} e with id ≟str out
+... | yes refl = trans wo e
+... | no  _    = sub e
+
+------------------------------------------------------------------------
+-- The witness-shape side condition.
+--
+-- `public-input`/`private-input` emit no constraint and ignore the guard
+-- (§7.2), so `satisfies w` pins neither the guard nor the free output
+-- cell.  A run reproducing `w` therefore needs, at `assign w`: the guard
+-- resolves to a bit `b`; if active (`b ≡ true`) the output cell is a
+-- value of the declared type `val-t` (so the transcript can carry
+-- `encode` of it and the run decodes it back); if inactive (`b ≡ false`)
+-- the cell is exactly `default-val val-t`, matching the run's default.
+-- The declared inputs are the same shape (each a value of its type).
+-- This constrains the INPUT witness only — the v3 analogue of v2's
+-- `length (mem w) ≡ nr-wires` — never the conclusion.
+------------------------------------------------------------------------
+
+-- The active/inactive witness condition on one input instruction's cell.
+WCell : CircuitWitness → IrType → Identifier → Bool → Set
+WCell w val-t o true  =
+  ∃ λ v → CircuitWitness.assign w o ≡ just v × typeof v ≡ val-t
+WCell w val-t o false = CircuitWitness.assign w o ≡ just (default-val val-t)
+
+-- `WSteps` is indexed by the source `S` too, because `circuit-output`'s
+-- executability (`collectOutputs` over `IrSource.outputs S`) mentions it.
+WSteps : IrSource → CircuitWitness → List Instruction → Set
+WSteps S w []       = ⊤
+WSteps S w (public-input guard val-t o ∷ is) =
+  (∃ λ b → eval-guard (CircuitWitness.assign w) guard ≡ just b × WCell w val-t o b)
+  × WSteps S w is
+WSteps S w (private-input guard val-t o ∷ is) =
+  (∃ λ b → eval-guard (CircuitWitness.assign w) guard ≡ just b × WCell w val-t o b)
+  × WSteps S w is
+-- `impact`'s guard is not forced to a bit by the constraint when `inputs`
+-- is empty (`impact-constraints … [] ≡ []`), so a run reproducing `w`
+-- needs the guard to read a bit at `assign w`.  (For non-empty `inputs`
+-- the pi-impact constraint already gives `is-bit`, but stating it here
+-- uniformly keeps the empty case in scope.)
+WSteps S w (impact guard inputs ∷ is) =
+  (∃ λ x → resolveᶜ-Fr w guard ≡ just x × ∃ λ b → to𝔹 x ≡ just b)
+  × WSteps S w is
+-- `assert` emits only `non-zero cond` (≢ 0), but the off-circuit `step`
+-- reads the guard as a bit and requires it `true`; so an executable
+-- witness reads `cond` as `1` (`to𝔹 … ≡ just true`).
+WSteps S w (assert cond ∷ is) =
+  (∃ λ x → resolveᶜ-Fr w cond ≡ just x × to𝔹 x ≡ just true)
+  × WSteps S w is
+-- `reconstitute-field`'s constraint carries the two range bounds but not
+-- the field-no-overflow guard (`valFr mo + 2ⁿ·valFr d < FR-ORDER`), which
+-- the off-circuit `step` checks — a producer/executability condition.
+WSteps S w (reconstitute-field divisor modulus bits o ∷ is) =
+  (∃ λ d → ∃ λ mo → resolveᶜ-Fr w divisor ≡ just d
+       × resolveᶜ-Fr w modulus ≡ just mo
+       × (valFr mo + 2 ^ bits * valFr d < FR-ORDER))
+  × WSteps S w is
+-- `div-mod` binds exactly two outputs; the off-circuit `step` `insertMany`s
+-- a two-element list, and `synth` emits its constraint only at `|outs| ≡ 2`
+-- — but `outtys`/producer-WT accept any length, so the two-output arity is
+-- an executability condition.  (`persistent-hash`/`keccak256` now bind a
+-- single Bytes32 output; their hash-function success comes from `holds`, so
+-- they need no `WSteps` condition and fall to the catch-all.)
+WSteps S w (div-mod-power-of-two val bits outs ∷ is) =
+  (∃ λ q → ∃ λ r → outs ≡ q ∷ r ∷ []) × WSteps S w is
+-- `circuit-output` emits no constraint, and its `OpTy` (`AllDefdᵒ`) gives
+-- only operand boundness, not the type match against the signature — so
+-- the `collectOutputs` over the declared output types must succeed at `w`.
+WSteps S w (circuit-output vals ∷ is) =
+  (∃ λ vs → collectOutputs (CircuitWitness.assign w) (IrSource.outputs S) vals
+              ≡ just vs)
+  × WSteps S w is
+-- `from-bytes32` `synth`s `from-bytes` regardless of the declared `val-t`;
+-- the `from-bytes` constraint pins the output cell to one of the three
+-- supported values (Native/Secp256k1Base/Secp256k1Scalar) but does NOT tie
+-- the disjunct to `val-t`.  Requiring the output cell to have type `val-t`
+-- selects the matching disjunct and, since the pinned value's constructor
+-- is one of the three, forces `val-t` into the supported set (the off-circuit
+-- `step` only succeeds there).
+WSteps S w (from-bytes32 bytes val-t o ∷ is) =
+  WCell w val-t o true × WSteps S w is
+-- `less-than`'s constraint pins only the chip's evened operand bounds
+-- (`< 2 ^ even4 bits`); the off-circuit `step` checks the exact
+-- `2 ^ bits` bounds, so for odd or small `bits` the exact bounds are an
+-- executability condition (spec §9, "Contract strength").
+WSteps S w (less-than a b bits o ∷ is) =
+  (∃ λ x → ∃ λ y → resolveᶜ-Fr w a ≡ just x × resolveᶜ-Fr w b ≡ just y
+       × (valFr x < 2 ^ bits) × (valFr y < 2 ^ bits))
+  × WSteps S w is
+WSteps S w (_ ∷ is) = WSteps S w is
+
+-- Each declared input cell is a value of its declared type.
+WInputs : CircuitWitness → List TypedIdentifier → Set
+WInputs w []         = ⊤
+WInputs w (ti ∷ tis) =
+  (∃ λ v → CircuitWitness.assign w (TypedIdentifier.name ti) ≡ just v
+         × typeof v ≡ TypedIdentifier.val-t ti)
+  × WInputs w tis
+
+WShape : IrSource → CircuitWitness → Set
+WShape S w = WInputs w (IrSource.inputs S) × WSteps S w (IrSource.instructions S)
+
+------------------------------------------------------------------------
+-- `WShape?` — the decidable witness-shape check, completing the runnable
+-- trio with `producer-SA?` / `producer-WT?`.  Enumerates all 34
+-- instructions (a catch-all would leave `WSteps S w (i ∷ is)` stuck).
+------------------------------------------------------------------------
+
+-- Decidable equality of witness values.  `JubjubScalar` has no primitive
+-- `DecidableEquality`, but `jubjubScalarToFr` is injective (its left
+-- inverse is `jubjubScalarFromFr`, by `jubjubScalar-round`), so scalar
+-- equality reduces to `_≟ᶠ_` on the images.
+_≟V_ : DecidableEquality IrValue
+val-native x ≟V val-native y =
+  map′ (cong val-native) (λ { refl → refl }) (x ≟ᶠ y)
+val-native _ ≟V val-bytes32 _        = no λ ()
+val-native _ ≟V val-jubjub-point _   = no λ ()
+val-native _ ≟V val-jubjub-scalar _  = no λ ()
+val-bytes32 _ ≟V val-native _        = no λ ()
+val-bytes32 a ≟V val-bytes32 b =
+  map′ (cong val-bytes32) (λ { refl → refl }) (a ≟B b)
+val-bytes32 _ ≟V val-jubjub-point _  = no λ ()
+val-bytes32 _ ≟V val-jubjub-scalar _ = no λ ()
+val-jubjub-point _ ≟V val-native _        = no λ ()
+val-jubjub-point _ ≟V val-bytes32 _       = no λ ()
+val-jubjub-point p ≟V val-jubjub-point q =
+  map′ (cong val-jubjub-point) (λ { refl → refl }) (p ≟J q)
+val-jubjub-point _ ≟V val-jubjub-scalar _ = no λ ()
+val-jubjub-scalar _ ≟V val-native _       = no λ ()
+val-jubjub-scalar _ ≟V val-bytes32 _      = no λ ()
+val-jubjub-scalar _ ≟V val-jubjub-point _ = no λ ()
+val-jubjub-scalar s ≟V val-jubjub-scalar t =
+  map′ (λ e → cong val-jubjub-scalar (sc-inj e)) (λ { refl → refl })
+       (jubjubScalarToFr s ≟ᶠ jubjubScalarToFr t)
+  where
+    sc-inj : jubjubScalarToFr s ≡ jubjubScalarToFr t → s ≡ t
+    sc-inj e = just-injective
+      (trans (sym (jubjubScalar-round s))
+        (trans (cong jubjubScalarFromFr e) (jubjubScalar-round t)))
+val-native _ ≟V val-secp-point _         = no λ ()
+val-native _ ≟V val-secp-base _          = no λ ()
+val-native _ ≟V val-secp-scalar _        = no λ ()
+val-bytes32 _ ≟V val-secp-point _        = no λ ()
+val-bytes32 _ ≟V val-secp-base _         = no λ ()
+val-bytes32 _ ≟V val-secp-scalar _       = no λ ()
+val-jubjub-point _ ≟V val-secp-point _   = no λ ()
+val-jubjub-point _ ≟V val-secp-base _    = no λ ()
+val-jubjub-point _ ≟V val-secp-scalar _  = no λ ()
+val-jubjub-scalar _ ≟V val-secp-point _  = no λ ()
+val-jubjub-scalar _ ≟V val-secp-base _   = no λ ()
+val-jubjub-scalar _ ≟V val-secp-scalar _ = no λ ()
+val-secp-point _ ≟V val-native _         = no λ ()
+val-secp-point _ ≟V val-bytes32 _        = no λ ()
+val-secp-point _ ≟V val-jubjub-point _   = no λ ()
+val-secp-point _ ≟V val-jubjub-scalar _  = no λ ()
+val-secp-point p ≟V val-secp-point q =
+  map′ (cong val-secp-point) (λ { refl → refl }) (p ≟K q)
+val-secp-point _ ≟V val-secp-base _      = no λ ()
+val-secp-point _ ≟V val-secp-scalar _    = no λ ()
+val-secp-base _ ≟V val-native _          = no λ ()
+val-secp-base _ ≟V val-bytes32 _         = no λ ()
+val-secp-base _ ≟V val-jubjub-point _    = no λ ()
+val-secp-base _ ≟V val-jubjub-scalar _   = no λ ()
+val-secp-base _ ≟V val-secp-point _      = no λ ()
+val-secp-base x ≟V val-secp-base y =
+  map′ (cong val-secp-base) (λ { refl → refl }) (x ≟ᵇ y)
+val-secp-base _ ≟V val-secp-scalar _     = no λ ()
+val-secp-scalar _ ≟V val-native _        = no λ ()
+val-secp-scalar _ ≟V val-bytes32 _       = no λ ()
+val-secp-scalar _ ≟V val-jubjub-point _  = no λ ()
+val-secp-scalar _ ≟V val-jubjub-scalar _ = no λ ()
+val-secp-scalar _ ≟V val-secp-point _    = no λ ()
+val-secp-scalar _ ≟V val-secp-base _     = no λ ()
+val-secp-scalar x ≟V val-secp-scalar y =
+  map′ (cong val-secp-scalar) (λ { refl → refl }) (x ≟ˢ y)
+
+-- `mx` is defined.
+defined? : ∀ {A : Set} (mx : Maybe A) → Dec (∃ λ x → mx ≡ just x)
+defined? nothing  = no λ { (_ , ()) }
+defined? (just x) = yes (x , refl)
+
+-- `mx` is defined and its value satisfies a decidable `Q`.
+∃just? : ∀ {A : Set} {Q : A → Set} (mx : Maybe A) → (∀ x → Dec (Q x))
+  → Dec (∃ λ x → mx ≡ just x × Q x)
+∃just? nothing  q? = no λ { (_ , () , _) }
+∃just? {Q = Q} (just x) q? =
+  map′ (λ qx → x , refl , qx)
+       (λ { (x' , je , qx) → subst Q (sym (just-injective je)) qx })
+       (q? x)
+
+-- `WCell w val-t o b` is decidable.
+WCell? : ∀ w val-t o b → Dec (WCell w val-t o b)
+WCell? w val-t o true  =
+  ∃just? (CircuitWitness.assign w o) (λ v → typeof v ≟T val-t)
+WCell? w val-t o false =
+  ≡-dec _≟V_ (CircuitWitness.assign w o) (just (default-val val-t))
+
+-- `reconstitute-field`'s executability condition (two resolutions + the
+-- field-no-overflow bound).
+reconOK? : ∀ w divisor modulus bits
+  → Dec (∃ λ d → ∃ λ mo → resolveᶜ-Fr w divisor ≡ just d
+          × resolveᶜ-Fr w modulus ≡ just mo
+          × (valFr mo + 2 ^ bits * valFr d < FR-ORDER))
+reconOK? w divisor modulus bits
+  with resolveᶜ-Fr w divisor | resolveᶜ-Fr w modulus
+... | nothing | _       = no λ { (_ , _ , () , _ , _) }
+... | just d  | nothing = no λ { (_ , _ , _ , () , _) }
+... | just d  | just mo =
+      map′ (λ lt → d , mo , refl , refl , lt)
+           (λ { (d' , mo' , jd , jmo , lt) →
+                subst₂ (λ p q → valFr q + 2 ^ bits * valFr p < FR-ORDER)
+                  (sym (just-injective jd)) (sym (just-injective jmo)) lt })
+           (valFr mo + 2 ^ bits * valFr d <? FR-ORDER)
+
+-- `less-than`'s executability condition (two resolutions + the exact
+-- `2 ^ bits` operand bounds the off-circuit `step` checks).
+ltOK? : ∀ w a b bits
+  → Dec (∃ λ x → ∃ λ y → resolveᶜ-Fr w a ≡ just x × resolveᶜ-Fr w b ≡ just y
+          × (valFr x < 2 ^ bits) × (valFr y < 2 ^ bits))
+ltOK? w a b bits
+  with resolveᶜ-Fr w a | resolveᶜ-Fr w b
+... | nothing | _       = no λ { (_ , _ , () , _) }
+... | just x  | nothing = no λ { (_ , _ , _ , () , _) }
+... | just x  | just y  =
+      map′ (λ (bx , by) → x , y , refl , refl , bx , by)
+           (λ { (x' , y' , jx , jy , bx , by) →
+                subst (λ p → valFr p < 2 ^ bits)
+                  (sym (just-injective jx)) bx
+              , subst (λ p → valFr p < 2 ^ bits)
+                  (sym (just-injective jy)) by })
+           ((valFr x <? 2 ^ bits) ×-dec (valFr y <? 2 ^ bits))
+
+-- `div-mod`'s two-output arity.
+divmodArity? : (outs : List Identifier)
+  → Dec (∃ λ q → ∃ λ r → outs ≡ q ∷ r ∷ [])
+divmodArity? []              = no λ { (_ , _ , ()) }
+divmodArity? (q ∷ [])        = no λ { (_ , _ , ()) }
+divmodArity? (q ∷ r ∷ [])    = yes (q , r , refl)
+divmodArity? (q ∷ r ∷ _ ∷ _) = no λ { (_ , _ , ()) }
+
+WSteps? : ∀ S w is → Dec (WSteps S w is)
+WSteps? S w []                                      = yes tt
+WSteps? S w (public-input guard val-t o ∷ is)       =
+  ∃just? (eval-guard (CircuitWitness.assign w) guard) (WCell? w val-t o)
+  ×-dec WSteps? S w is
+WSteps? S w (private-input guard val-t o ∷ is)      =
+  ∃just? (eval-guard (CircuitWitness.assign w) guard) (WCell? w val-t o)
+  ×-dec WSteps? S w is
+WSteps? S w (impact guard inputs ∷ is)              =
+  ∃just? (resolveᶜ-Fr w guard) (λ x → defined? (to𝔹 x)) ×-dec WSteps? S w is
+WSteps? S w (assert cond ∷ is)                      =
+  ∃just? (resolveᶜ-Fr w cond) (λ x → ≡-dec _≟𝔹_ (to𝔹 x) (just true))
+  ×-dec WSteps? S w is
+WSteps? S w (reconstitute-field divisor modulus bits o ∷ is) =
+  reconOK? w divisor modulus bits ×-dec WSteps? S w is
+WSteps? S w (div-mod-power-of-two val bits outs ∷ is) =
+  divmodArity? outs ×-dec WSteps? S w is
+WSteps? S w (circuit-output vals ∷ is)              =
+  defined? (collectOutputs (CircuitWitness.assign w) (IrSource.outputs S) vals)
+  ×-dec WSteps? S w is
+WSteps? S w (from-bytes32 bytes val-t o ∷ is)       =
+  WCell? w val-t o true ×-dec WSteps? S w is
+WSteps? S w (encode _ _ ∷ is)                       = WSteps? S w is
+WSteps? S w (cond-select _ _ _ _ ∷ is)              = WSteps? S w is
+WSteps? S w (constrain-bits _ _ ∷ is)               = WSteps? S w is
+WSteps? S w (constrain-eq _ _ ∷ is)                 = WSteps? S w is
+WSteps? S w (constrain-to-boolean _ ∷ is)           = WSteps? S w is
+WSteps? S w (copy _ _ ∷ is)                         = WSteps? S w is
+WSteps? S w (ec-mul _ _ _ ∷ is)                     = WSteps? S w is
+WSteps? S w (ec-mul-generator _ _ ∷ is)             = WSteps? S w is
+WSteps? S w (hash-to-curve _ _ ∷ is)                = WSteps? S w is
+WSteps? S w (into-coordinates _ _ ∷ is)             = WSteps? S w is
+WSteps? S w (from-coordinates _ _ ∷ is)             = WSteps? S w is
+WSteps? S w (into-bytes32 _ _ ∷ is)                 = WSteps? S w is
+WSteps? S w (reverse-bytes _ _ ∷ is)                = WSteps? S w is
+WSteps? S w (bytes32-into-low-high _ _ ∷ is)        = WSteps? S w is
+WSteps? S w (bytes32-from-low-high _ _ ∷ is)        = WSteps? S w is
+WSteps? S w (transient-hash _ _ ∷ is)               = WSteps? S w is
+WSteps? S w (persistent-hash _ _ _ ∷ is)            = WSteps? S w is
+WSteps? S w (keccak256 _ _ _ ∷ is)                  = WSteps? S w is
+WSteps? S w (test-eq _ _ _ ∷ is)                    = WSteps? S w is
+WSteps? S w (add _ _ _ ∷ is)                        = WSteps? S w is
+WSteps? S w (mul _ _ _ ∷ is)                        = WSteps? S w is
+WSteps? S w (neg _ _ ∷ is)                          = WSteps? S w is
+WSteps? S w (inv _ _ ∷ is)                          = WSteps? S w is
+WSteps? S w (not _ _ ∷ is)                          = WSteps? S w is
+WSteps? S w (less-than a b bits _ ∷ is)             =
+  ltOK? w a b bits ×-dec WSteps? S w is
+WSteps? S w (jubjub-scalar-from-native _ _ ∷ is)    = WSteps? S w is
+
+WInputs? : ∀ w tis → Dec (WInputs w tis)
+WInputs? w []         = yes tt
+WInputs? w (ti ∷ tis) =
+  ∃just? (CircuitWitness.assign w (TypedIdentifier.name ti))
+    (λ v → typeof v ≟T TypedIdentifier.val-t ti)
+  ×-dec WInputs? w tis
+
+WShape? : ∀ S w → Dec (WShape S w)
+WShape? S w =
+  WInputs? w (IrSource.inputs S) ×-dec WSteps? S w (IrSource.instructions S)
+
+------------------------------------------------------------------------
+-- Transcript-cursor arithmetic and the pis-invariant seeding.
+--
+-- The transcript pre-pass fixes `P'`'s lists as in-order concatenations;
+-- the build fold threads a cursor invariant of the form `drop cursor list
+-- ≡ (future contributions)`.  These list lemmas discharge the window
+-- reads/advances (`take-len-++` for the active-impact transcript check,
+-- `drop-len-++` for the cursor advance).
+------------------------------------------------------------------------
+
+take-len-++ : ∀ {A : Set} (xs ys : List A) → take (length xs) (xs ++ ys) ≡ xs
+take-len-++ []       ys = refl
+take-len-++ (x ∷ xs) ys = cong (x ∷_) (take-len-++ xs ys)
+
+drop-len-++ : ∀ {A : Set} (xs ys : List A) → drop (length xs) (xs ++ ys) ≡ ys
+drop-len-++ []       ys = refl
+drop-len-++ (x ∷ xs) ys = drop-len-++ xs ys
+
+-- `drop k xs` exposes the `k`-th element when `pi-lookup` finds it.
+drop-lookup : ∀ (xs : List Fr) k {v} → pi-lookup xs k ≡ just v
+  → drop k xs ≡ v ∷ drop (suc k) xs
+drop-lookup []       zero    e = case e of λ ()
+drop-lookup []       (suc k) e = case e of λ ()
+drop-lookup (x ∷ xs) zero    refl = refl
+drop-lookup (x ∷ xs) (suc k) e    = drop-lookup xs k e
+
+-- The pis-invariant seeding kernel (the v2 make-pti-correctness analogue).
+-- On an active `impact` group the witness's pi entries at
+-- `[start, start + length inputs)` are EXACTLY the resolved input values —
+-- so the group the run appends to `pis` is precisely the slice of `pis w`
+-- the prefix invariant `pis st ≼ pis w` requires.  `g ≡ 1ᶠ` (from the run's
+-- active decision, transported to `w` by agreement) is shared across the
+-- group; each `pi-impact` pins its entry to the input value.
+impact-slice : ∀ w start guard inputs {vals}
+  → resolveᶜ-all-Fr w inputs ≡ just vals
+  → resolveᶜ-Fr w guard ≡ just 1ᶠ
+  → satisfies-constraints (impact-constraints start guard inputs) w
+  → take (length inputs) (drop start (CircuitWitness.pis w)) ≡ vals
+impact-slice w start guard []       refl rg _ = refl
+impact-slice w start guard (x ∷ xs) rall rg
+  ((g , xv , pv , wg , wx , _ , wpv , g1→ , _) , rest)
+  with refl ← trans (sym rg) wg
+  with resolveᶜ-Fr w x | wx
+... | .(just xv) | refl
+  with resolveᶜ-all-Fr w xs in rxs
+...   | just vs
+  with refl ← rall
+  rewrite drop-lookup (CircuitWitness.pis w) start wpv
+        | g1→ refl
+        | impact-slice w (suc start) guard xs rxs rg rest
+  = refl
+
+------------------------------------------------------------------------
+-- Transcript pre-pass (partial): the pub-transcript-inputs stream.
+--
+-- Read from the witness's pi vector at the pi-cursor `k` (= next-pi
+-- position): an active impact group (guard reads 1 in w) contributes its
+-- pi slice `take (length inputs) (drop k (pis w))`; the pi-cursor advances
+-- by `length inputs` for every impact (active or skipped — both advance
+-- `next-pi` / the run's pis length), but only active groups feed the
+-- pub-transcript-inputs stream.  (`mkPTO`/`mkPRV`/`mkInputs` below are
+-- the companion pre-passes for the other preimage streams.)
+------------------------------------------------------------------------
+
+mkPTI : CircuitWitness → ℕ → List Instruction → List Fr
+mkPTI w k [] = []
+mkPTI w k (impact guard inputs ∷ is)
+  with resolve𝔹 (CircuitWitness.assign w) guard
+... | just true = take (length inputs) (drop k (CircuitWitness.pis w))
+                    ++ mkPTI w (k + length inputs) is
+... | just false = mkPTI w (k + length inputs) is
+... | nothing    = mkPTI w (k + length inputs) is
+mkPTI w k (_ ∷ is) = mkPTI w k is
+
+-- On an active impact, the run's transcript check reads exactly `vals` from
+-- the pub-transcript-inputs window (cursor invariant + `impact-slice`).
+pti-check : ∀ {w k guard inputs is vals cur} {PTI : List Fr}
+  → resolve𝔹 (CircuitWitness.assign w) guard ≡ just true
+  → drop cur PTI ≡ mkPTI w k (impact guard inputs ∷ is)
+  → take (length inputs) (drop k (CircuitWitness.pis w)) ≡ vals
+  → take (length vals) (drop cur PTI) ≡ vals
+pti-check {vals = vals} active ptiI slice
+  rewrite active | ptiI | slice = take-len-++ vals _
+
+-- The pub-transcript-inputs cursor advances by `length inputs` past an
+-- active impact.  The slice is full-length under `satisfies` (it equals the
+-- resolved `vals`, of length `length inputs`).
+pti-adv : ∀ {w k guard inputs is cur} {PTI : List Fr}
+  → resolve𝔹 (CircuitWitness.assign w) guard ≡ just true
+  → drop cur PTI ≡ mkPTI w k (impact guard inputs ∷ is)
+  → length (take (length inputs) (drop k (CircuitWitness.pis w))) ≡ length inputs
+  → drop (cur + length inputs) PTI ≡ mkPTI w (k + length inputs) is
+pti-adv {w} {k} {inputs = inputs} {is} {cur} {PTI} active ptiI slicefull
+  rewrite active
+  = trans (sym (drop-drop cur (length inputs) PTI))
+          (trans (cong (drop (length inputs)) ptiI)
+                 (subst (λ n → drop n (slice ++ tail) ≡ tail) slicefull
+                        (drop-len-++ slice tail)))
+  where slice = take (length inputs) (drop k (CircuitWitness.pis w))
+        tail  = mkPTI w (k + length inputs) is
+
+------------------------------------------------------------------------
+-- The remaining w-only pre-passes: the transcript-output streams
+-- (`mkPTO`/`mkPRV`) and the declared-input stream (`mkInputs`).  Each
+-- fixes the corresponding `P'` list in-order from the witness.  `cellEnc w o` is the raw encoding of the witness's cell
+-- `o` (under `WShape` the cell is defined, so this is `encode` of its
+-- value; the default `[]` never fires).
+------------------------------------------------------------------------
+
+cellEnc : CircuitWitness → Identifier → List Fr
+cellEnc w o = maybe′ encodeᵉ [] (CircuitWitness.assign w o)
+
+-- pub-transcript-outputs: the encoding of every ACTIVE public-input cell,
+-- in order (private-input and every other instruction contribute none).
+mkPTO : CircuitWitness → List Instruction → List Fr
+mkPTO w [] = []
+mkPTO w (public-input guard val-t o ∷ is)
+  with eval-guard (CircuitWitness.assign w) guard
+... | just true  = cellEnc w o ++ mkPTO w is
+... | just false = mkPTO w is
+... | nothing    = mkPTO w is
+mkPTO w (_ ∷ is) = mkPTO w is
+
+-- priv-transcript: the encoding of every ACTIVE private-input cell.
+mkPRV : CircuitWitness → List Instruction → List Fr
+mkPRV w [] = []
+mkPRV w (private-input guard val-t o ∷ is)
+  with eval-guard (CircuitWitness.assign w) guard
+... | just true  = cellEnc w o ++ mkPRV w is
+... | just false = mkPRV w is
+... | nothing    = mkPRV w is
+mkPRV w (_ ∷ is) = mkPRV w is
+
+-- inputs (the `decode-inputs` inverse): the encoding of every declared
+-- input cell, in signature order.
+mkInputs : CircuitWitness → List TypedIdentifier → List Fr
+mkInputs w []         = []
+mkInputs w (ti ∷ tis) =
+  cellEnc w (TypedIdentifier.name ti) ++ mkInputs w tis
+
+
+-- pub-transcript-outputs cursor: an active public-input reads back its
+-- cell (`encode-len` + `encode-decode`) and the cursor advances by
+-- `encoded-len val-t`.  Mirrors `pti-check`/`pti-adv`.
+mkPTO-active : ∀ {w guard val-t o is v}
+  → eval-guard (CircuitWitness.assign w) guard ≡ just true
+  → CircuitWitness.assign w o ≡ just v
+  → mkPTO w (public-input guard val-t o ∷ is) ≡ encodeᵉ v ++ mkPTO w is
+mkPTO-active active wo rewrite active | wo = refl
+
+pto-check : ∀ {w guard val-t o is v cur} {PTO : List Fr}
+  → eval-guard (CircuitWitness.assign w) guard ≡ just true
+  → CircuitWitness.assign w o ≡ just v → typeof v ≡ val-t
+  → drop cur PTO ≡ mkPTO w (public-input guard val-t o ∷ is)
+  → decode val-t (take (encoded-len val-t) (drop cur PTO)) ≡ just v
+pto-check {w = w} {guard = guard} {val-t = val-t} {o = o} {is = is} {v = v}
+  active wo tyv ptoI
+  rewrite trans ptoI
+            (mkPTO-active {w = w} {guard = guard} {val-t = val-t} {o = o}
+                          {is = is} active wo)
+        | sym tyv | sym (encode-len v)
+        | take-len-++ (encodeᵉ v) (mkPTO w is) = encode-decode v
+
+pto-adv : ∀ {w guard val-t o is v cur} {PTO : List Fr}
+  → eval-guard (CircuitWitness.assign w) guard ≡ just true
+  → CircuitWitness.assign w o ≡ just v → typeof v ≡ val-t
+  → drop cur PTO ≡ mkPTO w (public-input guard val-t o ∷ is)
+  → drop (cur + encoded-len val-t) PTO ≡ mkPTO w is
+pto-adv {w = w} {guard = guard} {val-t = val-t} {o = o} {is = is} {v = v}
+  {cur = cur} {PTO = PTO} active wo tyv ptoI
+  rewrite sym tyv | sym (encode-len v)
+  = trans (sym (drop-drop cur (length (encodeᵉ v)) PTO))
+          (trans (cong (drop (length (encodeᵉ v)))
+                       (trans ptoI
+                         (mkPTO-active {w = w} {guard = guard} {val-t = val-t}
+                                       {o = o} {is = is} active wo)))
+                 (drop-len-++ (encodeᵉ v) (mkPTO w is)))
+
+-- priv-transcript cursor (private-input): identical over `mkPRV`.
+mkPRV-active : ∀ {w guard val-t o is v}
+  → eval-guard (CircuitWitness.assign w) guard ≡ just true
+  → CircuitWitness.assign w o ≡ just v
+  → mkPRV w (private-input guard val-t o ∷ is) ≡ encodeᵉ v ++ mkPRV w is
+mkPRV-active active wo rewrite active | wo = refl
+
+prv-check : ∀ {w guard val-t o is v cur} {PRV : List Fr}
+  → eval-guard (CircuitWitness.assign w) guard ≡ just true
+  → CircuitWitness.assign w o ≡ just v → typeof v ≡ val-t
+  → drop cur PRV ≡ mkPRV w (private-input guard val-t o ∷ is)
+  → decode val-t (take (encoded-len val-t) (drop cur PRV)) ≡ just v
+prv-check {w = w} {guard = guard} {val-t = val-t} {o = o} {is = is} {v = v}
+  active wo tyv prvI
+  rewrite trans prvI
+            (mkPRV-active {w = w} {guard = guard} {val-t = val-t} {o = o}
+                          {is = is} active wo)
+        | sym tyv | sym (encode-len v)
+        | take-len-++ (encodeᵉ v) (mkPRV w is) = encode-decode v
+
+prv-adv : ∀ {w guard val-t o is v cur} {PRV : List Fr}
+  → eval-guard (CircuitWitness.assign w) guard ≡ just true
+  → CircuitWitness.assign w o ≡ just v → typeof v ≡ val-t
+  → drop cur PRV ≡ mkPRV w (private-input guard val-t o ∷ is)
+  → drop (cur + encoded-len val-t) PRV ≡ mkPRV w is
+prv-adv {w = w} {guard = guard} {val-t = val-t} {o = o} {is = is} {v = v}
+  {cur = cur} {PRV = PRV} active wo tyv prvI
+  rewrite sym tyv | sym (encode-len v)
+  = trans (sym (drop-drop cur (length (encodeᵉ v)) PRV))
+          (trans (cong (drop (length (encodeᵉ v)))
+                       (trans prvI
+                         (mkPRV-active {w = w} {guard = guard} {val-t = val-t}
+                                       {o = o} {is = is} active wo)))
+                 (drop-len-++ (encodeᵉ v) (mkPRV w is)))
+
+------------------------------------------------------------------------
+-- `encode` agreement + the declared-input decode.
+--
+-- `insertMany` realises a `bind-each`: agreement on the pre-state plus
+-- the witness carrying each cell's value at its position (exactly
+-- `holds (encode-eq …)`) forces the multi-cell insert to SUCCEED (arity
+-- from `bind-each` being inhabited) and preserves agreement — the list
+-- generalisation of `ins-⊑ᵂ`, used by the `encode` `build` clause.
+------------------------------------------------------------------------
+
+insertMany-realize : ∀ {w} st ids vs
+  → State.mem st ⊑ᵂ w → bind-each w vs ids
+  → ∃ λ st′ → insertMany st ids vs ≡ just st′ × State.mem st′ ⊑ᵂ w
+insertMany-realize st []         []       sub _          = st , refl , sub
+insertMany-realize {w} st (id ∷ ids) (v ∷ vs) sub (wid , be) =
+  insertMany-realize {w} (out1 st id v) ids vs (ins-⊑ᵂ {w = w} id sub wid) be
+insertMany-realize st []         (_ ∷ _)  _ ()
+insertMany-realize st (_ ∷ _)    []       _ ()
+
+-- `holds (encode-eq input outputs)` yields the `bind-each` at the encoded
+-- values, once the input operand is pinned to the witness value.
+agree-encode : ∀ {m w a outputs v}
+  → m ⊑ᵂ w → resolve m a ≡ just v
+  → holds w (encode-eq a outputs)
+  → bind-each w (map val-native (encodeᵉ v)) outputs
+agree-encode {a = a} sub ra (v′ , wa , be)
+  with trans (sym (⊑-resolve a sub ra)) wa
+... | refl = be
+
+-- `decode-inputs` inverts `mkInputs`: decoding the declared-input stream
+-- built from the witness reproduces a memory agreeing with `w`, so
+-- `init S P'` succeeds with `mem st0 ⊑ᵂ w`.  `WInputs` supplies each
+-- cell's value + type; the recursion mirrors `pto-check`.
+mkInputs-cons : ∀ {w ti tis v}
+  → CircuitWitness.assign w (TypedIdentifier.name ti) ≡ just v
+  → mkInputs w (ti ∷ tis) ≡ encodeᵉ v ++ mkInputs w tis
+mkInputs-cons wo rewrite wo = refl
+
+∅⊑ᵂ : ∀ {w} → ∅ ⊑ᵂ w
+∅⊑ᵂ {w} ()
+
+decode-mkInputs : ∀ {w} tis → WInputs w tis
+  → ∃ λ m₀ → decode-inputs tis (mkInputs w tis) ≡ just m₀ × m₀ ⊑ᵂ w
+decode-mkInputs {w} []         _ = ∅ , refl , ∅⊑ᵂ {w}
+decode-mkInputs {w} (ti ∷ tis) ((v , wo , tyv) , wins)
+  with decode-mkInputs {w} tis wins
+... | m₀ , deq , sub
+  rewrite mkInputs-cons {w = w} {ti} {tis} {v} wo
+        | sym tyv | sym (encode-len v)
+        | take-len-++ (encodeᵉ v) (mkInputs w tis)
+        | drop-len-++ (encodeᵉ v) (mkInputs w tis)
+        | encode-decode v
+        | deq
+  = ins (TypedIdentifier.name ti) v m₀
+  , refl
+  , ins-⊑ᵂ {w = w} (TypedIdentifier.name ti) sub wo
+
+------------------------------------------------------------------------
+-- Step-success for the transcript / pi / output cluster (the `*-step`
+-- companions the `build` fold's impact / public-input / private-input /
+-- circuit-output clauses use).  Each is a `rewrite … = refl` onto a
+-- concrete record-update post-state; active/inactive are separate (the
+-- post-states differ, exactly as the `*-bwd` batch-3 lemmas).
+------------------------------------------------------------------------
+
+impact-active-step : ∀ {P S st guard inputs vals}
+  → resolve-all-Fr (State.mem st) inputs ≡ just vals
+  → resolve𝔹 (State.mem st) guard ≡ just true
+  → take (length vals)
+      (drop (State.pti-idx st) (ProofPreimage.pub-transcript-inputs P)) ≡ vals
+  → step P S st (impact guard inputs)
+      ≡ just (record st { pis      = State.pis st ++ vals
+                        ; pi-skips = State.pi-skips st ++ (nothing ∷ [])
+                        ; pti-idx  = State.pti-idx st + length vals })
+impact-active-step {P = P} {st = st} {vals = vals} rall rg chk
+  rewrite rall | rg
+  with take (length vals)
+         (drop (State.pti-idx st) (ProofPreimage.pub-transcript-inputs P))
+       ≟LFr vals
+... | yes _  = refl
+... | no ¬p  = case ¬p chk of λ ()
+
+impact-inactive-step : ∀ {P S st guard inputs vals}
+  → resolve-all-Fr (State.mem st) inputs ≡ just vals
+  → resolve𝔹 (State.mem st) guard ≡ just false
+  → step P S st (impact guard inputs)
+      ≡ just (record st { pis      = State.pis st ++ map (λ _ → 0ᶠ) vals
+                        ; pi-skips = State.pi-skips st
+                                       ++ (just (length vals) ∷ []) })
+impact-inactive-step rall rg rewrite rall | rg = refl
+
+public-input-active-step : ∀ {P S st guard val-t output v}
+  → eval-guard (State.mem st) guard ≡ just true
+  → decode val-t (take (encoded-len val-t) (State.pto-rem st)) ≡ just v
+  → step P S st (public-input guard val-t output)
+      ≡ just (record st { mem     = ins output v (State.mem st)
+                        ; pto-rem = drop (encoded-len val-t)
+                                      (State.pto-rem st) })
+public-input-active-step eg dec rewrite eg | dec = refl
+
+public-input-inactive-step : ∀ {P S st guard val-t output}
+  → eval-guard (State.mem st) guard ≡ just false
+  → step P S st (public-input guard val-t output)
+      ≡ just (out1 st output (default-val val-t))
+public-input-inactive-step eg rewrite eg = refl
+
+private-input-active-step : ∀ {P S st guard val-t output v}
+  → eval-guard (State.mem st) guard ≡ just true
+  → decode val-t (take (encoded-len val-t) (State.priv-rem st)) ≡ just v
+  → step P S st (private-input guard val-t output)
+      ≡ just (record st { mem      = ins output v (State.mem st)
+                        ; priv-rem = drop (encoded-len val-t)
+                                       (State.priv-rem st) })
+private-input-active-step eg dec rewrite eg | dec = refl
+
+private-input-inactive-step : ∀ {P S st guard val-t output}
+  → eval-guard (State.mem st) guard ≡ just false
+  → step P S st (private-input guard val-t output)
+      ≡ just (out1 st output (default-val val-t))
+private-input-inactive-step eg rewrite eg = refl
+
+circuit-output-step : ∀ {P S st vals vs}
+  → collectOutputs (State.mem st) (IrSource.outputs S) vals ≡ just vs
+  → step P S st (circuit-output vals)
+      ≡ just (record st { outs = State.outs st ++ vs })
+circuit-output-step co rewrite co = refl
+
+------------------------------------------------------------------------
+-- `collectOutputs` transport (for the `circuit-output` `build` clause).
+--
+-- `circuit-output`'s operands carry no constraint, so `OpTy` was extended
+-- to `AllDefdᵒ` (each operand defined); with agreement, `collectOutputs`
+-- then reads the same at the run memory as at the witness, moving the
+-- WShape success (`collectOutputs (assign w) …`) down to `mem st`.
+------------------------------------------------------------------------
+
+resolveᶜ≡resolveᵐ : ∀ w op
+  → resolveᶜ w op ≡ resolve (CircuitWitness.assign w) op
+resolveᶜ≡resolveᵐ w (var id) = refl
+resolveᶜ≡resolveᵐ w (imm x)  = refl
+
+collectOutputs-agree : ∀ {m w Γ} ts ops → TyEq m Γ → m ⊑ᵂ w → AllDefdᵒ Γ ops
+  → collectOutputs (CircuitWitness.assign w) ts ops ≡ collectOutputs m ts ops
+collectOutputs-agree []       []         teq agr _ = refl
+collectOutputs-agree []       (op ∷ ops) teq agr _ = refl
+collectOutputs-agree (t ∷ ts) []         teq agr _ = refl
+collectOutputs-agree {m} {w} (t ∷ ts) (op ∷ ops) teq agr ((t' , ot') ∷ adr)
+  with optype-resolve {op = op} teq ot'
+... | (v₀ , r₀)
+  rewrite r₀
+        | trans (sym (resolveᶜ≡resolveᵐ w op)) (⊑-resolve {m} {w} op agr r₀)
+  = cong (λ z → guardD (typeof v₀ ≟T t) (z >>= λ vs′ → just (v₀ ∷ vs′)))
+      (collectOutputs-agree {m} {w} ts ops teq agr adr)
+
+------------------------------------------------------------------------
+-- The witness-reconstruction fold `build`.
+--
+-- From a satisfying witness `w` and the static well-formedness threads
+-- (TyEq/OpTy/SA/WT), `build` reconstructs the forward `run` of a
+-- synthesised preimage `P'` on `w`, maintaining the memory-agreement
+-- invariant `mem st ⊑ᵂ w`, the pis-prefix invariant, and the three
+-- transcript-cursor invariants (`mkPTI`/`mkPTO`/`mkPRV`).  Each clause
+-- peels its constraint (`csOf-peel`), reads the output cell(s) off `w`
+-- (`agree-*`), runs the deterministic step (`*-step`), and re-establishes
+-- agreement (`ins-⊑ᵂ`/`insertMany-realize`) before recursing.
+------------------------------------------------------------------------
+
+record BuildOut {S w} (P' : ProofPreimage) (st : State)
+                (is : List Instruction) : Set where
+  constructor mk-build
+  field
+    fs    : State
+    frun  : run P' S st is ≡ just fs
+    fagr  : State.mem fs ⊑ᵂ w
+    fpis  : State.pis fs ≡ take (length (State.pis fs)) (CircuitWitness.pis w)
+    flen  : State.pti-idx fs
+              ≡ length (ProofPreimage.pub-transcript-inputs P')
+    fpto  : State.pto-rem fs ≡ []
+    fprv  : State.priv-rem fs ≡ []
+
+resolveᶠ-nat : ∀ {m a x} → resolve m a ≡ just (val-native x)
+  → resolveᶠ m a ≡ just x
+resolveᶠ-nat ra rewrite ra = refl
+
+
+-- A boolean wire (`is-bit x`) reads to some `to𝔹` bit — used by
+-- `constrain-to-boolean`, where the reading is the only step precondition.
+is-bit→to𝔹 : ∀ {x} → is-bit x → ∃ λ b → to𝔹 x ≡ just b
+is-bit→to𝔹 (inj₁ x≡0) = false , to𝔹-0 x≡0
+is-bit→to𝔹 (inj₂ x≡1) = true  , to𝔹-1 x≡1
+
+take-take-++ : ∀ (m n : ℕ) (xs : List Fr)
+  → take m xs ++ take n (drop m xs) ≡ take (m + n) xs
+take-take-++ zero    n xs       = refl
+take-take-++ (suc m) n (x ∷ xs) = cong (x ∷_) (take-take-++ m n xs)
+take-take-++ (suc m) n []       = tnil n
+  where tnil : ∀ k → take k [] ≡ []
+        tnil zero    = refl
+        tnil (suc _) = refl
+
+-- The Circuit `resolveᶜ-Fr` and Semantics `resolveᶠ (assign w)` agree, but
+-- not definitionally (distinct inline native-filters); case the value.
+resolveᶜ-Fr≡resolveᶠᵐ : ∀ w op
+  → resolveᶜ-Fr w op ≡ resolveᶠ (CircuitWitness.assign w) op
+resolveᶜ-Fr≡resolveᶠᵐ w (var id) with CircuitWitness.assign w id
+... | nothing                    = refl
+... | just (val-native _)        = refl
+... | just (val-bytes32 _)       = refl
+... | just (val-jubjub-point _)  = refl
+... | just (val-jubjub-scalar _) = refl
+... | just (val-secp-point _)    = refl
+... | just (val-secp-base _)     = refl
+... | just (val-secp-scalar _)   = refl
+resolveᶜ-Fr≡resolveᶠᵐ w (imm x)  = refl
+
+-- The inactive companion of `impact-slice`: on a skipped group (guard 0)
+-- the witness's pi entries are all zeros (`g ≡ 0ᶠ → pv ≡ 0ᶠ`).
+impact-slice-0 : ∀ w start guard inputs {vals}
+  → resolveᶜ-all-Fr w inputs ≡ just vals
+  → resolveᶜ-Fr w guard ≡ just 0ᶠ
+  → satisfies-constraints (impact-constraints start guard inputs) w
+  → take (length inputs) (drop start (CircuitWitness.pis w))
+      ≡ map (λ _ → 0ᶠ) vals
+impact-slice-0 w start guard []       refl rg _ = refl
+impact-slice-0 w start guard (x ∷ xs) rall rg
+  ((g , xv , pv , wg , wx , _ , wpv , _ , g0→) , rest)
+  with refl ← trans (sym rg) wg
+  with resolveᶜ-Fr w x | wx
+... | .(just xv) | refl
+  with resolveᶜ-all-Fr w xs in rxs
+...   | just vs
+  with refl ← rall
+  rewrite drop-lookup (CircuitWitness.pis w) start wpv | g0→ refl
+        | impact-slice-0 w (suc start) guard xs rxs rg rest = refl
+
+-- mkPTI on a skipped impact: the pub-transcript-inputs stream is unchanged
+-- (only the pi-cursor advances by `length inputs`).
+mkPTI-false : ∀ {w guard inputs is} k
+  → resolve𝔹 (CircuitWitness.assign w) guard ≡ just false
+  → mkPTI w k (impact guard inputs ∷ is) ≡ mkPTI w (k + length inputs) is
+mkPTI-false k active rewrite active = refl
+
+-- mkPTI on an active impact: the pub-transcript-inputs stream prepends the
+-- pi window `vals` before advancing the cursor.
+mkPTI-true : ∀ {w guard inputs is} k
+  → resolve𝔹 (CircuitWitness.assign w) guard ≡ just true
+  → mkPTI w k (impact guard inputs ∷ is)
+      ≡ take (length inputs) (drop k (CircuitWitness.pis w))
+          ++ mkPTI w (k + length inputs) is
+mkPTI-true k active rewrite active = refl
+
+-- The run's guard reading agrees with the witness's (used by public/
+-- private-input).  `nothing` guard is `just true` both sides; a present
+-- guard resolves natively (from `GuardNat`) and transports via the
+-- `resolveᶜ-Fr`/`resolveᶠ` bridge + `to𝔹`.
+eval-guard-agree : ∀ {m w Γ} guard {b} → m ⊑ᵂ w → TyEq m Γ → GuardNat Γ guard
+  → eval-guard (CircuitWitness.assign w) guard ≡ just b
+  → eval-guard m guard ≡ just b
+eval-guard-agree nothing        agr teq _     e = e
+eval-guard-agree {m} {w} (just op) agr teq ognat e =
+  let (x , rgf) = optype-resolveᶠ {m} {op = op} teq ognat
+      rafw = trans (sym (resolveᶜ-Fr≡resolveᶠᵐ w op))
+                   (⊑-resolveᶠ {m} {w} op agr rgf)
+      tbx  = trans (sym (cong (_>>= to𝔹) rafw)) e
+  in trans (cong (_>>= to𝔹) rgf) tbx
+
+-- mkPTO/mkPRV on a skipped input (guard reads false): the transcript-output
+-- stream is unchanged.
+mkPTO-false : ∀ {w guard val-t o is}
+  → eval-guard (CircuitWitness.assign w) guard ≡ just false
+  → mkPTO w (public-input guard val-t o ∷ is) ≡ mkPTO w is
+mkPTO-false e rewrite e = refl
+
+mkPRV-false : ∀ {w guard val-t o is}
+  → eval-guard (CircuitWitness.assign w) guard ≡ just false
+  → mkPRV w (private-input guard val-t o ∷ is) ≡ mkPRV w is
+mkPRV-false e rewrite e = refl
+
+insertMany-shape : ∀ st ids vs {st'} → insertMany st ids vs ≡ just st'
+  → (State.pis st' ≡ State.pis st) × (State.pti-idx st' ≡ State.pti-idx st)
+  × (State.pto-rem st' ≡ State.pto-rem st)
+  × (State.priv-rem st' ≡ State.priv-rem st)
+insertMany-shape st []         []       refl = refl , refl , refl , refl
+insertMany-shape st (id ∷ ids) (v ∷ vs) e =
+  insertMany-shape (out1 st id v) ids vs e
+insertMany-shape st []         (_ ∷ _)  ()
+insertMany-shape st (_ ∷ _)    []       ()
+
+-- `from-bytes32` packages the run's output value, its step equation, and the
+-- witness agreement uniformly, so `build` need not case-split on `val-t`.
+-- `WCell`'s `typeof v ≡ val-t` selects the matching `from-bytes` disjunct
+-- (supported `val-t`) or refutes an unsupported `val-t`.
+from-bytes32-realize : ∀ {P' S w st bytes val-t o bs}
+  → State.mem st ⊑ᵂ w
+  → resolve (State.mem st) bytes ≡ just (val-bytes32 bs)
+  → holds w (from-bytes o bytes)
+  → WCell w val-t o true
+  → ∃ λ v → step P' S st (from-bytes32 bytes val-t o) ≡ just (out1 st o v)
+          × CircuitWitness.assign w o ≡ just v
+from-bytes32-realize {P' = P'} {S} {w} {st} {bytes} {val-t = native} {o} {bs}
+  sub rb hc (v , wo , tv) =
+    val-native (nativeFromBytes bs)
+  , from-bytes32-step {P'} {S} {st} {bytes} {o} {bs} rb
+  , agree-from-bytes-native {State.mem st} {w} {bytes} {o} {bs} {v} sub rb hc wo tv
+from-bytes32-realize {P' = P'} {S} {w} {st} {bytes} {val-t = secp-base} {o} {bs}
+  sub rb hc (v , wo , tv) =
+    val-secp-base (secpBaseFromBytes bs)
+  , from-bytes32-secp-base-step {P'} {S} {st} {bytes} {o} {bs} rb
+  , agree-from-bytes-secp-base {State.mem st} {w} {bytes} {o} {bs} {v}
+      sub rb hc wo tv
+from-bytes32-realize {P' = P'} {S} {w} {st} {bytes} {val-t = secp-scalar} {o} {bs}
+  sub rb hc (v , wo , tv) =
+    val-secp-scalar (secpScalarFromBytes bs)
+  , from-bytes32-secp-scalar-step {P'} {S} {st} {bytes} {o} {bs} rb
+  , agree-from-bytes-secp-scalar {State.mem st} {w} {bytes} {o} {bs} {v}
+      sub rb hc wo tv
+from-bytes32-realize {w = w} {bytes = bytes} {val-t = bytes32} {o = o}
+  sub rb hc (v , wo , tv) =
+  case from-bytes-out-typeof {w} {o} {bytes} {v} hc wo of λ
+    { (inj₁ tn)        → case trans (sym tn) tv of λ ()
+    ; (inj₂ (inj₁ tb)) → case trans (sym tb) tv of λ ()
+    ; (inj₂ (inj₂ ts)) → case trans (sym ts) tv of λ () }
+from-bytes32-realize {w = w} {bytes = bytes} {val-t = jubjub-point} {o = o}
+  sub rb hc (v , wo , tv) =
+  case from-bytes-out-typeof {w} {o} {bytes} {v} hc wo of λ
+    { (inj₁ tn)        → case trans (sym tn) tv of λ ()
+    ; (inj₂ (inj₁ tb)) → case trans (sym tb) tv of λ ()
+    ; (inj₂ (inj₂ ts)) → case trans (sym ts) tv of λ () }
+from-bytes32-realize {w = w} {bytes = bytes} {val-t = jubjub-scalar} {o = o}
+  sub rb hc (v , wo , tv) =
+  case from-bytes-out-typeof {w} {o} {bytes} {v} hc wo of λ
+    { (inj₁ tn)        → case trans (sym tn) tv of λ ()
+    ; (inj₂ (inj₁ tb)) → case trans (sym tb) tv of λ ()
+    ; (inj₂ (inj₂ ts)) → case trans (sym ts) tv of λ () }
+from-bytes32-realize {w = w} {bytes = bytes} {val-t = secp-point} {o = o}
+  sub rb hc (v , wo , tv) =
+  case from-bytes-out-typeof {w} {o} {bytes} {v} hc wo of λ
+    { (inj₁ tn)        → case trans (sym tn) tv of λ ()
+    ; (inj₂ (inj₁ tb)) → case trans (sym tb) tv of λ ()
+    ; (inj₂ (inj₂ ts)) → case trans (sym ts) tv of λ () }
+
+------------------------------------------------------------------------
+-- Two helpers shared by every non-nil `build` clause.  `cons-build`
+-- prepends one reconstructed step to a tail `BuildOut`: the run grows by
+-- `run-cons`, every other component is copied verbatim.  `adv3` advances
+-- the static well-formedness thread (the domain equation, the typing
+-- invariant, and the pi-count link) from the pre-state to the
+-- post-instruction state, uniformly for every instruction.
+------------------------------------------------------------------------
+
+cons-build : ∀ {S w} {P' : ProofPreimage} {st st' : State} {i is}
+  → step P' S st i ≡ just st'
+  → BuildOut {S} {w} P' st' is
+  → BuildOut {S} {w} P' st (i ∷ is)
+cons-build {i = i} {is} steq rec =
+  mk-build (BuildOut.fs rec) (run-cons i is steq (BuildOut.frun rec))
+    (BuildOut.fagr rec) (BuildOut.fpis rec) (BuildOut.flen rec)
+    (BuildOut.fpto rec) (BuildOut.fprv rec)
+
+-- `P`/`S`/`st`/`ss` are explicit: they occur only in non-injective
+-- positions (`step P S st i` reduces on a concrete `i`; `State.mem st`,
+-- `State.pis st`, `SynthState.next-pi ss` are projections), so they must be
+-- supplied, exactly as the per-clause `step-ty`/`pi-inv-step` calls used to
+-- pin `P`/`S` and pass `ss`.  `st'`/`Γ`/`Γ'`/`bound` stay inferred (they sit
+-- at injective positions of `steq`/`oty`/`dΓ`).
+adv3 : ∀ {st' Γ Γ' bound} (P : ProofPreimage) (S : IrSource) (st : State)
+       (ss : SynthState) (i : Instruction)
+  → outtys Γ i ≡ just Γ'
+  → dom-ty Γ ≡ bound
+  → All (λ o → ¬ (o ∈ bound)) (outs-of i)
+  → NoDup (outs-of i)
+  → TyEq (State.mem st) Γ
+  → SynthState.next-pi ss ≡ length (State.pis st)
+  → step P S st i ≡ just st'
+  → (dom-ty Γ' ≡ bound ++ outs-of i)
+  × TyEq (State.mem st') Γ'
+  × (SynthState.next-pi (synth-instr i ss) ≡ length (State.pis st'))
+adv3 {Γ = Γ} P S st ss i oty dΓ af nd teq npi steq =
+    trans (outtys-dom Γ i oty) (cong (_++ outs-of i) dΓ)
+  , step-ty {P} {S} i oty steq teq (all∉-cast (outs-of i) dΓ af) nd
+  , pi-inv-step {P} {S} i ss steq npi
+
+build : ∀ {S w} (P' : ProofPreimage) is st Γ bound ss
+  → dom-ty Γ ≡ bound → SA bound is → WT Γ is
+  → TyEq (State.mem st) Γ
+  → State.mem st ⊑ᵂ w
+  → satisfies-constraints (csOf is ss) w
+  → SynthState.next-pi ss ≡ length (State.pis st)
+  → State.pis st ≡ take (length (State.pis st)) (CircuitWitness.pis w)
+  → drop (State.pti-idx st) (ProofPreimage.pub-transcript-inputs P')
+      ≡ mkPTI w (length (State.pis st)) is
+  → State.pto-rem st ≡ mkPTO w is
+  → State.priv-rem st ≡ mkPRV w is
+  → State.pti-idx st + length (mkPTI w (length (State.pis st)) is)
+      ≡ length (ProofPreimage.pub-transcript-inputs P')
+  → WSteps S w is
+  → BuildOut {S} {w} P' st is
+build P' [] st Γ bound ss dΓ sa wt teq agr csat npi pisP ptiI ptoI prvI
+  alen ws =
+  mk-build st refl agr pisP
+    (trans (sym (+-identityʳ (State.pti-idx st))) alen) ptoI prvI
+
+-- mul: split on the FM disjunction (native / secp-base / secp-scalar).
+build {S} {w} P' (mul a b output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , (t , oa , ob , fm) , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws with fm
+... | inj₁ refl =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {native} teq oa
+      (x , ra)   = mul-support-l {State.mem st} {Γ} {a} {av} teq oa rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {native} teq ob
+      (y , rb)   = mul-support-l {State.mem st} {Γ} {b} {bv} teq ob rbv
+      (hc , tc)  = csOf-peel (mul a b output) is ss csat
+      wout = agree-mul {a = a} {b} {out = output} agr
+               (resolveᶠ-nat {State.mem st} {a} ra)
+               (resolveᶠ-nat {State.mem st} {b} rb) (proj₁ hc)
+      steq = mul-step {P'} {S} {st} {a} {b} {output} ra rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (mul a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-native (x *ᶠ y)))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (mul a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₁ refl) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-base} teq oa
+      (x , ra)   = secp-base-support {State.mem st} {Γ} {a} {av} teq oa rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {secp-base} teq ob
+      (y , rb)   = secp-base-support {State.mem st} {Γ} {b} {bv} teq ob rbv
+      (hc , tc)  = csOf-peel (mul a b output) is ss csat
+      wout = agree-mul-sb {a = a} {b} {out = output} agr ra rb (proj₁ hc)
+      steq = mul-step-sb {P'} {S} {st} {a} {b} {output} ra rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (mul a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-base (x *ᵇ y)))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (mul a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ refl) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-scalar} teq oa
+      (x , ra)   = secp-scalar-support {State.mem st} {Γ} {a} {av} teq oa rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {secp-scalar} teq ob
+      (y , rb)   = secp-scalar-support {State.mem st} {Γ} {b} {bv} teq ob rbv
+      (hc , tc)  = csOf-peel (mul a b output) is ss csat
+      wout = agree-mul-ss {a = a} {b} {out = output} agr ra rb (proj₁ hc)
+      steq = mul-step-ss {P'} {S} {st} {a} {b} {output} ra rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (mul a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-scalar (x *ˢ y)))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (mul a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- add: split on the FP disjunction (native vs jubjub-point).
+build {S} {w} P' (add a b output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , (t , ota , otb , fp) , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws with fp
+... | inj₁ refl =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {native} teq ota
+      (x , ra)   = mul-support-l {State.mem st} {Γ} {a} {av} teq ota rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {native} teq otb
+      (y , rb)   = mul-support-l {State.mem st} {Γ} {b} {bv} teq otb rbv
+      (hc , tc)  = csOf-peel (add a b output) is ss csat
+      wout = agree-add-n {a = a} {b} {out = output} agr ra rb (proj₁ hc)
+      steq = add-step-n {P'} {S} {st} {a} {b} {output} ra rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (add a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-native (x +ᶠ y)))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (add a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₁ refl) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {jubjub-point} teq ota
+      (p , ra)   = point-support {State.mem st} {Γ} {a} {av} teq ota rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {jubjub-point} teq otb
+      (q , rb)   = point-support {State.mem st} {Γ} {b} {bv} teq otb rbv
+      (hc , tc)  = csOf-peel (add a b output) is ss csat
+      wout = agree-add-p {a = a} {b} {out = output} agr ra rb (proj₁ hc)
+      steq = add-step-p {P'} {S} {st} {a} {b} {output} ra rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (add a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-jubjub-point (p +J q)))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (add a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ (inj₁ refl)) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-point} teq ota
+      (p , ra)   = secp-point-support {State.mem st} {Γ} {a} {av} teq ota rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {secp-point} teq otb
+      (q , rb)   = secp-point-support {State.mem st} {Γ} {b} {bv} teq otb rbv
+      (hc , tc)  = csOf-peel (add a b output) is ss csat
+      wout = agree-add-sp {a = a} {b} {out = output} agr ra rb (proj₁ hc)
+      steq = add-step-sp {P'} {S} {st} {a} {b} {output} ra rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (add a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-point (p +K q)))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (add a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ (inj₂ (inj₁ refl))) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-base} teq ota
+      (x , ra)   = secp-base-support {State.mem st} {Γ} {a} {av} teq ota rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {secp-base} teq otb
+      (y , rb)   = secp-base-support {State.mem st} {Γ} {b} {bv} teq otb rbv
+      (hc , tc)  = csOf-peel (add a b output) is ss csat
+      wout = agree-add-sb {a = a} {b} {out = output} agr ra rb (proj₁ hc)
+      steq = add-step-sb {P'} {S} {st} {a} {b} {output} ra rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (add a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-base (x +ᵇ y)))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (add a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ (inj₂ (inj₂ refl))) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-scalar} teq ota
+      (x , ra)   = secp-scalar-support {State.mem st} {Γ} {a} {av} teq ota rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {secp-scalar} teq otb
+      (y , rb)   = secp-scalar-support {State.mem st} {Γ} {b} {bv} teq otb rbv
+      (hc , tc)  = csOf-peel (add a b output) is ss csat
+      wout = agree-add-ss {a = a} {b} {out = output} agr ra rb (proj₁ hc)
+      steq = add-step-ss {P'} {S} {st} {a} {b} {output} ra rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (add a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-scalar (x +ˢ y)))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (add a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- inv: partial-op, split on FM (native / secp-base / secp-scalar).  Each
+-- `agree-inv*` returns the Σ with the field/subgroup inverse equation.
+build {S} {w} P' (inv a output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , (t , oa , fm) , wt') teq agr csat npi pisP ptiI ptoI prvI alen ws
+  with fm
+... | inj₁ refl =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {native} teq oa
+      (x , ra)   = mul-support-l {State.mem st} {Γ} {a} {av} teq oa rav
+      (hc , tc)  = csOf-peel (inv a output) is ss csat
+      (xi , invEq , wout) = agree-inv {a = a} {out = output} agr
+                              (resolveᶠ-nat {State.mem st} {a} ra) (proj₁ hc)
+      steq = inv-step {P'} {S} {st} {a} {output} ra invEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (inv a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-native xi))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (inv a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₁ refl) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-base} teq oa
+      (x , ra)   = secp-base-support {State.mem st} {Γ} {a} {av} teq oa rav
+      (hc , tc)  = csOf-peel (inv a output) is ss csat
+      (xi , invEq , wout) = agree-inv-sb {a = a} {out = output} agr ra (proj₁ hc)
+      steq = inv-step-sb {P'} {S} {st} {a} {output} ra invEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (inv a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-base xi))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (inv a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ refl) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-scalar} teq oa
+      (x , ra)   = secp-scalar-support {State.mem st} {Γ} {a} {av} teq oa rav
+      (hc , tc)  = csOf-peel (inv a output) is ss csat
+      (xi , invEq , wout) = agree-inv-ss {a = a} {out = output} agr ra (proj₁ hc)
+      steq = inv-step-ss {P'} {S} {st} {a} {output} ra invEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (inv a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-scalar xi))
+               Γ' (bound ++ (output ∷ [])) (synth-instr (inv a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- constrain-bits: no output (st' = st); the bound comes from `in-range`.
+build {S} {w} P' (constrain-bits val bits ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , ov , wt') teq agr csat npi pisP ptiI ptoI prvI alen ws =
+  let (x , raf) = optype-resolveᶠ {State.mem st} {Γ} {val} teq ov
+      (hc , tc) = csOf-peel (constrain-bits val bits) is ss csat
+      (x' , wval , bnd) = proj₁ hc
+      steq = constrain-bits-step {P'} {S} {st} {val} {bits} {x} raf
+               (subst (λ z → valFr z < 2 ^ bits)
+                 (sym (just-injective
+                   (trans (sym (⊑-resolveᶠ {State.mem st} {w} val agr raf)) wval)))
+                 bnd)
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (constrain-bits val bits)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is st
+               Γ' (bound ++ outs-of (constrain-bits val bits))
+               (synth-instr (constrain-bits val bits) ss)
+               dΓ' sa' wt' teq' agr tc npi'
+               pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- copy: OpDefd operand (any type), agree-copy returns the cell directly.
+build {S} {w} P' (copy val output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , (t , ov) , wt') teq agr csat npi pisP ptiI ptoI prvI alen ws =
+  let (v , rv)  = optype-resolve {State.mem st} {Γ} {val} {t} teq ov
+      (hc , tc) = csOf-peel (copy val output) is ss csat
+      wout = agree-copy {a = val} {out = output} agr rv (proj₁ hc)
+      steq = copy-step {P'} {S} {st} {val} {output} rv
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (copy val output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output v)
+               Γ' (bound ++ outs-of (copy val output))
+               (synth-instr (copy val output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- hash-to-curve: all-native input list (allNat-resolve + ⊑-resolve-all).
+build {S} {w} P' (hash-to-curve inputs output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , oinp , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws =
+  let (frs , rall) = allNat-resolve {State.mem st} {Γ} inputs teq oinp
+      (hc , tc) = csOf-peel (hash-to-curve inputs output) is ss csat
+      wout = agree-h2c {inputs = inputs} {out = output} agr rall (proj₁ hc)
+      steq = hash-to-curve-step {P'} {S} {st} {inputs} {output} rall
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (hash-to-curve inputs output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 st output (val-jubjub-point (hash-to-curve-fn frs)))
+               Γ' (bound ++ outs-of (hash-to-curve inputs output))
+               (synth-instr (hash-to-curve inputs output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- not: boolean-reading Σ (agree-not gives the bit + the output cell).
+build {S} {w} P' (not a output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , oa , wt') teq agr csat npi pisP ptiI ptoI prvI alen ws =
+  let (x , raf) = optype-resolveᶠ {State.mem st} {Γ} {a} teq oa
+      (hc , tc) = csOf-peel (not a output) is ss csat
+      (b , r𝔹 , wout) = agree-not {a = a} {out = output} agr raf (proj₁ hc)
+      steq = not-step {P'} {S} {st} {a} {output} {b} r𝔹
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (not a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-native (χˢ (bnot b))))
+               Γ' (bound ++ outs-of (not a output))
+               (synth-instr (not a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- assert: no output; the true-reading comes from the WShape condition.
+build {S} {w} P' (assert cond ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , oc , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ((x , wcond , tb) , ws') =
+  let (x₀ , raf) = optype-resolveᶠ {State.mem st} {Γ} {cond} teq oc
+      (hc , tc) = csOf-peel (assert cond) is ss csat
+      x₀≡x = just-injective
+               (trans (sym (⊑-resolveᶠ {State.mem st} {w} cond agr raf)) wcond)
+      steq = assert-step {P'} {S} {st} {cond}
+               (trans (cong (_>>= to𝔹) raf)
+                 (subst (λ z → to𝔹 z ≡ just true) (sym x₀≡x) tb))
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (assert cond)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is st
+               Γ' (bound ++ outs-of (assert cond))
+               (synth-instr (assert cond) ss)
+               dΓ' sa' wt' teq' agr tc npi'
+               pisP ptiI ptoI prvI alen ws'
+  in cons-build steq rec
+
+-- encode: list output via `insertMany-realize` (agreement) + `insertMany-
+-- shape` (transport the pis/cursor invariants, since insertMany changes
+-- only mem, PROPOSITIONALLY not definitionally).
+build {S} {w} P' (encode input outputs ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , (t , oinp) , wt') teq agr csat npi pisP ptiI ptoI prvI alen ws =
+  let (v , rv)  = optype-resolve {State.mem st} {Γ} {input} {t} teq oinp
+      (hc , tc) = csOf-peel (encode input outputs) is ss csat
+      be = agree-encode {a = input} {outputs = outputs} agr rv (proj₁ hc)
+      (st' , im , agr') =
+        insertMany-realize {w} st outputs (map val-native (encodeᵉ v)) agr be
+      steq = encode-step {P'} {S} {st} {input} {outputs} {v} {st'} rv im
+      (peq , pteq , poeq , preq) =
+        insertMany-shape st outputs (map val-native (encodeᵉ v)) im
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (encode input outputs)
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is st' Γ'
+              (bound ++ outs-of (encode input outputs))
+              (synth-instr (encode input outputs) ss)
+              dΓ' sa' wt' teq' agr' tc npi'
+              (trans peq (trans pisP
+                (cong (λ n → take n (CircuitWitness.pis w))
+                  (cong length (sym peq)))))
+              (trans (cong (λ n → drop n
+                             (ProofPreimage.pub-transcript-inputs P')) pteq)
+                     (trans ptiI
+                       (cong (λ n → mkPTI w n is) (cong length (sym peq)))))
+              (trans poeq ptoI) (trans preq prvI)
+              (subst₂ (λ p q → p + length (mkPTI w q is)
+                        ≡ length (ProofPreimage.pub-transcript-inputs P'))
+                (sym pteq) (sym (cong length peq)) alen) ws
+  in cons-build steq rec
+
+-- impact: the transcript cursor pattern (active/inactive on the guard bit).
+build {S} {w} P' (impact guard inputs ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , (og , oinp) , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ((gᶠw , wguard , (gb , tb)) , ws')
+  with optype-resolveᶠ {State.mem st} {Γ} {guard} teq og
+     | allNat-resolve {State.mem st} {Γ} inputs teq oinp
+     | csOf-peel (impact guard inputs) is ss csat
+     | gb
+... | (gᶠ , rgf) | (vals , rall) | (hc , tc) | true =
+  let k        = length (State.pis st)
+      PTI      = ProofPreimage.pub-transcript-inputs P'
+      gᶠ≡      = just-injective (trans (sym (⊑-resolveᶠ {State.mem st} {w} guard agr rgf))
+                                 wguard)
+      tbf      : to𝔹 gᶠ ≡ just true
+      tbf      = subst (λ z → to𝔹 z ≡ just true) (sym gᶠ≡) tb
+      gᶠ≡1     = to𝔹-true tbf
+      r𝔹mem    : resolve𝔹 (State.mem st) guard ≡ just true
+      r𝔹mem    = trans (cong (_>>= to𝔹) rgf) tbf
+      r𝔹w      : resolve𝔹 (CircuitWitness.assign w) guard ≡ just true
+      r𝔹w      = trans (cong (_>>= to𝔹)
+                   (trans (sym (resolveᶜ-Fr≡resolveᶠᵐ w guard)) wguard)) tb
+      rᶜg1     : resolveᶜ-Fr w guard ≡ just 1ᶠ
+      rᶜg1     = trans (⊑-resolveᶠ {State.mem st} {w} guard agr rgf)
+                       (cong just gᶠ≡1)
+      rᶜall    = ⊑-resolve-all inputs agr rall
+      hc'      = subst (λ κ → satisfies-constraints
+                          (impact-constraints κ guard inputs) w) npi hc
+      slice    = impact-slice w k guard inputs rᶜall rᶜg1 hc'
+      lenvals  : length vals ≡ length inputs
+      lenvals  = resolve-all-Fr-length (State.mem st) inputs rall
+      chk      = pti-check {w} {k} {guard} {inputs} {is} {vals}
+                   {State.pti-idx st} {PTI} r𝔹w ptiI slice
+      steq     = impact-active-step {P'} {S} {st} {guard} {inputs} {vals}
+                   rall r𝔹mem chk
+      lenpis'  : length (State.pis st ++ vals) ≡ k + length inputs
+      lenpis'  = trans (length-++ (State.pis st)) (cong (k +_) lenvals)
+      slicefull : length (take (length inputs) (drop k (CircuitWitness.pis w)))
+                    ≡ length inputs
+      slicefull = trans (cong length slice) lenvals
+      pa       = pti-adv {w} {k} {guard} {inputs} {is} {State.pti-idx st} {PTI}
+                   r𝔹w ptiI slicefull
+      alen'    : State.pti-idx st + length vals
+                   + length (mkPTI w (length (State.pis st ++ vals)) is)
+                   ≡ length PTI
+      alen'    = subst (λ n → State.pti-idx st + length vals
+                                + length (mkPTI w n is) ≡ length PTI)
+                   (sym lenpis')
+                   (trans (+-assoc (State.pti-idx st) (length vals)
+                             (length (mkPTI w (k + length inputs) is)))
+                     (subst (λ z → State.pti-idx st
+                              + (z + length (mkPTI w (k + length inputs) is))
+                              ≡ length PTI)
+                       (trans slicefull (sym lenvals))
+                       (subst (λ z → State.pti-idx st + z ≡ length PTI)
+                         (length-++ (take (length inputs)
+                                      (drop k (CircuitWitness.pis w))))
+                         (subst (λ z → State.pti-idx st + length z ≡ length PTI)
+                           (mkPTI-true {w} {guard} {inputs} {is} k r𝔹w)
+                           alen))))
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (impact guard inputs)
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is
+              (record st { pis      = State.pis st ++ vals
+                         ; pi-skips = State.pi-skips st ++ (nothing ∷ [])
+                         ; pti-idx  = State.pti-idx st + length vals })
+              Γ' (bound ++ outs-of (impact guard inputs))
+              (synth-instr (impact guard inputs) ss)
+              dΓ' sa' wt' teq' agr tc npi'
+              (trans (cong₂ _++_ pisP (sym slice))
+                     (trans (take-take-++ k (length inputs) (CircuitWitness.pis w))
+                            (cong (λ n → take n (CircuitWitness.pis w))
+                              (sym lenpis'))))
+              (trans (cong (λ n → drop (State.pti-idx st + n) PTI) lenvals)
+                     (trans pa
+                       (sym (cong (λ n → mkPTI w n is) lenpis'))))
+              ptoI prvI alen' ws'
+  in cons-build steq rec
+... | (gᶠ , rgf) | (vals , rall) | (hc , tc) | false =
+  let k        = length (State.pis st)
+      PTI      = ProofPreimage.pub-transcript-inputs P'
+      gᶠ≡      = just-injective (trans (sym (⊑-resolveᶠ {State.mem st} {w} guard agr rgf))
+                                 wguard)
+      tbf      : to𝔹 gᶠ ≡ just false
+      tbf      = subst (λ z → to𝔹 z ≡ just false) (sym gᶠ≡) tb
+      gᶠ≡0     = to𝔹-false tbf
+      r𝔹mem    : resolve𝔹 (State.mem st) guard ≡ just false
+      r𝔹mem    = trans (cong (_>>= to𝔹) rgf) tbf
+      r𝔹w      : resolve𝔹 (CircuitWitness.assign w) guard ≡ just false
+      r𝔹w      = trans (cong (_>>= to𝔹)
+                   (trans (sym (resolveᶜ-Fr≡resolveᶠᵐ w guard)) wguard)) tb
+      rᶜg0     : resolveᶜ-Fr w guard ≡ just 0ᶠ
+      rᶜg0     = trans (⊑-resolveᶠ {State.mem st} {w} guard agr rgf)
+                       (cong just gᶠ≡0)
+      rᶜall    = ⊑-resolve-all inputs agr rall
+      hc'      = subst (λ κ → satisfies-constraints
+                          (impact-constraints κ guard inputs) w) npi hc
+      slice0   = impact-slice-0 w k guard inputs rᶜall rᶜg0 hc'
+      lenvals  : length vals ≡ length inputs
+      lenvals  = resolve-all-Fr-length (State.mem st) inputs rall
+      steq     = impact-inactive-step {P'} {S} {st} {guard} {inputs} {vals}
+                   rall r𝔹mem
+      lenpis'  : length (State.pis st ++ map (λ _ → 0ᶠ) vals) ≡ k + length inputs
+      lenpis'  = trans (length-++ (State.pis st))
+                   (cong (k +_) (trans (length-map (λ _ → 0ᶠ) vals) lenvals))
+      alen'    : State.pti-idx st
+                   + length (mkPTI w (length (State.pis st
+                                                ++ map (λ _ → 0ᶠ) vals)) is)
+                   ≡ length PTI
+      alen'    = subst (λ n → State.pti-idx st + length (mkPTI w n is)
+                                ≡ length PTI)
+                   (sym lenpis')
+                   (subst (λ z → State.pti-idx st + length z ≡ length PTI)
+                     (mkPTI-false {w} {guard} {inputs} {is} k r𝔹w) alen)
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (impact guard inputs)
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is
+              (record st { pis      = State.pis st ++ map (λ _ → 0ᶠ) vals
+                         ; pi-skips = State.pi-skips st
+                                        ++ (just (length vals) ∷ []) })
+              Γ' (bound ++ outs-of (impact guard inputs))
+              (synth-instr (impact guard inputs) ss)
+              dΓ' sa' wt' teq' agr tc npi'
+              (trans (cong₂ _++_ pisP (sym slice0))
+                     (trans (take-take-++ k (length inputs) (CircuitWitness.pis w))
+                            (cong (λ n → take n (CircuitWitness.pis w))
+                              (sym lenpis'))))
+              (trans (trans ptiI
+                        (mkPTI-false {w} {guard} {inputs} {is} k r𝔹w))
+                     (sym (cong (λ n → mkPTI w n is) lenpis')))
+              ptoI prvI alen' ws'
+  in cons-build steq rec
+
+-- public-input: guard (eval-guard-agree) + a decoded transcript cell
+-- (WCell + pto-check/pto-adv at cursor 0, since pto-rem IS the remaining).
+build {S} {w} P' (public-input guard val-t o ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , og , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ((b , evw , wcell) , ws')
+  with csOf-peel (public-input guard val-t o) is ss csat | b | evw | wcell
+... | (_ , tc) | true | evw' | (v , wo , tyv) =
+  let egm  = eval-guard-agree {State.mem st} {w} guard agr teq og evw'
+      dec  = pto-check {w} {guard} {val-t} {o} {is} {v} {0} {State.pto-rem st}
+               evw' wo tyv ptoI
+      steq = public-input-active-step {P'} {S} {st} {guard} {val-t} {o} {v}
+               egm dec
+      padv = pto-adv {w} {guard} {val-t} {o} {is} {v} {0} {State.pto-rem st}
+               evw' wo tyv ptoI
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (public-input guard val-t o)
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is
+              (record st { mem     = ins o v (State.mem st)
+                         ; pto-rem = drop (encoded-len val-t) (State.pto-rem st) })
+              Γ' (bound ++ outs-of (public-input guard val-t o))
+              (synth-instr (public-input guard val-t o) ss)
+              dΓ' sa' wt' teq'
+              (λ {id} {v'} e → ins-⊑ᵂ {w = w} o agr wo {id} {v'} e) tc
+              npi' pisP ptiI padv prvI alen ws'
+  in cons-build steq rec
+... | (_ , tc) | false | evw' | wo =
+  let egm  = eval-guard-agree {State.mem st} {w} guard agr teq og evw'
+      steq = public-input-inactive-step {P'} {S} {st} {guard} {val-t} {o} egm
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (public-input guard val-t o)
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is (out1 st o (default-val val-t))
+              Γ' (bound ++ outs-of (public-input guard val-t o))
+              (synth-instr (public-input guard val-t o) ss)
+              dΓ' sa' wt' teq'
+              (λ {id} {v'} e → ins-⊑ᵂ {w = w} o agr wo {id} {v'} e) tc
+              npi' pisP ptiI
+              (trans ptoI (mkPTO-false {w} {guard} {val-t} {o} evw'))
+              prvI alen ws'
+  in cons-build steq rec
+
+-- private-input: symmetric to public-input over priv-rem / mkPRV.
+build {S} {w} P' (private-input guard val-t o ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , og , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ((b , evw , wcell) , ws')
+  with csOf-peel (private-input guard val-t o) is ss csat | b | evw | wcell
+... | (_ , tc) | true | evw' | (v , wo , tyv) =
+  let egm  = eval-guard-agree {State.mem st} {w} guard agr teq og evw'
+      dec  = prv-check {w} {guard} {val-t} {o} {is} {v} {0} {State.priv-rem st}
+               evw' wo tyv prvI
+      steq = private-input-active-step {P'} {S} {st} {guard} {val-t} {o} {v}
+               egm dec
+      padv = prv-adv {w} {guard} {val-t} {o} {is} {v} {0} {State.priv-rem st}
+               evw' wo tyv prvI
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (private-input guard val-t o)
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is
+              (record st { mem      = ins o v (State.mem st)
+                         ; priv-rem = drop (encoded-len val-t)
+                                        (State.priv-rem st) })
+              Γ' (bound ++ outs-of (private-input guard val-t o))
+              (synth-instr (private-input guard val-t o) ss)
+              dΓ' sa' wt' teq'
+              (λ {id} {v'} e → ins-⊑ᵂ {w = w} o agr wo {id} {v'} e) tc
+              npi' pisP ptiI ptoI padv alen ws'
+  in cons-build steq rec
+... | (_ , tc) | false | evw' | wo =
+  let egm  = eval-guard-agree {State.mem st} {w} guard agr teq og evw'
+      steq = private-input-inactive-step {P'} {S} {st} {guard} {val-t} {o} egm
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (private-input guard val-t o)
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is (out1 st o (default-val val-t))
+              Γ' (bound ++ outs-of (private-input guard val-t o))
+              (synth-instr (private-input guard val-t o) ss)
+              dΓ' sa' wt' teq'
+              (λ {id} {v'} e → ins-⊑ᵂ {w = w} o agr wo {id} {v'} e) tc
+              npi' pisP ptiI ptoI
+              (trans prvI (mkPRV-false {w} {guard} {val-t} {o} evw')) alen ws'
+  in cons-build steq rec
+
+-- circuit-output: `collectOutputs-agree` moves the WShape success to mem st;
+-- the state grows only `outs`, so every invariant passes unchanged.
+build {S} {w} P' (circuit-output vals ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , oc , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ((vs , cow) , ws') =
+  let (_ , tc) = csOf-peel (circuit-output vals) is ss csat
+      co-mem = trans (sym (collectOutputs-agree {State.mem st} {w} {Γ}
+                            (IrSource.outputs S) vals teq agr oc)) cow
+      steq = circuit-output-step {P'} {S} {st} {vals} {vs} co-mem
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (circuit-output vals)
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is (record st { outs = State.outs st ++ vs })
+              Γ' (bound ++ outs-of (circuit-output vals))
+              (synth-instr (circuit-output vals) ss)
+              dΓ' sa' wt' teq' agr tc npi'
+              pisP ptiI ptoI prvI alen ws'
+  in cons-build steq rec
+
+build {S} {w} P' (neg a output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , (t , ota , fp) , wt') teq agr csat npi pisP ptiI ptoI prvI alen ws
+  with fp
+... | inj₁ refl =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {native} teq ota
+      (x , ra)   = mul-support-l {State.mem st} {Γ} {a} {av} teq ota rav
+      (hc , tc)  = csOf-peel (neg a output) is ss csat
+      wout = agree-neg-n {a = a} {out = output} agr ra (proj₁ hc)
+      steq = neg-step-n {P'} {S} {st} {a} {output} ra
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (neg a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-native (-ᶠ x)))
+               Γ' (bound ++ outs-of (neg a output))
+               (synth-instr (neg a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₁ refl) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {jubjub-point} teq ota
+      (p , ra)   = point-support {State.mem st} {Γ} {a} {av} teq ota rav
+      (hc , tc)  = csOf-peel (neg a output) is ss csat
+      wout = agree-neg-p {a = a} {out = output} agr ra (proj₁ hc)
+      steq = neg-step-p {P'} {S} {st} {a} {output} ra
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (neg a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-jubjub-point (negJ p)))
+               Γ' (bound ++ outs-of (neg a output))
+               (synth-instr (neg a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ (inj₁ refl)) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-point} teq ota
+      (p , ra)   = secp-point-support {State.mem st} {Γ} {a} {av} teq ota rav
+      (hc , tc)  = csOf-peel (neg a output) is ss csat
+      wout = agree-neg-sp {a = a} {out = output} agr ra (proj₁ hc)
+      steq = neg-step-sp {P'} {S} {st} {a} {output} ra
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (neg a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-point (negK p)))
+               Γ' (bound ++ outs-of (neg a output))
+               (synth-instr (neg a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ (inj₂ (inj₁ refl))) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-base} teq ota
+      (x , ra)   = secp-base-support {State.mem st} {Γ} {a} {av} teq ota rav
+      (hc , tc)  = csOf-peel (neg a output) is ss csat
+      wout = agree-neg-sb {a = a} {out = output} agr ra (proj₁ hc)
+      steq = neg-step-sb {P'} {S} {st} {a} {output} ra
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (neg a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-base (-ᵇ x)))
+               Γ' (bound ++ outs-of (neg a output))
+               (synth-instr (neg a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ (inj₂ (inj₂ refl))) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-scalar} teq ota
+      (x , ra)   = secp-scalar-support {State.mem st} {Γ} {a} {av} teq ota rav
+      (hc , tc)  = csOf-peel (neg a output) is ss csat
+      wout = agree-neg-ss {a = a} {out = output} agr ra (proj₁ hc)
+      steq = neg-step-ss {P'} {S} {st} {a} {output} ra
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (neg a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-scalar (-ˢ x)))
+               Γ' (bound ++ outs-of (neg a output))
+               (synth-instr (neg a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- ec-mul: split on the OpTy ⊎ (jubjub / secp).
+build {S} {w} P' (ec-mul a scalar output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , oty⊎ , wt') teq agr csat npi pisP ptiI ptoI prvI alen ws
+  with oty⊎
+... | inj₁ (oa , osc) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {jubjub-point} teq oa
+      (p , ra)   = point-support {State.mem st} {Γ} {a} {av} teq oa rav
+      (sv , rsv) = optype-resolve {State.mem st} {Γ} {scalar} {jubjub-scalar}
+                     teq osc
+      (s , rs)   = scalar-support {State.mem st} {Γ} {scalar} {sv} teq osc rsv
+      (hc , tc)  = csOf-peel (ec-mul a scalar output) is ss csat
+      wout = agree-ec-mul {a = a} {scalar} {out = output} agr ra rs (proj₁ hc)
+      steq = ec-mul-step {P'} {S} {st} {a} {scalar} {output} ra rs
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (ec-mul a scalar output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-jubjub-point (s ·J p)))
+               Γ' (bound ++ outs-of (ec-mul a scalar output))
+               (synth-instr (ec-mul a scalar output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (oa , osc) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-point} teq oa
+      (p , ra)   = secp-point-support {State.mem st} {Γ} {a} {av} teq oa rav
+      (sv , rsv) = optype-resolve {State.mem st} {Γ} {scalar} {secp-scalar}
+                     teq osc
+      (s , rs)   = secp-scalar-support {State.mem st} {Γ} {scalar} {sv} teq osc rsv
+      (hc , tc)  = csOf-peel (ec-mul a scalar output) is ss csat
+      wout = agree-ec-mul-secp {a = a} {scalar} {out = output} agr ra rs (proj₁ hc)
+      steq = ec-mul-step-secp {P'} {S} {st} {a} {scalar} {output} ra rs
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (ec-mul a scalar output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-point (s ·K p)))
+               Γ' (bound ++ outs-of (ec-mul a scalar output))
+               (synth-instr (ec-mul a scalar output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- ec-mul-generator: split on the OpTy ⊎ (jubjub / secp).
+build {S} {w} P' (ec-mul-generator scalar output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , osc⊎ , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws with osc⊎
+... | inj₁ osc =
+  let (sv , rsv) = optype-resolve {State.mem st} {Γ} {scalar} {jubjub-scalar}
+                     teq osc
+      (s , rs)   = scalar-support {State.mem st} {Γ} {scalar} {sv} teq osc rsv
+      (hc , tc)  = csOf-peel (ec-mul-generator scalar output) is ss csat
+      wout = agree-ec-gen {scalar = scalar} {out = output} agr rs (proj₁ hc)
+      steq = ec-mul-generator-step {P'} {S} {st} {scalar} {output} rs
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (ec-mul-generator scalar output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-jubjub-point (s ·J genJ)))
+               Γ' (bound ++ outs-of (ec-mul-generator scalar output))
+               (synth-instr (ec-mul-generator scalar output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ osc =
+  let (sv , rsv) = optype-resolve {State.mem st} {Γ} {scalar} {secp-scalar}
+                     teq osc
+      (s , rs)   = secp-scalar-support {State.mem st} {Γ} {scalar} {sv} teq osc rsv
+      (hc , tc)  = csOf-peel (ec-mul-generator scalar output) is ss csat
+      wout = agree-ec-gen-secp {scalar = scalar} {out = output} agr rs (proj₁ hc)
+      steq = ec-mul-generator-step-secp {P'} {S} {st} {scalar} {output} rs
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (ec-mul-generator scalar output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-point (s ·K genK)))
+               Γ' (bound ++ outs-of (ec-mul-generator scalar output))
+               (synth-instr (ec-mul-generator scalar output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+build {S} {w} P' (transient-hash inputs output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , oinp , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws =
+  let (frs , rall) = allNat-resolve {State.mem st} {Γ} inputs teq oinp
+      (hc , tc) = csOf-peel (transient-hash inputs output) is ss csat
+      wout = agree-transient-hash {inputs = inputs} {out = output} agr rall
+               (proj₁ hc)
+      steq = transient-hash-step {P'} {S} {st} {inputs} {output} rall
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (transient-hash inputs output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 st output (val-native (transient-hash-fn frs)))
+               Γ' (bound ++ outs-of (transient-hash inputs output))
+               (synth-instr (transient-hash inputs output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- into-bytes32: output is always Bytes32; split on the input's FM type.
+build {S} {w} P' (into-bytes32 a output ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , (t , oa , fm) , wt') teq agr csat npi pisP ptiI ptoI prvI alen ws
+  with fm
+... | inj₁ refl =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {native} teq oa
+      (x , ra)   = mul-support-l {State.mem st} {Γ} {a} {av} teq oa rav
+      (hc , tc) = csOf-peel (into-bytes32 a output) is ss csat
+      wout = agree-into-bytes {a = a} {out = output} agr
+               (resolveᶠ-nat {State.mem st} {a} ra) (proj₁ hc)
+      steq = into-bytes32-step {P'} {S} {st} {a} {output} ra
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (into-bytes32 a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-bytes32 (nativeToBytes x)))
+               Γ' (bound ++ outs-of (into-bytes32 a output))
+               (synth-instr (into-bytes32 a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₁ refl) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-base} teq oa
+      (x , ra)   = secp-base-support {State.mem st} {Γ} {a} {av} teq oa rav
+      (hc , tc) = csOf-peel (into-bytes32 a output) is ss csat
+      wout = agree-into-bytes-sb {a = a} {out = output} agr ra (proj₁ hc)
+      steq = into-bytes32-step-sb {P'} {S} {st} {a} {output} ra
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (into-bytes32 a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 st output (val-bytes32 (secpBaseToBytes x)))
+               Γ' (bound ++ outs-of (into-bytes32 a output))
+               (synth-instr (into-bytes32 a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (inj₂ refl) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {secp-scalar} teq oa
+      (x , ra)   = secp-scalar-support {State.mem st} {Γ} {a} {av} teq oa rav
+      (hc , tc) = csOf-peel (into-bytes32 a output) is ss csat
+      wout = agree-into-bytes-ss {a = a} {out = output} agr ra (proj₁ hc)
+      steq = into-bytes32-step-ss {P'} {S} {st} {a} {output} ra
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (into-bytes32 a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 st output (val-bytes32 (secpScalarToBytes x)))
+               Γ' (bound ++ outs-of (into-bytes32 a output))
+               (synth-instr (into-bytes32 a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+build {S} {w} P' (jubjub-scalar-from-native a output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , oa , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws =
+  let (x , raf) = optype-resolveᶠ {State.mem st} {Γ} {a} teq oa
+      (hc , tc) = csOf-peel (jubjub-scalar-from-native a output) is ss csat
+      wout = agree-scalar-from-native {a = a} {out = output} agr raf (proj₁ hc)
+      steq = jubjub-scalar-from-native-step {P'} {S} {st} {a} {output} raf
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (jubjub-scalar-from-native a output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 st output (val-jubjub-scalar (native→jubjubScalar x)))
+               Γ' (bound ++ outs-of (jubjub-scalar-from-native a output))
+               (synth-instr (jubjub-scalar-from-native a output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- less-than: single output; the exact range bounds come from the `WSteps`
+-- side condition (the constraint carries only the evened chip bounds),
+-- unified to the run's operand values; the `<?` reading is χˢ/χ-bridged
+-- by `agree-less-than`.
+build {S} {w} P' (less-than a b bits output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , (oa , ob) , wt') teq agr csat npi pisP ptiI
+  ptoI prvI alen ((x* , y* , rwa , rwb , bx* , by*) , ws) =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {a} {native} teq oa
+      (x , ra)   = mul-support-l {State.mem st} {Γ} {a} {av} teq oa rav
+      (bv , rbv) = optype-resolve {State.mem st} {Γ} {b} {native} teq ob
+      (y , rb)   = mul-support-l {State.mem st} {Γ} {b} {bv} teq ob rbv
+      raf = resolveᶠ-nat {State.mem st} {a} ra
+      rbf = resolveᶠ-nat {State.mem st} {b} rb
+      (hc , tc)  = csOf-peel (less-than a b bits output) is ss csat
+      hlt : holds w (less-than output a b bits)
+      hlt = proj₁ hc
+      x≡x* = just-injective (trans (sym (⊑-resolveᶠ {State.mem st} {w} a agr raf)) rwa)
+      y≡y* = just-injective (trans (sym (⊑-resolveᶠ {State.mem st} {w} b agr rbf)) rwb)
+      bx = subst (λ z → valFr z < 2 ^ bits) (sym x≡x*) bx*
+      by = subst (λ z → valFr z < 2 ^ bits) (sym y≡y*) by*
+      wout = agree-less-than {a = a} {b = b} {bits = bits} {out = output}
+               agr raf rbf hlt
+      steq = less-than-step {P'} {S} {st} {a} {b} {bits} {output} {x} {y}
+               raf rbf bx by
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (less-than a b bits output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 st output (val-native (χˢ (isYes (valFr x <? valFr y)))))
+               Γ' (bound ++ outs-of (less-than a b bits output))
+               (synth-instr (less-than a b bits output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- from-coordinates: split on the OpTy ⊎ (native→jubjub / secp-base→secp).
+build {S} {w} P' (from-coordinates (xop , yop) output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , oty⊎ , wt') teq agr csat npi pisP ptiI
+  ptoI prvI alen ws with oty⊎
+... | inj₁ (ox , oy) =
+  let (xav , xrav) = optype-resolve {State.mem st} {Γ} {xop} {native} teq ox
+      (x , rx)     = mul-support-l {State.mem st} {Γ} {xop} {xav} teq ox xrav
+      (yav , yrav) = optype-resolve {State.mem st} {Γ} {yop} {native} teq oy
+      (y , ry)     = mul-support-l {State.mem st} {Γ} {yop} {yav} teq oy yrav
+      (hc , tc)    = csOf-peel (from-coordinates (xop , yop) output) is ss csat
+      (p , fcEq , wout) = agree-from-coords {xop = xop} {yop} {out = output} agr
+                            (resolveᶠ-nat {State.mem st} {xop} rx)
+                            (resolveᶠ-nat {State.mem st} {yop} ry) (proj₁ hc)
+      steq = from-coordinates-step {P'} {S} {st} {xop} {yop} {output} {x} {y} {p}
+               rx ry fcEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (from-coordinates (xop , yop) output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-jubjub-point p))
+               Γ' (bound ++ outs-of (from-coordinates (xop , yop) output))
+               (synth-instr (from-coordinates (xop , yop) output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ (ox , oy) =
+  let (xav , xrav) = optype-resolve {State.mem st} {Γ} {xop} {secp-base} teq ox
+      (x , rx)     = secp-base-support {State.mem st} {Γ} {xop} {xav} teq ox xrav
+      (yav , yrav) = optype-resolve {State.mem st} {Γ} {yop} {secp-base} teq oy
+      (y , ry)     = secp-base-support {State.mem st} {Γ} {yop} {yav} teq oy yrav
+      (hc , tc)    = csOf-peel (from-coordinates (xop , yop) output) is ss csat
+      (p , fcEq , wout) = agree-from-coords-secp {xop = xop} {yop} {out = output}
+                            agr rx ry (proj₁ hc)
+      steq = from-coordinates-step-secp {P'} {S} {st} {xop} {yop} {output}
+               {x} {y} {p} rx ry fcEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (from-coordinates (xop , yop) output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-secp-point p))
+               Γ' (bound ++ outs-of (from-coordinates (xop , yop) output))
+               (synth-instr (from-coordinates (xop , yop) output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- bytes32-from-low-high: single output (bytes32) from two native operands.
+build {S} {w} P' (bytes32-from-low-high (loop , hiop) output ∷ is) st Γ bound ss
+  dΓ (af , nd , sa') (Γ' , oty , (olo , ohi) , wt') teq agr csat npi pisP
+  ptiI ptoI prvI alen ws =
+  let (lo , rl) = optype-resolveᶠ {State.mem st} {Γ} {loop} teq olo
+      (hi , rh) = optype-resolveᶠ {State.mem st} {Γ} {hiop} teq ohi
+      (hc , tc) = csOf-peel (bytes32-from-low-high (loop , hiop) output) is ss csat
+      (bs , lhEq , wout) = agree-bytes-from-low-high {lop = loop} {hip = hiop}
+                             {out = output} agr rl rh (proj₁ hc)
+      steq = bytes32-from-low-high-step {P'} {S} {st} {loop} {hiop} {output}
+               {lo} {hi} {bs} rl rh lhEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (bytes32-from-low-high (loop , hiop) output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-bytes32 bs))
+               Γ' (bound ++ outs-of (bytes32-from-low-high (loop , hiop) output))
+               (synth-instr (bytes32-from-low-high (loop , hiop) output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- from-bytes32: `synth` emits `from-bytes` regardless of `val-t`.
+-- `from-bytes32-realize` uses the `WCell` type witness to pick the output
+-- value, its step, and the witness agreement, keeping `val-t` abstract here.
+build {S} {w} P' (from-bytes32 bytes val-t o ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , ob , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  (wcell , ws') =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {bytes} {bytes32} teq ob
+      (bs , rb)  = bytes32-support {State.mem st} {Γ} {bytes} {av} teq ob rav
+      (hc , tc)  = csOf-peel (from-bytes32 bytes val-t o) is ss csat
+      (v , steq , wout) = from-bytes32-realize {P'} {S} {w} {st} {bytes} {val-t}
+                            {o} {bs} agr rb (proj₁ hc) wcell
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (from-bytes32 bytes val-t o)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st o v)
+               Γ' (bound ++ outs-of (from-bytes32 bytes val-t o))
+               (synth-instr (from-bytes32 bytes val-t o) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} o agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws'
+  in cons-build steq rec
+
+-- reverse-bytes: single Bytes32 output; deterministic `Data.Vec.reverse`.
+build {S} {w} P' (reverse-bytes bytes o ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , ob , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ws =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {bytes} {bytes32} teq ob
+      (bs , rb)  = bytes32-support {State.mem st} {Γ} {bytes} {av} teq ob rav
+      (hc , tc)  = csOf-peel (reverse-bytes bytes o) is ss csat
+      wout = agree-reverse-bytes {b = bytes} {out = o} agr rb (proj₁ hc)
+      steq = reverse-bytes-step {P'} {S} {st} {bytes} {o} {bs} rb
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (reverse-bytes bytes o)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st o (val-bytes32 (reverse bs)))
+               Γ' (bound ++ outs-of (reverse-bytes bytes o))
+               (synth-instr (reverse-bytes bytes o) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} o agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- test-eq: single output; the `valEq?` reading comes from `holds (test-eq …)`
+-- (unified to the run's operands).
+build {S} {w} P' (test-eq a b out ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , ((ta , oa) , (tb , ob)) , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws =
+  let (av , ra) = optype-resolve {State.mem st} {Γ} {a} {ta} teq oa
+      (bv , rb) = optype-resolve {State.mem st} {Γ} {b} {tb} teq ob
+      (hc , tc) = csOf-peel (test-eq a b out) is ss csat
+      (av' , bv' , ee , wa , wb , wveq , _) = proj₁ hc
+      av≡av' = just-injective (trans (sym (⊑-resolve {State.mem st} {w} a agr ra)) wa)
+      bv≡bv' = just-injective (trans (sym (⊑-resolve {State.mem st} {w} b agr rb)) wb)
+      ve : valEq? av bv ≡ just ee
+      ve = subst (λ p → valEq? p bv ≡ just ee) (sym av≡av')
+             (subst (λ q → valEq? av' q ≡ just ee) (sym bv≡bv') wveq)
+      wout = agree-test-eq {a = a} {b} {e = ee} agr ra rb ve (proj₁ hc)
+      steq = test-eq-step {P'} {S} {st} {a} {b} {out} {av} {bv} {ee} ra rb ve
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (test-eq a b out)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st out (val-native (χˢ ee)))
+               Γ' (bound ++ outs-of (test-eq a b out))
+               (synth-instr (test-eq a b out) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} out agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- cond-select: single output; operands `a`/`b` typed via `outtys`' `same-ty`,
+-- the selector bit's boolean reading from `agree-cond-select`.
+build {S} {w} P' (cond-select bit a b output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , obit , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws =
+  let (t , sty)    = mapᵐ-inv oty
+      (xbit , rbf) = optype-resolveᶠ {State.mem st} {Γ} {bit} teq obit
+      (av , ra)    = optype-resolve {State.mem st} {Γ} {a} {t}
+                       teq (same-ty-l {Γ} {a} {b} sty)
+      (bvl , rb)   = optype-resolve {State.mem st} {Γ} {b} {t}
+                       teq (same-ty-r {Γ} {a} {b} sty)
+      tmatch = cond-select-support {State.mem st} {Γ} {a} {b} teq
+                 (same-ty-l {Γ} {a} {b} sty) (same-ty-r {Γ} {a} {b} sty) ra rb
+      (hc , tc) = csOf-peel (cond-select bit a b output) is ss csat
+      (bb , r𝔹 , wout) = agree-cond-select {bit = bit} {a = a} {b = b}
+                           agr rbf ra rb (proj₁ hc)
+      steq = cond-select-step {P'} {S} {st} {bit} {a} {b} {output} r𝔹 ra rb tmatch
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (cond-select bit a b output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (if bb then av else bvl))
+               Γ' (bound ++ outs-of (cond-select bit a b output))
+               (synth-instr (cond-select bit a b output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- constrain-eq: no output; `valEq? av bv ≡ just true` from the reflexive
+-- support (`holds (eq …)` pins both operands to the same witness value).
+build {S} {w} P' (constrain-eq a b ∷ is) st Γ bound ss dΓ (af , nd , sa')
+  (Γ' , oty , ((t , ota , tsup) , (tb , otb)) , wt') teq agr csat npi pisP
+  ptiI ptoI prvI alen ws =
+  let (av , ra) = optype-resolve {State.mem st} {Γ} {a} {t}  teq ota
+      (bv , rb) = optype-resolve {State.mem st} {Γ} {b} {tb} teq otb
+      (hc , tc) = csOf-peel (constrain-eq a b) is ss csat
+      (v , wa , wb) = proj₁ hc
+      av≡v = just-injective (trans (sym (⊑-resolve {State.mem st} {w} a agr ra)) wa)
+      bv≡v = just-injective (trans (sym (⊑-resolve {State.mem st} {w} b agr rb)) wb)
+      (_ , ve0) = constrain-eq-support {State.mem st} {Γ} {a} {t} {av}
+                    teq ota tsup ra
+      ve = subst (λ z → valEq? av z ≡ just true) (trans av≡v (sym bv≡v)) ve0
+      steq = constrain-eq-step {P'} {S} {st} {a} {b} {av} {bv} ra rb ve
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (constrain-eq a b)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is st
+               Γ' (bound ++ outs-of (constrain-eq a b))
+               (synth-instr (constrain-eq a b) ss)
+               dΓ' sa' wt' teq' agr tc npi'
+               pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- constrain-to-boolean: no output; the run's guard reads the boolean the
+-- `boolean` constraint pins (`is-bit`).
+build {S} {w} P' (constrain-to-boolean val ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , ov , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ws =
+  let (x , raf) = optype-resolveᶠ {State.mem st} {Γ} {val} teq ov
+      (hc , tc) = csOf-peel (constrain-to-boolean val) is ss csat
+      (xw , wval , isbit) = proj₁ hc
+      x≡xw = just-injective
+               (trans (sym (⊑-resolveᶠ {State.mem st} {w} val agr raf)) wval)
+      (bb , tbx) = is-bit→to𝔹 (subst is-bit (sym x≡xw) isbit)
+      r𝔹 = trans (cong (_>>= to𝔹) raf) tbx
+      steq = constrain-to-boolean-step {P'} {S} {st} {val} {bb} r𝔹
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (constrain-to-boolean val)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is st
+               Γ' (bound ++ outs-of (constrain-to-boolean val))
+               (synth-instr (constrain-to-boolean val) ss)
+               dΓ' sa' wt' teq' agr tc npi'
+               pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- into-coordinates: two outputs, double `out1`; split on the OpTy ⊎
+-- (jubjub→native coords / secp→secp-base coords, the latter partial via
+-- `coordsK`).  Agreement by nested `ins-⊑ᵂ`.
+build {S} {w} P' (into-coordinates point (xid , yid) ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , op⊎ , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ws with op⊎
+... | inj₁ op =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {point} {jubjub-point}
+                     teq op
+      (p , rp)   = point-support {State.mem st} {Γ} {point} {av} teq op rav
+      (hc , tc)  = csOf-peel (into-coordinates point (xid , yid)) is ss csat
+      (x , y , coordsEq , wxo , wyo) =
+        agree-into-coords {point = point} {xo = xid} {yo = yid} {p = p} agr rp
+          (proj₁ hc)
+      steq = into-coordinates-step {P'} {S} {st} {point} {xid} {yid} {p} {x} {y}
+               rp coordsEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (into-coordinates point (xid , yid))
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 (out1 st xid (val-native x)) yid (val-native y))
+               Γ' (bound ++ outs-of (into-coordinates point (xid , yid)))
+               (synth-instr (into-coordinates point (xid , yid)) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} yid
+                 (ins-⊑ᵂ {w = w} xid agr wxo) wyo {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+... | inj₂ op =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {point} {secp-point}
+                     teq op
+      (p , rp)   = secp-point-support {State.mem st} {Γ} {point} {av} teq op rav
+      (hc , tc)  = csOf-peel (into-coordinates point (xid , yid)) is ss csat
+      (x , y , coordsEq , wxo , wyo) =
+        agree-into-coords-secp {point = point} {xo = xid} {yo = yid} {p = p} agr
+          rp (proj₁ hc)
+      steq = into-coordinates-step-secp {P'} {S} {st} {point} {xid} {yid} {p}
+               {x} {y} rp coordsEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (into-coordinates point (xid , yid))
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 (out1 st xid (val-secp-base x)) yid (val-secp-base y))
+               Γ' (bound ++ outs-of (into-coordinates point (xid , yid)))
+               (synth-instr (into-coordinates point (xid , yid)) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} yid
+                 (ins-⊑ᵂ {w = w} xid agr wxo) wyo {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- bytes32-into-low-high: two outputs (native low/high), double `out1`.
+build {S} {w} P' (bytes32-into-low-high bytes (loid , hiid) ∷ is) st Γ bound ss
+  dΓ (af , nd , sa') (Γ' , oty , ob , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws =
+  let (av , rav) = optype-resolve {State.mem st} {Γ} {bytes} {bytes32} teq ob
+      (bs , rb)  = bytes32-support {State.mem st} {Γ} {bytes} {av} teq ob rav
+      (hc , tc)  = csOf-peel (bytes32-into-low-high bytes (loid , hiid)) is ss
+                     csat
+      (l , h , splitEq , wlo , whi) =
+        agree-bytes-into-low-high {bytes = bytes} {lo = loid} {hi = hiid} {bs = bs}
+          agr rb (proj₁ hc)
+      steq = bytes32-into-low-high-step {P'} {S} {st} {bytes} {loid} {hiid} {bs}
+               {l} {h} rb splitEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (bytes32-into-low-high bytes (loid , hiid))
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 (out1 st loid (val-native l)) hiid (val-native h))
+               Γ' (bound ++ outs-of (bytes32-into-low-high bytes (loid , hiid)))
+               (synth-instr (bytes32-into-low-high bytes (loid , hiid)) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} hiid
+                 (ins-⊑ᵂ {w = w} loid agr wlo) whi {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- div-mod-power-of-two: two outputs via `insertMany` (like `encode`); the
+-- arity `outs ≡ q ∷ r ∷ []` is a WShape executability condition.
+build {S} {w} P' (div-mod-power-of-two val bits outs ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , ov , wt') teq agr csat npi pisP ptiI ptoI prvI alen
+  ((q , r , refl) , ws') =
+  let (x , rvf) = optype-resolveᶠ {State.mem st} {Γ} {val} teq ov
+      (hc , tc) = csOf-peel (div-mod-power-of-two val bits (q ∷ r ∷ [])) is ss
+                    csat
+      (wq , wr) = agree-div-mod {val = val} agr rvf (proj₁ hc)
+      (st' , im , agr') = insertMany-realize {w} st (q ∷ r ∷ [])
+        ( val-native (from-le-bits (drop bits (to-le-bits x)))
+        ∷ val-native (from-le-bits (take bits (to-le-bits x))) ∷ [])
+        agr (wq , wr , tt)
+      steq = div-mod-step {P'} {S} {st} {val} {bits} {q ∷ r ∷ []} {x} {st'}
+               rvf im
+      (peq , pteq , poeq , preq) =
+        insertMany-shape st (q ∷ r ∷ [])
+          ( val-native (from-le-bits (drop bits (to-le-bits x)))
+          ∷ val-native (from-le-bits (take bits (to-le-bits x))) ∷ []) im
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (div-mod-power-of-two val bits (q ∷ r ∷ []))
+          oty dΓ af nd teq npi steq
+      rec = build {S} {w} P' is st' Γ'
+              (bound ++ outs-of (div-mod-power-of-two val bits (q ∷ r ∷ [])))
+              (synth-instr (div-mod-power-of-two val bits (q ∷ r ∷ [])) ss)
+              dΓ' sa' wt' teq' agr' tc npi'
+              (trans peq (trans pisP
+                (cong (λ n → take n (CircuitWitness.pis w))
+                  (cong length (sym peq)))))
+              (trans (cong (λ n → drop n
+                             (ProofPreimage.pub-transcript-inputs P')) pteq)
+                     (trans ptiI
+                       (cong (λ n → mkPTI w n is) (cong length (sym peq)))))
+              (trans poeq ptoI) (trans preq prvI)
+              (subst₂ (λ p q → p + length (mkPTI w q is)
+                        ≡ length (ProofPreimage.pub-transcript-inputs P'))
+                (sym pteq) (sym (cong length peq)) alen) ws'
+  in cons-build steq rec
+
+-- reconstitute-field: single output; range bounds from `holds`, the no-overflow
+-- guard from WShape (unified to the run's operands).
+build {S} {w} P' (reconstitute-field divisor modulus bits out ∷ is) st Γ bound
+  ss dΓ (af , nd , sa') (Γ' , oty , (od , om) , wt') teq agr csat npi pisP
+  ptiI ptoI prvI alen ((d , mo , rd-w , rmo-w , novf) , ws') =
+  let (dv , rd)  = optype-resolveᶠ {State.mem st} {Γ} {divisor} teq od
+      (mv , rmo) = optype-resolveᶠ {State.mem st} {Γ} {modulus} teq om
+      (hc , tc)  = csOf-peel (reconstitute-field divisor modulus bits out) is ss
+                     csat
+      (bm , bd , wout) = agree-reconstitute {divisor = divisor} {modulus}
+                           {bits = bits} {out = out} agr rd rmo (proj₁ hc)
+      dv≡d = just-injective
+               (trans (sym (⊑-resolveᶠ {State.mem st} {w} divisor agr rd)) rd-w)
+      mv≡mo = just-injective
+                (trans (sym (⊑-resolveᶠ {State.mem st} {w} modulus agr rmo)) rmo-w)
+      novf' = subst₂ (λ dd mm → valFr mm + 2 ^ bits * valFr dd < FR-ORDER)
+                (sym dv≡d) (sym mv≡mo) novf
+      steq = reconstitute-field-step {P'} {S} {st} {divisor} {modulus} {bits}
+               {out} {dv} {mv} rd rmo bm bd novf'
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (reconstitute-field divisor modulus bits out)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is
+               (out1 st out (val-native ((pow2ᶠˢ bits *ᶠ dv) +ᶠ mv)))
+               Γ' (bound ++ outs-of (reconstitute-field divisor modulus bits out))
+               (synth-instr (reconstitute-field divisor modulus bits out) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} out agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws'
+  in cons-build steq rec
+
+-- persistent-hash: single Bytes32 output; the SHA-256 success comes from
+-- `holds` (via `agree-persistent-hash`).
+build {S} {w} P' (persistent-hash al inputs output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , oinp , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws =
+  let (frs , rall) = allNat-resolve {State.mem st} {Γ} inputs teq oinp
+      (hc , tc) = csOf-peel (persistent-hash al inputs output) is ss csat
+      (v , phEq , wout) =
+        agree-persistent-hash {inputs = inputs} agr rall (proj₁ hc)
+      steq = persistent-hash-step {P'} {S} {st} {al} {inputs} {output} {frs} {v}
+               rall phEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (persistent-hash al inputs output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-bytes32 v))
+               Γ' (bound ++ outs-of (persistent-hash al inputs output))
+               (synth-instr (persistent-hash al inputs output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+-- keccak256: single Bytes32 output; the Keccak-256 success comes from
+-- `holds` (via `agree-keccak`).
+build {S} {w} P' (keccak256 al inputs output ∷ is) st Γ bound ss dΓ
+  (af , nd , sa') (Γ' , oty , oinp , wt') teq agr csat npi pisP ptiI ptoI
+  prvI alen ws =
+  let (frs , rall) = allNat-resolve {State.mem st} {Γ} inputs teq oinp
+      (hc , tc) = csOf-peel (keccak256 al inputs output) is ss csat
+      (v , kfEq , wout) =
+        agree-keccak {inputs = inputs} agr rall (proj₁ hc)
+      steq = keccak256-step {P'} {S} {st} {al} {inputs} {output} {frs} {v}
+               rall kfEq
+      (dΓ' , teq' , npi') =
+        adv3 P' S st ss (keccak256 al inputs output)
+          oty dΓ af nd teq npi steq
+      rec  = build {S} {w} P' is (out1 st output (val-bytes32 v))
+               Γ' (bound ++ outs-of (keccak256 al inputs output))
+               (synth-instr (keccak256 al inputs output) ss)
+               dΓ' sa' wt' teq'
+               (λ {id} {v'} e → ins-⊑ᵂ {w = w} output agr wout {id} {v'} e) tc
+               npi' pisP ptiI ptoI prvI alen ws
+  in cons-build steq rec
+
+------------------------------------------------------------------------
+-- Constructive pis-form statement soundness (no-comm fragment).
+--
+-- From a satisfying witness of a well-typed producer circuit (and the
+-- minimal witness shape), synthesise a preimage `P'` and a final state
+-- `s` with `run-shaped S P' s`, `pis (witness-of P' s) ≡ pis w`, the
+-- memory sub-assignment `mem s ⊑ᵂ w`, and (vacuously in the no-comm
+-- branch) the comm-rand agreement.
+------------------------------------------------------------------------
+
+-- pi tracking over a whole run (fold-free; mirrors `fwd-go`'s pi component).
+pi-run : ∀ {P S s} is st ss → run P S st is ≡ just s
+  → SynthState.next-pi ss ≡ length (State.pis st)
+  → SynthState.next-pi (synth-instrs is ss) ≡ length (State.pis s)
+pi-run [] st ss run-eq pi rewrite just-injective run-eq = pi
+pi-run {P} {S} (i ∷ is) st ss run-eq pi =
+  let (st' , step-eq , run-rest) = run-inv i is st run-eq in
+  pi-run {P} {S} is st' (synth-instr i ss) run-rest
+    (pi-inv-step {P} {S} i ss step-eq pi)
+
+-- The witness's leading pi entry (its binding input).
+take1-lookup : ∀ {v} (xs : List Fr) → pi-lookup xs 0 ≡ just v → take 1 xs ≡ v ∷ []
+take1-lookup xs e = cong (take 1) (drop-lookup xs 0 e)
+
+-- The leading `pi-binding 0` constraint holds at `w` (no-comm entry).
+pi-binding-false : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ false
+  → satisfies (synth S) w
+  → ∃ λ bv → pi-lookup (CircuitWitness.pis w) 0 ≡ just bv
+pi-binding-false {S} {w} hc sat
+  with IrSource.do-communications-commitment S | hc
+... | false | refl =
+  proj₁ (subst (λ z → satisfies-constraints z w)
+           (synth-cs-acc (IrSource.instructions S) ss₁)
+           (satisfies.constraint-ok sat))
+
+-- pi-len of the no-comm circuit equals the run-final pi cursor seed.
+pilen-false : ∀ {S}
+  → IrSource.do-communications-commitment S ≡ false
+  → Circuit.pi-len (synth S)
+      ≡ SynthState.next-pi (synth-instrs (IrSource.instructions S) ss₁)
+pilen-false {S} hc =
+  cong (λ b → SynthState.next-pi
+                (synth-instrs (IrSource.instructions S)
+                  (mk-synth (pi-binding 0 ∷ []) (preamble-pi-count b) [])))
+       hc
+
+-- `init` succeeds on a no-comm preimage whose declared inputs decode.
+init-false : ∀ {S} (P' : ProofPreimage) m₀
+  → IrSource.do-communications-commitment S ≡ false
+  → decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P') ≡ just m₀
+  → init S P'
+      ≡ just (record { mem = m₀ ; pis = ProofPreimage.binding-input P' ∷ []
+                     ; pi-skips = [] ; pti-idx = 0
+                     ; pto-rem = ProofPreimage.pub-transcript-outputs P'
+                     ; priv-rem = ProofPreimage.priv-transcript P' ; outs = [] })
+init-false P' m₀ hc decEq rewrite decEq | hc = refl
+
+-- A successful `run` whose terminal cursors are exhausted (and no comm)
+-- discharges `preprocess`.
+preproc-false : ∀ {S} (P' : ProofPreimage) st0 fs
+  → IrSource.do-communications-commitment S ≡ false
+  → init S P' ≡ just st0
+  → run P' S st0 (IrSource.instructions S) ≡ just fs
+  → State.pti-idx fs ≡ length (ProofPreimage.pub-transcript-inputs P')
+  → State.pto-rem fs ≡ [] → State.priv-rem fs ≡ []
+  → preprocess S P' ≡ just fs
+preproc-false P' st0 fs hc ieq run≡ flen fpto fprv
+  rewrite ieq | run≡
+  with State.pti-idx fs ≟ℕ length (ProofPreimage.pub-transcript-inputs P')
+... | no ¬p = case ¬p flen of λ ()
+... | yes _ rewrite fpto | fprv | hc = refl
+
+------------------------------------------------------------------------
+-- A commitment-well-shaped realizer.  This bundles exactly what the branch
+-- lemmas and `statement-sound` return: a preimage/state pair with
+-- `run-shaped` and outright `preprocess` success (the latter subsumes the
+-- former, which is kept as a field for direct consumption), the
+-- pis-agreement, the memory-agreement and, under the flag, the
+-- commitment-randomness agreement, together with `CommWF` on the
+-- preimage's commitment.  `CommWF b cc` says an absent-commitment flag
+-- (`b ≡ false`) forces the absent commitment (`cc ≡ nothing`); it is
+-- vacuously inhabited when the flag is on.
+------------------------------------------------------------------------
+
+CommWF : Bool → Maybe (Fr × Fr) → Set
+CommWF b cc = b ≡ false → cc ≡ nothing
+
+record SubRealizer (S : IrSource) (w : CircuitWitness) : Set where
+  constructor mk-subrealizer
+  field
+    P          : ProofPreimage
+    s          : State
+    shaped     : run-shaped S P s
+    preproc-ok : preprocess S P ≡ just s
+    pis-agree  : CircuitWitness.pis (witness-of P s) ≡ CircuitWitness.pis w
+    mem-agree  : State.mem s ⊑ᵂ w
+    rand-agree : IrSource.do-communications-commitment S ≡ true
+      → CircuitWitness.comm-rand (witness-of P s)
+        ≡ CircuitWitness.comm-rand w
+    comm-wf    : CommWF (IrSource.do-communications-commitment S)
+                        (ProofPreimage.comm-commitment P)
+
+statement-sound-false : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ false
+  → producer-WT S → satisfies (synth S) w → WShape S w
+  → SubRealizer S w
+statement-sound-false {S} {w} hc ((saND , sa) , wt) sat (wins , wsteps) =
+  mk-subrealizer P' fs (preprocess→run-shaped {S} {P'} {fs} {st0} ieq peq)
+    peq pisfs (BuildOut.fagr rec) commrand commnothing
+  where
+    is  = IrSource.instructions S
+    tis = IrSource.inputs S
+    bvp = pi-binding-false {S} {w} hc sat
+    bv  = proj₁ bvp
+    dm  = decode-mkInputs {w} tis wins
+    m₀  = proj₁ dm
+
+    P' : ProofPreimage
+    P' = record { inputs                 = mkInputs w tis
+                ; binding-input          = bv
+                ; comm-commitment        = nothing
+                ; pub-transcript-inputs  = mkPTI w 1 is
+                ; pub-transcript-outputs = mkPTO w is
+                ; priv-transcript        = mkPRV w is }
+
+    st0 : State
+    st0 = record { mem = m₀ ; pis = bv ∷ [] ; pi-skips = [] ; pti-idx = 0
+                 ; pto-rem = mkPTO w is ; priv-rem = mkPRV w is ; outs = [] }
+
+    ieq : init S P' ≡ just st0
+    ieq = init-false {S} P' m₀ hc (proj₁ (proj₂ dm))
+
+    rec : BuildOut {S} {w} P' st0 is
+    rec = build {S} {w} P' is st0 (input-ctx tis)
+            (map TypedIdentifier.name tis) ss₁
+            (dom-ty-input-ctx tis) sa wt
+            (init-ty {S} {P'} {st0} ieq)            (proj₂ (proj₂ dm))
+            (csOf-from-sat-false {S} {w} hc sat)
+            refl (sym (take1-lookup (CircuitWitness.pis w) (proj₂ bvp)))
+            refl refl refl refl wsteps
+
+    fs = BuildOut.fs rec
+
+    peq : preprocess S P' ≡ just fs
+    peq = preproc-false {S} P' st0 fs hc ieq (BuildOut.frun rec)
+            (BuildOut.flen rec) (BuildOut.fpto rec) (BuildOut.fprv rec)
+
+    lenw : length (CircuitWitness.pis w) ≡ length (State.pis fs)
+    lenw = trans (satisfies.pi-length sat)
+             (trans (pilen-false {S} hc)
+               (pi-run {P'} {S} is st0 ss₁ (BuildOut.frun rec) refl))
+
+    pisfs : State.pis fs ≡ CircuitWitness.pis w
+    pisfs = trans (BuildOut.fpis rec)
+              (take-all (length (State.pis fs)) (CircuitWitness.pis w)
+                (≤-reflexive lenw))
+
+    -- Vacuous here: the comm-rand agreement is guarded by `do-comm ≡ true`,
+    -- which contradicts this branch's `hc : do-comm ≡ false`.
+    commrand : IrSource.do-communications-commitment S ≡ true
+      → CircuitWitness.comm-rand (witness-of P' fs)
+        ≡ CircuitWitness.comm-rand w
+    commrand ht = case trans (sym hc) ht of λ ()
+
+    -- This branch builds `P'` with `comm-commitment = nothing`.
+    commnothing : IrSource.do-communications-commitment S ≡ false
+      → ProofPreimage.comm-commitment P' ≡ nothing
+    commnothing _ = refl
+
+------------------------------------------------------------------------
+-- Constructive pis-form statement soundness (comm fragment).
+--
+-- The `do-comm = true` branch.  The extra work over the no-comm branch is
+-- the TC2 discharge: `preprocess` checks the binding π[1] equals
+-- `transient-commit` of the encoded inputs and collected outputs.  The
+-- `comm` constraint pins that at `w`; we transport its input/output
+-- encodings to the run's actual inputs (`resolve-encode-mkInputs`, from
+-- `WInputs`) and outputs (`out-go` at the built witness, lowered to `w`).
+-- The same `comm` constraint pins `comm-rand w ≡ just rv`, which yields the
+-- comm-rand agreement (`P'`'s commitment pair carries randomness `rv`).
+------------------------------------------------------------------------
+
+-- The leading `pi-binding 0` and trailing `comm` constraints of a has-comm
+-- circuit hold at `w` — the two facts `csOf-from-sat-true` drops.
+comm-preamble : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ true
+  → satisfies (synth S) w
+  → (∃ λ bv → pi-lookup (CircuitWitness.pis w) 0 ≡ just bv)
+  × holds w (comm (input-operands (IrSource.inputs S))
+              (SynthState.output-ops
+                (synth-instrs (IrSource.instructions S) ss₂)))
+comm-preamble {S} {w} hc sat =
+  let (h , _ , c) = synth-true-split {S} {w} hc sat in h , c
+
+-- `take 2` of a stream whose first two entries `pi-lookup` finds.
+take2-lookup : ∀ {u v} (xs : List Fr)
+  → pi-lookup xs 0 ≡ just u → pi-lookup xs 1 ≡ just v
+  → take 2 xs ≡ u ∷ v ∷ []
+take2-lookup xs e0 e1 =
+  trans (cong (take 2) (drop-lookup xs 0 e0))
+        (cong (λ l → _ ∷ take 1 l) (drop-lookup xs 1 e1))
+
+-- pi-len of the has-comm circuit equals the run-final pi cursor seed.
+pilen-true : ∀ {S}
+  → IrSource.do-communications-commitment S ≡ true
+  → Circuit.pi-len (synth S)
+      ≡ SynthState.next-pi (synth-instrs (IrSource.instructions S) ss₂)
+pilen-true {S} hc =
+  cong (λ b → SynthState.next-pi
+                (synth-instrs (IrSource.instructions S)
+                  (mk-synth (pi-binding 0 ∷ []) (preamble-pi-count b) [])))
+       hc
+
+-- The declared inputs' operands resolve (at `w`) to exactly `mkInputs w`.
+resolve-encode-mkInputs : ∀ {w} tis → WInputs w tis
+  → resolve-encode w (input-operands tis) ≡ just (mkInputs w tis)
+resolve-encode-mkInputs         []         _              = refl
+resolve-encode-mkInputs {w} (ti ∷ tis) ((v , wo , _) , wins)
+  rewrite wo | resolve-encode-mkInputs {w} tis wins = refl
+
+-- Lower a `resolve-encode` from the built witness to `w`: every operand
+-- resolves in `mem fs`, and `mem fs ⊑ᵂ w` transports each resolution.
+resolve-encode-⊑ : ∀ {P' fs w} ops {r}
+  → State.mem fs ⊑ᵂ w
+  → resolve-encode (witness-of P' fs) ops ≡ just r
+  → resolve-encode w ops ≡ just r
+resolve-encode-⊑ []       fagr e = e
+resolve-encode-⊑ {P'} {fs} {w} (op ∷ ops) fagr e
+  with resolveᶜ (witness-of P' fs) op in eqop
+... | nothing = case e of λ ()
+... | just v
+  with resolve-encode (witness-of P' fs) ops in eqrest
+...   | nothing = case e of λ ()
+...   | just rest with refl ← e
+  rewrite ⊑-resolve {State.mem fs} {w} op fagr
+            (trans (sym (resolve-agree P' fs op)) eqop)
+        | resolve-encode-⊑ {P'} {fs} {w} ops fagr eqrest = refl
+
+-- `init` succeeds on a has-comm preimage whose inputs decode; the π
+-- preamble binds the input and the commitment.
+init-true : ∀ {S} (P' : ProofPreimage) m₀ c r
+  → IrSource.do-communications-commitment S ≡ true
+  → ProofPreimage.comm-commitment P' ≡ just (c , r)
+  → decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P') ≡ just m₀
+  → init S P'
+      ≡ just (record { mem = m₀
+                     ; pis = ProofPreimage.binding-input P' ∷ c ∷ []
+                     ; pi-skips = [] ; pti-idx = 0
+                     ; pto-rem = ProofPreimage.pub-transcript-outputs P'
+                     ; priv-rem = ProofPreimage.priv-transcript P' ; outs = [] })
+init-true P' m₀ c r hc cceq decEq rewrite decEq | hc | cceq = refl
+
+-- The has-comm `preprocess`, discharging the TC2 commitment check.
+preproc-true : ∀ {S} (P' : ProofPreimage) st0 fs c r
+  → IrSource.do-communications-commitment S ≡ true
+  → ProofPreimage.comm-commitment P' ≡ just (c , r)
+  → init S P' ≡ just st0
+  → run P' S st0 (IrSource.instructions S) ≡ just fs
+  → State.pti-idx fs ≡ length (ProofPreimage.pub-transcript-inputs P')
+  → State.pto-rem fs ≡ [] → State.priv-rem fs ≡ []
+  → c ≡ transient-commit
+          (ProofPreimage.inputs P' ++ concatMap encodeᵉ (State.outs fs)) r
+  → preprocess S P' ≡ just fs
+preproc-true P' st0 fs c r hc cceq ieq run≡ flen fpto fprv tc2
+  rewrite ieq | run≡
+  with State.pti-idx fs ≟ℕ length (ProofPreimage.pub-transcript-inputs P')
+... | no ¬p = case ¬p flen of λ ()
+... | yes _ rewrite fpto | fprv | hc | cceq
+  with c ≟ᶠ transient-commit
+             (ProofPreimage.inputs P' ++ concatMap encodeᵉ (State.outs fs)) r
+...   | yes _  = refl
+...   | no ¬c = case ¬c tc2 of λ ()
+
+statement-sound-true : ∀ {S w}
+  → IrSource.do-communications-commitment S ≡ true
+  → producer-WT S → satisfies (synth S) w → WShape S w
+  → SubRealizer S w
+statement-sound-true {S} {w} hc ((saND , sa) , wt) sat (wins , wsteps) =
+  mk-subrealizer P' fs (preprocess→run-shaped {S} {P'} {fs} {st0} ieq peq)
+    peq pisfs (BuildOut.fagr rec) commrand commnothing
+  where
+    is  = IrSource.instructions S
+    tis = IrSource.inputs S
+
+    cpb = comm-preamble {S} {w} hc sat
+    bv      = proj₁ (proj₁ cpb)
+    bv-look = proj₂ (proj₁ cpb)
+
+    ivs = proj₁ (proj₂ cpb)
+    ovs = proj₁ (proj₂ (proj₂ cpb))
+    rv  = proj₁ (proj₂ (proj₂ (proj₂ cpb)))
+    pv  = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ cpb))))
+    ri  = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ cpb)))))
+    ro  = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ cpb))))))
+    rr  = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ cpb)))))))
+    rpv = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ cpb))))))))
+    pv≡ = proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ cpb))))))))
+
+    dm  = decode-mkInputs {w} tis wins
+    m₀  = proj₁ dm
+
+    P' : ProofPreimage
+    P' = record { inputs                 = mkInputs w tis
+                ; binding-input          = bv
+                ; comm-commitment        = just (pv , rv)
+                ; pub-transcript-inputs  = mkPTI w 2 is
+                ; pub-transcript-outputs = mkPTO w is
+                ; priv-transcript        = mkPRV w is }
+
+    st0 : State
+    st0 = record { mem = m₀ ; pis = bv ∷ pv ∷ [] ; pi-skips = [] ; pti-idx = 0
+                 ; pto-rem = mkPTO w is ; priv-rem = mkPRV w is ; outs = [] }
+
+    ieq : init S P' ≡ just st0
+    ieq = init-true {S} P' m₀ pv rv hc refl (proj₁ (proj₂ dm))
+
+    rec : BuildOut {S} {w} P' st0 is
+    rec = build {S} {w} P' is st0 (input-ctx tis)
+            (map TypedIdentifier.name tis) ss₂
+            (dom-ty-input-ctx tis) sa wt
+            (init-ty {S} {P'} {st0} ieq)            (proj₂ (proj₂ dm))
+            (csOf-from-sat-true {S} {w} hc sat)
+            refl (sym (take2-lookup (CircuitWitness.pis w) bv-look rpv))
+            refl refl refl refl wsteps
+
+    fs = BuildOut.fs rec
+
+    wf : WF-run P' S is st0
+    wf = producer-safe→WF (saND , sa) ieq
+
+    ovs≡ : ovs ≡ concatMap encodeᵉ (State.outs fs)
+    ovs≡ = just-injective (trans (sym ro)
+             (resolve-encode-⊑ {P'} {fs} {w}
+               (SynthState.output-ops (synth-instrs is ss₂))
+               (BuildOut.fagr rec)
+               (out-go {P'} {S} {fs} is st0 ss₂ (BuildOut.frun rec) wf refl)))
+
+    ivs≡ : ivs ≡ mkInputs w tis
+    ivs≡ = just-injective (trans (sym ri) (resolve-encode-mkInputs {w} tis wins))
+
+    tc2 : pv ≡ transient-commit
+                 (mkInputs w tis ++ concatMap encodeᵉ (State.outs fs)) rv
+    tc2 = subst₂ (λ a b → pv ≡ transient-commit (a ++ b) rv) ivs≡ ovs≡ pv≡
+
+    peq : preprocess S P' ≡ just fs
+    peq = preproc-true {S} P' st0 fs pv rv hc refl ieq (BuildOut.frun rec)
+            (BuildOut.flen rec) (BuildOut.fpto rec) (BuildOut.fprv rec) tc2
+
+    lenw : length (CircuitWitness.pis w) ≡ length (State.pis fs)
+    lenw = trans (satisfies.pi-length sat)
+             (trans (pilen-true {S} hc)
+               (pi-run {P'} {S} is st0 ss₂ (BuildOut.frun rec) refl))
+
+    pisfs : State.pis fs ≡ CircuitWitness.pis w
+    pisfs = trans (BuildOut.fpis rec)
+              (take-all (length (State.pis fs)) (CircuitWitness.pis w)
+                (≤-reflexive lenw))
+
+    -- `witness-of P' fs` carries `comm-rand-of (just (pv , rv)) = just rv`;
+    -- the `comm` constraint (via `rr`) pins `comm-rand w ≡ just rv`.
+    commrand : IrSource.do-communications-commitment S ≡ true
+      → CircuitWitness.comm-rand (witness-of P' fs)
+        ≡ CircuitWitness.comm-rand w
+    commrand _ = sym rr
+
+    -- Vacuous: this branch's `hc` contradicts `do-comm ≡ false`.
+    commnothing : IrSource.do-communications-commitment S ≡ false
+      → ProofPreimage.comm-commitment P' ≡ nothing
+    commnothing hf = case trans (sym hc) hf of λ ()
+
+-- The combined result: statement soundness for both branches.
+statement-sound : ∀ {S w}
+  → producer-WT S → satisfies (synth S) w → WShape S w
+  → SubRealizer S w
+statement-sound {S} {w} wt sat ws =
+  aux (IrSource.do-communications-commitment S) refl
+  where
+    aux : (b : Bool) → IrSource.do-communications-commitment S ≡ b
+      → SubRealizer S w
+    aux false hc = statement-sound-false {S} {w} hc wt sat ws
+    aux true  hc = statement-sound-true  {S} {w} hc wt sat ws
+
+------------------------------------------------------------------------
+-- Extractor completeness.
+--
+-- The extracted preimage actually proves: the canonical witness of a
+-- `SubRealizer`'s preimage/state pair satisfies the synthesized circuit
+-- — `forward-sa` applied through the realizer's `preproc-ok` field.
+-- Composed with `statement-sound`, extraction is a round trip into the
+-- satisfying set: extract from `w`, and the extracted run's own witness
+-- satisfies the same circuit.
+------------------------------------------------------------------------
+
+extractor-complete : ∀ {S w}
+  → producer-SA S
+  → (r : SubRealizer S w)
+  → satisfies (synth S)
+      (witness-of (SubRealizer.P r) (SubRealizer.s r))
+extractor-complete {S} {w} sa r =
+  forward-sa {S} {SubRealizer.P r} {SubRealizer.s r}
+    {run-shaped.start (SubRealizer.shaped r)} sa
+    (run-shaped.init≡ (SubRealizer.shaped r))
+    (SubRealizer.preproc-ok r)
+
+------------------------------------------------------------------------
+-- `WShape` non-vacuity: the canonical witness of a successful run is in
+-- the extraction class.
+--
+-- Every `WSteps` conjunct is forced by the corresponding step's success:
+-- the step's own inversion (`step→bwd`) supplies the resolutions, guard
+-- readings, bounds, and post-state shape at the pre-step memory, and the
+-- run's extension (`step-extends` / `run-extends`) transports them to
+-- the final memory — which is exactly
+-- `CircuitWitness.assign (witness-of P s)`.  `WInputs` similarly follows
+-- from the input decoding (`init-decode`), each cell typed by
+-- `decode-typeof` and surviving the run by single assignment.  Combined
+-- with `statement-sound`/`statement-sound-unique`, extraction is
+-- non-vacuous on every honestly-provable statement.
+------------------------------------------------------------------------
+
+-- The declared inputs are well-typed cells of the final memory.
+winputs-of : ∀ {P s} tis {raw m₀}
+  → decode-inputs tis raw ≡ just m₀
+  → NoDup (map TypedIdentifier.name tis)
+  → m₀ ⊑ State.mem s
+  → WInputs (witness-of P s) tis
+winputs-of []         {raw = []}    refl _          _   = tt
+winputs-of []         {raw = _ ∷ _} ()   _          _
+winputs-of {P} {s} (ti ∷ tis) {raw} e    (nin , nd) sub
+  with decode (TypedIdentifier.val-t ti)
+              (take (encoded-len (TypedIdentifier.val-t ti)) raw) in eqv
+... | just v
+  with decode-inputs tis
+         (drop (encoded-len (TypedIdentifier.val-t ti)) raw) in eqm
+...   | just m′ with refl ← e =
+        ( v
+        , sub (ins-here (TypedIdentifier.name ti) v m′)
+        , decode-typeof (TypedIdentifier.val-t ti) _ eqv )
+      , winputs-of {P} {s} tis eqm nd
+          (⊑-trans {m′} {ins (TypedIdentifier.name ti) v m′} {State.mem s}
+            (ins-⊑ {TypedIdentifier.name ti} {v} {m′}
+              (decode-inputs-dom tis _ eqm
+                (notIn-∉ (map TypedIdentifier.name tis) nin)))
+            sub)
+
+-- The per-instruction walk: each `WSteps` conjunct from its step's
+-- inversion, transported to the final memory.
+wsteps-go : ∀ {P S s} is st
+  → WF-run P S is st
+  → run P S st is ≡ just s
+  → WSteps S (witness-of P s) is
+wsteps-go [] st _ _ = tt
+wsteps-go {P} {S} {s} (assert cond ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (assert cond) is st req
+      (_ , m⊑₁) = step-extends {P} {S} {st} {st-mid} (assert cond) seq of
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      m⊑s = ⊑-trans {State.mem st} {State.mem st-mid} {State.mem s} m⊑₁ m⊑₂
+      (steq , x , rc , tb) = step→bwd {P} {S} {st} {st-mid} (assert cond) seq
+  in ( x
+     , trans (resolveᶜ-Fr-agree P s cond)
+         (resolveᶠ-mono {State.mem st} {State.mem s} cond m⊑s rc)
+     , tb )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (impact guard inputs ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (impact guard inputs) is st req
+      (_ , m⊑₁) = step-extends {P} {S} {st} {st-mid} (impact guard inputs) seq of
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      m⊑s = ⊑-trans {State.mem st} {State.mem st-mid} {State.mem s} m⊑₁ m⊑₂
+      (vals , gᶠ , rvals , rg , branch) = step→bwd {P} {S} {st} {st-mid} (impact guard inputs) seq
+  in ( gᶠ
+     , trans (resolveᶜ-Fr-agree P s guard)
+         (resolveᶠ-mono {State.mem st} {State.mem s} guard m⊑s rg)
+     , (case branch of λ
+         { (inj₁ (tb , _ , _)) → true  , tb
+         ; (inj₂ (tb , _))     → false , tb }) )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (reconstitute-field divisor modulus bits o ∷ is) st
+  (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (reconstitute-field divisor modulus bits o) is st req
+      (_ , m⊑₁) = step-extends {P} {S} {st} {st-mid} (reconstitute-field divisor modulus bits o)
+                    seq of
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      m⊑s = ⊑-trans {State.mem st} {State.mem st-mid} {State.mem s} m⊑₁ m⊑₂
+      (o¹ , d , rd , mo , rm , novf) =
+        step→bwd {P} {S} {st} {st-mid} (reconstitute-field divisor modulus bits o) seq
+  in ( d , mo
+     , trans (resolveᶜ-Fr-agree P s divisor)
+         (resolveᶠ-mono {State.mem st} {State.mem s} divisor m⊑s rd)
+     , trans (resolveᶜ-Fr-agree P s modulus)
+         (resolveᶠ-mono {State.mem st} {State.mem s} modulus m⊑s rm)
+     , novf )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (div-mod-power-of-two val bits [] ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (div-mod-power-of-two val bits []) is st req
+  in case step→bwd {P} {S} {st} {st-mid} (div-mod-power-of-two val bits []) seq of λ ()
+wsteps-go {P} {S} {s} (div-mod-power-of-two val bits (q ∷ []) ∷ is) st
+  (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (div-mod-power-of-two val bits (q ∷ [])) is st req
+  in case step→bwd {P} {S} {st} {st-mid} (div-mod-power-of-two val bits (q ∷ [])) seq of λ ()
+wsteps-go {P} {S} {s} (div-mod-power-of-two val bits (q ∷ r ∷ []) ∷ is) st
+  (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (div-mod-power-of-two val bits (q ∷ r ∷ [])) is st req
+  in (q , r , refl) , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (div-mod-power-of-two val bits (q ∷ r ∷ z ∷ zs) ∷ is) st
+  (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (div-mod-power-of-two val bits (q ∷ r ∷ z ∷ zs)) is st req
+  in case step→bwd {P} {S} {st} {st-mid} (div-mod-power-of-two val bits (q ∷ r ∷ z ∷ zs)) seq of
+       λ ()
+wsteps-go {P} {S} {s} (circuit-output vals ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (circuit-output vals) is st req
+      (_ , m⊑₁) = step-extends {P} {S} {st} {st-mid} (circuit-output vals) seq of
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      m⊑s = ⊑-trans {State.mem st} {State.mem st-mid} {State.mem s} m⊑₁ m⊑₂
+      (vs , ceq , steq) = step→bwd {P} {S} {st} {st-mid} (circuit-output vals) seq
+  in ( vs
+     , collectOutputs-mono {State.mem st} {State.mem s}
+         (IrSource.outputs S) vals m⊑s ceq )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (from-bytes32 bytes native o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (from-bytes32 bytes native o) is st req
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      (n , steq) = step→bwd {P} {S} {st} {st-mid} (from-bytes32 bytes native o) seq
+  in ( val-native n
+     , m⊑₂ (trans (cong (λ z → State.mem z o) steq)
+              (ins-here o (val-native n) (State.mem st)))
+     , refl )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (from-bytes32 bytes bytes32 o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (from-bytes32 bytes bytes32 o) is st req
+  in case step→bwd {P} {S} {st} {st-mid} (from-bytes32 bytes bytes32 o) seq of λ ()
+wsteps-go {P} {S} {s} (from-bytes32 bytes jubjub-point o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (from-bytes32 bytes jubjub-point o) is st req
+  in case step→bwd {P} {S} {st} {st-mid} (from-bytes32 bytes jubjub-point o) seq of λ ()
+wsteps-go {P} {S} {s} (from-bytes32 bytes jubjub-scalar o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (from-bytes32 bytes jubjub-scalar o) is st req
+  in case step→bwd {P} {S} {st} {st-mid} (from-bytes32 bytes jubjub-scalar o) seq of λ ()
+wsteps-go {P} {S} {s} (from-bytes32 bytes secp-point o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (from-bytes32 bytes secp-point o) is st req
+  in case step→bwd {P} {S} {st} {st-mid} (from-bytes32 bytes secp-point o) seq of λ ()
+wsteps-go {P} {S} {s} (from-bytes32 bytes secp-base o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (from-bytes32 bytes secp-base o) is st req
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      (x , steq) = step→bwd {P} {S} {st} {st-mid} (from-bytes32 bytes secp-base o) seq
+  in ( val-secp-base x
+     , m⊑₂ (trans (cong (λ z → State.mem z o) steq)
+              (ins-here o (val-secp-base x) (State.mem st)))
+     , refl )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (from-bytes32 bytes secp-scalar o ∷ is) st
+  (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (from-bytes32 bytes secp-scalar o) is st req
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      (x , steq) = step→bwd {P} {S} {st} {st-mid} (from-bytes32 bytes secp-scalar o) seq
+  in ( val-secp-scalar x
+     , m⊑₂ (trans (cong (λ z → State.mem z o) steq)
+              (ins-here o (val-secp-scalar x) (State.mem st)))
+     , refl )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (less-than a b bits o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (less-than a b bits o) is st req
+      (_ , m⊑₁) = step-extends {P} {S} {st} {st-mid} (less-than a b bits o) seq of
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      m⊑s = ⊑-trans {State.mem st} {State.mem st-mid} {State.mem s} m⊑₁ m⊑₂
+      (o¹ , (x , ra , px) , (y , rb , py)) =
+        step→bwd {P} {S} {st} {st-mid} (less-than a b bits o) seq
+  in ( x , y
+     , trans (resolveᶜ-Fr-agree P s a)
+         (resolveᶠ-mono {State.mem st} {State.mem s} a m⊑s ra)
+     , trans (resolveᶜ-Fr-agree P s b)
+         (resolveᶠ-mono {State.mem st} {State.mem s} b m⊑s rb)
+     , px , py )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (public-input guard val-t o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (public-input guard val-t o) is st req
+      (_ , m⊑₁) = step-extends {P} {S} {st} {st-mid} (public-input guard val-t o) seq of
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      m⊑s = ⊑-trans {State.mem st} {State.mem st-mid} {State.mem s} m⊑₁ m⊑₂
+  in ( case step→bwd {P} {S} {st} {st-mid} (public-input guard val-t o) seq of λ
+       { (inj₁ (geq , v , deq , steq)) →
+           true
+         , eval-guard-mono {State.mem st} {State.mem s} guard m⊑s geq
+         , ( v
+           , m⊑₂ (trans (cong (λ z → State.mem z o) steq)
+                    (ins-here o v (State.mem st)))
+           , decode-typeof val-t _ deq )
+       ; (inj₂ (geq , steq)) →
+           false
+         , eval-guard-mono {State.mem st} {State.mem s} guard m⊑s geq
+         , m⊑₂ (trans (cong (λ z → State.mem z o) steq)
+                  (ins-here o (default-val val-t) (State.mem st))) } )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (private-input guard val-t o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (private-input guard val-t o) is st req
+      (_ , m⊑₁) = step-extends {P} {S} {st} {st-mid} (private-input guard val-t o) seq of
+      (m⊑₂ , _) = run-extends {P} {S} {s} is st-mid rrest (wfr seq)
+      m⊑s = ⊑-trans {State.mem st} {State.mem st-mid} {State.mem s} m⊑₁ m⊑₂
+  in ( case step→bwd {P} {S} {st} {st-mid} (private-input guard val-t o) seq of λ
+       { (inj₁ (geq , v , deq , steq)) →
+           true
+         , eval-guard-mono {State.mem st} {State.mem s} guard m⊑s geq
+         , ( v
+           , m⊑₂ (trans (cong (λ z → State.mem z o) steq)
+                    (ins-here o v (State.mem st)))
+           , decode-typeof val-t _ deq )
+       ; (inj₂ (geq , steq)) →
+           false
+         , eval-guard-mono {State.mem st} {State.mem s} guard m⊑s geq
+         , m⊑₂ (trans (cong (λ z → State.mem z o) steq)
+                  (ins-here o (default-val val-t) (State.mem st))) } )
+   , wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (encode input outs ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (encode input outs) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (cond-select bit a b o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (cond-select bit a b o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (constrain-bits val bits ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (constrain-bits val bits) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (constrain-eq a b ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (constrain-eq a b) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (constrain-to-boolean val ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (constrain-to-boolean val) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (copy val o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (copy val o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (ec-mul a scalar o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (ec-mul a scalar o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (ec-mul-generator scalar o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (ec-mul-generator scalar o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (hash-to-curve inputs o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (hash-to-curve inputs o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (into-coordinates point xy ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (into-coordinates point xy) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (from-coordinates xy o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (from-coordinates xy o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (into-bytes32 input o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (into-bytes32 input o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (reverse-bytes bytes o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (reverse-bytes bytes o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (bytes32-into-low-high bytes lohi ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (bytes32-into-low-high bytes lohi) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (bytes32-from-low-high lohi o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (bytes32-from-low-high lohi o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (transient-hash inputs o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (transient-hash inputs o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (persistent-hash al inputs o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (persistent-hash al inputs o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (keccak256 al inputs o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (keccak256 al inputs o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (test-eq a b o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (test-eq a b o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (add a b o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (add a b o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (mul a b o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (mul a b o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (neg a o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (neg a o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (inv a o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (inv a o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (not a o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) = run-inv {P} {S} {s} (not a o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+wsteps-go {P} {S} {s} (jubjub-scalar-from-native a o ∷ is) st (of , wfr) req =
+  let (st-mid , seq , rrest) =
+        run-inv {P} {S} {s} (jubjub-scalar-from-native a o) is st req
+  in wsteps-go {P} {S} {s} is st-mid (wfr seq) rrest
+
+-- `WShape` at the canonical witness of a successful preprocess.
+preprocess→WShape : ∀ {S P s st0}
+  → producer-SA S
+  → init S P ≡ just st0
+  → preprocess S P ≡ just s
+  → WShape S (witness-of P s)
+preprocess→WShape {S} {P} {s} {st0} sa ieq peq =
+  let (walk , _) = preprocess-walk-consumed {S} {P} {s} {st0} ieq peq
+      wf = producer-safe→WF {S} {P} {st0} sa ieq
+      (m⊑ , _) = run-extends {P} {S} {s} (IrSource.instructions S) st0 walk wf
+  in winputs-of {P} {s} (IrSource.inputs S)
+       (init-decode {S} {P} {st0} ieq) (proj₁ sa) m⊑
+   , wsteps-go {P} {S} {s} (IrSource.instructions S) st0 wf walk

--- a/formal/src/zkir-v3/StatementUniqueness.agda
+++ b/formal/src/zkir-v3/StatementUniqueness.agda
@@ -1,0 +1,826 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Extraction (statement) uniqueness for zkir-v3.
+--
+--   statement-unique
+--     : ∀ {S w} → producer-SA S → WInputs w (IrSource.inputs S)
+--     → (r r′ : SubRealizer S w)
+--     → (SubRealizer.P r ≡ SubRealizer.P r′)
+--     × (SubRealizer.s r ≡ SubRealizer.s r′)
+--
+-- For a single-assignment producer and a witness `w` whose declared inputs
+-- are well-shaped, every commitment-well-shaped realizer of `w` is unique:
+-- any two agree on both their preimage and their preprocess state.  (Only
+-- the single-assignment discipline and the input half of the witness shape
+-- are needed — never operand well-typedness, never the per-step witness
+-- shape.)  Combined with
+-- `statement-sound` (existence) this pins EXACTLY ONE such realizer
+-- (`statement-sound-unique`).
+--
+-- Why the whole theorem reduces to `P ≡ P′`.  Unlike v2's relational `R`,
+-- v3's `run` is a deterministic FUNCTION.  Once the two preimages are
+-- equal, the two initial states coincide (`init S P ≡ init S P′` by
+-- `cong`, then `just`-injectivity), hence the two runs are the SAME
+-- computation and the two final states coincide too — plain propositional
+-- equality, no parallel two-run induction.  So the work is entirely the
+-- six-field equality `P ≡ P′`, which we obtain by pinning every field of
+-- each realizer's preimage to the same witness-derived value.
+--
+-- Commitment well-shapedness.  A preimage may carry a commitment pair only
+-- when the source's flag is set.  When the flag is off, `init` seeds the
+-- pis with `binding-input ∷ []` and ignores `comm-commitment` entirely, so
+-- a vestigial `just (c , r)` is invisible to the run.  It is NOT wholly
+-- invisible to the witness: `witness-of` reads
+-- `comm-rand-of (comm-commitment P)`, so the SECOND component `r` of a
+-- vestigial pair does surface as the witness's `comm-rand`.  What stays
+-- invisible at `do-comm ≡ false` is the FIRST component `c` — nothing the
+-- run or the witness consults depends on it — so two preimages differing
+-- only in that `c` realize the same witness data.  `CommWF` removes this
+-- residual slack (and, by forcing `nothing`, the `r` slack with it).
+------------------------------------------------------------------------
+
+module zkir-v3.StatementUniqueness (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+open import zkir-v3.Syntax ⋯
+open import zkir-v3.Semantics ⋯
+open import zkir-v3.SemanticsProperties ⋯
+open import zkir-v3.Circuit ⋯
+open import zkir-v3.CircuitBridge ⋯
+open import zkir-v3.CircuitFaithfulness ⋯
+open import zkir-v3.Obligations ⋯
+open import zkir-v3.CircuitProof ⋯
+open import zkir-v3.StatementSoundness ⋯
+open import zkir-v3.Encoding ⋯ renaming (encode to encodeᵉ)
+
+open import Data.Bool    using (Bool; true; false)
+open import Data.List    using (List; []; _∷_; _++_; take; drop; length; map;
+                                concatMap)
+open import Data.List.Properties
+  using (drop-drop; take++drop≡id; length-++; length-map; ++-assoc)
+open import Data.Maybe   using (Maybe; just; nothing; maybe′)
+open import Data.Nat     using (ℕ; zero; suc; _+_; _*_; _∸_; _^_; _<?_)
+open import Data.Nat.Properties using (+-comm)
+open import Data.Product using (_×_; _,_; Σ; ∃; ∃-syntax; proj₁; proj₂)
+open import Data.Sum     using (inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; cong₂; subst; subst₂)
+open import Data.Maybe.Properties using (just-injective)
+open import Relation.Nullary using (yes; no)
+open import Function using (case_of_)
+
+-- `CommWF` and the `SubRealizer` record (the bundled `statement-sound`
+-- conclusion) are defined in `StatementSoundness` and imported above.
+
+------------------------------------------------------------------------
+-- Preimage equality from field equalities (record eta).
+------------------------------------------------------------------------
+
+mk-preimage-cong : ∀ {P P′ : ProofPreimage}
+  → ProofPreimage.inputs P ≡ ProofPreimage.inputs P′
+  → ProofPreimage.binding-input P ≡ ProofPreimage.binding-input P′
+  → ProofPreimage.comm-commitment P ≡ ProofPreimage.comm-commitment P′
+  → ProofPreimage.pub-transcript-inputs P
+      ≡ ProofPreimage.pub-transcript-inputs P′
+  → ProofPreimage.pub-transcript-outputs P
+      ≡ ProofPreimage.pub-transcript-outputs P′
+  → ProofPreimage.priv-transcript P ≡ ProofPreimage.priv-transcript P′
+  → P ≡ P′
+mk-preimage-cong refl refl refl refl refl refl = refl
+
+------------------------------------------------------------------------
+-- Determinism: equal preimages give equal preprocess states.  This is the
+-- whole content of `s ≡ s′` once `P ≡ P′` is established.
+------------------------------------------------------------------------
+
+realizer-state-cong : ∀ {S w} (r r′ : SubRealizer S w)
+  → SubRealizer.P r ≡ SubRealizer.P r′
+  → SubRealizer.s r ≡ SubRealizer.s r′
+realizer-state-cong {S} r r′ pe =
+  just-injective
+    (trans (sym (run-shaped.walk (SubRealizer.shaped r)))
+      (trans (cong₂ (λ Q st → run Q S st (IrSource.instructions S))
+                    pe start≡)
+             (run-shaped.walk (SubRealizer.shaped r′))))
+  where
+    start≡ : run-shaped.start (SubRealizer.shaped r)
+           ≡ run-shaped.start (SubRealizer.shaped r′)
+    start≡ = just-injective
+      (trans (sym (run-shaped.init≡ (SubRealizer.shaped r)))
+        (trans (cong (init S) pe)
+               (run-shaped.init≡ (SubRealizer.shaped r′))))
+
+------------------------------------------------------------------------
+-- Per-realizer field pins.  Every field of a realizer's preimage is
+-- forced by the witness `w`, so two realizers of `w` agree field by field.
+------------------------------------------------------------------------
+
+-- Shared: the initial state's store and pis sit below the final ones (the
+-- run only extends the store and appends to the pis).
+private
+  init-⊑ : ∀ {S w} (r : SubRealizer S w) → producer-SA S
+    → (State.mem (run-shaped.start (SubRealizer.shaped r))
+         ⊑ State.mem (SubRealizer.s r))
+    × (State.pis (run-shaped.start (SubRealizer.shaped r))
+         ≼ State.pis (SubRealizer.s r))
+  init-⊑ {S} {w} r sa =
+    run-extends {SubRealizer.P r} {S} {SubRealizer.s r}
+      (IrSource.instructions S) st0 (run-shaped.walk (SubRealizer.shaped r))
+      (producer-safe→WF {S} {SubRealizer.P r} {st0} sa
+        (run-shaped.init≡ (SubRealizer.shaped r)))
+    where st0 = run-shaped.start (SubRealizer.shaped r)
+
+-- The binding input is π[0], stable from `init` through the run and pinned
+-- in `w` by the pis-agreement.
+binding-pin : ∀ {S w} (r : SubRealizer S w) → producer-SA S
+  → pi-lookup (CircuitWitness.pis w) 0
+    ≡ just (ProofPreimage.binding-input (SubRealizer.P r))
+binding-pin {S} {w} r sa =
+  subst (λ ps → pi-lookup ps 0
+                ≡ just (ProofPreimage.binding-input (SubRealizer.P r)))
+        (SubRealizer.pis-agree r)
+        (pi-lookup-mono (proj₂ (init-⊑ r sa))
+          (init-pi0 {S} {SubRealizer.P r} {st0}
+            (run-shaped.init≡ (SubRealizer.shaped r))))
+  where st0 = run-shaped.start (SubRealizer.shaped r)
+
+-- The declared inputs re-encode from the run's memory (a sub-assignment of
+-- `w`) to exactly `mkInputs w`, so the raw input stream `inputs P` is
+-- pinned.  Uses `decode-reencode` (needs `NoDup` of the input names, from
+-- `producer-SA`) against `resolve-encode-mkInputs` (needs `WInputs`).
+inputs-pin : ∀ {S w} (r : SubRealizer S w) → producer-SA S
+  → WInputs w (IrSource.inputs S)
+  → ProofPreimage.inputs (SubRealizer.P r) ≡ mkInputs w (IrSource.inputs S)
+inputs-pin {S} {w} r sa wins =
+  just-injective
+    (trans (sym (decode-reencode {w} tis
+                   (ProofPreimage.inputs (SubRealizer.P r))
+                   (State.mem st0)
+                   (init-decode {S} {SubRealizer.P r} {st0} ie)
+                   (proj₁ sa) st0⊑w))
+           (resolve-encode-mkInputs {w} tis wins))
+  where
+    tis = IrSource.inputs S
+    st0 = run-shaped.start (SubRealizer.shaped r)
+    ie  = run-shaped.init≡ (SubRealizer.shaped r)
+
+    st0⊑w : State.mem st0 ⊑ᵂ w
+    st0⊑w = ⊑-trans {State.mem st0} {State.mem (SubRealizer.s r)}
+              {CircuitWitness.assign w}
+              (proj₁ (init-⊑ r sa)) (SubRealizer.mem-agree r)
+
+-- Under the commitment flag, the commitment pair is `just (c , rd)` with
+-- `c` pinned as π[1] in `w` and `rd` pinned as `comm-rand w`.
+comm-true-facts : ∀ {S w} (r : SubRealizer S w) → producer-SA S
+  → IrSource.do-communications-commitment S ≡ true
+  → ∃ λ c → ∃ λ rd →
+       (ProofPreimage.comm-commitment (SubRealizer.P r) ≡ just (c , rd))
+     × (pi-lookup (CircuitWitness.pis w) 1 ≡ just c)
+     × (CircuitWitness.comm-rand w ≡ just rd)
+comm-true-facts {S} {w} r sa hc =
+  let (c , rd , cc) = init-comm {S} {SubRealizer.P r} {st0} hc ie
+  in c , rd , cc
+   , subst (λ ps → pi-lookup ps 1 ≡ just c) (SubRealizer.pis-agree r)
+       (pi-lookup-mono (proj₂ (init-⊑ r sa))
+         (init-pi1 {S} {SubRealizer.P r} {st0} {c} {rd} hc cc ie))
+   , sym (trans (sym (cong comm-rand-of cc)) (SubRealizer.rand-agree r hc))
+  where
+    st0 = run-shaped.start (SubRealizer.shaped r)
+    ie  = run-shaped.init≡ (SubRealizer.shaped r)
+
+------------------------------------------------------------------------
+-- The transcript-pinning walk.
+--
+-- Every field of a realizer's transcript is consumed by the run exactly
+-- as the corresponding w-only pre-pass (`mkPTI`/`mkPTO`/`mkPRV`) computes
+-- it.  The single per-step lemma `step-transcripts` peels one instruction
+-- of the run, relating the three transcript invariants at the pre-state to
+-- the post-state.  Only `impact` (pub-transcript-inputs), `public-input`
+-- (pub-transcript-outputs) and `private-input` (priv-transcript) touch a
+-- transcript; every other instruction preserves all three cursors, so its
+-- clause returns the inductive hypotheses unchanged.
+------------------------------------------------------------------------
+
+private
+  -- Store monotonicity of the Semantics resolvers (the guard bridge: a
+  -- guard resolving in the run's memory resolves the same against `w`).
+  resolveᶠ-⊑ : ∀ {m m′} op {x} → m ⊑ m′
+    → resolveᶠ m op ≡ just x → resolveᶠ m′ op ≡ just x
+  resolveᶠ-⊑ {m} {m′} op sub e =
+    resolveᶠ-intro m′ op (resolve-mono op sub (resolveᶠ-inv m op e))
+
+  resolve𝔹-⊑ : ∀ {m m′} op {b} → m ⊑ m′
+    → resolve𝔹 m op ≡ just b → resolve𝔹 m′ op ≡ just b
+  resolve𝔹-⊑ {m} op sub e with resolveᶠ m op in re | e
+  ... | just x  | e′ rewrite resolveᶠ-⊑ op sub re = e′
+  ... | nothing | e′ = case e′ of λ ()
+
+  eval-guard-⊑ : ∀ {m m′} guard {b} → m ⊑ m′
+    → eval-guard m guard ≡ just b → eval-guard m′ guard ≡ just b
+  eval-guard-⊑ nothing    sub e = e
+  eval-guard-⊑ (just op)  sub e = resolve𝔹-⊑ op sub e
+
+  drop-len : ∀ {A : Set} (xs : List A) → drop (length xs) xs ≡ []
+  drop-len []       = refl
+  drop-len (x ∷ xs) = drop-len xs
+
+  -- One step of the walk: given the three transcript invariants at the
+  -- post-state `st'`, re-establish them at the pre-state `st` for `i ∷ is`.
+  step-transcripts : ∀ {P S w st st'} i is
+    → step P S st i ≡ just st'
+    → State.mem st  ⊑ᵂ w
+    → State.mem st' ⊑ᵂ w
+    → State.pis st' ≼ CircuitWitness.pis w
+    → drop (State.pti-idx st') (ProofPreimage.pub-transcript-inputs P)
+        ≡ mkPTI w (length (State.pis st')) is
+    → State.pto-rem st' ≡ mkPTO w is
+    → State.priv-rem st' ≡ mkPRV w is
+    → (drop (State.pti-idx st) (ProofPreimage.pub-transcript-inputs P)
+         ≡ mkPTI w (length (State.pis st)) (i ∷ is))
+    × (State.pto-rem st ≡ mkPTO w (i ∷ is))
+    × (State.priv-rem st ≡ mkPRV w (i ∷ is))
+
+  -- encode / div-mod-power-of-two: bind via `insertMany`; only the store
+  -- changes, so the cursors are preserved (`insertMany-shape`).
+  step-transcripts {P = P} {w = w} {st = st} (encode input outputs) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) input
+  ... | just v with insertMany-shape st outputs
+                      (map val-native (encodeᵉ v)) e
+  ...   | (pis≡ , pti≡ , pto≡ , prv≡) =
+          subst₂ (λ a b → drop a (ProofPreimage.pub-transcript-inputs P)
+                          ≡ mkPTI w (length b) is) pti≡ pis≡ ptiIH
+        , subst (λ x → x ≡ mkPTO w is) pto≡ ptoIH
+        , subst (λ x → x ≡ mkPRV w is) prv≡ prvIH
+  step-transcripts {P = P} {w = w} {st = st} (div-mod-power-of-two val bits outs) is e
+    _ _ _ ptiIH ptoIH prvIH
+    with resolveᶠ (State.mem st) val
+  ... | just x with insertMany-shape st outs
+                      ( val-native (from-le-bits (drop bits (to-le-bits x)))
+                      ∷ val-native (from-le-bits (take bits (to-le-bits x)))
+                      ∷ []) e
+  ...   | (pis≡ , pti≡ , pto≡ , prv≡) =
+          subst₂ (λ a b → drop a (ProofPreimage.pub-transcript-inputs P)
+                          ≡ mkPTI w (length b) is) pti≡ pis≡ ptiIH
+        , subst (λ x₁ → x₁ ≡ mkPTO w is) pto≡ ptoIH
+        , subst (λ x₁ → x₁ ≡ mkPRV w is) prv≡ prvIH
+
+  -- assert / constrain-* leave the state unchanged.
+  step-transcripts {st = st} (assert cond) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve𝔹 (State.mem st) cond
+  ... | just true with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (constrain-bits val bits) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolveᶠ (State.mem st) val
+  ... | just x with valFr x <? 2 ^ bits
+  ...   | yes _ with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (constrain-eq a b) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) a | resolve (State.mem st) b
+  ... | just av | just bv with valEq? av bv
+  ...   | just true with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (constrain-to-boolean val) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve𝔹 (State.mem st) val
+  ... | just _ with refl ← e = ptiIH , ptoIH , prvIH
+
+  -- Single-output arithmetic / conversion instructions bind one fresh cell
+  -- (`out1`), preserving every transcript cursor.
+  step-transcripts {st = st} (cond-select bit a b output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve𝔹 (State.mem st) bit
+  ... | just bv with resolve (State.mem st) a | resolve (State.mem st) b
+  ...   | just av | just bvl with typeof av ≟T typeof bvl
+  ...     | yes _ with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (copy val output) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) val
+  ... | just v with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (ec-mul a scalar output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) a | resolve (State.mem st) scalar
+  ... | just (val-jubjub-point p) | just (val-jubjub-scalar s)
+          with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-point p) | just (val-secp-scalar s)
+          with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (ec-mul-generator scalar output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) scalar
+  ... | just (val-jubjub-scalar s) with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-scalar s) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (hash-to-curve inputs output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve-all-Fr (State.mem st) inputs
+  ... | just frs with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (into-coordinates point (xid , yid)) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) point
+  ... | just (val-jubjub-point p) with coordsJ p
+  ...   | (x , y) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (into-coordinates point (xid , yid)) is e _ _ _
+    ptiIH ptoIH prvIH
+    | just (val-secp-point p) with coordsK p
+  ...   | just (x , y) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (from-coordinates (xop , yop) output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) xop | resolve (State.mem st) yop
+  ... | just (val-native x) | just (val-native y) with fromCoordsJ x y
+  ...   | just p with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (from-coordinates (xop , yop) output) is e _ _ _
+    ptiIH ptoIH prvIH
+    | just (val-secp-base x) | just (val-secp-base y) with fromCoordsK x y
+  ...   | just p with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (into-bytes32 input output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) input
+  ... | just (val-native x) with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-base x) with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-scalar x) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (from-bytes32 bytes native output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (from-bytes32 bytes secp-base output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (from-bytes32 bytes secp-scalar output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (from-bytes32 bytes bytes32 output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) = case e of λ ()
+  step-transcripts {st = st} (from-bytes32 bytes jubjub-point output) is e
+    _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) = case e of λ ()
+  step-transcripts {st = st} (from-bytes32 bytes jubjub-scalar output) is e
+    _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) = case e of λ ()
+  step-transcripts {st = st} (from-bytes32 bytes secp-point output) is e
+    _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) = case e of λ ()
+  step-transcripts {st = st} (reverse-bytes bytes output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (bytes32-into-low-high bytes (loid , hiid)) is e
+    _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) bytes
+  ... | just (val-bytes32 b) with bytes32→low-high b
+  ...   | (lo , hi) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (bytes32-from-low-high (loop , hiop) output) is e
+    _ _ _ ptiIH ptoIH prvIH
+    with resolveᶠ (State.mem st) loop | resolveᶠ (State.mem st) hiop
+  ... | just lo | just hi with low-high→bytes32 lo hi
+  ...   | just b with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (reconstitute-field divisor modulus bits output)
+    is e _ _ _ ptiIH ptoIH prvIH
+    with resolveᶠ (State.mem st) divisor | resolveᶠ (State.mem st) modulus
+  ... | just d | just mo with valFr mo <? 2 ^ bits
+  ...   | yes _ with valFr d <? 2 ^ (FR-BITS ∸ bits)
+  ...     | yes _ with valFr mo + 2 ^ bits * valFr d <? FR-ORDER
+  ...       | yes _ with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (transient-hash inputs output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve-all-Fr (State.mem st) inputs
+  ... | just frs with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (persistent-hash alignment inputs output) is e
+    _ _ _ ptiIH ptoIH prvIH
+    with resolve-all-Fr (State.mem st) inputs
+  ... | just frs with persistent-hash-fn alignment frs
+  ...   | just h with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (keccak256 alignment inputs output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolve-all-Fr (State.mem st) inputs
+  ... | just frs with keccak-fn alignment frs
+  ...   | just h with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (test-eq a b output) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) a | resolve (State.mem st) b
+  ... | just av | just bv with valEq? av bv
+  ...   | just eqv with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (add a b output) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) a | resolve (State.mem st) b
+  ... | just (val-native x) | just (val-native y) with refl ← e =
+          ptiIH , ptoIH , prvIH
+  ... | just (val-jubjub-point p) | just (val-jubjub-point q)
+          with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-point p) | just (val-secp-point q)
+          with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-base x) | just (val-secp-base y)
+          with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-scalar x) | just (val-secp-scalar y)
+          with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (mul a b output) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) a | resolve (State.mem st) b
+  ... | just (val-native x) | just (val-native y) with refl ← e =
+          ptiIH , ptoIH , prvIH
+  ... | just (val-secp-base x) | just (val-secp-base y)
+          with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-scalar x) | just (val-secp-scalar y)
+          with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (neg a output) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) a
+  ... | just (val-native x) with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-jubjub-point p) with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-point p) with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-base x) with refl ← e = ptiIH , ptoIH , prvIH
+  ... | just (val-secp-scalar x) with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (inv a output) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve (State.mem st) a
+  ... | just (val-native x) with invᶠ x
+  ...   | just xi with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (inv a output) is e _ _ _ ptiIH ptoIH prvIH
+    | just (val-secp-base x) with invᵇ x
+  ...   | just xi with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (inv a output) is e _ _ _ ptiIH ptoIH prvIH
+    | just (val-secp-scalar x) with invˢ x
+  ...   | just xi with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (not a output) is e _ _ _ ptiIH ptoIH prvIH
+    with resolve𝔹 (State.mem st) a
+  ... | just b with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (less-than a b bits output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolveᶠ (State.mem st) a | resolveᶠ (State.mem st) b
+  ... | just x | just y with valFr x <? 2 ^ bits
+  ...   | yes _ with valFr y <? 2 ^ bits
+  ...     | yes _ with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {st = st} (jubjub-scalar-from-native a output) is e _ _ _
+    ptiIH ptoIH prvIH
+    with resolveᶠ (State.mem st) a
+  ... | just x with refl ← e = ptiIH , ptoIH , prvIH
+  step-transcripts {P = P} {S = S} {st = st} (circuit-output vals) is e _ _ _
+    ptiIH ptoIH prvIH
+    with collectOutputs (State.mem st) (IrSource.outputs S) vals
+  ... | just vs with refl ← e = ptiIH , ptoIH , prvIH
+
+  -- impact: the only pis-appending instruction.  Active guard consumes a
+  -- pub-transcript-inputs window equal to the pushed values; the window in
+  -- `w` matches because the run wrote those values into a pis prefix of `w`.
+  step-transcripts {P = P} {w = w} {st = st} (impact guard inputs) is e agrst _ p≼w
+    ptiIH ptoIH prvIH
+    with resolve-all-Fr (State.mem st) inputs in rav
+  ... | just vals with resolve𝔹 (State.mem st) guard in rgb
+  ...   | just g with g
+  ...     | true
+            with take (length vals)
+                   (drop (State.pti-idx st)
+                     (ProofPreimage.pub-transcript-inputs P)) ≟LFr vals | e
+  ...       | no ¬p       | ()
+  ...       | yes slice-eq | refl = goal1 , ptoIH , prvIH
+              where
+                PTI = ProofPreimage.pub-transcript-inputs P
+                nn  = length vals
+                r𝔹w : resolve𝔹 (CircuitWitness.assign w) guard ≡ just true
+                r𝔹w = resolve𝔹-⊑ guard agrst rgb
+                lenvals : length vals ≡ length inputs
+                lenvals = resolve-all-Fr-length (State.mem st) inputs rav
+                zs   = proj₁ p≼w
+                pweq : CircuitWitness.pis w ≡ (State.pis st ++ vals) ++ zs
+                pweq = proj₂ p≼w
+                drop-w : drop (length (State.pis st)) (CircuitWitness.pis w)
+                       ≡ vals ++ zs
+                drop-w =
+                  trans (cong (drop (length (State.pis st))) pweq)
+                    (trans (cong (drop (length (State.pis st)))
+                              (++-assoc (State.pis st) vals zs))
+                           (drop-len-++ (State.pis st) (vals ++ zs)))
+                window≡vals :
+                  take (length inputs)
+                    (drop (length (State.pis st)) (CircuitWitness.pis w))
+                  ≡ vals
+                window≡vals =
+                  trans (cong (take (length inputs)) drop-w)
+                    (trans (cong (λ k → take k (vals ++ zs)) (sym lenvals))
+                           (take-len-++ vals zs))
+                len-pis' : length (State.pis st ++ vals)
+                         ≡ length (State.pis st) + length inputs
+                len-pis' = trans (length-++ (State.pis st))
+                             (cong (length (State.pis st) +_) lenvals)
+                drop-tail :
+                  drop nn (drop (State.pti-idx st) PTI)
+                  ≡ mkPTI w (length (State.pis st) + length inputs) is
+                drop-tail =
+                  trans (drop-drop (State.pti-idx st) nn PTI)
+                    (trans ptiIH (cong (λ n → mkPTI w n is) len-pis'))
+                goal1 :
+                  drop (State.pti-idx st) PTI
+                  ≡ mkPTI w (length (State.pis st)) (impact guard inputs ∷ is)
+                goal1 =
+                  trans (sym (take++drop≡id nn (drop (State.pti-idx st) PTI)))
+                    (trans (cong₂ _++_ slice-eq drop-tail)
+                      (trans (cong (_++ mkPTI w
+                                     (length (State.pis st) + length inputs) is)
+                                (sym window≡vals))
+                        (sym (mkPTI-true {w} {guard} {inputs} {is}
+                                (length (State.pis st)) r𝔹w))))
+  step-transcripts {P = P} {w = w} {st = st} (impact guard inputs) is e agrst _ p≼w
+    ptiIH ptoIH prvIH | just vals | just g | false with refl ← e =
+      goal1 , ptoIH , prvIH
+      where
+        PTI = ProofPreimage.pub-transcript-inputs P
+        r𝔹w : resolve𝔹 (CircuitWitness.assign w) guard ≡ just false
+        r𝔹w = resolve𝔹-⊑ guard agrst rgb
+        lenvals : length vals ≡ length inputs
+        lenvals = resolve-all-Fr-length (State.mem st) inputs rav
+        len-pis' : length (State.pis st ++ map (λ _ → 0ᶠ) vals)
+                 ≡ length (State.pis st) + length inputs
+        len-pis' = trans (length-++ (State.pis st))
+                     (cong (length (State.pis st) +_)
+                       (trans (length-map (λ _ → 0ᶠ) vals) lenvals))
+        goal1 :
+          drop (State.pti-idx st) PTI
+          ≡ mkPTI w (length (State.pis st)) (impact guard inputs ∷ is)
+        goal1 =
+          trans ptiIH
+            (trans (cong (λ n → mkPTI w n is) len-pis')
+                   (sym (mkPTI-false {w} {guard} {inputs} {is}
+                           (length (State.pis st)) r𝔹w)))
+
+  -- public-input: an active guard pops the encoding of `w`'s output cell
+  -- from pub-transcript-outputs; an inactive guard pops nothing.
+  step-transcripts {P = P} {w = w} {st = st} (public-input guard val-t output) is e
+    agrst agrst' _ ptiIH ptoIH prvIH
+    with eval-guard (State.mem st) guard in egm
+  ... | just g with g
+  ...   | true with decode val-t (take (encoded-len val-t)
+                                    (State.pto-rem st)) in ded | e
+  ...     | nothing | ()
+  ...     | just v  | refl = ptiIH , goal2 , prvIH
+            where
+              n = encoded-len val-t
+              egw : eval-guard (CircuitWitness.assign w) guard ≡ just true
+              egw = eval-guard-⊑ guard agrst egm
+              wo : CircuitWitness.assign w output ≡ just v
+              wo = agrst' (ins-here output v (State.mem st))
+              chunk≡ : take n (State.pto-rem st) ≡ encodeᵉ v
+              chunk≡ = sym (decode-encode-chunk val-t
+                             (take n (State.pto-rem st)) ded)
+              goal2 : State.pto-rem st
+                    ≡ mkPTO w (public-input guard val-t output ∷ is)
+              goal2 =
+                trans (sym (take++drop≡id n (State.pto-rem st)))
+                  (trans (cong₂ _++_ chunk≡ ptoIH)
+                    (sym (mkPTO-active {w} {guard} {val-t} {output} {is} {v}
+                           egw wo)))
+  step-transcripts {P = P} {w = w} {st = st} (public-input guard val-t output) is e
+    agrst agrst' _ ptiIH ptoIH prvIH | just g | false with refl ← e =
+      ptiIH , goal2 , prvIH
+      where
+        egwf : eval-guard (CircuitWitness.assign w) guard ≡ just false
+        egwf = eval-guard-⊑ guard agrst egm
+        goal2 : State.pto-rem st
+              ≡ mkPTO w (public-input guard val-t output ∷ is)
+        goal2 = trans ptoIH
+                  (sym (mkPTO-false {w} {guard} {val-t} {output} {is} egwf))
+
+  -- private-input: the priv-transcript analogue of public-input.
+  step-transcripts {P = P} {w = w} {st = st} (private-input guard val-t output) is e
+    agrst agrst' _ ptiIH ptoIH prvIH
+    with eval-guard (State.mem st) guard in egm
+  ... | just g with g
+  ...   | true with decode val-t (take (encoded-len val-t)
+                                    (State.priv-rem st)) in ded | e
+  ...     | nothing | ()
+  ...     | just v  | refl = ptiIH , ptoIH , goal3
+            where
+              n = encoded-len val-t
+              egw : eval-guard (CircuitWitness.assign w) guard ≡ just true
+              egw = eval-guard-⊑ guard agrst egm
+              wo : CircuitWitness.assign w output ≡ just v
+              wo = agrst' (ins-here output v (State.mem st))
+              chunk≡ : take n (State.priv-rem st) ≡ encodeᵉ v
+              chunk≡ = sym (decode-encode-chunk val-t
+                             (take n (State.priv-rem st)) ded)
+              goal3 : State.priv-rem st
+                    ≡ mkPRV w (private-input guard val-t output ∷ is)
+              goal3 =
+                trans (sym (take++drop≡id n (State.priv-rem st)))
+                  (trans (cong₂ _++_ chunk≡ prvIH)
+                    (sym (mkPRV-active {w} {guard} {val-t} {output} {is} {v}
+                           egw wo)))
+  step-transcripts {P = P} {w = w} {st = st} (private-input guard val-t output) is e
+    agrst agrst' _ ptiIH ptoIH prvIH | just g | false with refl ← e =
+      ptiIH , ptoIH , goal3
+      where
+        egwf : eval-guard (CircuitWitness.assign w) guard ≡ just false
+        egwf = eval-guard-⊑ guard agrst egm
+        goal3 : State.priv-rem st
+              ≡ mkPRV w (private-input guard val-t output ∷ is)
+        goal3 = trans prvIH
+                  (sym (mkPRV-false {w} {guard} {val-t} {output} {is} egwf))
+
+  -- The walk: fold `step-transcripts` over the whole run.  The base case
+  -- reads the three pins off `Consumed` at the final state; the step case
+  -- derives the per-step memory/pis agreements from `run-extends` on the
+  -- tail run.
+  transcripts-walk : ∀ {P S w s} st is
+    → run P S st is ≡ just s
+    → WF-run P S is st
+    → State.mem s ⊑ᵂ w
+    → State.pis s ≡ CircuitWitness.pis w
+    → Consumed P s
+    → (drop (State.pti-idx st) (ProofPreimage.pub-transcript-inputs P)
+         ≡ mkPTI w (length (State.pis st)) is)
+    × (State.pto-rem st ≡ mkPTO w is)
+    × (State.priv-rem st ≡ mkPRV w is)
+  transcripts-walk {P} {S} {w} {s} st [] run-eq wf magr pagr (ci , cto , cpr)
+    with refl ← just-injective run-eq =
+      trans (cong (λ n → drop n (ProofPreimage.pub-transcript-inputs P)) ci)
+            (drop-len (ProofPreimage.pub-transcript-inputs P))
+    , cto , cpr
+  transcripts-walk {P} {S} {w} {s} st (i ∷ is) run-eq wf magr pagr consumed =
+    let (st-mid , step-eq , run-rest) = run-inv i is st run-eq
+        (of , wf-cont) = wf
+        wf-mid = wf-cont step-eq
+        agrst  = ⊑-trans {State.mem st} {State.mem s} {CircuitWitness.assign w}
+                   (proj₁ (run-extends (i ∷ is) st run-eq wf)) magr
+        agrst' = ⊑-trans {State.mem st-mid} {State.mem s}
+                   {CircuitWitness.assign w}
+                   (proj₁ (run-extends is st-mid run-rest wf-mid)) magr
+        p≼w    = subst (State.pis st-mid ≼_) pagr
+                   (proj₂ (run-extends is st-mid run-rest wf-mid))
+        (ptiIH , ptoIH , prvIH) =
+          transcripts-walk {P} {S} {w} {s} st-mid is run-rest wf-mid magr pagr
+            consumed
+    in step-transcripts {P} {S} {w} {st} {st-mid} i is step-eq agrst agrst' p≼w
+         ptiIH ptoIH prvIH
+
+------------------------------------------------------------------------
+-- Initial-cursor inversions: `init` seeds `pti-idx` to 0 and the two
+-- output cursors to the corresponding transcript fields of the preimage.
+------------------------------------------------------------------------
+
+-- One inversion of `init` reads off all three initial cursors; the
+-- named facts are projections.
+init-cursors : ∀ {S P st0} → init S P ≡ just st0
+  → State.pti-idx st0 ≡ 0
+  × State.pto-rem st0 ≡ ProofPreimage.pub-transcript-outputs P
+  × State.priv-rem st0 ≡ ProofPreimage.priv-transcript P
+init-cursors {S} {P} {st0} ieq
+  with decode-inputs (IrSource.inputs S) (ProofPreimage.inputs P)
+... | just m with IrSource.do-communications-commitment S
+...   | false = sym (cong State.pti-idx  (just-injective ieq))
+              , sym (cong State.pto-rem  (just-injective ieq))
+              , sym (cong State.priv-rem (just-injective ieq))
+init-cursors {S} {P} {st0} ieq | just m | true
+  with ProofPreimage.comm-commitment P
+...     | just (c , _) = sym (cong State.pti-idx  (just-injective ieq))
+                       , sym (cong State.pto-rem  (just-injective ieq))
+                       , sym (cong State.priv-rem (just-injective ieq))
+
+init-pti0 : ∀ {S P st0} → init S P ≡ just st0 → State.pti-idx st0 ≡ 0
+init-pti0 {S} {P} {st0} ieq = proj₁ (init-cursors {S} {P} {st0} ieq)
+
+init-pto0 : ∀ {S P st0} → init S P ≡ just st0
+  → State.pto-rem st0 ≡ ProofPreimage.pub-transcript-outputs P
+init-pto0 {S} {P} {st0} ieq = proj₁ (proj₂ (init-cursors {S} {P} {st0} ieq))
+
+init-priv0 : ∀ {S P st0} → init S P ≡ just st0
+  → State.priv-rem st0 ≡ ProofPreimage.priv-transcript P
+init-priv0 {S} {P} {st0} ieq = proj₂ (proj₂ (init-cursors {S} {P} {st0} ieq))
+
+------------------------------------------------------------------------
+-- The three transcript pins.  Each field of a realizer's transcript
+-- equals the w-only pre-pass, via `transcripts-walk` and the initial
+-- cursor values.
+------------------------------------------------------------------------
+
+private
+  walk-of : ∀ {S w} (r : SubRealizer S w) → producer-SA S
+    → (drop (State.pti-idx (run-shaped.start (SubRealizer.shaped r)))
+          (ProofPreimage.pub-transcript-inputs (SubRealizer.P r))
+        ≡ mkPTI w (length (State.pis (run-shaped.start (SubRealizer.shaped r))))
+                  (IrSource.instructions S))
+    × (State.pto-rem (run-shaped.start (SubRealizer.shaped r))
+        ≡ mkPTO w (IrSource.instructions S))
+    × (State.priv-rem (run-shaped.start (SubRealizer.shaped r))
+        ≡ mkPRV w (IrSource.instructions S))
+  walk-of {S} {w} r sa =
+    transcripts-walk {SubRealizer.P r} {S} {w} {SubRealizer.s r}
+      st0 (IrSource.instructions S) (run-shaped.walk (SubRealizer.shaped r))
+      (producer-safe→WF {S} {SubRealizer.P r} {st0} sa ie)
+      (SubRealizer.mem-agree r) (SubRealizer.pis-agree r)
+      (run-shaped.consumed (SubRealizer.shaped r))
+    where
+      st0 = run-shaped.start (SubRealizer.shaped r)
+      ie  = run-shaped.init≡ (SubRealizer.shaped r)
+
+pto-pin : ∀ {S w} (r : SubRealizer S w) → producer-SA S
+  → ProofPreimage.pub-transcript-outputs (SubRealizer.P r)
+    ≡ mkPTO w (IrSource.instructions S)
+pto-pin {S} {w} r sa =
+  trans (sym (init-pto0 {S} {SubRealizer.P r}
+                {run-shaped.start (SubRealizer.shaped r)}
+                (run-shaped.init≡ (SubRealizer.shaped r))))
+        (proj₁ (proj₂ (walk-of r sa)))
+
+priv-pin : ∀ {S w} (r : SubRealizer S w) → producer-SA S
+  → ProofPreimage.priv-transcript (SubRealizer.P r)
+    ≡ mkPRV w (IrSource.instructions S)
+priv-pin {S} {w} r sa =
+  trans (sym (init-priv0 {S} {SubRealizer.P r}
+                {run-shaped.start (SubRealizer.shaped r)}
+                (run-shaped.init≡ (SubRealizer.shaped r))))
+        (proj₂ (proj₂ (walk-of r sa)))
+
+pti-pin : ∀ {S w} (r : SubRealizer S w) → producer-SA S
+  → ProofPreimage.pub-transcript-inputs (SubRealizer.P r)
+    ≡ mkPTI w
+        (length (State.pis (run-shaped.start (SubRealizer.shaped r))))
+        (IrSource.instructions S)
+pti-pin {S} {w} r sa =
+  trans (sym (cong
+                (λ n → drop n (ProofPreimage.pub-transcript-inputs
+                                (SubRealizer.P r)))
+                (init-pti0 {S} {SubRealizer.P r}
+                  {run-shaped.start (SubRealizer.shaped r)}
+                  (run-shaped.init≡ (SubRealizer.shaped r)))))
+        (proj₁ (walk-of r sa))
+
+------------------------------------------------------------------------
+-- Extraction uniqueness: two realizers of the same witness agree.
+------------------------------------------------------------------------
+
+statement-unique : ∀ {S w} → producer-SA S → WInputs w (IrSource.inputs S)
+  → (r r′ : SubRealizer S w)
+  → (SubRealizer.P r ≡ SubRealizer.P r′)
+  × (SubRealizer.s r ≡ SubRealizer.s r′)
+statement-unique {S} {w} sa wins r r′ = pe , realizer-state-cong r r′ pe
+  where
+    is  = IrSource.instructions S
+    ie  = run-shaped.init≡ (SubRealizer.shaped r)
+    ie′ = run-shaped.init≡ (SubRealizer.shaped r′)
+
+    inputs≡ : ProofPreimage.inputs (SubRealizer.P r)
+            ≡ ProofPreimage.inputs (SubRealizer.P r′)
+    inputs≡ = trans (inputs-pin r sa wins) (sym (inputs-pin r′ sa wins))
+
+    bind≡ : ProofPreimage.binding-input (SubRealizer.P r)
+          ≡ ProofPreimage.binding-input (SubRealizer.P r′)
+    bind≡ = just-injective (trans (sym (binding-pin r sa)) (binding-pin r′ sa))
+
+    pto≡ : ProofPreimage.pub-transcript-outputs (SubRealizer.P r)
+         ≡ ProofPreimage.pub-transcript-outputs (SubRealizer.P r′)
+    pto≡ = trans (pto-pin r sa) (sym (pto-pin r′ sa))
+
+    priv≡ : ProofPreimage.priv-transcript (SubRealizer.P r)
+          ≡ ProofPreimage.priv-transcript (SubRealizer.P r′)
+    priv≡ = trans (priv-pin r sa) (sym (priv-pin r′ sa))
+
+    -- The two initial-preamble pis lengths agree (both the preamble count
+    -- of the shared flag), so the two `mkPTI` cursors coincide.
+    len≡ : length (State.pis (run-shaped.start (SubRealizer.shaped r)))
+         ≡ length (State.pis (run-shaped.start (SubRealizer.shaped r′)))
+    len≡ = trans (init-pis-len {S} {SubRealizer.P r} ie)
+             (sym (init-pis-len {S} {SubRealizer.P r′} ie′))
+
+    pti≡ : ProofPreimage.pub-transcript-inputs (SubRealizer.P r)
+         ≡ ProofPreimage.pub-transcript-inputs (SubRealizer.P r′)
+    pti≡ = trans (pti-pin r sa)
+             (trans (cong (λ k → mkPTI w k is) len≡)
+                    (sym (pti-pin r′ sa)))
+
+    comm≡ : ProofPreimage.comm-commitment (SubRealizer.P r)
+          ≡ ProofPreimage.comm-commitment (SubRealizer.P r′)
+    comm≡ = aux (IrSource.do-communications-commitment S) refl
+      where
+        aux : ∀ b → IrSource.do-communications-commitment S ≡ b
+            → ProofPreimage.comm-commitment (SubRealizer.P r)
+              ≡ ProofPreimage.comm-commitment (SubRealizer.P r′)
+        aux false hc =
+          trans (SubRealizer.comm-wf r hc) (sym (SubRealizer.comm-wf r′ hc))
+        aux true hc =
+          let (c  , rd  , ccr  , cl  , rr ) = comm-true-facts r  sa hc
+              (c′ , rd′ , ccr′ , cl′ , rr′) = comm-true-facts r′ sa hc
+              c≡  = just-injective (trans (sym cl) cl′)
+              rd≡ = just-injective (trans (sym rr) rr′)
+          in trans ccr (trans (cong just (cong₂ _,_ c≡ rd≡)) (sym ccr′))
+
+    pe : SubRealizer.P r ≡ SubRealizer.P r′
+    pe = mk-preimage-cong inputs≡ bind≡ comm≡ pti≡ pto≡ priv≡
+
+------------------------------------------------------------------------
+-- Exactly-one packaging.  `statement-sound` (existence) plus
+-- `statement-unique` (uniqueness): for a well-typed producer and a
+-- satisfying, minimally-shaped witness `w`, there is a commitment-well-
+-- shaped realizer whose preimage and state any other realizer of `w`
+-- agrees with.  `statement-sound`'s built `P'` is `CommWF`: at
+-- `do-comm ≡ false` it carries `comm-commitment ≡ nothing`, and at
+-- `do-comm ≡ true` any commitment is well-shaped.
+------------------------------------------------------------------------
+
+statement-sound-unique : ∀ {S w}
+  → producer-WT S → satisfies (synth S) w → WShape S w
+  → Σ (SubRealizer S w) (λ r → ∀ (r′ : SubRealizer S w)
+      → (SubRealizer.P r ≡ SubRealizer.P r′)
+      × (SubRealizer.s r ≡ SubRealizer.s r′))
+statement-sound-unique {S} {w} wt sat ws =
+  can , λ r′ → statement-unique (proj₁ wt) (proj₁ ws) can r′
+  where
+    can : SubRealizer S w
+    can = statement-sound {S} {w} wt sat ws

--- a/formal/src/zkir-v3/Syntax.agda
+++ b/formal/src/zkir-v3/Syntax.agda
@@ -1,0 +1,295 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Abstract syntax of zkir-v3  (ir.rs)
+--
+-- `Identifier`, `Operand`, the 34 `Instruction`s (in ir.rs order), and
+-- the `IrSource` record.  `Fr` and `Alignment` come from the trust base;
+-- `IrType` from the Types module.
+------------------------------------------------------------------------
+
+module zkir-v3.Syntax (⋯ : _) (open Assumptions ⋯) where
+
+open import zkir-v3.Types ⋯
+
+open import Data.Bool    using (Bool)
+open import Data.List    using (List)
+open import Data.Maybe   using (Maybe)
+open import Data.Nat     using (ℕ)
+open import Data.Product using (_×_)
+open import Data.String  using (String)
+
+------------------------------------------------------------------------
+-- Identifiers  (ir.rs: Identifier)
+--
+-- In the concrete syntax variables are '%'-prefixed strings; the
+-- leading-'%' invariant belongs to the well-formedness layer.
+------------------------------------------------------------------------
+
+Identifier : Set
+Identifier = String
+
+------------------------------------------------------------------------
+-- Operands  (ir.rs: Operand)
+--
+-- A reference to a bound variable, or an immediate.  An immediate always
+-- denotes a `Native` value.
+------------------------------------------------------------------------
+
+data Operand : Set where
+  var : Identifier → Operand
+  imm : Fr         → Operand
+
+------------------------------------------------------------------------
+-- Typed identifier  (ir.rs: TypedIdentifier) — a declared circuit input.
+------------------------------------------------------------------------
+
+record TypedIdentifier : Set where
+  constructor _⦂_
+  field
+    name  : Identifier
+    val-t : IrType
+
+------------------------------------------------------------------------
+-- Minor version  (ir.rs: IrMinorVersion) — only V0 at present.
+------------------------------------------------------------------------
+
+data IrMinorVersion : Set where
+  V0 : IrMinorVersion
+
+------------------------------------------------------------------------
+-- Instructions  (ir.rs: Instruction)
+--
+-- The 34 variants in ir.rs order.  `bits` fields are u32 in Rust (ℕ
+-- here).  Operand/identifier lists are `List`; pairs are `_×_`.  Arity
+-- and type-compatibility constraints belong to the semantics layer.
+------------------------------------------------------------------------
+
+data Instruction : Set where
+
+  -- Encode a typed value as its raw Fr elements.
+  encode
+    : (input   : Operand)
+    → (outputs : List Identifier)
+    → Instruction
+
+  -- Assert cond = 1.  UB if cond ∉ {0,1}.
+  assert
+    : (cond : Operand)
+    → Instruction
+
+  -- Select a when bit = 1, else b.  Requires a, b of the same type.
+  cond-select
+    : (bit    : Operand)
+    → (a b    : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Constrain val to fit in `bits` bits.
+  constrain-bits
+    : (val  : Operand)
+    → (bits : ℕ)
+    → Instruction
+
+  -- Constrain a = b.
+  constrain-eq
+    : (a b : Operand)
+    → Instruction
+
+  -- Constrain val ∈ {0,1}.
+  constrain-to-boolean
+    : (val : Operand)
+    → Instruction
+
+  -- Copy a value.
+  copy
+    : (val    : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Declare public inputs under a guard (fused declare + pi-skip).
+  impact
+    : (guard  : Operand)
+    → (inputs : List Operand)
+    → Instruction
+
+  -- Multiply a point by a scalar.
+  ec-mul
+    : (a      : Operand)
+    → (scalar : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Multiply the group generator by a scalar.
+  ec-mul-generator
+    : (scalar : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Hash native elements to a Jubjub point.
+  hash-to-curve
+    : (inputs : List Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Affine coordinates (x, y) of a point.
+  into-coordinates
+    : (point   : Operand)
+    → (outputs : Identifier × Identifier)
+    → Instruction
+
+  -- Reconstruct a point from affine coordinates.
+  from-coordinates
+    : (inputs : Operand × Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- 32-byte representation of a value.
+  into-bytes32
+    : (input  : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Value of the given type from a 32-byte representation.
+  from-bytes32
+    : (bytes  : Operand)
+    → (val-t  : IrType)
+    → (output : Identifier)
+    → Instruction
+
+  -- Reverse the byte order of a Bytes32 value.  Bytes32 → Bytes32.
+  reverse-bytes
+    : (bytes  : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Decompose Bytes32 into (low 31 bytes, high byte) as Native.
+  bytes32-into-low-high
+    : (bytes   : Operand)
+    → (outputs : Identifier × Identifier)
+    → Instruction
+
+  -- Reassemble Bytes32 from (low, high).  Requires low < 2²⁴⁸, high < 256.
+  bytes32-from-low-high
+    : (inputs : Operand × Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Divide by 2^bits: outputs [quotient, remainder].
+  div-mod-power-of-two
+    : (val     : Operand)
+    → (bits    : ℕ)
+    → (outputs : List Identifier)
+    → Instruction
+
+  -- divisor·2^bits + modulus, no field overflow, modulus < 2^bits.
+  reconstitute-field
+    : (divisor : Operand)
+    → (modulus : Operand)
+    → (bits    : ℕ)
+    → (output  : Identifier)
+    → Instruction
+
+  -- Circuit-friendly (transient) hash.
+  transient-hash
+    : (inputs : List Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Long-term (persistent, SHA-256) hash with alignment.  Output Bytes32.
+  persistent-hash
+    : (alignment : Alignment)
+    → (inputs    : List Operand)
+    → (output    : Identifier)
+    → Instruction
+
+  -- Keccak-256 hash with alignment.  Output Bytes32.
+  keccak256
+    : (alignment : Alignment)
+    → (inputs    : List Operand)
+    → (output    : Identifier)
+    → Instruction
+
+  -- Equality test.  Output is 1 iff a = b.
+  test-eq
+    : (a b    : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Addition (field or point).
+  add
+    : (a b    : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Prime-field multiplication.
+  mul
+    : (a b    : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Negation (field or point).
+  neg
+    : (a      : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Prime-field inverse.  Errors if a = 0.
+  inv
+    : (a      : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Boolean NOT.  UB if a ∉ {0,1}.
+  not
+    : (a      : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Unsigned less-than in `bits`-bit precision.
+  less-than
+    : (a b    : Operand)
+    → (bits   : ℕ)
+    → (output : Identifier)
+    → Instruction
+
+  -- Cast a Native value to a Jubjub scalar (modular reduction).
+  jubjub-scalar-from-native
+    : (a      : Operand)
+    → (output : Identifier)
+    → Instruction
+
+  -- Next value from the public transcript (or default if guard fails).
+  public-input
+    : (guard  : Maybe Operand)
+    → (val-t  : IrType)
+    → (output : Identifier)
+    → Instruction
+
+  -- Next value from the private transcript (or default if guard fails).
+  private-input
+    : (guard  : Maybe Operand)
+    → (val-t  : IrType)
+    → (output : Identifier)
+    → Instruction
+
+  -- Terminator: produce the circuit's return values, in signature order.
+  -- (ir.rs: Output; named `circuit-output` here so that `output` is free
+  -- as a per-instruction output-register binder.)
+  circuit-output
+    : (vals : List Operand)
+    → Instruction
+
+------------------------------------------------------------------------
+-- Circuit source  (ir.rs: IrSource)
+------------------------------------------------------------------------
+
+record IrSource : Set where
+  constructor mk-ir-source
+  field
+    version                       : IrMinorVersion
+    inputs                        : List TypedIdentifier
+    outputs                       : List IrType
+    do-communications-commitment  : Bool
+    instructions                  : List Instruction

--- a/formal/src/zkir-v3/Types.agda
+++ b/formal/src/zkir-v3/Types.agda
@@ -1,0 +1,119 @@
+{-# OPTIONS --safe #-}
+open import zkir-v3.Assumptions
+
+------------------------------------------------------------------------
+-- Types and values of zkir-v3  (ir_types.rs)
+--
+-- The IR's type set, the off-circuit value domain `IrValue`, the
+-- per-type encoding width, and the value→type and default-value maps.
+------------------------------------------------------------------------
+
+module zkir-v3.Types (⋯ : _) (open Assumptions ⋯) where
+
+open import Data.Nat using (ℕ)
+open import Relation.Binary.Definitions using (DecidableEquality)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Nullary using (yes; no)
+
+------------------------------------------------------------------------
+-- Types  (ir_types.rs: IrType)
+------------------------------------------------------------------------
+
+data IrType : Set where
+  native        : IrType   -- Scalar<BLS12-381>
+  bytes32       : IrType   -- Bytes<32>
+  jubjub-point  : IrType   -- Point<Jubjub>
+  jubjub-scalar : IrType   -- Scalar<Jubjub>
+  secp-point    : IrType   -- Point<Secp256k1>
+  secp-base     : IrType   -- Base<Secp256k1>
+  secp-scalar   : IrType   -- Scalar<Secp256k1>
+
+-- Number of raw Fr elements needed to encode a value of this type
+-- (ir_types.rs: IrType::encoded_len).
+encoded-len : IrType → ℕ
+encoded-len native        = 1
+encoded-len bytes32       = 2
+encoded-len jubjub-point  = 2
+encoded-len jubjub-scalar = 1
+encoded-len secp-point    = 5
+encoded-len secp-base     = 2
+encoded-len secp-scalar   = 2
+
+------------------------------------------------------------------------
+-- Off-circuit values  (ir_types.rs: IrValue)
+--
+-- Constructors carry the concrete carrier; they are named distinctly
+-- from the `IrType` tags to avoid overloading.
+------------------------------------------------------------------------
+
+data IrValue : Set where
+  val-native        : Fr           → IrValue
+  val-bytes32       : Bytes32      → IrValue
+  val-jubjub-point  : JubjubPoint  → IrValue
+  val-jubjub-scalar : JubjubScalar → IrValue
+  val-secp-point    : SecpPoint    → IrValue
+  val-secp-base     : SecpBase     → IrValue
+  val-secp-scalar   : SecpScalar   → IrValue
+
+-- The type of a value  (ir_types.rs: IrValue::get_type).
+typeof : IrValue → IrType
+typeof (val-native        _) = native
+typeof (val-bytes32       _) = bytes32
+typeof (val-jubjub-point  _) = jubjub-point
+typeof (val-jubjub-scalar _) = jubjub-scalar
+typeof (val-secp-point    _) = secp-point
+typeof (val-secp-base     _) = secp-base
+typeof (val-secp-scalar   _) = secp-scalar
+
+-- Decidable equality of types (used by the type checks of `cond-select`
+-- and the `output` terminator).
+_≟T_ : DecidableEquality IrType
+native        ≟T native        = yes refl
+native        ≟T bytes32       = no (λ ())
+native        ≟T jubjub-point  = no (λ ())
+native        ≟T jubjub-scalar = no (λ ())
+native        ≟T secp-point    = no (λ ())
+native        ≟T secp-base     = no (λ ())
+native        ≟T secp-scalar   = no (λ ())
+bytes32       ≟T native        = no (λ ())
+bytes32       ≟T bytes32       = yes refl
+bytes32       ≟T jubjub-point  = no (λ ())
+bytes32       ≟T jubjub-scalar = no (λ ())
+bytes32       ≟T secp-point    = no (λ ())
+bytes32       ≟T secp-base     = no (λ ())
+bytes32       ≟T secp-scalar   = no (λ ())
+jubjub-point  ≟T native        = no (λ ())
+jubjub-point  ≟T bytes32       = no (λ ())
+jubjub-point  ≟T jubjub-point  = yes refl
+jubjub-point  ≟T jubjub-scalar = no (λ ())
+jubjub-point  ≟T secp-point    = no (λ ())
+jubjub-point  ≟T secp-base     = no (λ ())
+jubjub-point  ≟T secp-scalar   = no (λ ())
+jubjub-scalar ≟T native        = no (λ ())
+jubjub-scalar ≟T bytes32       = no (λ ())
+jubjub-scalar ≟T jubjub-point  = no (λ ())
+jubjub-scalar ≟T jubjub-scalar = yes refl
+jubjub-scalar ≟T secp-point    = no (λ ())
+jubjub-scalar ≟T secp-base     = no (λ ())
+jubjub-scalar ≟T secp-scalar   = no (λ ())
+secp-point    ≟T native        = no (λ ())
+secp-point    ≟T bytes32       = no (λ ())
+secp-point    ≟T jubjub-point  = no (λ ())
+secp-point    ≟T jubjub-scalar = no (λ ())
+secp-point    ≟T secp-point    = yes refl
+secp-point    ≟T secp-base     = no (λ ())
+secp-point    ≟T secp-scalar   = no (λ ())
+secp-base     ≟T native        = no (λ ())
+secp-base     ≟T bytes32       = no (λ ())
+secp-base     ≟T jubjub-point  = no (λ ())
+secp-base     ≟T jubjub-scalar = no (λ ())
+secp-base     ≟T secp-point    = no (λ ())
+secp-base     ≟T secp-base     = yes refl
+secp-base     ≟T secp-scalar   = no (λ ())
+secp-scalar   ≟T native        = no (λ ())
+secp-scalar   ≟T bytes32       = no (λ ())
+secp-scalar   ≟T jubjub-point  = no (λ ())
+secp-scalar   ≟T jubjub-scalar = no (λ ())
+secp-scalar   ≟T secp-point    = no (λ ())
+secp-scalar   ≟T secp-base     = no (λ ())
+secp-scalar   ≟T secp-scalar   = yes refl


### PR DESCRIPTION
## What this is

A machine-checked **Agda mechanisation of the ZKIR v3 specification**
(`formal/docs/zkir-v3-spec.md`, companion PR #667), added under
`formal/src/zkir-v3/`, covering the **full seven-type surface** (`Native`,
`JubjubPoint`/`JubjubScalar`, `Bytes32`, `Secp256k1Point`/`Base`/`Scalar`)
and all 34 instructions. It typechecks under Agda's `--safe` flag with **no
postulates**; everything the development does not prove is collected in a
single `Assumptions` record (`zkir-v3/Assumptions.agda`) and taken as a
module parameter.

Also included: **`formal/docs/zkir-v3-divergence-review.md`** — a review,
addressed directly to the `zkir-v3` implementation team, of every place the
mechanisation's proof obligations flagged a spot where the in-circuit
constraint system enforces strictly less than the off-circuit interpreter.
Most such spots turned out to already be enforced in the real circuit; the
memo reports the ones that are genuine divergences (e.g. `ReconstituteField`
wrap-around, the Secp256k1 non-canonical-decode gap), each with an assessment
and a suggested action.

## What is proven

Over the preprocess semantics and an abstract constraint-level model of the
synthesised Halo2 circuit, for all seven types and all 34 instructions:

- **P5, faithfulness**, both directions (`CircuitFaithfulness.agda` /
  `CircuitBackward.agda`, combined in `CircuitProof.agda`): preprocess
  acceptance ⇔ the synthesised constraints are satisfied by the run's
  witness.
- **Statement soundness** (`StatementSoundness.agda`): for a source
  discharging the producer obligations, every satisfying witness agrees
  with the canonical witness of a genuine preprocess run on the public
  inputs, every cell the run binds, and (when enabled) the commitment
  randomness.
- **Extractor completeness** and **extraction uniqueness**
  (`StatementUniqueness.agda`): the realising preimage/run is unique
  whenever the commitment flag state matches, making extraction a function
  of the witness.
- The producer obligations (O1–O4) as **decidable, runnable checkers**
  (`Obligations.agda`), not just existence proofs.

## What is *not* covered

- **The trust base** (`Assumptions.agda`): chip primitives (Poseidon,
  SHA-256, Keccak-256, hash-to-curve, the curve group laws, the per-type
  encoders), taken as assumed rather than derived from a concrete Halo2
  backend instantiation.
- **Type surface added after the pin.** `zkir-v3` has since gained
  Secp256r1 (P256) and Curve25519 support; this mechanisation, like its
  companion spec, covers the seven types at the pin (`a1d1611c`) only.
  Flagged here, not silently — extending coverage is follow-up work.
- **One genuine soundness gap, by design:** the Secp256k1 decoder's
  handling of non-canonical limb encodings is *stricter in the trust base
  than in the deployed code* (§8.6/§9 of the spec, finding 5 of the
  divergence review) — a documented, deliberate divergence rather than an
  oversight, with its protocol-level blast radius scoped in both documents.

## Layout and CI

- `formal/src/zkir-v3/` — the development; `Main.agda` imports every
  module. See `zkir-v3/README.md` for the module map and result inventory.
- `formal/src/flake.nix` — self-contained Agda toolchain, independent of
  the workspace flake.
- `.github/workflows/agda.yml` — typechecks `Main.agda`, **path-filtered to
  `formal/**`** so it never runs on Rust-only PRs. A cold check takes a few
  minutes.

```sh
cd formal/src
nix run .#agda -- zkir-v3/Main.agda
```

## How to review

1. `Assumptions.agda` — is everything in the trusted base acceptable to
   assume?
2. The *definitions* (`Types.agda`, `Syntax.agda`, `Semantics.agda`,
   `Circuit.agda`, `Obligations.agda`) — do they model what the spec (and
   the Rust) says?
3. The theorem *statements* in `StatementSoundness.agda`,
   `StatementUniqueness.agda` — are they the claims we want?
4. **`zkir-v3-divergence-review.md`** independently of the Agda — its
   findings are actionable regardless of whether the mechanisation itself
   gets a deep review.

The proofs in between are checked by Agda itself under `--safe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
