### PR TITLE
chore(ci): pin npm to 12.0.2 and add supply-chain cooldown

### DIFF
--- a/.github/workflows/generate-markdown-docs.yml
+++ b/.github/workflows/generate-markdown-docs.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  #v7.0.0
 
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - name: Install dependencies
         run: |
           npm install --save-dev typedoc-plugin-markdown

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -47,7 +47,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
+
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
 
       - name: Bump crate versions
         # Pass the input via env (not inline ${{ }}) so it cannot inject shell.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,6 +52,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Supply-chain cooldown: refuse dependency versions published <7 days ago (npm 12+).
+# Own packages are exempt so same-day @midnight-ntwrk releases stay installable.
+min-release-age=7
+min-release-age-exclude[]=@midnight-ntwrk/*
+min-release-age-exclude[]=@midnightntwrk/*


### PR DESCRIPTION
Supply-chain hardening following the 2026-08-04 keyv/cacheable npm worm (868+ packages compromised via `preinstall` payloads published through legitimate maintainer accounts).

- Pin the npm CLI to 12.0.2 in CI (npm 12 blocks dependency lifecycle scripts by default behind `allowScripts`) instead of floating `npm@latest`/setup-node default
- Bump `node-version` where npm 12 requires it (engines: `^22.22.2 || ^24.15.0 || >=26`)
- Add `.npmrc` cooldown: `min-release-age=7` so freshly-published (potentially wormed) versions can't resolve for 7 days; `@midnight-ntwrk/*` and `@midnightntwrk/*` exempt so same-day internal releases still install
- Renovate: npm CLI pins in workflows/Earthfiles are matched by new custom managers in `midnightntwrk/renovate-config`, so this pin stays bumpable automatically
