### PR TITLE
Check for `Bytes` length out of circuit

### DIFF
--- a/zkir-v3/src/ir_instructions/eq.rs
+++ b/zkir-v3/src/ir_instructions/eq.rs
@@ -26,7 +26,7 @@ use crate::{
 ///   - `Native`
 ///   - `Bool`
 ///   - `Byte`
-///   - `Bytes(n)`
+///   - `Bytes(n)` (both operands must have the same length)
 ///   - `JubjubPoint`
 ///   - `Secp256k1Point`
 ///   - `Secp256k1Base`
@@ -41,7 +41,7 @@ pub fn test_eq_offcircuit(a: &IrValue, b: &IrValue) -> Result<bool, anyhow::Erro
         (Native(x), Native(y)) => Ok(x == y),
         (Bool(a), Bool(b)) => Ok(a == b),
         (Byte(a), Byte(b)) => Ok(a == b),
-        (Bytes(xs), Bytes(ys)) => Ok(xs == ys),
+        (Bytes(xs), Bytes(ys)) if xs.len() == ys.len() => Ok(xs == ys),
         (JubjubPoint(p), JubjubPoint(q)) => Ok(p == q),
 
         (Secp256k1Point(p), Secp256k1Point(q)) => Ok(p == q),
@@ -136,7 +136,9 @@ mod tests {
 
         let bytes: Vec<u8> = (0..32).map(|_| rand::thread_rng().r#gen()).collect();
         assert!(test_eq_offcircuit(&Bytes(bytes.clone()), &Bytes(bytes.clone())).unwrap());
-        assert!(!test_eq_offcircuit(&Bytes(bytes), &Bytes(vec![0u8; 32])).unwrap());
+        assert!(!test_eq_offcircuit(&Bytes(bytes.clone()), &Bytes(vec![0u8; 32])).unwrap());
+        // Length mismatches are rejected, matching the in-circuit behavior.
+        assert!(test_eq_offcircuit(&Bytes(bytes), &Bytes(vec![0u8; 64])).is_err());
 
         let p = JubjubSubgroup::random(OsRng);
         assert!(test_eq_offcircuit(&JubjubPoint(p), &JubjubPoint(p)).unwrap());


### PR DESCRIPTION
## Description

Fixes a minor inconsistency where two  `Bytes` objects of different lengths will cause errors in-circuit but wouldn't out of circuit.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
