### PR TITLE
feat(storage-core): attach opaque metadata to GC roots to support later pruning decisions

### DIFF
--- a/CHANGELOG_storage_core.md
+++ b/CHANGELOG_storage_core.md
@@ -3,6 +3,7 @@
 ## Version `1.2.0`
 
 - feat: add incremental garbage collector, running in a time-bounded way. This requires databases to support a new scan operation.
+- feat: add GC-root metadata (behind `gc-v1`): `Sp::persist_with_metadata` / `StorageBackend::persist_with_metadata` attach an opaque value (e.g. a block hash) when the tag is known at persist time; `StorageBackend::set_root_metadata` tags an already-persisted root without changing its persist count. `StorageBackend::unpersist_by_metadata` later releases matching roots given only those values -- zero-clamped, in one backend borrow, with no caller-side index. Metadata is staged in the write cache and committed in the same `batch_update` as any persist-count change, and deleted on flush when the count drops to zero. Backed by a new `root_metadata` table in SQLite, and the previously reserved column 2 in ParityDb.
 - feat: allow parityDB to use existing instance
 - fix: removed race condition from `force_as_arc`
 - fix: prevent a panic in `Sp` serialization with a mix of 'promoted' and 'unpromoted' keys.

--- a/storage-core/src/arena.rs
+++ b/storage-core/src/arena.rs
@@ -475,6 +475,10 @@ type MetaData<D> = HashMap<ArenaHash<<D as DB>::Hasher>, Node>;
 /// need to include the type in the key to avoid collisions in some cases.
 type DynTypedArenaHash<H> = (ArenaHash<H>, TypeId);
 
+/// Map from content hash to the child-key representation used while
+/// deserializing `Sp`s from an [`IntermediateRepr`] graph.
+type KeyToChildRepr<D> = HashMap<ArenaHash<<D as DB>::Hasher>, ArenaKey<<D as DB>::Hasher>>;
+
 /// Keys are `hash x type_id` because the hash alone is ambiguous for
 /// determining the typed value with this hash: the hash is determined only by
 /// the binary serialization, which need not be disjoint across types.
@@ -872,8 +876,7 @@ impl<D: DB> Arena<D> {
             result = Ok(root);
         }
 
-        let mut key_to_child_repr: HashMap<ArenaHash<<D as DB>::Hasher>, ArenaKey<D::Hasher>> =
-            std::collections::HashMap::new();
+        let mut key_to_child_repr: KeyToChildRepr<D> = HashMap::new();
         for node in nodes.nodes.iter() {
             let children = node
                 .child_indices
@@ -1081,7 +1084,7 @@ pub(crate) struct IrLoader<'a, D: DB> {
     recursion_depth: u32,
     /// The keys we've already deserialized once.
     visited: Rc<RefCell<HashSet<DynTypedArenaHash<D::Hasher>>>>,
-    key_to_child_repr: Rc<HashMap<ArenaHash<D::Hasher>, ArenaKey<D::Hasher>>>,
+    key_to_child_repr: Rc<KeyToChildRepr<D>>,
 }
 
 #[cfg(test)]
@@ -1089,7 +1092,7 @@ impl<'a, D: DB> IrLoader<'a, D> {
     pub(crate) fn new(
         arena: &'a Arena<D>,
         all: &'a HashMap<ArenaHash<D::Hasher>, IntermediateRepr<D>>,
-        key_to_child_repr: HashMap<ArenaHash<D::Hasher>, ArenaKey<D::Hasher>>,
+        key_to_child_repr: KeyToChildRepr<D>,
     ) -> IrLoader<'a, D> {
         IrLoader {
             arena,
@@ -1543,6 +1546,36 @@ impl<T: Storable<D>, D: DB> Sp<T, D> {
                 .into_iter()
                 .for_each(|ref_| backend.persist(ref_))
         });
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Like [`Self::persist`], but additionally associates opaque `metadata`
+    /// (e.g. a block hash) with the persisted GC root, overwriting any
+    /// existing metadata for it. The root can later be unpersisted by
+    /// providing only that metadata value, via
+    /// `Arena::with_backend(|b| b.unpersist_by_metadata(values))`. The
+    /// metadata is deleted when the root's persist count drops back to zero.
+    ///
+    /// See [`StorageBackend::persist_with_metadata`].
+    pub fn persist_with_metadata(&mut self, metadata: std::vec::Vec<u8>) {
+        // Promote self to Ref if not already, mirroring `persist`.
+        if let ArenaKey::Direct(..) = self.child_repr {
+            *self = self.into_tracked();
+        }
+        self.arena.with_backend(|backend| {
+            self.child_repr
+                .refs()
+                .into_iter()
+                .for_each(|ref_| backend.persist_with_metadata(ref_, metadata.clone()))
+        });
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Associate opaque `metadata` with this object as a GC root, without
+    /// changing its persist count. See [`StorageBackend::set_root_metadata`].
+    pub fn set_root_metadata(&self, metadata: std::vec::Vec<u8>) {
+        self.arena
+            .with_backend(|backend| backend.set_root_metadata(&self.root, metadata))
     }
 
     /// Notify the storage back-end to decrement the persist count on this

--- a/storage-core/src/backend.rs
+++ b/storage-core/src/backend.rs
@@ -294,6 +294,11 @@ pub struct StorageBackend<D: DB> {
     /// Intermediate garbage collection state
     #[cfg(all(feature = "layout-v2", feature = "gc-v1"))]
     gc_state: GcState<D>,
+    /// Pending GC-root metadata writes, applied on flush in the same
+    /// `batch_update` as the corresponding root-count changes.
+    /// `Some(bytes)` is a set; `None` is a delete.
+    #[cfg(feature = "gc-v1")]
+    pending_root_metadata: HashMap<ArenaHash<D::Hasher>, Option<Vec<u8>>>,
 }
 
 /// Run-time stats to help with performance tuning.
@@ -337,6 +342,8 @@ impl<D: DB> StorageBackend<D> {
             }),
             #[cfg(feature = "gc-v1")]
             gc_state: Default::default(),
+            #[cfg(feature = "gc-v1")]
+            pending_root_metadata: HashMap::new(),
         }
     }
 
@@ -628,6 +635,10 @@ impl<D: DB> StorageBackend<D> {
     }
 
     /// Un-mark `key` as GC root. See [`Self::persist`].
+    ///
+    /// If this drops the effective root count of `key` to zero, any metadata
+    /// associated with `key` via [`Self::persist_with_metadata`] is deleted
+    /// on the next flush, in the same `batch_update` as the zero root count.
     pub fn unpersist(&mut self, key: &ArenaHash<D::Hasher>) {
         self.update_counts(&[ArenaKey::Ref(key.clone())], Delta::new_root_delta(-1));
     }
