### PR TITLE
fix(ci): pin npm-installed CI tool versions

### DIFF
--- a/.github/workflows/generate-markdown-docs.yml
+++ b/.github/workflows/generate-markdown-docs.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install --save-dev typedoc-plugin-markdown
-          npm install -g rimraf
+          npm install --save-dev typedoc-plugin-markdown@4.12.0
+          npm install -g rimraf@6.1.3
 
       - name: Build markdown docs
         run: |


### PR DESCRIPTION
Closes #680

Pins floating-version npm tool installs in workflows to exact versions (vercel 58.7.1 / typedoc-plugin-markdown 4.12.0 / rimraf 6.1.3 / junit-report-merger 9.0.4 / npm 12.0.2 as applicable). Floating tags execute whatever the registry serves at run time; pinning closes that window.