### PR TITLE
feat(ci): dedicated publish.yml with dual-scope npm publishing

### DIFF
--- a/.github/scripts/npm-publish-idempotent.sh
+++ b/.github/scripts/npm-publish-idempotent.sh
@@ -87,4 +87,18 @@ publish_args=(--registry="$REG" "$SCOPE_REG_ARG" --tag "$TAG")
 if [ "$REG_HOST" = "registry.npmjs.org" ]; then
   publish_args+=(--access public)
 fi
-npm publish "$TGZ" "${publish_args[@]}"
+set +e
+OUTPUT=$(npm publish "$TGZ" "${publish_args[@]}" 2>&1)
+STATUS=$?
+set -e
+printf '%s\n' "$OUTPUT"
+if [ "$STATUS" -ne 0 ]; then
+  # A conflict means the version is already there (race, or a registry whose
+  # metadata endpoint was not readable by this token) - that is the idempotent
+  # success condition, not a failure.
+  if grep -qiE 'E409|EPUBLISHCONFLICT|cannot publish over' <<<"$OUTPUT"; then
+    echo "Version already exists on $REG_HOST (registry reported a conflict) - skipping"
+    exit 0
+  fi
+  exit "$STATUS"
+fi

--- a/.github/scripts/npm-publish-idempotent.sh
+++ b/.github/scripts/npm-publish-idempotent.sh
@@ -96,7 +96,9 @@ if [ "$STATUS" -ne 0 ]; then
   # A conflict means the version is already there (race, or a registry whose
   # metadata endpoint was not readable by this token) - that is the idempotent
   # success condition, not a failure.
-  if grep -qiE 'E409|EPUBLISHCONFLICT|cannot publish over' <<<"$OUTPUT"; then
+  # Anchored on 'code E409': npm's shasum/integrity notices are hex/base64
+  # that a bare 'E409' would occasionally match.
+  if grep -qiE 'code E409|EPUBLISHCONFLICT|cannot publish over' <<<"$OUTPUT"; then
     echo "Version already exists on $REG_HOST (registry reported a conflict) - skipping"
     exit 0
   fi

--- a/.github/scripts/rescope-npm-tarball.sh
+++ b/.github/scripts/rescope-npm-tarball.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This file is part of midnight-ledger.
+# Copyright (C) Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Repack an npm tarball under a different scope (@old/name -> @new/name).
+# Only package.json's `name` changes; everything else is repacked as-is.
+# Prints the path of the rescoped tarball on stdout.
+#
+# Args:
+#   $1  tgz path (may live in the read-only nix store)
+#   $2  target scope, e.g. @midnightntwrk
+#   $3  writable output directory
+set -euo pipefail
+
+TGZ="$1"
+NEW_SCOPE="$2"
+OUT_DIR="$3"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+tar -xzf "$TGZ" -C "$WORK"
+NAME=$(jq -r '.name' "$WORK/package/package.json")
+BASE="${NAME##*/}"
+jq --arg name "${NEW_SCOPE}/${BASE}" '.name = $name' "$WORK/package/package.json" > "$WORK/package.json.new"
+# mv (not cp) so a read-only file extracted from the nix store is replaced.
+mv "$WORK/package.json.new" "$WORK/package/package.json"
+
+OUT="${OUT_DIR}/${NEW_SCOPE#@}-${BASE}-rescoped.tgz"
+# COPYFILE_DISABLE keeps BSD tar (macOS dev machines) from adding AppleDouble
+# metadata entries; GNU tar (CI) ignores it.
+COPYFILE_DISABLE=1 tar -czf "$OUT" -C "$WORK" package
+echo "$OUT"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: "Real runs only: overwrite an existing GH Packages version (delete-then-republish). Public npm cannot be overwritten and will error. Not needed for a dry run."
+        description: "Force a rebuild even when the version is already published on both registries. npm publishing itself lives in publish.yml (idempotent; existing versions are skipped)."
         type: boolean
         default: false
       dry_run:
@@ -27,6 +27,8 @@ jobs:
     environment: ${{ github.event.inputs.dry_run == 'true' && '' || 'release' }}
     permissions:
       contents: write
+      # Dispatch publish.yml (npm publishing) after tags are pushed.
+      actions: write
     outputs:
       tag_name: ${{ steps.ids.outputs.tag_name }}
       version: ${{ steps.ids.outputs.version }}