@@ -641,6 +652,117 @@ impl<D: DB> StorageBackend<D> {
     /// int, not a bool.
     pub fn persist(&mut self, key: &ArenaHash<D::Hasher>) {
         self.update_counts(&[ArenaKey::Ref(key.clone())], Delta::new_root_delta(1));
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Like [`Self::persist`], but additionally associates opaque `metadata`
+    /// with the GC root `key`, overwriting any existing metadata for `key`.
+    ///
+    /// The metadata (e.g. a block hash) later serves as the only handle needed
+    /// to release the root again, via [`Self::unpersist_by_metadata`] -- no
+    /// caller-side index from metadata back to root hashes is required.
+    ///
+    /// Like [`Self::persist`], this is not durable until flush. On flush the
+    /// persist count and tag are committed in a single `batch_update`, so a
+    /// crash cannot persist one without the other. Until then both are visible
+    /// only through the in-memory overlay. The tag is deleted, also in that
+    /// same batch, when `unpersist` drops the root count of `key` to zero.
+    ///
+    /// Note that a root has a single metadata value, even if it has been
+    /// `persist`ed multiple times: the last write wins.
+    pub fn persist_with_metadata(&mut self, key: &ArenaHash<D::Hasher>, metadata: Vec<u8>) {
+        self.persist(key);
+        self.set_root_metadata(key, metadata);
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Associate opaque `metadata` with the GC root `key` without changing its
+    /// persist count.
+    ///
+    /// Use this when the tag is not known at persist time and should be
+    /// attached later. Staged until flush, then committed in one `batch_update`
+    /// together with this key's persist count (rewritten even if unchanged).
+    /// Last write wins. See [`Self::persist_with_metadata`].
+    pub fn set_root_metadata(&mut self, key: &ArenaHash<D::Hasher>, metadata: Vec<u8>) {
+        self.pending_root_metadata
+            .insert(key.clone(), Some(metadata));
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Metadata associated with `key` as a GC root, if any.
+    ///
+    /// Incorporates pending in-memory writes that have not yet been flushed,
+    /// and returns `None` when the effective root count is zero.
+    pub fn get_root_metadata(&self, key: &ArenaHash<D::Hasher>) -> Option<Vec<u8>> {
+        if self.get_root_count(key) == 0 {
+            return None;
+        }
+        match self.pending_root_metadata.get(key) {
+            Some(pending) => pending.clone(),
+            None => self.database.get_root_metadata(key),
+        }
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Mapping from key to metadata for GC roots with a positive persist
+    /// count. Incorporates pending in-memory writes that have not yet been
+    /// flushed.
+    pub fn get_all_root_metadata(&self) -> HashMap<ArenaHash<D::Hasher>, Vec<u8>> {
+        let mut map = self.database.get_all_root_metadata();
+        for (key, pending) in &self.pending_root_metadata {
+            match pending {
+                Some(metadata) => {
+                    map.insert(key.clone(), metadata.clone());
+                }
+                None => {
+                    map.remove(key);
+                }
+            }
+        }
+        map.retain(|key, _| self.get_root_count(key) > 0);
+        map
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Unpersist every GC root whose metadata equals one of the values in
+    /// `metadata`, decrementing each matching root's count once. Roots whose
+    /// count is already zero are skipped rather than underflowing, so
+    /// replaying values that exceed the actually held counts is safe. Returns
+    /// the number of roots decremented.
+    ///
+    /// This is the counterpart of [`Self::persist_with_metadata`]: the
+    /// metadata value is the only handle needed. When a decrement drops a
+    /// root's count to zero, its metadata is deleted on the next flush, in
+    /// the same `batch_update` as the zero root count, so a crash before
+    /// that flush leaves the tag on disk and a later call can retry.
+    /// Re-submitting after a successful flush is a safe no-op.
+    ///
+    /// The entire batch runs under the single backend borrow of this call:
+    /// one scan of the root-metadata table (expected to stay small, e.g. one
+    /// entry per block in a pruning window) serves all values, and no other
+    /// backend operation can interleave with the decrements.
+    ///
+    /// Note that a root persisted multiple times holds only its most recent
+    /// metadata, so a match decrements it once per call, not down to zero.
+    pub fn unpersist_by_metadata<M: AsRef<[u8]>>(&mut self, metadata: &[M]) -> usize {
+        if metadata.is_empty() {
+            return 0;
+        }
+        let wanted: HashSet<&[u8]> = metadata.iter().map(|m| m.as_ref()).collect();
+        let matching: std::vec::Vec<_> = self
+            .get_all_root_metadata()
+            .into_iter()
+            .filter(|(_, m)| wanted.contains(m.as_slice()))
+            .map(|(root, _)| root)
+            .collect();
+        let mut decremented = 0;
+        for root in matching {
+            if self.get_root_count(&root) > 0 {
+                self.unpersist(&root);
+                decremented += 1;
+            }
+        }
+        decremented
     }
 
     /// Load DAG rooted at `key` into the cache from the DB.
@@ -703,8 +825,15 @@ impl<D: DB> StorageBackend<D> {
         I: Iterator<Item = (ArenaHash<D::Hasher>, CacheValue<D::Hasher>)>,
     {
         let mut updates = vec![];
+        #[cfg(feature = "gc-v1")]
+        let mut flushed_keys = Vec::new();
+        #[cfg(feature = "gc-v1")]
+        let mut flushed_root_counts = HashMap::new();
         #[allow(unused_mut, reason = "feature flags complicate this")]
+        #[allow(unused_variables, reason = "feature flags complicate this")]
         for (k, mut v) in writes {
+            #[cfg(feature = "gc-v1")]
+            flushed_keys.push(k.clone());
             // Check for reads first, to give better error messages.
             if matches!(v, CacheValue::Read { .. }) {
                 panic!("BUG: unexpected CacheValue::Read!")
@@ -764,6 +893,8 @@ impl<D: DB> StorageBackend<D> {
                         );
                         #[cfg(feature = "gc-v1")]
                         self.gc_state.force_rescan();
+                        #[cfg(feature = "gc-v1")]
+                        flushed_root_counts.insert(k.clone(), root_count as u32);
                         updates.push((k, Update::SetRootCount(root_count as u32)));
                     }
                 }
@@ -792,6 +923,8 @@ impl<D: DB> StorageBackend<D> {
                         };
                         #[cfg(feature = "gc-v1")]
                         self.gc_state.force_rescan();
+                        #[cfg(feature = "gc-v1")]
+                        flushed_root_counts.insert(k.clone(), root_count);
                         updates.push((k, Update::SetRootCount(root_count)));
                     }
                 }
@@ -809,13 +942,86 @@ impl<D: DB> StorageBackend<D> {
                         );
                         #[cfg(feature = "gc-v1")]
                         self.gc_state.force_rescan();
+                        #[cfg(feature = "gc-v1")]
+                        flushed_root_counts.insert(k.clone(), root_count as u32);
                         updates.push((k, Update::SetRootCount(root_count as u32)));
                     }
                 }
                 CacheValue::Dummy => {}
             }
         }
+        #[cfg(feature = "gc-v1")]
+        self.flush_pending_root_metadata(flushed_keys, &flushed_root_counts, &mut updates);
         self.database.batch_update(updates.into_iter());
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Commit pending root metadata into `updates` for every key whose persist
+    /// count is durable in this batch.
+    ///
+    /// A count is durable here if this batch writes it (`flushed_keys`), or it
+    /// is already on disk (key not in the write cache). Each metadata write is
+    /// paired with that key's `SetRootCount` in the same `updates` vec, so
+    /// [`DB::batch_update`] cannot commit a tag without its count.
+    fn flush_pending_root_metadata(
+        &mut self,
+        flushed_keys: Vec<ArenaHash<D::Hasher>>,
+        flushed_root_counts: &HashMap<ArenaHash<D::Hasher>, u32>,
+        updates: &mut Vec<(ArenaHash<D::Hasher>, Update<D::Hasher>)>,
+    ) {
+        self.append_pending_metadata_updates(flushed_keys, flushed_root_counts, updates);
+        let already_durable: std::vec::Vec<_> = self
+            .pending_root_metadata
+            .keys()
+            .filter(|k| self.write_cache.peek(k).is_none())
+            .cloned()
+            .collect();
+        self.append_pending_metadata_updates(already_durable, flushed_root_counts, updates);
+    }
+
+    #[cfg(feature = "gc-v1")]
+    /// Pair each metadata op with its persist count in `updates`.
+    fn append_pending_metadata_updates(
+        &mut self,
+        keys: impl IntoIterator<Item = ArenaHash<D::Hasher>>,
+        flushed_root_counts: &HashMap<ArenaHash<D::Hasher>, u32>,
+        updates: &mut Vec<(ArenaHash<D::Hasher>, Update<D::Hasher>)>,
+    ) {
+        for k in keys {
+            debug_assert!(
+                self.write_cache.peek(&k).is_none(),
+                "cannot commit root metadata for {k:?} while its persist count is still cached"
+            );
+            let pending = self.pending_root_metadata.remove(&k);
+            let count = flushed_root_counts
+                .get(&k)
+                .copied()
+                .unwrap_or_else(|| self.get_root_count(&k));
+            let metadata_update = if count == 0 {
+                // Drop any pending set (do not commit a tag on a non-root)
+                // and delete on-disk metadata with the zero count.
+                if pending.is_some() || flushed_root_counts.contains_key(&k) {
+                    Some(Update::DeleteRootMetadata)
+                } else {
+                    None
+                }
+            } else if let Some(Some(metadata)) = pending {
+                Some(Update::SetRootMetadata(metadata))
+            } else if let Some(None) = pending {
+                Some(Update::DeleteRootMetadata)
+            } else {
+                None
+            };
+            let Some(metadata_update) = metadata_update else {
+                continue;
+            };
+            // Same batch as the count: either this flush already queued
+            // `SetRootCount`, or we rewrite the durable count next to the tag.
+            if !flushed_root_counts.contains_key(&k) {
+                updates.push((k.clone(), Update::SetRootCount(count)));
+            }
+            updates.push((k, metadata_update));
+        }
     }
 
     /// Push pending writes to shrink the write cache to `self.cache_size`.
@@ -1466,6 +1672,50 @@ mod tests {
         assert!(backend.write_cache.peek(&k2).is_some());
         assert_eq!(backend.get(&k3).unwrap().data, d3);
         assert!(backend.write_cache.peek(&k3).is_some());
+    }
+
+    /// Evicting unrelated write-cache entries must not write a tag whose persist
+    /// count is still cached. `set_root_metadata` on an already-durable persist
+    /// can flush with those evictions, because its count is already on disk.
+    #[cfg(feature = "gc-v1")]
+    #[test]
+    fn eviction_flushes_metadata_only_when_count_is_durable() {
+        use crate::db::DB;
+        let mut backend = StorageBackend::new(2, InMemoryDB::<crate::DefaultHasher>::default());
+        let (k1, d1) = (childless_hash::<InMemoryDB, u8>(&0), vec![0]);
+        let (k2, d2) = (childless_hash::<InMemoryDB, u8>(&1), vec![1]);
+        let (k3, d3) = (childless_hash::<InMemoryDB, u8>(&2), vec![2]);
+        let k_tag = childless_hash::<InMemoryDB, u8>(&3);
+        let tag = vec![9u8];
+
+        backend.cache(k1.clone(), d1, vec![]);
+        backend.cache(k2.clone(), d2, vec![]);
+        backend.cache(k3.clone(), d3, vec![]);
+        backend.persist_with_metadata(&k_tag, tag.clone());
+        assert!(backend.write_cache.peek(&k_tag).is_some());
+        backend.flush_cache_evictions_to_db();
+        assert!(backend.write_cache.peek(&k_tag).is_some());
+        assert_eq!(backend.get_root_metadata(&k_tag), Some(tag.clone()));
+        assert_eq!(backend.database.get_root_metadata(&k_tag), None);
+
+        backend.flush_all_changes_to_db();
+        assert_eq!(
+            backend.database.get_root_metadata(&k_tag),
+            Some(tag.clone())
+        );
+
+        let k_late = childless_hash::<InMemoryDB, u8>(&4);
+        let (k4, d4) = (childless_hash::<InMemoryDB, u8>(&5), vec![5]);
+        let (k5, d5) = (childless_hash::<InMemoryDB, u8>(&6), vec![6]);
+        let (k6, d6) = (childless_hash::<InMemoryDB, u8>(&7), vec![7]);
+        backend.persist(&k_late);
+        backend.flush_all_changes_to_db();
+        backend.set_root_metadata(&k_late, tag.clone());
+        backend.cache(k4, d4, vec![]);
+        backend.cache(k5, d5, vec![]);
+        backend.cache(k6, d6, vec![]);
+        backend.flush_cache_evictions_to_db();
+        assert_eq!(backend.database.get_root_metadata(&k_late), Some(tag));
     }
 
     fn in_database_repr<D: DB, T: Storable<D>>(

--- a/storage-core/src/db.rs
+++ b/storage-core/src/db.rs
@@ -51,6 +51,13 @@ pub enum Update<H: WellBehavedHasher> {
     /// Set the root count of a DAG node. Setting this to zero means the node is
     /// no longer a GC root.
     SetRootCount(u32),
+    /// Associate opaque metadata with a GC root. The storage backend issues this
+    /// in the same `batch_update` as the corresponding [`Self::SetRootCount`].
+    #[cfg(feature = "gc-v1")]
+    SetRootMetadata(std::vec::Vec<u8>),
+    /// Delete any opaque metadata associated with a GC root.
+    #[cfg(feature = "gc-v1")]
+    DeleteRootMetadata,
 }
 
 #[cfg(feature = "proptest")]
@@ -145,6 +152,11 @@ pub trait DB: Default + Sync + Send + Debug + DummyArbitrary + 'static {
     ///
     /// For `DB`s that use expensive write transactions, implementors should
     /// combine many updates in a single transaction.
+    ///
+    /// Under `gc-v1`, a persist count and its root metadata for the same key
+    /// are issued together in one call. The implementation must commit the
+    /// whole iterator atomically: a crash may apply all of it or none of it,
+    /// never a tag without its count or a count without its tag.
     fn batch_update<I>(&mut self, iter: I)
     where
         I: Iterator<Item = (ArenaHash<Self::Hasher>, Update<Self::Hasher>)>;
@@ -278,6 +290,37 @@ pub trait DB: Default + Sync + Send + Debug + DummyArbitrary + 'static {
     /// DB. All mapped root counts will be positive.
     fn get_roots(&self) -> HashMap<ArenaHash<Self::Hasher>, u32>;
 
+    #[cfg(feature = "gc-v1")]
+    /// Get the metadata associated with the GC root `key`, if any.
+    ///
+    /// See [`Self::set_root_metadata`].
+    fn get_root_metadata(&self, key: &ArenaHash<Self::Hasher>) -> Option<Vec<u8>>;
+
+    #[cfg(feature = "gc-v1")]
+    /// Associate opaque `metadata` with the GC root `key`, overwriting any
+    /// existing metadata for `key`.
+    ///
+    /// The metadata is intended to help identify roots for later pruning --
+    /// e.g. record a block height or timestamp when persisting a root, so a
+    /// pruning job can later decide which roots to unpersist. The DB does not
+    /// interpret the metadata, and does not tie its lifecycle to the root
+    /// count: like root counts, metadata may be set for keys that are not (or
+    /// not yet) roots or nodes in the DB.
+    fn set_root_metadata(&mut self, key: ArenaHash<Self::Hasher>, metadata: Vec<u8>);
+
+    #[cfg(feature = "gc-v1")]
+    /// Delete the metadata associated with the GC root `key`, if any.
+    ///
+    /// See [`Self::set_root_metadata`].
+    fn delete_root_metadata(&mut self, key: &ArenaHash<Self::Hasher>);
+
+    #[cfg(feature = "gc-v1")]
+    /// Return a mapping from key to metadata, for all keys with root metadata
+    /// in this DB.
+    ///
+    /// See [`Self::set_root_metadata`].
+    fn get_all_root_metadata(&self) -> HashMap<ArenaHash<Self::Hasher>, Vec<u8>>;
+
     /// Return the number of nodes in this DB.
     fn size(&self) -> usize;
 
@@ -315,6 +358,10 @@ where
             InsertNode(value) => db.insert_node(k, value),
             DeleteNode => db.delete_node(&k),
             SetRootCount(count) => db.set_root_count(k, count),
+            #[cfg(feature = "gc-v1")]
+            SetRootMetadata(metadata) => db.set_root_metadata(k, metadata),
+            #[cfg(feature = "gc-v1")]
+            DeleteRootMetadata => db.delete_root_metadata(&k),
         }
     }
 }
