### PR TITLE
ZKIR-v3: Enforce canonicity checks on `decode`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
  "ff",
  "hex",
  "midnight-curves 0.3.1",
- "midnight-proofs 0.8.1",
+ "midnight-proofs 0.8.2",
  "num-bigint",
  "rand 0.8.6",
  "serde",
@@ -1747,7 +1747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2375,7 +2375,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2615,7 +2615,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3035,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "midnight-circuits"
-version = "7.2.2"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f17609477cc373fa26e89dcc69ad5e31455dfeceedc152e926f132e37c8240f"
+checksum = "a3040d26341a9168a3db7adeb365da9b9b8e756bc911a08c5f76a6a93d441ca7"
 dependencies = [
  "base64 0.13.1",
  "ff",
@@ -3045,7 +3045,7 @@ dependencies = [
  "group",
  "lazy_static",
  "midnight-curves 0.3.1",
- "midnight-proofs 0.8.1",
+ "midnight-proofs 0.8.2",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -3380,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "midnight-proofs"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2fdf3f037284217bc19cf5678bcb82be70ca17657a336b8149bf4ca1a30c9db"
+checksum = "22b1526bc7d9d1fad29505a15b81fe54aa7698a7dcd1948b447021bc8571f543"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -3610,13 +3610,13 @@ dependencies = [
  "lru 0.18.0",
  "midnight-base-crypto",
  "midnight-base-crypto-derive 1.1.0",
- "midnight-circuits 7.2.2",
+ "midnight-circuits 7.2.4",
  "midnight-curves 0.3.1",
- "midnight-proofs 0.8.1",
+ "midnight-proofs 0.8.2",
  "midnight-serialize",
  "midnight-storage-core 1.2.0",
  "midnight-transient-crypto 3.0.0",
- "midnight-zk-stdlib 2.3.3",
+ "midnight-zk-stdlib 2.3.5",
  "pastey",
  "proptest",
  "proptest-derive",
@@ -3658,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "midnight-zk-stdlib"
-version = "2.3.3"
+version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2efda6c377c6ff82e368a72d5b237fa94971d9ed7334f13d71305ff8921801"
+checksum = "01ec8ff46d47734090358ac4dbfb444f2bfeede7cecd792225fbd9333dcf7758"
 dependencies = [
  "base64 0.13.1",
  "bincode 2.0.1",
@@ -3669,9 +3669,9 @@ dependencies = [
  "ff",
  "group",
  "hex-literal",
- "midnight-circuits 7.2.2",
+ "midnight-circuits 7.2.4",
  "midnight-curves 0.3.1",
- "midnight-proofs 0.8.1",
+ "midnight-proofs 0.8.2",
  "num-bigint",
  "num-traits",
  "rand 0.8.6",
@@ -3698,14 +3698,14 @@ dependencies = [
  "log",
  "midnight-base-crypto",
  "midnight-circuits 6.2.1",
- "midnight-circuits 7.2.2",
+ "midnight-circuits 7.2.4",
  "midnight-proofs 0.7.2",
- "midnight-proofs 0.8.1",
+ "midnight-proofs 0.8.2",
  "midnight-serialize",
  "midnight-transient-crypto 2.2.0",
  "midnight-transient-crypto 3.0.0",
  "midnight-zk-stdlib 1.2.1",
- "midnight-zk-stdlib 2.3.3",
+ "midnight-zk-stdlib 2.3.5",
  "midnight-zkir",
  "num-bigint",
  "pastey",
@@ -3739,12 +3739,12 @@ dependencies = [
  "indicatif",
  "log",
  "midnight-base-crypto",
- "midnight-circuits 7.2.2",
+ "midnight-circuits 7.2.4",
  "midnight-curves 0.3.1",
- "midnight-proofs 0.8.1",
+ "midnight-proofs 0.8.2",
  "midnight-serialize",
  "midnight-transient-crypto 3.0.0",
- "midnight-zk-stdlib 2.3.3",
+ "midnight-zk-stdlib 2.3.5",
  "midnight-zkir-v3",
  "num-bigint",
  "num-traits",
@@ -3937,7 +3937,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4127,7 +4127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4532,7 +4532,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -4570,7 +4570,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4968,7 +4968,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5026,7 +5026,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5389,7 +5389,7 @@ dependencies = [
  "blake2b_simd",
  "ff",
  "midnight-curves 0.3.1",
- "midnight-proofs 0.8.1",
+ "midnight-proofs 0.8.2",
  "num-bigint",
  "rand 0.8.6",
 ]
@@ -5789,7 +5789,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6443,7 +6443,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/ledger/src/test_utilities.rs
+++ b/ledger/src/test_utilities.rs
@@ -50,7 +50,7 @@ use rand::{CryptoRng, Rng, seq::SliceRandom};
 use reqwest::Client;
 use serialize::{Serializable, Tagged};
 #[cfg(feature = "proving")]
-use serialize::{tagged_deserialize, tagged_serialize, peek_tag};
+use serialize::{peek_tag, tagged_deserialize, tagged_serialize};
 use std::collections::VecDeque;
 use std::env;
 use std::io;

--- a/transient-crypto/Cargo.toml
+++ b/transient-crypto/Cargo.toml
@@ -29,8 +29,8 @@ ff = "^0.13.1"
 group = "^0.13.0"
 midnight-curves = { version = "^0.3.1" }
 midnight-proofs = { version = "^0.8.1" }
-midnight-circuits = { version = "^7.2.2" }
-midnight-zk-stdlib = { version = "^2.3.3" }
+midnight-circuits = { version = "^7.2.4" }
+midnight-zk-stdlib = { version = "^2.3.5" }
 anyhow = { version = "^1.0.102" }
 lru = "0.18.0"
 

--- a/zkir-v3/Cargo.toml
+++ b/zkir-v3/Cargo.toml
@@ -40,8 +40,8 @@ transient-crypto = { version = "3.0.0", path = "../transient-crypto", package = 
 
 midnight-curves = { version = "^0.3.1" }
 midnight-proofs = { version = "^0.8.1" }
-midnight-circuits = { version = "^7.2.2" }
-midnight-zk-stdlib = { version = "^2.3.3" }
+midnight-circuits = { version = "^7.2.4" }
+midnight-zk-stdlib = { version = "^2.3.5" }
 
 group = "^0.13.0"
 const-hex = "^1.14.0"

--- a/zkir-v3/src/ir.rs
+++ b/zkir-v3/src/ir.rs
@@ -359,7 +359,10 @@ mod constant_encoding {
     use super::{Fr, Operand};
     use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
-    pub(super) fn serialize<S: Serializer>(values: &[Fr], serializer: S) -> Result<S::Ok, S::Error> {
+    pub(super) fn serialize<S: Serializer>(
+        values: &[Fr],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
         let immediates: Vec<Operand> = values.iter().map(|f| Operand::Immediate(*f)).collect();
         immediates.serialize(serializer)
     }

--- a/zkir-v3/src/ir_instructions/assign_constant.rs
+++ b/zkir-v3/src/ir_instructions/assign_constant.rs
@@ -34,13 +34,17 @@ pub fn assign_constant_incircuit(
     value: &IrValue,
 ) -> Result<CircuitValue, Error> {
     match value {
-        IrValue::Native(x) => std_lib.assign_fixed(layouter, x.0).map(CircuitValue::Native),
+        IrValue::Native(x) => std_lib
+            .assign_fixed(layouter, x.0)
+            .map(CircuitValue::Native),
 
         IrValue::Bool(b) => std_lib.assign_fixed(layouter, *b).map(CircuitValue::Bool),
 
         IrValue::Byte(b) => std_lib.assign_fixed(layouter, *b).map(CircuitValue::Byte),
 
-        IrValue::Bytes(bs) => std_lib.assign_many_fixed(layouter, bs).map(CircuitValue::Bytes),
+        IrValue::Bytes(bs) => std_lib
+            .assign_many_fixed(layouter, bs)
+            .map(CircuitValue::Bytes),
 
         IrValue::JubjubPoint(p) => std_lib
             .jubjub()

--- a/zkir-v3/src/ir_instructions/encode.rs
+++ b/zkir-v3/src/ir_instructions/encode.rs
@@ -44,17 +44,18 @@ pub fn encode_offcircuit(value: &IrValue) -> Vec<IrValue> {
                 // one field element.
                 let mut buf = [0u8; 32];
                 buf[..chunk.len()].copy_from_slice(chunk);
-                F::from_bytes_le(&buf).unwrap()
+                F::from_bytes_le(&buf).expect("a 31-byte value always fits in F")
             })
             .collect(),
         IrValue::JubjubPoint(p) => AssignedNativePoint::<JubjubExtended>::as_public_input(p),
+        // A Jubjub scalar is at most 252 bits wide, so it takes a single native
+        // field element, as `IrType::JubjubScalar.encoded_len()` declares. The
+        // `encoded_width_matches_encoded_len` test pins that down: were it to
+        // change upstream, every caller reports it (an `Encode` output-length
+        // mismatch, a failed canonicity check, or a communications commitment
+        // mismatch) rather than panicking here.
         IrValue::JubjubScalar(s) => {
-            let encoded = AssignedScalarOfNativeCurve::<JubjubExtended>::as_public_input(s);
-            // In ZKIRv3, an assigned scalar can only originate from a circuit
-            // input (PublicInput or PrivateInput), which yields canonical assigned
-            // scalars (whose internal representation uses at most 252 bits).
-            assert_eq!(encoded.len(), 1);
-            encoded
+            AssignedScalarOfNativeCurve::<JubjubExtended>::as_public_input(s)
         }
 
         IrValue::Secp256k1Point(p) => {
@@ -137,7 +138,7 @@ fn decode_bytes(encoded: &[F], n: usize) -> Option<IrValue> {
 /// Returns an error if the provided raw values cannot be decoded as the given type.
 pub fn decode_offcircuit(encoded: &[Fr], val_t: &IrType) -> Result<IrValue, anyhow::Error> {
     let encoded: Vec<F> = encoded.iter().map(|f| f.0).collect();
-    match val_t {
+    let decoded = match val_t {
         IrType::Native => AssignedNative::<F>::from_public_input(&encoded)
             .map(Fr)
             .map(IrValue::Native),
@@ -167,7 +168,23 @@ pub fn decode_offcircuit(encoded: &[Fr], val_t: &IrType) -> Result<IrValue, anyh
         IrType::Secp256k1Scalar => AssignedField::<F, k256::Fq, MEP>::from_public_input(&encoded)
             .map(IrValue::Secp256k1Scalar),
     }
-    .ok_or_else(|| anyhow!("Failed to decode {encoded:?} as {val_t:?}"))
+    .ok_or_else(|| anyhow!("Failed to decode {encoded:?} as {val_t:?}"))?;
+
+    // We make sure that the encoded value was in canonical form by re-encoding
+    // it and comparing it with the given input.
+    let re_encoded: Vec<F> = encode_offcircuit(&decoded)
+        .into_iter()
+        .map(|x| x.try_into().unwrap())
+        .map(|x: Fr| x.0)
+        .collect();
+
+    if re_encoded != encoded {
+        return Err(anyhow!(
+            "The encoded value of type {val_t:?} is not in canonical form: {encoded:?}"
+        ));
+    }
+
+    Ok(decoded)
 }
 
 /// Converts a native field element to a Jubjub scalar by reducing modulo
@@ -197,16 +214,25 @@ pub fn jubjub_scalar_from_biguint(
 
 #[cfg(test)]
 mod tests {
+    use group::{Group, ff::Field};
+    use midnight_curves::{JubjubSubgroup, k256::K256};
+    use rand_chacha::rand_core::OsRng;
+
     use super::*;
+
+    /// The off-circuit encoding of `value`, as raw field elements.
+    fn raw(value: &IrValue) -> Vec<Fr> {
+        encode_offcircuit(value)
+            .into_iter()
+            .map(|v| v.try_into().unwrap())
+            .collect()
+    }
 
     #[test]
     fn encode_decode_bool_roundtrip() {
         for b in [true, false] {
             let value = IrValue::Bool(b);
-            let encoded: Vec<Fr> = encode_offcircuit(&value)
-                .into_iter()
-                .map(|v| v.try_into().unwrap())
-                .collect();
+            let encoded: Vec<Fr> = raw(&value);
             // A Bool encodes to a single native field element.
             assert_eq!(encoded.len(), IrType::Bool.encoded_len());
             let decoded = decode_offcircuit(&encoded, &IrType::Bool).unwrap();
@@ -218,10 +244,7 @@ mod tests {
     fn encode_decode_byte_roundtrip() {
         for b in [0u8, 1, 42, 255] {
             let value = IrValue::Byte(b);
-            let encoded: Vec<Fr> = encode_offcircuit(&value)
-                .into_iter()
-                .map(|v| v.try_into().unwrap())
-                .collect();
+            let encoded: Vec<Fr> = raw(&value);
             // A Byte encodes to a single native field element.
             assert_eq!(encoded.len(), IrType::Byte.encoded_len());
             let decoded = decode_offcircuit(&encoded, &IrType::Byte).unwrap();
@@ -234,12 +257,11 @@ mod tests {
         // Cover lengths straddling the field-element chunk boundary.
         let c = BYTES_PER_FIELD_ELEMENT;
         for n in [1, c - 1, c, c + 1, 2 * c, 2 * c + 1, 100] {
-            let bytes: Vec<u8> = (0..n).map(|i| (i as u8).wrapping_mul(7).wrapping_add(1)).collect();
-            let value = IrValue::Bytes(bytes);
-            let encoded: Vec<Fr> = encode_offcircuit(&value)
-                .into_iter()
-                .map(|v| v.try_into().unwrap())
+            let bytes: Vec<u8> = (0..n)
+                .map(|i| (i as u8).wrapping_mul(7).wrapping_add(1))
                 .collect();
+            let value = IrValue::Bytes(bytes);
+            let encoded: Vec<Fr> = raw(&value);
             assert_eq!(encoded.len(), IrType::Bytes(n as u32).encoded_len());
             let decoded = decode_offcircuit(&encoded, &IrType::Bytes(n as u32)).unwrap();
             assert_eq!(decoded, value, "n = {n}");
@@ -250,5 +272,128 @@ mod tests {
     fn decode_bytes_wrong_element_count_fails() {
         // Bytes(32) needs exactly 2 field elements.
         assert!(decode_offcircuit(&[Fr::from(0u64)], &IrType::Bytes(32)).is_err());
+    }
+
+    // `IrType::encoded_len` hardcodes the width of every encoding, and the
+    // transcripts are sliced according to it, so a value must encode to exactly
+    // that many field elements. For most types the width comes from a
+    // `midnight-circuits` chip, so this also guards against a dependency bump
+    // silently changing one of them.
+    #[test]
+    fn encoded_width_matches_encoded_len() {
+        // The widest value of each type: the largest field elements, and (for
+        // `Bytes`) a length that is not a multiple of the chunk size.
+        let values = [
+            IrValue::Native(Fr(-F::ONE)),
+            IrValue::Bool(true),
+            IrValue::Byte(u8::MAX),
+            IrValue::Bytes(vec![u8::MAX; BYTES_PER_FIELD_ELEMENT + 1]),
+            IrValue::JubjubPoint(JubjubSubgroup::generator()),
+            IrValue::JubjubScalar(-JubjubFr::ONE),
+            IrValue::Secp256k1Point(K256::generator()),
+            IrValue::Secp256k1Base(-k256::Fp::ONE),
+            IrValue::Secp256k1Scalar(-k256::Fq::ONE),
+        ];
+        for value in values {
+            let val_t = value.get_type();
+            assert_eq!(raw(&value).len(), val_t.encoded_len(), "{val_t:?}");
+        }
+    }
+
+    // The curve and emulated-field encodings are the ones where `decode` is not
+    // injective on its own, so make sure the canonical encodings still decode
+    // back to the value they came from (including the edge values: identity,
+    // zero, and the largest field element).
+    #[test]
+    fn encode_decode_curve_types_roundtrip() {
+        let values = [
+            IrValue::JubjubPoint(JubjubSubgroup::identity()),
+            IrValue::JubjubPoint(JubjubSubgroup::generator()),
+            IrValue::JubjubPoint(JubjubSubgroup::random(OsRng)),
+            IrValue::JubjubScalar(JubjubFr::ZERO),
+            IrValue::JubjubScalar(-JubjubFr::ONE),
+            IrValue::JubjubScalar(JubjubFr::random(OsRng)),
+            IrValue::Secp256k1Point(K256::identity()),
+            IrValue::Secp256k1Point(K256::generator()),
+            IrValue::Secp256k1Point(K256::random(OsRng)),
+            IrValue::Secp256k1Base(k256::Fp::ZERO),
+            IrValue::Secp256k1Base(-k256::Fp::ONE),
+            IrValue::Secp256k1Base(k256::Fp::random(OsRng)),
+            IrValue::Secp256k1Scalar(k256::Fq::ZERO),
+            IrValue::Secp256k1Scalar(-k256::Fq::ONE),
+            IrValue::Secp256k1Scalar(k256::Fq::random(OsRng)),
+        ];
+        for value in values {
+            let val_t = value.get_type();
+            let encoded = raw(&value);
+            assert_eq!(encoded.len(), val_t.encoded_len(), "{val_t:?}");
+            let decoded = decode_offcircuit(&encoded, &val_t).unwrap();
+            assert_eq!(decoded, value, "{val_t:?}");
+        }
+    }
+
+    // `JubjubExtended::from_xy` recovers the point from `y` and the parity bit of
+    // `x`, so tampering with the rest of `x` used to decode to the same point.
+    #[test]
+    fn decode_rejects_non_canonical_jubjub_point() {
+        let value = IrValue::JubjubPoint(JubjubSubgroup::generator());
+        let encoded = raw(&value);
+        // `+ 2` leaves the parity of `x` (and hence the decoded point) untouched.
+        let tampered = vec![Fr(encoded[0].0 + F::from(2u64)), encoded[1]];
+        assert_ne!(tampered, encoded);
+        assert!(decode_offcircuit(&tampered, &IrType::JubjubPoint).is_err());
+    }
+
+    // A Jubjub scalar is encoded in the low 252 bits of a single field element,
+    // and the two bits above them used to be ignored on decoding.
+    #[test]
+    fn decode_rejects_non_canonical_jubjub_scalar() {
+        let value = IrValue::JubjubScalar(JubjubFr::from(12345u64));
+        let encoded = raw(&value);
+        let two_pow_252 = {
+            let mut buf = [0u8; 32];
+            buf[31] = 0x10;
+            F::from_bytes_le(&buf).unwrap()
+        };
+        let tampered = vec![Fr(encoded[0].0 + two_pow_252)];
+        assert!(decode_offcircuit(&tampered, &IrType::JubjubScalar).is_err());
+    }
+
+    // An emulated secp256k1 field element is packed into 4 64-bit limbs, i.e.
+    // 256 bits, which is wider than either modulus. The limb representation of
+    // `(k - 1) + q` therefore used to decode to `k` as well.
+    #[test]
+    fn decode_rejects_non_canonical_secp256k1_scalar() {
+        // (7 - 1) + q, as little-endian 64-bit limbs.
+        let limbs: [u64; 4] = [
+            0xBFD2_5E8C_D036_4141 + 6,
+            0xBAAE_DCE6_AF48_A03B,
+            0xFFFF_FFFF_FFFF_FFFE,
+            0xFFFF_FFFF_FFFF_FFFF,
+        ];
+        // The first field element carries three limbs, the second the last one.
+        let mut buf = [0u8; 32];
+        for (i, limb) in limbs[..3].iter().enumerate() {
+            buf[8 * i..8 * (i + 1)].copy_from_slice(&limb.to_le_bytes());
+        }
+        let tampered = vec![Fr(F::from_bytes_le(&buf).unwrap()), Fr(F::from(limbs[3]))];
+        assert_ne!(
+            tampered,
+            raw(&IrValue::Secp256k1Scalar(k256::Fq::from(7u64)))
+        );
+        assert!(decode_offcircuit(&tampered, &IrType::Secp256k1Scalar).is_err());
+    }
+
+    // A secp256k1 point carries an "is identity" flag as its last field element,
+    // and the coordinates used to be ignored altogether when that flag is set.
+    #[test]
+    fn decode_rejects_non_canonical_secp256k1_identity() {
+        let value = IrValue::Secp256k1Point(K256::identity());
+        let encoded = raw(&value);
+        assert_eq!(*encoded.last().unwrap(), Fr::from(1u64));
+        // Garbage coordinates, identity flag still set.
+        let mut tampered = encoded.clone();
+        tampered[0] = Fr(encoded[0].0 + F::ONE);
+        assert!(decode_offcircuit(&tampered, &IrType::Secp256k1Point).is_err());
     }
 }

--- a/zkir-v3/src/ir_instructions/from_bytes32.rs
+++ b/zkir-v3/src/ir_instructions/from_bytes32.rs
@@ -132,7 +132,8 @@ mod tests {
         use IrValue::*;
 
         // `into_bytes32` yields a `Bytes(32)` value; extract its fixed array.
-        let to_arr = |v: IrValue| -> [u8; 32] { <Vec<u8>>::try_from(v).unwrap().try_into().unwrap() };
+        let to_arr =
+            |v: IrValue| -> [u8; 32] { <Vec<u8>>::try_from(v).unwrap().try_into().unwrap() };
 
         let x = Native(Fr(F::random(OsRng)));
         let bytes = to_arr(into_bytes32_offcircuit(&x).unwrap());

--- a/zkir-v3/src/ir_instructions/into_bytes32.rs
+++ b/zkir-v3/src/ir_instructions/into_bytes32.rs
@@ -106,7 +106,8 @@ mod tests {
         use IrValue::*;
 
         // `into_bytes32` yields a `Bytes(32)` value; extract its fixed array.
-        let to_arr = |v: IrValue| -> [u8; 32] { <Vec<u8>>::try_from(v).unwrap().try_into().unwrap() };
+        let to_arr =
+            |v: IrValue| -> [u8; 32] { <Vec<u8>>::try_from(v).unwrap().try_into().unwrap() };
 
         let x = Native(Fr(F::random(OsRng)));
         let bytes = to_arr(into_bytes32_offcircuit(&x).unwrap());

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -670,10 +670,7 @@ impl IrSource {
                         .checked_add(l)
                         .filter(|end| *end <= bs.len())
                         .ok_or_else(|| {
-                            anyhow!(
-                                "slice out of bounds: {s}..{s}+{l} into Bytes<{}>",
-                                bs.len()
-                            )
+                            anyhow!("slice out of bounds: {s}..{s}+{l} into Bytes<{}>", bs.len())
                         })?;
                     memory.insert(output.clone(), IrValue::Bytes(bs[s..end].to_vec()));
                 }
@@ -1296,12 +1293,15 @@ impl Relation for IrSource {
                     if l == 0 {
                         return Err(Error::Synthesis("slice length must be at least 1".into()));
                     }
-                    let end = s.checked_add(l).filter(|end| *end <= bs.len()).ok_or_else(|| {
-                        Error::Synthesis(format!(
-                            "slice out of bounds: {s}..{s}+{l} into Bytes<{}>",
-                            bs.len()
-                        ))
-                    })?;
+                    let end = s
+                        .checked_add(l)
+                        .filter(|end| *end <= bs.len())
+                        .ok_or_else(|| {
+                            Error::Synthesis(format!(
+                                "slice out of bounds: {s}..{s}+{l} into Bytes<{}>",
+                                bs.len()
+                            ))
+                        })?;
                     mem_insert(
                         output.clone(),
                         CircuitValue::Bytes(bs[s..end].to_vec()),
@@ -1342,7 +1342,11 @@ impl Relation for IrSource {
                             bs.len()
                         )));
                     }
-                    mem_insert(output.clone(), CircuitValue::Byte(bs[k].clone()), &mut memory)?;
+                    mem_insert(
+                        output.clone(),
+                        CircuitValue::Byte(bs[k].clone()),
+                        &mut memory,
+                    )?;
                 }
                 I::Concat { inputs, output } => {
                     let mut bytes = vec![];

--- a/zkir-v3/tests/proofs.rs
+++ b/zkir-v3/tests/proofs.rs
@@ -1705,10 +1705,7 @@ mod proof_tests {
                 },
             )
             .await;
-        assert!(
-            result.is_err(),
-            "constrain_eq on unequal Bools should fail"
-        );
+        assert!(result.is_err(), "constrain_eq on unequal Bools should fail");
     }
 
     #[actix_rt::test]

--- a/zkir/Cargo.toml
+++ b/zkir/Cargo.toml
@@ -12,8 +12,20 @@ path = "src/main.rs"
 required-features = ["binary"]
 
 [features]
-binary = ["dep:log", "dep:tracing-subscriber", "dep:clap", "dep:env_logger", "dep:tokio", "dep:indicatif", "dep:console", "dep:futures-executor"]
-mock-verify = ["transient-crypto-old/mock-verify", "transient-crypto/mock-verify"]
+binary = [
+  "dep:log",
+  "dep:tracing-subscriber",
+  "dep:clap",
+  "dep:env_logger",
+  "dep:tokio",
+  "dep:indicatif",
+  "dep:console",
+  "dep:futures-executor",
+]
+mock-verify = [
+  "transient-crypto-old/mock-verify",
+  "transient-crypto/mock-verify",
+]
 proptest = [
   "dep:pastey",
   "dep:proptest",
@@ -26,11 +38,13 @@ proptest = [
 [dependencies]
 base-crypto = { version = "1.1.0", path = "../base-crypto", package = "midnight-base-crypto" }
 serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
-transient-crypto = { version = "3.0.0", path = "../transient-crypto", package = "midnight-transient-crypto", features = ["cli"] }
+transient-crypto = { version = "3.0.0", path = "../transient-crypto", package = "midnight-transient-crypto", features = [
+  "cli",
+] }
 
 midnight-proofs = { version = "^0.8.1" }
-midnight-circuits = { version = "^7.2.2" }
-midnight-zk-stdlib = { version = "^2.3.3" }
+midnight-circuits = { version = "^7.2.4" }
+midnight-zk-stdlib = { version = "^2.3.5" }
 
 # Pinned pre-zk-stdlib-v2 versions for backwards-compatible v1 proving.
 transient-crypto-old = { package = "midnight-transient-crypto", version = "^2.2.0" }
@@ -58,7 +72,11 @@ log = { version = "^0.4.28", optional = true }
 tracing-subscriber = { version = "^0.3.19", optional = true }
 clap = { version = "^4.5.40", features = ["derive"], optional = true }
 env_logger = { version = "^0.11.8", optional = true }
-tokio = { version = "^1.46.1", features = ["rt", "macros", "rt-multi-thread"], optional = true }
+tokio = { version = "^1.46.1", features = [
+  "rt",
+  "macros",
+  "rt-multi-thread",
+], optional = true }
 indicatif = { version = "^0.18.4", optional = true }
 console = { version = "^0.16.3", optional = true }
 futures-executor = { version = "^0.3.32", optional = true }


### PR DESCRIPTION
## Description

This addresses Point 5 of the report by the IOG Formal Methods team:
https://github.com/input-output-hk/arc-zkir/blob/879a45d5bd5080e2f714966edebbce4ae8d69389/docs/zkir-v3-divergence-review.md

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [x] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