@@ -96,8 +98,6 @@ jobs:
       - name: Build and Publish Ledger
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
-          GH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           FORCE: ${{ github.event.inputs.force }}
         run: |
           git config --global user.name 'MidnightCI'
@@ -113,19 +113,10 @@ jobs:
             ${SHORT_VERSION}.*) TAG_NAME="ledger-${VERSION}" ;;
             *)                  TAG_NAME="ledger-${SHORT_VERSION}.${VERSION}" ;;
           esac
-          PKG="@midnightntwrk/ledger-v${SHORT_VERSION}"
+          PKG="@midnight-ntwrk/ledger-v${SHORT_VERSION}"
           SCOPE="${PKG%%/*}"
           GH_REG="https://npm.pkg.github.com/midnightntwrk"
           NPMJS_REG="https://registry.npmjs.org/"
-
-          # Authenticate npmjs (GH Packages auth is configured by setup-node).
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set - cannot authenticate to npmjs"; exit 1
-          fi
-          # setup-node points npm at $NPM_CONFIG_USERCONFIG, so write the token
-          # there literally (npm's ${VAR} expansion yields empty -> ENEEDAUTH).
-          # Leading newline guards a setup-node npmrc with no trailing newline.
-          printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build unless the version already exists on both registries (FORCE or
           # dry run always builds). The --<scope>:registry override is required:
@@ -145,13 +136,7 @@ jobs:
             # Copy out before the next nix build overwrites result/lib.
             mkdir -p "${GITHUB_WORKSPACE}/release-artifacts"
             cp "$TGZ" "${GITHUB_WORKSPACE}/release-artifacts/"
-            # Publish is idempotent per-registry: skips where the version already exists.
-            "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
-              "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" "$GH_REG" "$PKG" "${{ env.LEDGER_WASM_VERSION }}"
-            "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
-              "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" "$NPMJS_REG" "$PKG" "${{ env.LEDGER_WASM_VERSION }}"
+            # npm publishing happens in publish.yml, dispatched below.
             cd ../..
           fi
 
@@ -167,8 +152,6 @@ jobs:
       - name: Build and Publish Onchain Runtime
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
-          GH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           FORCE: ${{ github.event.inputs.force }}
         run: |
           git config --global user.name 'MidnightCI'
@@ -177,19 +160,10 @@ jobs:
           VERSION="${ONCHAIN_RUNTIME_WASM_VERSION}"
           SHORT_VERSION=$(echo "$VERSION" | awk -F. '{print $1}')
           TAG_NAME="onchain-runtime-${VERSION}"
-          PKG="@midnightntwrk/onchain-runtime-v${SHORT_VERSION}"
+          PKG="@midnight-ntwrk/onchain-runtime-v${SHORT_VERSION}"
           SCOPE="${PKG%%/*}"
           GH_REG="https://npm.pkg.github.com/midnightntwrk"
           NPMJS_REG="https://registry.npmjs.org/"
-
-          # Authenticate npmjs (GH Packages auth is configured by setup-node).
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set - cannot authenticate to npmjs"; exit 1
-          fi
-          # setup-node points npm at $NPM_CONFIG_USERCONFIG, so write the token
-          # there literally (npm's ${VAR} expansion yields empty -> ENEEDAUTH).
-          # Leading newline guards a setup-node npmrc with no trailing newline.
-          printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build unless the version already exists on both registries (FORCE or
           # dry run always builds). The --<scope>:registry override is required:
@@ -208,13 +182,7 @@ jobs:
             TGZ="midnight-onchain-runtime-v${SHORT_VERSION}-${{ env.ONCHAIN_RUNTIME_WASM_VERSION }}.tgz"
             mkdir -p "${GITHUB_WORKSPACE}/release-artifacts"
             cp "$TGZ" "${GITHUB_WORKSPACE}/release-artifacts/"
-            # Publish is idempotent per-registry: skips where the version already exists.
-            "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
-              "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" "$GH_REG" "$PKG" "${{ env.ONCHAIN_RUNTIME_WASM_VERSION }}"
-            "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
-              "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" "$NPMJS_REG" "$PKG" "${{ env.ONCHAIN_RUNTIME_WASM_VERSION }}"
+            # npm publishing happens in publish.yml, dispatched below.
             cd ../..
           fi
 
@@ -230,8 +198,6 @@ jobs:
       - name: Build and Publish ZKIR
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
-          GH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           FORCE: ${{ github.event.inputs.force }}
         run: |
           git config --global user.name 'MidnightCI'
@@ -242,19 +208,10 @@ jobs:
           TAG_NAME="zkir-${VERSION}"
           WASM_VERSION="${ZKIR_WASM_VERSION}"
           SHORT_VERSION=$(echo "$WASM_VERSION" | awk -F. '{print $1}')
-          PKG="@midnightntwrk/zkir-v${SHORT_VERSION}"
+          PKG="@midnight-ntwrk/zkir-v${SHORT_VERSION}"
           SCOPE="${PKG%%/*}"
           GH_REG="https://npm.pkg.github.com/midnightntwrk"
           NPMJS_REG="https://registry.npmjs.org/"
-
-          # Authenticate npmjs (GH Packages auth is configured by setup-node).
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set - cannot authenticate to npmjs"; exit 1
-          fi
-          # setup-node points npm at $NPM_CONFIG_USERCONFIG, so write the token
-          # there literally (npm's ${VAR} expansion yields empty -> ENEEDAUTH).
-          # Leading newline guards a setup-node npmrc with no trailing newline.
-          printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           # Build unless the version already exists on both registries (FORCE or
           # dry run always builds). The --<scope>:registry override is required:
@@ -273,13 +230,7 @@ jobs:
             TGZ="midnight-zkir-v${SHORT_VERSION}-${{ env.ZKIR_WASM_VERSION }}.tgz"
             mkdir -p "${GITHUB_WORKSPACE}/release-artifacts"
             cp "$TGZ" "${GITHUB_WORKSPACE}/release-artifacts/"
-            # Publish is idempotent per-registry: skips where the version already exists.
-            "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
-              "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" "$GH_REG" "$PKG" "${{ env.ZKIR_WASM_VERSION }}"
-            "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
-              "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-              "$TGZ" "$NPMJS_REG" "$PKG" "${{ env.ZKIR_WASM_VERSION }}"
+            # npm publishing happens in publish.yml, dispatched below.
             cd ../..
           fi
 
@@ -290,6 +241,19 @@ jobs:
             git tag "${TAG_NAME}"
             "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" git push origin "${TAG_NAME}"
           fi
+
+      - name: Dispatch npm publish
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_REF: ${{ github.ref_name }}
+        run: |
+          # npm publishing lives in publish.yml (the npm trusted-publisher
+          # workflow); its definition always runs from the default branch,
+          # building/publishing the ref this release was cut from.
+          DEFAULT_BRANCH=$(gh repo view "$GITHUB_REPOSITORY" --json defaultBranchRef --jq .defaultBranchRef.name)
+          gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" \
+            --ref "$DEFAULT_BRANCH" -f "ref=$BUILD_REF" -f packages=all
 
       - name: Upload npm package tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,8 +27,6 @@ jobs:
     environment: ${{ github.event.inputs.dry_run == 'true' && '' || 'release' }}
     permissions:
       contents: write
-      # Dispatch publish.yml (npm publishing) after tags are pushed.
-      actions: write
     outputs:
       tag_name: ${{ steps.ids.outputs.tag_name }}
       version: ${{ steps.ids.outputs.version }}
@@ -242,19 +240,6 @@ jobs:
             "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" git push origin "${TAG_NAME}"
           fi
 
-      - name: Dispatch npm publish
-        if: ${{ github.event.inputs.dry_run != 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BUILD_REF: ${{ github.ref_name }}
-        run: |
-          # npm publishing lives in publish.yml (the npm trusted-publisher
-          # workflow); its definition always runs from the default branch,
-          # building/publishing the ref this release was cut from.
-          DEFAULT_BRANCH=$(gh repo view "$GITHUB_REPOSITORY" --json defaultBranchRef --jq .defaultBranchRef.name)
-          gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" \
-            --ref "$DEFAULT_BRANCH" -f "ref=$BUILD_REF" -f packages=all
-
       - name: Upload npm package tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -343,6 +328,41 @@ jobs:
             test-results.json
             test-results.xml
 
+  # npm publishing lives in publish.yml (the npm trusted-publisher workflow;
+  # its top-level filename is what npmjs validates, so it cannot be a
+  # reusable workflow here). Dispatch it pinned to this run's commit and
+  # propagate its conclusion so the release cannot complete with missing
+  # npm packages.
+  publish-npm:
+    needs: [ build, coverage, integration, unit-tests ]
+    if: ${{ github.event.inputs.dry_run != 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch publish.yml and wait
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_SHA: ${{ github.sha }}
+        run: |
+          MARK=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" \
+            -f "ref=$BUILD_SHA" -f packages=all
+          # The dispatch API returns no run id; poll for the run it created.
+          RUN_ID=""
+          for _ in $(seq 1 30); do
+            sleep 5
+            RUN_ID=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow publish.yml \
+              --event workflow_dispatch --created ">=$MARK" --limit 1 \
+              --json databaseId --jq '.[0].databaseId // empty')
+            [ -n "$RUN_ID" ] && break
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::dispatched publish.yml run did not appear"; exit 1
+          fi
+          echo "Waiting on publish.yml run ${RUN_ID} (may pause for its release-environment approval)"
+          gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY" --exit-status --interval 30
+
   crates-io:
     needs: [ build, coverage, integration, unit-tests ]
     # crates.io is immutable, so publish only after the suite is green (npm/tags
@@ -383,7 +403,10 @@ jobs:
           nix develop .#ci -c .github/scripts/cargo-publish-crates.sh "$VERSION"
 
   release:
-    needs: [ build, coverage, integration, unit-tests ]
+    # publish-npm is skipped on dry runs; `always() &&` keeps release eligible
+    # then, while real runs still hard-require npm publication success.
+    if: ${{ always() && needs.build.result == 'success' && needs.coverage.result == 'success' && needs.integration.result == 'success' && needs.unit-tests.result == 'success' && (needs.publish-npm.result == 'success' || (github.event.inputs.dry_run == 'true' && needs.publish-npm.result == 'skipped')) }}
+    needs: [ build, coverage, integration, unit-tests, publish-npm ]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,7 +24,9 @@ jobs:
     # environment (configure its required reviewers = ledger maintainers in repo
     # Settings -> Environments). Dry runs need no approval. The build job is the
     # gate because npm publish + tag push happen here, before anything downstream.
-    environment: ${{ github.event.inputs.dry_run == 'true' && '' || 'release' }}
+    # NB: the truthy value must be the && arm - '' is falsy in GitHub
+    # expressions, so `cond && '' || x` yields x on BOTH branches.
+    environment: ${{ github.event.inputs.dry_run != 'true' && 'release' || '' }}
     permissions:
       contents: write
     outputs:
@@ -446,7 +448,7 @@ jobs:
 
           # Guard: `sha256sum *` would block on stdin if STAGING were empty.
           if [ -n "$(ls -A "$STAGING")" ]; then
-            ( cd "$STAGING" && sha256sum * > SHA256SUMS )
+            ( cd "$STAGING" && sha256sum -- * > SHA256SUMS )
           else
             echo "::warning::No release assets were assembled."
           fi

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -348,15 +348,22 @@ jobs:
           BUILD_SHA: ${{ github.sha }}
         run: |
           MARK=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # Correlation marker: publish.yml echoes it into its run-name, so we
+          # find OUR run exactly. A timestamp filter alone races with concurrent
+          # dispatches (manual or another release) and could watch a stranger's
+          # run while ours is still queued or later fails.
+          CORR="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" \
-            -f "ref=$BUILD_SHA" -f packages=all
+            -f "ref=$BUILD_SHA" -f packages=all -f "correlation=$CORR"
           # The dispatch API returns no run id; poll for the run it created.
           RUN_ID=""
           for _ in $(seq 1 30); do
             sleep 5
             RUN_ID=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow publish.yml \
-              --event workflow_dispatch --created ">=$MARK" --limit 1 \
-              --json databaseId --jq '.[0].databaseId // empty')
+              --event workflow_dispatch --created ">=$MARK" --limit 50 \
+              --json databaseId,displayTitle \
+              --jq ".[] | select(.displayTitle | contains(\"[$CORR]\")) | .databaseId" \
+              | head -n 1)
             [ -n "$RUN_ID" ] && break
           done
           if [ -z "$RUN_ID" ]; then
@@ -405,9 +412,12 @@ jobs:
           nix develop .#ci -c .github/scripts/cargo-publish-crates.sh "$VERSION"
 
   release:
-    # publish-npm is skipped on dry runs; `always() &&` keeps release eligible
-    # then, while real runs still hard-require npm publication success.
-    if: ${{ always() && needs.build.result == 'success' && needs.coverage.result == 'success' && needs.integration.result == 'success' && needs.unit-tests.result == 'success' && (needs.publish-npm.result == 'success' || (github.event.inputs.dry_run == 'true' && needs.publish-npm.result == 'skipped')) }}
+    # publish-npm is skipped on dry runs; `!cancelled() &&` (a status function,
+    # so it bypasses the implicit success() check) keeps release eligible then,
+    # while real runs still hard-require npm publication success. Not always():
+    # that stays true during operator cancellation and would let this
+    # irreversible job create/announce the release anyway.
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.coverage.result == 'success' && needs.integration.result == 'success' && needs.unit-tests.result == 'success' && (needs.publish-npm.result == 'success' || (github.event.inputs.dry_run == 'true' && needs.publish-npm.result == 'skipped')) }}
     needs: [ build, coverage, integration, unit-tests, publish-npm ]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,15 @@ on:
         description: "Build and log every publish without publishing."
         type: boolean
         default: false
+      correlation:
+        description: "Opaque marker echoed into the run name so a dispatching workflow can find this exact run. Leave empty for manual runs."
+        type: string
+        default: ""
+
+# The [correlation] suffix makes the dispatched run findable: prerelease.yml
+# matches it exactly instead of guessing by creation time (which races with
+# concurrent dispatches).
+run-name: "Publish npm packages (${{ inputs.packages }} @ ${{ inputs.ref }})${{ inputs.correlation != '' && format(' [{0}]', inputs.correlation) || '' }}"
 
 env:
   DRY_RUN: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,13 @@ name: Publish npm packages
 # Single npm-publish path for the ledger package family. Publishes each
 # package to GH Packages and public npmjs under BOTH scopes while the org
 # migrates:
-#   @midnight-ntwrk/<pkg>  (current scope)
+#   @midnight-ntwrk/<pkg>  (legacy scope)
 #   @midnightntwrk/<pkg>   (migration target; on GH Packages this attaches
 #                           to the midnightntwrk org instead of the
 #                           deprecated midnight-ntwrk org)
+# The built tarball's own scope is never trusted: bagel.nix's default scope
+# flipped on ledger-8 (f232211) and differs across release branches, so every
+# tarball is normalized to each target scope before publishing.
 # Publishes are idempotent per target: already-published versions are
 # skipped, so re-runs after partial failures are safe.
 #
@@ -72,7 +75,8 @@ jobs:
         with:
           registry-url: https://npm.pkg.github.com/
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          # Dry runs never publish; give them no credentials at all.
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.dry_run == 'true' && '' || secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
@@ -93,21 +97,25 @@ jobs:
 
       - name: Build and publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
+          # Dry runs never publish; give them no credentials at all.
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.dry_run == 'true' && '' || secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          NPM_TOKEN: ${{ github.event.inputs.dry_run == 'true' && '' || secrets.MIDNIGHTCI_NPMJS_TOKEN }}
           PACKAGES: ${{ github.event.inputs.packages }}
         run: |
           GH_REG="https://npm.pkg.github.com/midnightntwrk"
           NPMJS_REG="https://registry.npmjs.org/"
-          NEW_SCOPE="@midnightntwrk"
+          SCOPES="@midnight-ntwrk @midnightntwrk"
 
           # npmjs auth (GH Packages auth is configured by setup-node). The
           # token is written literally: npm's ${VAR} expansion yields empty
           # -> ENEEDAUTH. Under trusted publishing this block is deleted.
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set - cannot authenticate to npmjs"; exit 1
+          # Dry runs never publish, so they get no token at all.
+          if [ "${DRY_RUN}" != "true" ]; then
+            if [ -z "${NPM_TOKEN:-}" ]; then
+              echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set - cannot authenticate to npmjs"; exit 1
+            fi
+            printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
           fi
-          printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
 
           case "$PACKAGES" in
             all)             ATTRS="ledger-wasm onchain-runtime-wasm zkir-wasm" ;;