@@ -339,6 +386,8 @@ where
 pub struct InMemoryDB<H: WellBehavedHasher = DefaultHasher> {
     nodes: Arc<Mutex<BTreeMap<ArenaHash<H>, OnDiskObject<H>>>>,
     roots: Arc<Mutex<HashMap<ArenaHash<H>, u32>>>,
+    #[cfg(feature = "gc-v1")]
+    root_metadata: Arc<Mutex<HashMap<ArenaHash<H>, Vec<u8>>>>,
 }
 
 impl<H: WellBehavedHasher> DummyArbitrary for InMemoryDB<H> {}
@@ -398,6 +447,11 @@ impl<H: WellBehavedHasher> InMemoryDB<H> {
     fn lock_roots(&self) -> std::sync::MutexGuard<'_, HashMap<ArenaHash<H>, u32>> {
         self.roots.lock().expect("db lock poisoned")
     }
+
+    #[cfg(feature = "gc-v1")]
+    fn lock_root_metadata(&self) -> std::sync::MutexGuard<'_, HashMap<ArenaHash<H>, Vec<u8>>> {
+        self.root_metadata.lock().expect("db lock poisoned")
+    }
 }
 
 impl<H: WellBehavedHasher> DB for InMemoryDB<H> {
@@ -445,6 +499,26 @@ impl<H: WellBehavedHasher> DB for InMemoryDB<H> {
 
     fn get_roots(&self) -> HashMap<ArenaHash<Self::Hasher>, u32> {
         self.lock_roots().clone()
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn get_root_metadata(&self, key: &ArenaHash<Self::Hasher>) -> Option<Vec<u8>> {
+        self.lock_root_metadata().get(key).cloned()
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn set_root_metadata(&mut self, key: ArenaHash<Self::Hasher>, metadata: Vec<u8>) {
+        self.lock_root_metadata().insert(key, metadata);
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn delete_root_metadata(&mut self, key: &ArenaHash<Self::Hasher>) {
+        self.lock_root_metadata().remove(key);
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn get_all_root_metadata(&self) -> HashMap<ArenaHash<Self::Hasher>, Vec<u8>> {
+        self.lock_root_metadata().clone()
     }
 
     fn size(&self) -> usize {
@@ -497,6 +571,8 @@ impl<H: WellBehavedHasher> Default for InMemoryDB<H> {
         Self {
             nodes: Arc::default(),
             roots: Arc::default(),
+            #[cfg(feature = "gc-v1")]
+            root_metadata: Arc::default(),
         }
     }
 }
@@ -956,6 +1032,56 @@ mod tests {
         assert_eq!(keys, db.get_unreachable_keys().into_iter().collect());
         db.set_root_count(n11.key.clone(), 0);
         db.set_root_count(n22.key.clone(), 0);
+    }
+
+    #[cfg(feature = "gc-v1")]
+    #[test]
+    fn root_metadata_inmemorydb() {
+        test_root_metadata::<InMemoryDB>();
+    }
+    #[cfg(all(feature = "gc-v1", feature = "sqlite"))]
+    #[test]
+    fn root_metadata_sqldb() {
+        test_root_metadata::<crate::db::SqlDB>();
+    }
+    #[cfg(all(feature = "gc-v1", feature = "parity-db"))]
+    #[test]
+    fn root_metadata_paritydb() {
+        test_root_metadata::<crate::db::ParityDb>();
+    }
+    /// Test the root-metadata API: set, overwrite, get, get-all, and delete,
+    /// including for keys that have no corresponding node or root count in the
+    /// DB (metadata is independent of both, like root counts are independent
+    /// of nodes).
+    #[cfg(feature = "gc-v1")]
+    fn test_root_metadata<D: DB<Hasher = DefaultHasher>>() {
+        let mut db = D::default();
+        let mut rng = rand::thread_rng();
+        let k1: ArenaHash<DefaultHasher> = rng.r#gen();
+        let k2: ArenaHash<DefaultHasher> = rng.r#gen();
+
+        assert_eq!(db.get_root_metadata(&k1), None);
+        assert!(db.get_all_root_metadata().is_empty());
+
+        db.set_root_metadata(k1.clone(), vec![1, 2, 3]);
+        db.set_root_metadata(k2.clone(), vec![4]);
+        assert_eq!(db.get_root_metadata(&k1), Some(vec![1, 2, 3]));
+        assert_eq!(db.get_root_metadata(&k2), Some(vec![4]));
+
+        // Overwriting replaces the previous metadata.
+        db.set_root_metadata(k1.clone(), vec![9]);
+        assert_eq!(db.get_root_metadata(&k1), Some(vec![9]));
+
+        let all = db.get_all_root_metadata();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[&k1], vec![9]);
+        assert_eq!(all[&k2], vec![4]);
+
+        db.delete_root_metadata(&k1);
+        assert_eq!(db.get_root_metadata(&k1), None);
+        // Deleting metadata that doesn't exist is a no-op.
+        db.delete_root_metadata(&k1);
+        assert_eq!(db.get_all_root_metadata().len(), 1);
     }
 
     #[test]

--- a/storage-core/src/db/paritydb.rs
+++ b/storage-core/src/db/paritydb.rs
@@ -30,16 +30,33 @@ use super::{DB, DummyArbitrary, Update};
 
 // Different value to Substrate: polkadot-sdk/substrate/client/db/src/utils.rs
 // This means the `storage` database must be stored in a different file
-// NOTE: We stay at 3 columns even with layout v2, to reserve a column for future GC purposes
+// NOTE: We stay at 3 columns even with layout v2. Column 2 was originally
+// reserved for future GC purposes when layout v2 removed ref-count tracking;
+// it is now used for GC-root metadata under the `gc-v1` feature (see
+// `ROOT_METADATA_COLUMN`).
 /// Number of columns used for ParityDb instance
 pub const NUM_COLUMNS: u8 = 3;
 /// Column index for storing storage nodes
 pub const NODE_COLUMN: u8 = 0;
 /// Column index for storing reference counts
 pub const GC_ROOT_COLUMN: u8 = 1;
+/// Third column. Always allocated (`NUM_COLUMNS` is 3). Meaning depends on
+/// features: zero-refcount tracking without `layout-v2`, GC-root metadata
+/// with `gc-v1`, otherwise unused.
+pub const THIRD_COLUMN: u8 = 2;
 #[cfg(not(feature = "layout-v2"))]
 /// Column to track which nodes have a ref count of zero
-pub const REF_COUNT_ZERO: u8 = 2;
+pub const REF_COUNT_ZERO: u8 = THIRD_COLUMN;
+#[cfg(feature = "gc-v1")]
+/// Column for storing opaque GC-root metadata, to support pruning decisions.
+/// This uses the column reserved when layout v2 removed ref-count tracking
+/// (see NOTE on `NUM_COLUMNS`); `gc-v1` implies `layout-v2`, so it can't
+/// conflict with `REF_COUNT_ZERO`.
+///
+/// WARNING: a pre-layout-v2 database opened with `gc-v1` may contain stale
+/// `REF_COUNT_ZERO` entries in this column, which would be misread as root
+/// metadata; such databases need their column 2 cleared as part of migration.
+pub const ROOT_METADATA_COLUMN: u8 = THIRD_COLUMN;
 
 /// A wrapper around `Arc<parity_db::Db>` that owns a database instance.
 pub struct OwnedDb(pub Arc<parity_db::Db>);
@@ -96,10 +113,9 @@ pub fn set_init_options(
     use_compression: bool,
 ) {
     // Add indexes to all columns - we need this to be able to iterate over them
-    options.columns[(column_offset + GC_ROOT_COLUMN) as usize].btree_index = true;
-    // NOTE: Hardcoded because the constant is behind a feature flag.
-    options.columns[(column_offset + 2) as usize].btree_index = true;
     options.columns[(column_offset + NODE_COLUMN) as usize].btree_index = true;
+    options.columns[(column_offset + GC_ROOT_COLUMN) as usize].btree_index = true;
+    options.columns[(column_offset + THIRD_COLUMN) as usize].btree_index = true;
     if use_compression {
         options.columns[(column_offset + NODE_COLUMN) as usize].compression =
             parity_db::CompressionType::Lz4;
@@ -151,16 +167,21 @@ fn serialize_node<H: WellBehavedHasher>(node: &OnDiskObject<H>) -> Vec<u8> {
 }
 
 fn bytes_to_arena_key<H: WellBehavedHasher>(key_bytes: Vec<u8>) -> ArenaHash<H> {
-    if key_bytes.len() != <H as OutputSizeUser>::output_size() {
+    try_bytes_to_arena_key(key_bytes).unwrap_or_else(|len| {
         panic!(
-            "incorrect length for gc_root key: found {}, expected {}",
-            key_bytes.len(),
+            "incorrect length for gc_root key: found {len}, expected {}",
             <H as OutputSizeUser>::output_size()
-        );
+        )
+    })
+}
+
+fn try_bytes_to_arena_key<H: WellBehavedHasher>(key_bytes: Vec<u8>) -> Result<ArenaHash<H>, usize> {
+    if key_bytes.len() != <H as OutputSizeUser>::output_size() {
+        return Err(key_bytes.len());
     }
 
     #[allow(deprecated)]
-    ArenaHash(Array::from_iter(key_bytes))
+    Ok(ArenaHash(Array::from_iter(key_bytes)))
 }
 
 impl<H: WellBehavedHasher, const COLUMN_OFFSET: u8> ParityDb<H, OwnedDb, COLUMN_OFFSET> {
@@ -326,6 +347,20 @@ impl<
                         },
                     ));
                 }
+                #[cfg(feature = "gc-v1")]
+                Update::SetRootMetadata(metadata) => {
+                    ops.push((
+                        COLUMN_OFFSET + ROOT_METADATA_COLUMN,
+                        parity_db::Operation::Set(key.0.to_vec(), metadata),
+                    ));
+                }
+                #[cfg(feature = "gc-v1")]
+                Update::DeleteRootMetadata => {
+                    ops.push((
+                        COLUMN_OFFSET + ROOT_METADATA_COLUMN,
+                        parity_db::Operation::Dereference(key.0.to_vec()),
+                    ));
+                }
                 Update::DeleteNode => {
                     ops.push((
                         COLUMN_OFFSET + NODE_COLUMN,
@@ -339,6 +374,7 @@ impl<
                 }
             }
         }
+        // Single ParityDb commit: persist counts and root metadata apply together.
         self.db.commit_changes(ops).expect("Failed to commit to db");
     }
 
@@ -385,6 +421,49 @@ impl<
             let k = bytes_to_arena_key(key);
             let v = u32::from_le_bytes(value.try_into().expect("gc root count should be 4 bytes"));
             map.insert(k, v);
+        }
+        map
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn get_root_metadata(&self, key: &ArenaHash<Self::Hasher>) -> Option<Vec<u8>> {
+        self.db
+            .get(COLUMN_OFFSET + ROOT_METADATA_COLUMN, &key.0)
+            .expect("failed to get from db")
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn set_root_metadata(&mut self, key: ArenaHash<Self::Hasher>, metadata: Vec<u8>) {
+        let ops = vec![(
+            COLUMN_OFFSET + ROOT_METADATA_COLUMN,
+            parity_db::Operation::Set(key.0.to_vec(), metadata),
+        )];
+        self.db.commit_changes(ops).expect("Failed to commit to db");
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn delete_root_metadata(&mut self, key: &ArenaHash<Self::Hasher>) {
+        let ops = vec![(
+            COLUMN_OFFSET + ROOT_METADATA_COLUMN,
+            parity_db::Operation::Dereference(key.0.to_vec()),
+        )];
+        self.db.commit_changes(ops).expect("Failed to commit to db");
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn get_all_root_metadata(&self) -> HashMap<ArenaHash<Self::Hasher>, Vec<u8>> {
+        let mut it = self
+            .db
+            .iter(COLUMN_OFFSET + ROOT_METADATA_COLUMN)
+            .expect("Failed to iterate over db");
+
+        let mut map = HashMap::new();
+        while let Some((key, value)) = it.next().expect("Failed to get next from iterator") {
+            // Skip leftover `REF_COUNT_ZERO` keys from a pre-layout-v2 database
+            // opened with `gc-v1` (wrong key length) rather than panicking.
+            if let Ok(k) = try_bytes_to_arena_key(key) {
+                map.insert(k, value);
+            }
         }
         map
     }

--- a/storage-core/src/db/sql.rs
+++ b/storage-core/src/db/sql.rs
@@ -281,6 +281,19 @@ impl<H: WellBehavedHasher> SqlDB<H> {
             tx.execute(sql, ()).unwrap();
             let sql = "CREATE INDEX IF NOT EXISTS ix_root_count ON root (count)";
             tx.execute(sql, ()).unwrap();
+            // Opaque metadata associated with GC roots, to support pruning
+            // decisions (e.g. recording a block height when persisting a
+            // root). As with `root`, the `key` is logically a foreign key
+            // referencing `node.key`, but we don't enforce that, for the same
+            // reasons as for `root`.
+            #[cfg(feature = "gc-v1")]
+            {
+                let sql = "CREATE TABLE IF NOT EXISTS root_metadata (
+                         key BLOB NOT NULL PRIMARY KEY,
+                         metadata BLOB NOT NULL
+                       )";
+                tx.execute(sql, ()).unwrap();
+            }
         })
     }
 
@@ -617,8 +630,9 @@ impl<H: WellBehavedHasher> DB for SqlDB<H> {
         I: Iterator<Item = (ArenaHash<H>, Update<H>)>,
     {
         use Update::*;
-        // For batching at the SQL level, this approach is supposed to be faster
-        // (and easier!) than building up large INSERTs:
+        // One Immediate transaction: persist counts and root metadata in this
+        // iterator commit together. For batching at the SQL level this is also
+        // faster than building large INSERTs:
         // https://stackoverflow.com/a/5209093/470844
         self.with_tx(Immediate, |tx| {
             #[cfg(not(feature = "layout-v2"))]
@@ -635,6 +649,17 @@ impl<H: WellBehavedHasher> DB for SqlDB<H> {
             let mut set_root_count = tx.prepare(sql).unwrap();
             let sql = "DELETE FROM root WHERE key = (?1)";
             let mut delete_root_count = tx.prepare(sql).unwrap();
+            #[cfg(feature = "gc-v1")]
+            let mut set_root_metadata = tx
+                .prepare(
+                    "INSERT OR REPLACE INTO root_metadata (key, metadata) \
+                     VALUES (?1, ?2)",
+                )
+                .unwrap();
+            #[cfg(feature = "gc-v1")]
+            let mut delete_root_metadata = tx
+                .prepare("DELETE FROM root_metadata WHERE key = (?1)")
+                .unwrap();
             for (key, update) in iter {
                 match update {
                     DeleteNode => delete_node.execute(params![key]).unwrap(),
@@ -658,12 +683,23 @@ impl<H: WellBehavedHasher> DB for SqlDB<H> {
                             delete_root_count.execute(params![key]).unwrap()
                         }
                     }
+                    #[cfg(feature = "gc-v1")]
+                    SetRootMetadata(metadata) => {
+                        set_root_metadata.execute(params![key, metadata]).unwrap()
+                    }
+                    #[cfg(feature = "gc-v1")]
+                    DeleteRootMetadata => delete_root_metadata.execute(params![key]).unwrap(),
                 };
             }
             insert_node.finalize().unwrap();
             delete_node.finalize().unwrap();
             set_root_count.finalize().unwrap();
             delete_root_count.finalize().unwrap();
+            #[cfg(feature = "gc-v1")]
+            {
+                set_root_metadata.finalize().unwrap();
+                delete_root_metadata.finalize().unwrap();
+            }
         })
     }
 
@@ -718,6 +754,62 @@ impl<H: WellBehavedHasher> DB for SqlDB<H> {
                     let key: ArenaHash<H> = row.get(0)?;
                     let count: u32 = row.get(1)?;
                     Ok((key, count))
+                })
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            stmt.finalize().unwrap();
+            result
+        })
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn get_root_metadata(&self, key: &ArenaHash<Self::Hasher>) -> Option<Vec<u8>> {
+        let key = key.clone();
+        self.with_tx(Deferred, |tx| {
+            let sql = "SELECT metadata FROM root_metadata WHERE key = (?1)";
+            let mut stmt = tx.prepare(sql).unwrap();
+            let result = stmt
+                .query_row(params![key], |row| row.get(0))
+                .optional()
+                .unwrap();
+            stmt.finalize().unwrap();
+            result
+        })
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn set_root_metadata(&mut self, key: ArenaHash<Self::Hasher>, metadata: Vec<u8>) {
+        self.with_tx(Immediate, |tx| {
+            let sql = "INSERT OR REPLACE INTO root_metadata (key, metadata) \
+                       VALUES (?1, ?2)";
+            let mut stmt = tx.prepare(sql).unwrap();
+            stmt.execute(params![key, metadata]).unwrap();
+            stmt.finalize().unwrap();
+        })
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn delete_root_metadata(&mut self, key: &ArenaHash<Self::Hasher>) {
+        let key = key.clone();
+        self.with_tx(Immediate, |tx| {
+            let sql = "DELETE FROM root_metadata WHERE key = (?1)";
+            let mut stmt = tx.prepare(sql).unwrap();
+            stmt.execute(params![key]).unwrap();
+            stmt.finalize().unwrap();
+        })
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn get_all_root_metadata(&self) -> HashMap<ArenaHash<Self::Hasher>, Vec<u8>> {
+        self.with_tx(Deferred, |tx| {
+            let sql = "SELECT key, metadata FROM root_metadata";
+            let mut stmt = tx.prepare(sql).unwrap();
+            let result = stmt
+                .query_map([], |row| {
+                    let key: ArenaHash<H> = row.get(0)?;
+                    let metadata: Vec<u8> = row.get(1)?;
+                    Ok((key, metadata))
                 })
                 .unwrap()
                 .map(|r| r.unwrap())

--- a/storage-core/src/gc.rs
+++ b/storage-core/src/gc.rs
@@ -255,6 +255,204 @@ impl<D: DB> GcState<D> {
 
 #[cfg(test)]
 mod tests {
+    /// Test the metadata-handle pruning workflow: persist roots tagged with a
+    /// "block hash", then unpersist by providing only those hashes -- no
+    /// caller-side mapping from hash back to roots -- and let the GC collect
+    /// the released roots.
+    #[test]
+    fn test_unpersist_by_metadata() {
+        use crate::db::DB;
+        use std::time::Duration;
+        let arena = crate::arena::Arena::new_from_backend(crate::backend::StorageBackend::new(
+            1,
+            crate::db::InMemoryDB::<crate::DefaultHasher>::default(),
+        ));
+        let size = || arena.with_backend(|b| b.database.size());
+        let block_1 = vec![1u8; 32];
+        let block_2 = vec![2u8; 32];
+        let block_3 = vec![3u8; 32];
+
+        // Two roots tagged with block 1, one each with blocks 2 and 3.
+        let sps = [
+            (1u64, &block_1),
+            (2, &block_1),
+            (3, &block_2),
+            (4, &block_3),
+        ]
+        .map(|(value, block)| {
+            let mut sp = arena.alloc(value);
+            sp.persist_with_metadata(block.clone());
+            sp
+        });
+        arena.with_backend(|b| b.flush_all_changes_to_db());
+        assert_eq!(size(), 4);
+
+        // Nothing is collected while the roots are persisted.
+        drop(sps);
+        assert_eq!(arena.with_backend(|b| b.gc(Duration::from_hours(1))), 0);
+        assert_eq!(size(), 4);
+
+        // One lock, one call: release blocks 1 and 2 by metadata alone. Both
+        // block-1 roots and the block-2 root are decremented.
+        let pruned = [block_1.clone(), block_2.clone()];
+        assert_eq!(arena.with_backend(|b| b.unpersist_by_metadata(&pruned)), 3);
+        // Count is already zero, so a repeat is a no-op even before flush.
+        // On-disk tags remain until flush, so a crash could retry.
+        assert_eq!(arena.with_backend(|b| b.unpersist_by_metadata(&pruned)), 0);
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_all_root_metadata().len()),
+            4
+        );
+        arena.with_backend(|b| b.flush_all_changes_to_db());
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_all_root_metadata().len()),
+            1
+        );
+
+        // GC collects exactly the released roots; block 3 stays.
+        assert_eq!(arena.with_backend(|b| b.gc(Duration::from_hours(1))), 3);
+        assert_eq!(size(), 1);
+    }
+
+    /// Test metadata lifecycle against multiple persists of the same root:
+    /// each `unpersist_by_metadata` call decrements a matching root once, and
+    /// the metadata survives until the root count drops to zero.
+    #[test]
+    fn test_root_metadata_multi_persist() {
+        let arena = crate::arena::Arena::new_from_backend(crate::backend::StorageBackend::new(
+            1,
+            crate::db::InMemoryDB::<crate::DefaultHasher>::default(),
+        ));
+        let mut sp = arena.alloc(100u64);
+        sp.persist_with_metadata(vec![1]);
+        let hash = sp.hash();
+        let meta = || arena.with_backend(|b| b.get_root_metadata(&hash));
+        sp.persist();
+        // Overwriting metadata doesn't change the root count.
+        sp.persist_with_metadata(vec![2]);
+        assert_eq!(meta(), Some(vec![2]));
+        // Root count is 3: each call decrements once, keeping the metadata
+        // until the count reaches zero.
+        assert_eq!(
+            arena.with_backend(|b| b.unpersist_by_metadata(&[vec![2]])),
+            1
+        );
+        assert_eq!(
+            arena.with_backend(|b| b.unpersist_by_metadata(&[vec![2]])),
+            1
+        );
+        assert_eq!(meta(), Some(vec![2]));
+        assert_eq!(
+            arena.with_backend(|b| b.unpersist_by_metadata(&[vec![2]])),
+            1
+        );
+        // Count dropped to zero: metadata is hidden, further calls are no-ops.
+        assert_eq!(meta(), None);
+        assert_eq!(
+            arena.with_backend(|b| b.unpersist_by_metadata(&[vec![2]])),
+            0
+        );
+    }
+
+    /// Persist-count and metadata commit in the same flush. Unpersist-by-metadata
+    /// before flush leaves the on-disk tag in place so a crash can retry.
+    #[test]
+    fn test_root_metadata_flush_atomicity() {
+        use crate::db::DB;
+        let arena = crate::arena::Arena::new_from_backend(crate::backend::StorageBackend::new(
+            1,
+            crate::db::InMemoryDB::<crate::DefaultHasher>::default(),
+        ));
+        let mut sp = arena.alloc(7u64);
+        let hash = sp.hash();
+        let tag = vec![9u8; 32];
+        sp.persist_with_metadata(tag.clone());
+        drop(sp);
+
+        // Staged, not durable: overlay sees the tag, the DB does not.
+        assert_eq!(
+            arena.with_backend(|b| b.get_root_metadata(&hash)),
+            Some(tag.clone())
+        );
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_root_metadata(&hash)),
+            None
+        );
+        assert_eq!(arena.with_backend(|b| b.get_root_count(&hash)), 1);
+
+        arena.with_backend(|b| b.flush_all_changes_to_db());
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_root_metadata(&hash)),
+            Some(tag.clone())
+        );
+        assert_eq!(arena.with_backend(|b| b.database.get_root_count(&hash)), 1);
+
+        assert_eq!(arena.with_backend(|b| b.unpersist_by_metadata(&[&tag])), 1);
+        // Logical view is already unpersisted; on-disk tag and count stay
+        // until flush — the retry handle survives a crash here.
+        assert_eq!(arena.with_backend(|b| b.get_root_metadata(&hash)), None);
+        assert_eq!(arena.with_backend(|b| b.get_root_count(&hash)), 0);
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_root_metadata(&hash)),
+            Some(tag.clone())
+        );
+        assert_eq!(arena.with_backend(|b| b.database.get_root_count(&hash)), 1);
+
+        arena.with_backend(|b| b.flush_all_changes_to_db());
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_root_metadata(&hash)),
+            None
+        );
+        assert_eq!(arena.with_backend(|b| b.database.get_root_count(&hash)), 0);
+        assert_eq!(arena.with_backend(|b| b.unpersist_by_metadata(&[&tag])), 0);
+    }
+
+    /// Tag-timing: persist first (tag unknown), then `set_root_metadata` once
+    /// the handle exists, without bumping the persist count.
+    #[test]
+    fn test_set_root_metadata_after_persist() {
+        use crate::db::DB;
+        let arena = crate::arena::Arena::new_from_backend(crate::backend::StorageBackend::new(
+            1,
+            crate::db::InMemoryDB::<crate::DefaultHasher>::default(),
+        ));
+        let mut sp = arena.alloc(11u64);
+        let hash = sp.hash();
+        let tag = vec![8u8; 32];
+        sp.persist();
+        arena.with_backend(|b| b.flush_all_changes_to_db());
+        assert_eq!(arena.with_backend(|b| b.get_root_count(&hash)), 1);
+        assert_eq!(arena.with_backend(|b| b.get_root_metadata(&hash)), None);
+
+        arena.with_backend(|b| b.set_root_metadata(&hash, tag.clone()));
+        // Overlay sees the tag; persist count is unchanged; DB waits for flush.
+        assert_eq!(
+            arena.with_backend(|b| b.get_root_metadata(&hash)),
+            Some(tag.clone())
+        );
+        assert_eq!(arena.with_backend(|b| b.get_root_count(&hash)), 1);
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_root_metadata(&hash)),
+            None
+        );
+
+        arena.with_backend(|b| b.flush_all_changes_to_db());
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_root_metadata(&hash)),
+            Some(tag.clone())
+        );
+        assert_eq!(arena.with_backend(|b| b.database.get_root_count(&hash)), 1);
+
+        drop(sp);
+        assert_eq!(arena.with_backend(|b| b.unpersist_by_metadata(&[&tag])), 1);
+        arena.with_backend(|b| b.flush_all_changes_to_db());
+        assert_eq!(arena.with_backend(|b| b.database.get_root_count(&hash)), 0);
+        assert_eq!(
+            arena.with_backend(|b| b.database.get_root_metadata(&hash)),
+            None
+        );
+    }
+
     #[test]
     fn test_gc() {
         use crate::db::DB;

--- a/storage-core/src/storage.rs
+++ b/storage-core/src/storage.rs
@@ -300,6 +300,26 @@ impl<D: DB, T: Sync + Send + 'static> DB for WrappedDB<D, T> {
         self.db.get_roots()
     }
 
