### PR TITLE
fix(ci): run publish helper scripts from the workflow ref, not the dispatched ref

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,14 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
 
+      - name: Checkout publish scripts (workflow ref)
+        # The checkout above is the dispatched ref, which may be a historical
+        # branch/tag that predates the helper scripts. The scripts must always
+        # come from the workflow's own commit, so check them out separately.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  #v7.0.0
+        with:
+          path: .publish-scripts
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
@@ -116,6 +124,7 @@ jobs:
           GH_REG="https://npm.pkg.github.com/midnightntwrk"
           NPMJS_REG="https://registry.npmjs.org/"
           SCOPES="@midnight-ntwrk @midnightntwrk"
+          SCRIPTS="${GITHUB_WORKSPACE}/.publish-scripts/.github/scripts"
 
           # npmjs auth (GH Packages auth is configured by setup-node). The
           # token is written literally: npm's ${VAR} expansion yields empty
@@ -161,10 +170,10 @@ jobs:
             # Normalize to every target scope (rescoping to the tarball's own
             # scope is a harmless identity repack).
             for SCOPE in $SCOPES; do
-              T=$("${GITHUB_WORKSPACE}/.github/scripts/rescope-npm-tarball.sh" "$TGZ" "$SCOPE" "$ATTR_DIR")
+              T=$("${SCRIPTS}/rescope-npm-tarball.sh" "$TGZ" "$SCOPE" "$ATTR_DIR")
               for REG in "$GH_REG" "$NPMJS_REG"; do
-                "${GITHUB_WORKSPACE}/.github/scripts/run-unless-dry.sh" \
-                  "${GITHUB_WORKSPACE}/.github/scripts/npm-publish-idempotent.sh" \
+                "${SCRIPTS}/run-unless-dry.sh" \
+                  "${SCRIPTS}/npm-publish-idempotent.sh" \
                   "$T" "$REG" "${SCOPE}/${BASE}" "$VER"
               done
             done


### PR DESCRIPTION
## Description

`publish.yml` resolves its helper scripts from `${GITHUB_WORKSPACE}`, which is the checkout of `inputs.ref`. `rescope-npm-tarball.sh` exists only on `ledger-8` — `.github/scripts/` on `js/array-tests` contains 6 files and does not include it — so a dispatch against a ref that predates #673 exits at the first rescope call, before any publish. Publishing historical refs is the workflow's stated purpose (its `ref` input and the 8.1.1 plan in #673).

This PR adds a second checkout of the workflow's own commit into `.publish-scripts/` and points the three script invocations at it. The `inputs.ref` checkout remains the build source; only where the scripts are read from changes.

Validation: `actionlint -shellcheck="" .github/workflows/publish.yml` reports no findings.

Refs #673.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [x] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [x] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.

<details><summary>🤖 Agent handover (context for reviewers)</summary>

**Files read**

- `.github/workflows/publish.yml` @ `ledger-8` (d8d38654) — single `actions/checkout` with `ref: ${{ github.event.inputs.ref }}`; script calls under `${GITHUB_WORKSPACE}/.github/scripts/`
- `.github/scripts/` listings on both branches (contents API, 2026-08-04)

**Commands run**

- `gh api "repos/midnightntwrk/midnight-ledger/contents/.github/scripts?ref=js/array-tests" --jq '.[].name'` → `cargo-publish-crates.sh, configure-cargo.sh, draft-release-bullets.sh, gh-commit.sh, npm-publish-idempotent.sh, run-unless-dry.sh`
- Same for `ref=ledger-8` → the above plus `rescope-npm-tarball.sh`
- `actionlint -shellcheck="" .github/workflows/publish.yml` → no output

**Motivating failure**

- Run 30841286183 (2026-08-03, `workflow_dispatch` on `js/array-tests`): the pre-#673 inline publish; its npmjs leg failed on `PUT https://registry.npmjs.org/@midnightntwrk%2fledger-v8` (404). The dispatch-a-historical-ref path added in #673 has not yet run against that branch.

**Docs consulted**

- #673 PR body ("After merge: dispatch Publish npm packages with ref=js/array-tests")

</details>