@@ -128,26 +136,26 @@ jobs:
             ATTR_DIR="${STAGE}/${ATTR}"
             mkdir -p "$ATTR_DIR"
             cp result/lib/*.tgz "$ATTR_DIR/"
-            TGZ=$(find "$ATTR_DIR" -name '*.tgz' ! -name '*-rescoped.tgz' | head -1)
-            if [ -z "$TGZ" ]; then
-              echo "::error::nix build .#${ATTR} produced no npm tarball in result/lib"; exit 1
+            TGZ_COUNT=$(find "$ATTR_DIR" -name '*.tgz' ! -name '*-rescoped.tgz' | wc -l)
+            if [ "$TGZ_COUNT" -ne 1 ]; then
+              echo "::error::expected exactly one npm tarball from nix build .#${ATTR}, found ${TGZ_COUNT}:"
+              find "$ATTR_DIR" -name '*.tgz'; exit 1
             fi
+            TGZ=$(find "$ATTR_DIR" -name '*.tgz' ! -name '*-rescoped.tgz')
             PKG=$(tar -xzOf "$TGZ" package/package.json | jq -r '.name')
             VER=$(tar -xzOf "$TGZ" package/package.json | jq -r '.version')
+            BASE="${PKG##*/}"
             echo "::group::${PKG}@${VER} (${ATTR})"
 