+    #[cfg(feature = "gc-v1")]
+    fn get_root_metadata(&self, key: &ArenaHash<Self::Hasher>) -> Option<Vec<u8>> {
+        self.db.get_root_metadata(key)
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn set_root_metadata(&mut self, key: ArenaHash<Self::Hasher>, metadata: Vec<u8>) {
+        self.db.set_root_metadata(key, metadata)
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn delete_root_metadata(&mut self, key: &ArenaHash<Self::Hasher>) {
+        self.db.delete_root_metadata(key)
+    }
+
+    #[cfg(feature = "gc-v1")]
+    fn get_all_root_metadata(&self) -> std::collections::HashMap<ArenaHash<Self::Hasher>, Vec<u8>> {
+        self.db.get_all_root_metadata()
+    }
+
     fn size(&self) -> usize {
         self.db.size()
     }


### PR DESCRIPTION
## Description

Adds GC-root metadata to `storage-core` (behind `gc-v1`): a persisted root can be tagged with an opaque value (e.g. a block hash), and later released by providing only that value — no caller-side index from tags back to root hashes.

**Motivation.** `persist()` marks a root but records nothing about what it was persisted *for*. A pruning job (e.g. a node reclaiming ledger states once their blocks fall out of the state-pruning window) would otherwise have to maintain its own durable `tag → root` index in a separate database, with the cross-database crash-consistency reasoning that entails (independent WALs, remove-then-act ordering, retry logic, clamping against replayed decrements). Storing the tag in the same database as the root count it guards reduces the caller's lifecycle to three calls, each using only data in hand at that moment:

```rust
sp.persist();                                  // execution time (tag not yet known)
sp.set_root_metadata(block_hash);              // finality time (tag known)
backend.unpersist_by_metadata(&pruned_hashes); // pruning time (one lock, one call)
```

**API** (all `gc-v1`-gated):

- `Sp::persist_with_metadata(tag)` — persist and tag in one step, when the tag is known at persist time.
- `Sp::set_root_metadata(tag)` / `StorageBackend::set_root_metadata` — tag an already-persisted root without changing its persist count.
- `StorageBackend::unpersist_by_metadata(&[tags]) -> usize` — release every root tagged with one of the given values, decrementing each matching root once. Zero-clamped: roots at count 0 are skipped, so submitting values that exceed the actually held counts is safe. The whole batch runs under a single backend borrow with one scan of the tag table.
- `StorageBackend::get_root_metadata` / `get_all_root_metadata` — read views that incorporate pending writes and hide tags of zero-count roots.
- A root holds one tag (last write wins); the tag is deleted automatically when the root count drops to zero.

**Durability.** Tags are staged in memory and committed via `Update::SetRootMetadata` / `DeleteRootMetadata` in the same `DB::batch_update` as the key's persist count — `batch_update` is atomic over its whole iterator (SQLite: one transaction; ParityDb: one `commit_changes`), and every batch that writes a tag also carries that key's count, so a crash can never make one durable without the other. A pending tag flushes at the first flush (full or eviction-driven) at which its key's count is durable. A crash mid-pruning leaves the on-disk tags intact, so re-submitting the same values retries the release; a crash after the flush makes re-submission a no-op. Unpersisting itself does no metadata I/O — all metadata decisions are deferred to flush, where they batch.

**Storage.**

- SQLite: new `root_metadata` table, created with `IF NOT EXISTS` — existing files upgrade transparently.
- ParityDb: uses column 2, reserved for GC purposes since layout v2. `NUM_COLUMNS` is unchanged, so existing databases (including embedded, column-offset instances) stay compatible.
- Implemented for `InMemoryDB`, `SqlDB`, `ParityDb`, and the `WrappedDB` pass-through.

**Testing.** Per-backend metadata CRUD across all three backends; the end-to-end pruning workflow (tag at persist → release a batch of tags in one call → repeat is a no-op → GC collects exactly the released roots); multi-persist lifecycle (tag survives until the count reaches zero); flush atomicity (staged view visible immediately, disk unchanged until flush, crash-retry handle intact in between); deferred tagging after a durable persist; eviction-flush timing (a tag never flushes while its count delta is still cached, but flushes with unrelated evictions once its count is durable).

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [x] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [x] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.