### PR TITLE
fix: widen VM lt operation to u128 for unshielded balance comparisons

### DIFF
--- a/CHANGELOG_onchain-runtime.md
+++ b/CHANGELOG_onchain-runtime.md
@@ -2,6 +2,10 @@
 
 ## Version `4.0.0`
 
+- fix: the VM `lt` operation now decodes its operands as `u128` instead of
+  `u64`, so comparisons cover the full range of unshielded token balances.
+  Previously the `unshieldedBalance{Lt,Lte,Gt,Gte}` Compact builtins failed
+  with `InvalidBuiltinDecode("u64")` for any operand above `u64::MAX`.
 - feat: `ContractOperation` includes ir field
 - feat: add support for ECDSA signatures.
 - feat: Changed the structure of logged events according to events MIP (link tbd).

--- a/onchain-runtime/tests/vm.rs
+++ b/onchain-runtime/tests/vm.rs
@@ -84,6 +84,20 @@ mod tests {
             );
         }
 
+        // lt over values exceeding u64::MAX (e.g. unshielded balances are u128)
+        let cmp_operands_u128 = vec![
+            (u64::MAX as u128 + 1, u64::MAX as u128 + 2),
+            (u128::MAX, u128::MAX),
+            (u128::MAX, 5u128),
+            (5u128, u128::MAX),
+        ];
+        for ops in cmp_operands_u128 {
+            assert_eq!(
+                run_program(&[vmval!((ops.0)), vmval!((ops.1))], &ops![lt]),
+                Ok((vec![vmval!((ops.0 < ops.1))], vec![]))
+            );
+        }
+
         for ops in logic_operands {
             // and
             assert_eq!(

--- a/onchain-vm/src/vm.rs
+++ b/onchain-vm/src/vm.rs
@@ -142,8 +142,10 @@ where
 }
 
 fn lt<D: DB>(a: &Value, b: &Value) -> Result<AlignedValue, OnchainProgramError<D>> {
-    let a: u64 = (&**a).try_into()?;
-    let b: u64 = (&**b).try_into()?;
+    // u128 so comparisons cover the full range of unshielded balances, which
+    // are stored as u128.
+    let a: u128 = (&**a).try_into()?;
+    let b: u128 = (&**b).try_into()?;
     Ok((a < b).into())
 }
 


### PR DESCRIPTION
## Description

Closes https://github.com/shieldedtech/mnf-stl-support/issues/275, a breaking change - possibly worth targetting ledger-10

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.