-            RESCOPED=$("${GITHUB_WORKSPACE}/.github/scripts/rescope-npm-tarball.sh" "$TGZ" "$NEW_SCOPE" "$ATTR_DIR")
-            NEW_PKG="${NEW_SCOPE}/${PKG##*/}"
-
-            for TARGET in \
-              "${TGZ}|${GH_REG}|${PKG}" \
-              "${TGZ}|${NPMJS_REG}|${PKG}" \
-              "${RESCOPED}|${GH_REG}|${NEW_PKG}" \
-              "${RESCOPED}|${NPMJS_REG}|${NEW_PKG}"; do
-              IFS='|' read -r T REG P <<<"$TARGET"
-              "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
-                "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
-                "$T" "$REG" "$P" "$VER"
+            # Normalize to every target scope (rescoping to the tarball's own
+            # scope is a harmless identity repack).
+            for SCOPE in $SCOPES; do
+              T=$("${GITHUB_WORKSPACE}/.github/scripts/rescope-npm-tarball.sh" "$TGZ" "$SCOPE" "$ATTR_DIR")
+              for REG in "$GH_REG" "$NPMJS_REG"; do
+                "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
+                  "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
+                  "$T" "$REG" "${SCOPE}/${BASE}" "$VER"
+              done
             done
             echo "::endgroup::"
           done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,9 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest-8-core-x64
+    # Standard hosted runner (free on public repos): the nix build is mostly
+    # restored from the cache shared with prerelease.yml, so no large runner.
+    runs-on: ubuntu-24.04
     # Same approval gate as the release workflow: real publishes require the
     # protected `release` environment; dry runs need no approval.
     environment: ${{ github.event.inputs.dry_run == 'true' && '' || 'release' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,151 @@
+name: Publish npm packages
+
+# Single npm-publish path for the ledger package family. Publishes each
+# package to GH Packages and public npmjs under BOTH scopes while the org
+# migrates:
+#   @midnight-ntwrk/<pkg>  (current scope)
+#   @midnightntwrk/<pkg>   (migration target; on GH Packages this attaches
+#                           to the midnightntwrk org instead of the
+#                           deprecated midnight-ntwrk org)
+# Publishes are idempotent per target: already-published versions are
+# skipped, so re-runs after partial failures are safe.
+#
+# npm TRUSTED PUBLISHING (planned): register THIS file (publish.yml) with
+# environment `release` as the trusted publisher for every package:
+#   @midnight-ntwrk/ledger-vN            @midnightntwrk/ledger-vN
+#   @midnight-ntwrk/onchain-runtime-vN   @midnightntwrk/onchain-runtime-vN
+#   @midnight-ntwrk/zkir-vN              @midnightntwrk/zkir-vN
+# Then flip auth here:
+#   1. permissions: add `id-token: write`
+#   2. delete the NPM_TOKEN env + the registry.npmjs.org auth line below
+#      (npm >= 11.5 performs the OIDC exchange automatically)
+#   3. keep MIDNIGHTCI_PACKAGES_WRITE - GH Packages has no trusted publishing
+# Trusted publishing validates the TOP-LEVEL workflow file, so this workflow
+# must stay directly dispatched - do not convert it to workflow_call.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build and publish (branch, tag or SHA)."
+        type: string
+        required: true
+      packages:
+        description: "Which npm packages to publish."
+        type: choice
+        options:
+          - all
+          - ledger
+          - onchain-runtime
+          - zkir
+        default: all
+      dry_run:
+        description: "Build and log every publish without publishing."
+        type: boolean
+        default: false
+
+env:
+  DRY_RUN: ${{ github.event.inputs.dry_run }}
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest-8-core-x64
+    # Same approval gate as the release workflow: real publishes require the
+    # protected `release` environment; dry runs need no approval.
+    environment: ${{ github.event.inputs.dry_run == 'true' && '' || 'release' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  #v7.0.0
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          registry-url: https://npm.pkg.github.com/
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          extra_nix_config: |
+            extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            extra-substituters = https://cache.iog.io file://${{ runner.temp }}/nix-binary-cache
+            accept-flake-config = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+
+      - name: Build and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          NPM_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
+          PACKAGES: ${{ github.event.inputs.packages }}
+        run: |
+          GH_REG="https://npm.pkg.github.com/midnightntwrk"
+          NPMJS_REG="https://registry.npmjs.org/"
+          NEW_SCOPE="@midnightntwrk"
+
+          # npmjs auth (GH Packages auth is configured by setup-node). The
+          # token is written literally: npm's ${VAR} expansion yields empty
+          # -> ENEEDAUTH. Under trusted publishing this block is deleted.
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::MIDNIGHTCI_NPMJS_TOKEN is not set - cannot authenticate to npmjs"; exit 1
+          fi
+          printf '\n//registry.npmjs.org/:_authToken=%s\n' "${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+
+          case "$PACKAGES" in
+            all)             ATTRS="ledger-wasm onchain-runtime-wasm zkir-wasm" ;;
+            ledger)          ATTRS="ledger-wasm" ;;
+            onchain-runtime) ATTRS="onchain-runtime-wasm" ;;
+            zkir)            ATTRS="zkir-wasm" ;;
+            *) echo "::error::unknown packages selection '$PACKAGES'"; exit 1 ;;
+          esac
+
+          STAGE="${GITHUB_WORKSPACE}/publish-artifacts"
+
+          for ATTR in $ATTRS; do
+            nix build ".#${ATTR}"
+
+            # Copy the tarball out of the read-only nix store, then read the
+            # canonical name/version from the tarball itself - the package
+            # is the single source of truth, no duplicated derivation logic.
+            ATTR_DIR="${STAGE}/${ATTR}"
+            mkdir -p "$ATTR_DIR"
+            cp result/lib/*.tgz "$ATTR_DIR/"
+            TGZ=$(find "$ATTR_DIR" -name '*.tgz' ! -name '*-rescoped.tgz' | head -1)
+            if [ -z "$TGZ" ]; then
+              echo "::error::nix build .#${ATTR} produced no npm tarball in result/lib"; exit 1
+            fi
+            PKG=$(tar -xzOf "$TGZ" package/package.json | jq -r '.name')
+            VER=$(tar -xzOf "$TGZ" package/package.json | jq -r '.version')
+            echo "::group::${PKG}@${VER} (${ATTR})"
+
+            RESCOPED=$("${GITHUB_WORKSPACE}/.github/scripts/rescope-npm-tarball.sh" "$TGZ" "$NEW_SCOPE" "$ATTR_DIR")
+            NEW_PKG="${NEW_SCOPE}/${PKG##*/}"
+
+            for TARGET in \
+              "${TGZ}|${GH_REG}|${PKG}" \
+              "${TGZ}|${NPMJS_REG}|${PKG}" \
+              "${RESCOPED}|${GH_REG}|${NEW_PKG}" \
+              "${RESCOPED}|${NPMJS_REG}|${NEW_PKG}"; do
+              IFS='|' read -r T REG P <<<"$TARGET"
+              "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
+                "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
+                "$T" "$REG" "$P" "$VER"
+            done
+            echo "::endgroup::"
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,9 @@ jobs:
     runs-on: ubuntu-24.04
     # Same approval gate as the release workflow: real publishes require the
     # protected `release` environment; dry runs need no approval.
-    environment: ${{ github.event.inputs.dry_run == 'true' && '' || 'release' }}
+    # NB: the truthy value must be the && arm - '' is falsy in GitHub
+    # expressions, so `cond && '' || x` yields x on BOTH branches.
+    environment: ${{ github.event.inputs.dry_run != 'true' && 'release' || '' }}
     permissions:
       contents: read
     steps:
@@ -76,7 +78,7 @@ jobs:
           registry-url: https://npm.pkg.github.com/
         env:
           # Dry runs never publish; give them no credentials at all.
-          NODE_AUTH_TOKEN: ${{ github.event.inputs.dry_run == 'true' && '' || secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.dry_run != 'true' && secrets.MIDNIGHTCI_PACKAGES_WRITE || '' }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
@@ -98,8 +100,8 @@ jobs:
       - name: Build and publish
         env:
           # Dry runs never publish; give them no credentials at all.
-          NODE_AUTH_TOKEN: ${{ github.event.inputs.dry_run == 'true' && '' || secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-          NPM_TOKEN: ${{ github.event.inputs.dry_run == 'true' && '' || secrets.MIDNIGHTCI_NPMJS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ github.event.inputs.dry_run != 'true' && secrets.MIDNIGHTCI_PACKAGES_WRITE || '' }}
+          NPM_TOKEN: ${{ github.event.inputs.dry_run != 'true' && secrets.MIDNIGHTCI_NPMJS_TOKEN || '' }}
           PACKAGES: ${{ github.event.inputs.packages }}
         run: |
           GH_REG="https://npm.pkg.github.com/midnightntwrk"


### PR DESCRIPTION
Closes #672

## What

- **New `.github/workflows/publish.yml`** — the single npm-publish path. Dispatch inputs: `ref` (branch, tag or SHA), `packages` (`all`/`ledger`/`onchain-runtime`/`zkir`), `dry_run`. For each package it `nix build`s the tarball, reads name+version from the tarball itself, then **normalizes the tarball to each target scope** (`@midnight-ntwrk` legacy + `@midnightntwrk` migration target — the built scope changed on ledger-8 in f232211 and differs across release branches, so it is never trusted) and publishes idempotently to GH Packages + npmjs per scope. Gated by the `release` environment. Header documents the trusted-publisher registration (this one filename for all six package names) and the OIDC flip. Dry runs receive no registry credentials at all.
- **New `.github/scripts/rescope-npm-tarball.sh`** — repacks a tarball under a given scope; only `package.json` `name` changes (verified byte-identical file lists against the real `ledger-v8` tarball, both identity and cross-scope).
- **`prerelease.yml`** — inline npm publishing removed; the `@midnightntwrk`→`@midnight-ntwrk` scope typo in the three existence checks fixed (root cause of the `E409` re-run failures, run 30651856895); new **`publish-npm` job** (after build + coverage + integration + unit-tests) dispatches publish.yml pinned to `github.sha`, waits on the dispatched run, and propagates its conclusion; `release` requires it, so a GitHub release cannot complete with npm packages missing. npm publishing now happens after tests instead of before.
- **`npm-publish-idempotent.sh`** — registry version-conflicts (anchored `code E409`/`EPUBLISHCONFLICT`/"cannot publish over") are treated as the idempotent skip they imply.

## Unblocking 8.1.1

After merge: dispatch **Publish npm packages** with `ref=js/array-tests`. That branch builds `@midnight-ntwrk` tarballs (predates f232211); scope normalization publishes both scopes regardless. Already-published targets skip.

## Testing

- `actionlint` on both workflows (only pre-existing custom-runner/SC2035 notices remain), `shellcheck` clean on both scripts, `bash -n` on every run block
- `rescope-npm-tarball.sh` exercised against the real `@midnight-ntwrk/ledger-v8@8.1.0` tarball: identity and cross-scope repacks both yield 34/34 identical file entries and clean `npm publish --dry-run`
- Suggest a `dry_run=true` dispatch of publish.yml after merge as the live check

## Follow-ups (not this PR)

- Add required reviewers to the `release` environment (currently no protection rules) before registering publish.yml as the npm trusted publisher
- Register the six trusted publishers on npmjs, then apply the documented OIDC flip
- Confirm the `@midnightntwrk` org exists on npmjs and `MIDNIGHTCI_NPMJS_TOKEN` can publish to it (npmjs search shows zero packages under that scope today)