### PR TITLE
Unembargo 8.1.2 fixes (onyx-coyote)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   check:
     strategy:
       matrix:
-        os: [ubuntu-latest-8-core-x64]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git rewrite
@@ -164,7 +164,7 @@ jobs:
   build-ledger:
     strategy:
       matrix:
-        os: [ubuntu-latest-8-core-x64, ubuntu-24.04-arm, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git rewrite
@@ -226,7 +226,7 @@ jobs:
   build-proof-server:
     strategy:
       matrix:
-        os: [ubuntu-latest-8-core-x64, ubuntu-24.04-arm]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git rewrite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   check:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest-8-core-x64]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git rewrite
@@ -164,7 +164,7 @@ jobs:
   build-ledger:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        os: [ubuntu-latest-8-core-x64, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git rewrite
@@ -226,7 +226,7 @@ jobs:
   build-proof-server:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest-8-core-x64, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git rewrite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 # Change Log
 
+## Ledger 8.1.2
+
+Security patch. All bumps are patch-level so that the release reads as one, even
+where an individual change carries wider semver implications; internal dependency
+requirements are pinned to the new exact versions so that consumers cannot
+resolve past the fix.
+
+- security: hardening of low-level deserialization across `serialize`,
+  `base-crypto`, `storage`, `onchain-state`, `onchain-vm` and
+  `transient-crypto`. Encodings that are not canonical, and values violating
+  their type's invariant, are now rejected rather than decoded. This narrows what
+  deserializes: an 8.1.2 node rejects data an 8.1.1 node accepts. See the
+  per-crate changelogs for the individual rules.
+- fix: `DustParameters::time_to_cap` guards against a zero
+  `generation_decay_rate` instead of dividing by zero.
+- fix: Dust `seq` increments saturate.
+- fix: Zswap binding randomness extraction no longer panics on a proof preimage
+  with no witness to extract from.
+- fix: delta accumulation in `normalize_deltas` saturates.
+- fix: contract call cost accounting counts public inputs via
+  `ContractCall::public_inputs_len`, with saturating arithmetic, rather than
+  materializing the inputs to take their length.
+
 ## Ledger 8.1.1
 
 - note: npm packages are now published under the `@midnightntwrk` scope (previously `@midnight-ntwrk`); update package.json dependencies accordingly

--- a/CHANGELOG_base-crypto.md
+++ b/CHANGELOG_base-crypto.md
@@ -1,5 +1,14 @@
 # `base-crypto` Changelog
 
+## Version `1.0.1`
+
+- security: reject non-canonical `Value` and `ValueAtom` encodings: a singleton
+  value encoded in the multi-entry form, and an atom that fits the single-byte
+  form encoded as multiple bytes.
+- security: `AlignedValue` deserialization now rejects a value that does not fit
+  its declared alignment.
+- fix: `Duration::from_hours` saturates instead of overflowing.
+
 ## Version `1.0.0`
 
 - version bump in preparation for full stablisation

--- a/CHANGELOG_coin-structure.md
+++ b/CHANGELOG_coin-structure.md
@@ -1,5 +1,10 @@
 # `coin-structure` Changelog
 
+## Version `2.0.2`
+
+- pull in hardened `serialize`, `base-crypto`, `storage-core` and
+  `transient-crypto` deserialization.
+
 ## Version `2.0.0`
 
 - breaking: pull in breaking transient-crypto changes

--- a/CHANGELOG_onchain-runtime.md
+++ b/CHANGELOG_onchain-runtime.md
@@ -1,5 +1,20 @@
 # `midnight-onchain-runtime` Changelog
 
+## Version `3.1.1`
+
+Covers `onchain-state` `3.0.1` and `onchain-vm` `3.1.1`.
+
+- security: `Op` deserialization rejects operands outside their legal encoding
+  bound: `dup`, `swap` and `ins` with `n >= 16`, and `idx` with a path length
+  outside `1..=16`.
+- security: serde `StateValue` deserialization now enforces the type's
+  invariant.
+- security: taking the `type` of an array with more than 16 entries is a type
+  error instead of producing an out-of-range tag byte.
+- fix: the Merkle tree bound checks in `idx` and `ins` no longer overflow for
+  large tree heights.
+- pull in hardened `serialize`, `base-crypto` and `storage` deserialization.
+
 ## Version `3.1.0`
 
 - feat: add more flexibility to `findPathForLeaf`, allowing it to scan index

--- a/CHANGELOG_serialize.md
+++ b/CHANGELOG_serialize.md
@@ -1,5 +1,22 @@
 # `serialize` Changelog
 
+## Version `1.1.1`
+
+- security: `HashMap` and `HashSet` deserialization now requires a normalized
+  encoding (sorted, without duplicate keys), rejecting the non-canonical
+  encodings that previously decoded to the same value.
+- security: reject non-canonical `ScaleBigInt` encodings that use the 4-byte
+  form for a value that fits the smaller form.
+- security: `Box<T>` deserialization now counts against the recursion depth
+  budget.
+- fix: `Vec::with_bounded_capacity` no longer divides by zero for zero-sized
+  types.
+- fix: `serialized_size` for `HashMap` and `HashSet` accounts for the actual
+  width of the length prefix.
+- note: `Deserializable for HashSet<T>` now additionally requires
+  `T: PartialOrd`. `Serializable for HashSet<T>` already required `T: Ord`, so
+  any consumer that round-trips a `HashSet` is unaffected.
+
 ## Version `1.1.0`
 
 - feat: add `tagged_deserialize_sequence`, which deserializes a sequence of tagged values

--- a/CHANGELOG_storage.md
+++ b/CHANGELOG_storage.md
@@ -1,5 +1,20 @@
 # `storage` Changelog
 
+## Version `2.0.3`
+
+- security: `MerklePatriciaTrie` deserialization now enforces full structural
+  canonicity rather than annotation consistency alone, so a trie whose structure
+  is not uniquely determined by its contents no longer decodes.
+- security: an `Extension` node whose declared nibble length disagrees with the
+  length of its encoded path is rejected.
+- security: `MultiSet` rejects zero-count entries.
+- security: `TimeFilterMap` rejects an encoding whose set and time-map
+  representations disagree.
+- security: nibble-encoded keys reject trailing bytes left over after decoding.
+- feat: add `MerklePatriciaTrie::canonicity` and
+  `MerklePatriciaTrie::is_canonical`, which state the canonicity rules
+  explicitly.
+
 ## Version `2.0.2`
 
 - fix: clear clippy::useless_borrows_in_formatting across workspace

--- a/CHANGELOG_storage_core.md
+++ b/CHANGELOG_storage_core.md
@@ -1,5 +1,9 @@
 # `storage-core` Changelog
 
+## Version `1.2.1`
+
+- pull in hardened `serialize` and `base-crypto` deserialization.
+
 ## Version `1.2.0`
 
 - feat: add incremental garbage collector, running in a time-bounded way. This requires databases to support a new scan operation.

--- a/CHANGELOG_transient-crypto.md
+++ b/CHANGELOG_transient-crypto.md
@@ -1,7 +1,13 @@
 # `transient-crypto` Changelog
 
-## Unreleased
+## Version `2.1.1`
 
+- security: `VerifierKey` serialization is now independent of whether the key has
+  been initialized: the bytes a key was decoded from are preserved, so
+  initializing in place (which is shared across clones) no longer changes what
+  the key serializes to.
+- security: reject a verifier key with trailing bytes after the encoded key, so
+  that two encodings cannot map to the same key.
 - fix: rehashing serde deserialized `MerkleTree`s
 
 ## Version `2.1.0`

--- a/CHANGELOG_zkir.md
+++ b/CHANGELOG_zkir.md
@@ -1,5 +1,10 @@
 # `zkir` Changelog
 
+## Version `2.1.1`
+
+- pull in hardened `serialize`, `base-crypto` and `transient-crypto`
+  deserialization.
+
 ## Version `2.1.0`
 
 - breaking: pull in breaking proof system changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-base-crypto"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "actix-rt",
  "anyhow",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-coin-structure"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "fake",
  "lazy_static",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-ledger"
-version = "8.1.1"
+version = "8.1.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-ledger-wasm"
-version = "8.1.1"
+version = "8.1.2"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-runtime"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "criterion",
  "derive-where",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-runtime-wasm"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-state"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "derive-where",
  "fake",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-vm"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "derive-where",
  "fake",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-proof-server"
-version = "8.1.1"
+version = "8.1.2"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-serialize"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crypto",
  "konst",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-storage"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "criterion",
  "crypto",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-storage-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "archery",
  "criterion",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-transient-crypto"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "actix-rt",
  "anyhow",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-zkir"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "actix-rt",
  "anyhow",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-zkir-wasm"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-zswap"
-version = "8.1.1"
+version = "8.1.2"
 dependencies = [
  "criterion",
  "derive-where",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 package.license = "Apache-2.0"
 package.repository = "https://github.com/midnightntwrk/midnight-ledger"
-package.version = "8.1.1"
+package.version = "8.1.2"
 members = [
     "zswap",
     "ledger",

--- a/base-crypto/Cargo.toml
+++ b/base-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-base-crypto"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true
@@ -14,7 +14,7 @@ fixed-point-custom-serde = []
 
 [dependencies]
 derive = { version = "1.0.0", path = "../base-crypto-derive", package = "midnight-base-crypto-derive" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
 
 ff = "^0.13.1"
 group = "^0.13.0"

--- a/base-crypto/src/fab/serialize.rs
+++ b/base-crypto/src/fab/serialize.rs
@@ -136,6 +136,9 @@ impl Deserializable for Value {
                 x, y, int, reader,
             )?])),
             (true, false) => {
+                if int == 1 {
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, "singleton value encoded as multi-entry value"));
+                };
                 let mut res = Vec::new();
                 for _ in 0..int {
                     res.push(<ValueAtom as Deserializable>::deserialize(
@@ -298,6 +301,9 @@ impl Deserializable for AlignedValue {
         Self::check_rec(&mut recursion_depth)?;
         let value: Value = Deserializable::deserialize(reader, recursion_depth)?;
         let alignment: Alignment = Deserializable::deserialize(reader, recursion_depth)?;
+        if !alignment.fits(&value) {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "deserialized AlignedValue is not aligned"));
+        }
         Ok(AlignedValue { value, alignment })
     }
 }
@@ -411,6 +417,11 @@ impl ValueAtom {
                 Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "ValueAtom ended with zero byte",
+                ))
+            } else if int == 1 && res[0] < 32 {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "ValueAtom fitting into single-byte form encoded as multiple bytes",
                 ))
             } else {
                 Ok(ValueAtom(res))

--- a/base-crypto/src/time.rs
+++ b/base-crypto/src/time.rs
@@ -157,7 +157,7 @@ impl Duration {
 
     /// Gets the `Duration` from a number of hours
     pub const fn from_hours(h: i128) -> Self {
-        Duration::from_secs(h * 60 * 60)
+        Duration::from_secs(h.saturating_mul(3600))
     }
 
     /// Returns the duration's raw value in seconds.

--- a/coin-structure/Cargo.toml
+++ b/coin-structure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-coin-structure"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 license.workspace = true
 repository.workspace = true
@@ -10,10 +10,10 @@ description = "Describes low-level address format and shielded token representat
 proptest = ["dep:proptest", "dep:proptest-derive", "storage/proptest", "transient-crypto/proptest", "serialize/proptest"]
 
 [dependencies]
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
-storage = { version = "1.0.0", path = "../storage-core", package = "midnight-storage-core" }
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
+storage = { version = "1.2.1", path = "../storage-core", package = "midnight-storage-core" }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+transient-crypto = { version = "2.1.1", path = "../transient-crypto", package = "midnight-transient-crypto" }
 
 lazy_static = "^1.5.0"
 # rand 0.9.0 is not yet supported by some of our dependencies, we will

--- a/ledger-wasm/Cargo.toml
+++ b/ledger-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-ledger-wasm"
-version = "8.1.1"
+version = "8.1.2"
 license.workspace = true
 edition = "2024"
 publish = false

--- a/ledger-wasm/package-lock.json
+++ b/ledger-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@midnight/ledger",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@midnight/ledger",
-      "version": "8.1.1",
+      "version": "8.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "typescript": "^6.0.0"

--- a/ledger-wasm/package.json
+++ b/ledger-wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@midnight/ledger",
   "license": "Apache-2.0",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "devDependencies": {
     "rimraf": "6.0.1",
     "lodash": "4.18.1",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -19,16 +19,16 @@ mock-verify = ["transient-crypto/mock-verify"]
 fixed-point-custom-serde = [ "base-crypto/fixed-point-custom-serde" ]
 
 [dependencies]
-coin-structure = { version = "2.0.0", path = "../coin-structure", package = "midnight-coin-structure" }
-onchain-runtime = { version = "3.1.0", path = "../onchain-runtime", package = "midnight-onchain-runtime" }
-zswap = { version = "8.1.1", path = "../zswap", package = "midnight-zswap" }
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto" }
-storage = { version = "2.0.2", path = "../storage", package = "midnight-storage" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
+coin-structure = { version = "2.0.2", path = "../coin-structure", package = "midnight-coin-structure" }
+onchain-runtime = { version = "3.1.1", path = "../onchain-runtime", package = "midnight-onchain-runtime" }
+zswap = { version = "8.1.2", path = "../zswap", package = "midnight-zswap" }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+transient-crypto = { version = "2.1.1", path = "../transient-crypto", package = "midnight-transient-crypto" }
+storage = { version = "2.0.3", path = "../storage", package = "midnight-storage" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
 midnight-ledger-static = { version = "9.0.0", path = "../static", package = "midnight-ledger-static" }
 
-zkir_v2 = { version = "2.1.0", path = "../zkir", package = "midnight-zkir", optional = true }
+zkir_v2 = { version = "2.1.1", path = "../zkir", package = "midnight-zkir", optional = true }
 
 tokio = { version = "^1.46.1", features = ["rt", "macros"] }
 lazy_static = "^1.5.0"

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -842,10 +842,15 @@ tag_enforcement_test!(DustParameters);
 
 impl DustParameters {
     pub const fn time_to_cap(&self) -> Duration {
-        Duration::from_secs(
-            self.night_dust_ratio
-                .div_ceil(self.generation_decay_rate as u64) as i128,
-        )
+        // Should not happen, but panic-guards
+        if self.generation_decay_rate == 0 {
+            Duration::from_secs(i128::MAX)
+        } else {
+            Duration::from_secs(
+                self.night_dust_ratio
+                    .div_ceil(self.generation_decay_rate as u64) as i128,
+            )
+        }
     }
 }
 
@@ -1509,8 +1514,8 @@ impl<D: DB> DustLocalState<D> {
             backing_night: utxo.backing_night,
             ctime: *now,
             initial_value: v_now,
-            seq: utxo.seq + 1,
-            nonce: dust_nonce(&utxo.backing_night, utxo.seq + 1, sk),
+            seq: utxo.seq.saturating_add(1),
+            nonce: dust_nonce(&utxo.backing_night, utxo.seq.saturating_add(1), sk),
             owner: utxo.owner,
             mt_index: new_commitment_index,
         };

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -1877,7 +1877,7 @@ where
                             ContractAction::Call(call) => {
                                 cost.compute_time += model.runtime_cost_model.verifier_key_load;
                                 cost += model
-                                    .proof_verify(call.public_inputs(Default::default()).len());
+                                    .proof_verify(call.public_inputs_len());
                             }
                             ContractAction::Maintain(upd) => {
                                 cost.compute_time +=

--- a/ledger/src/verify.rs
+++ b/ledger/src/verify.rs
@@ -1892,6 +1892,10 @@ impl<P: ProofKind<D>, D: DB> ContractCall<P, D> {
         res
     }
 
+    pub fn public_inputs_len(&self) -> usize {
+        2usize.saturating_add(self.guaranteed_transcript.iter().chain(self.fallible_transcript.iter()).flat_map(|t| t.program.iter()).map(|op| op.field_size()).fold(0, |a, b| a.saturating_add(b)))
+    }
+
     pub(crate) fn binding_input(&self, binding_com: Pedersen) -> Fr {
         let mut binding_input = Vec::new();
 

--- a/onchain-runtime-wasm/Cargo.toml
+++ b/onchain-runtime-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-onchain-runtime-wasm"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 license.workspace = true
 publish = false

--- a/onchain-runtime-wasm/package-lock.json
+++ b/onchain-runtime-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@midnight-ntwrk/onchain-runtime",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@midnight-ntwrk/onchain-runtime",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "typedoc": "0.27.9",

--- a/onchain-runtime-wasm/package.json
+++ b/onchain-runtime-wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@midnight-ntwrk/onchain-runtime",
   "license": "Apache-2.0",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "scripts": {
 	  "build:markdown-docs": "rm -rf ../docs/api/midnight-onchain-runtime && npx typedoc onchain-runtime-v3.d.ts --plugin typedoc-plugin-markdown"
   },

--- a/onchain-runtime/Cargo.toml
+++ b/onchain-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-onchain-runtime"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true
@@ -12,13 +12,13 @@ vendored = []
 proptest = ["dep:proptest", "dep:proptest-derive", "coin-structure/proptest", "onchain-runtime-state/proptest", "onchain-vm/proptest"]
 
 [dependencies]
-coin-structure = { version = "2.0.0", path = "../coin-structure", package = "midnight-coin-structure" }
-onchain-runtime-state = { version = "3.0.0", path = "../onchain-state", package = "midnight-onchain-state" }
-onchain-vm = { version = "3.0.0", path = "../onchain-vm", package = "midnight-onchain-vm" }
-storage = { version = "2.0.2", path = "../storage", package = "midnight-storage" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto" }
+coin-structure = { version = "2.0.2", path = "../coin-structure", package = "midnight-coin-structure" }
+onchain-runtime-state = { version = "3.0.1", path = "../onchain-state", package = "midnight-onchain-state" }
+onchain-vm = { version = "3.1.1", path = "../onchain-vm", package = "midnight-onchain-vm" }
+storage = { version = "2.0.3", path = "../storage", package = "midnight-storage" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+transient-crypto = { version = "2.1.1", path = "../transient-crypto", package = "midnight-transient-crypto" }
 
 derive-where = "^1.6.1"
 enum_index = "^0.2.0"

--- a/onchain-state/Cargo.toml
+++ b/onchain-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-onchain-state"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true
@@ -11,11 +11,11 @@ proptest = ["dep:proptest", "dep:proptest-derive", "coin-structure/proptest", "s
 public-internal-structure = []
 
 [dependencies]
-coin-structure = { version = "2.0.0", path = "../coin-structure", package = "midnight-coin-structure" }
-transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto" }
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-storage = { version = "2.0.2", path = "../storage", package = "midnight-storage" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
+coin-structure = { version = "2.0.2", path = "../coin-structure", package = "midnight-coin-structure" }
+transient-crypto = { version = "2.1.1", path = "../transient-crypto", package = "midnight-transient-crypto" }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+storage = { version = "2.0.3", path = "../storage", package = "midnight-storage" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
 
 hex = "^0.4.3"
 # rand 0.9.0 is not yet supported by some of our dependencies, we will

--- a/onchain-state/src/state.rs
+++ b/onchain-state/src/state.rs
@@ -339,11 +339,13 @@ impl<'de, D: DB> Visitor<'de> for StateValueVisitor<D> {
 
 impl<'de, D1: DB> Deserialize<'de> for StateValue<D1> {
     fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        de.deserialize_struct(
+        let v = de.deserialize_struct(
             "StateValue",
             &["tag", "content"],
             StateValueVisitor(PhantomData),
-        )
+        )?;
+        v.invariant().map_err(serde::de::Error::custom)?;
+        Ok(v)
     }
 }
 

--- a/onchain-vm/Cargo.toml
+++ b/onchain-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-onchain-vm"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true
@@ -10,12 +10,12 @@ description = "Implements the onchain VM for Midnight's ledger."
 proptest = ["dep:proptest", "dep:proptest-derive", "coin-structure/proptest", "runtime-state/proptest"]
 
 [dependencies]
-coin-structure = { version = "2.0.0", path = "../coin-structure", package = "midnight-coin-structure" }
-transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto" }
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-storage = { version = "2.0.2", path = "../storage", package = "midnight-storage" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
-runtime-state = { version = "3.0.0", path = "../onchain-state", package = "midnight-onchain-state" }
+coin-structure = { version = "2.0.2", path = "../coin-structure", package = "midnight-coin-structure" }
+transient-crypto = { version = "2.1.1", path = "../transient-crypto", package = "midnight-transient-crypto" }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+storage = { version = "2.0.3", path = "../storage", package = "midnight-storage" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
+runtime-state = { version = "3.0.1", path = "../onchain-state", package = "midnight-onchain-state" }
 
 hex = "^0.4.3"
 konst = "0.4.3"

--- a/onchain-vm/src/ops.rs
+++ b/onchain-vm/src/ops.rs
@@ -89,7 +89,7 @@ impl FieldRepr for Key {
 ))]
 #[serde(rename_all = "lowercase", expecting = "operation")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
-#[storable(db = D)]
+#[storable(db = D, invariant = Op::invariant)]
 #[tag = "impact-op[v1]"]
 #[phantom(M)]
 pub enum Op<M: ResultMode<D>, D: DB = DefaultDB> {
@@ -342,6 +342,14 @@ impl<M: ResultMode<D>, D: DB> Debug for Op<M, D> {
 }
 
 impl<M: ResultMode<D>, D: DB> Op<M, D> {
+    fn invariant(&self) -> std::io::Result<()> {
+        match self {
+            Op::Dup { n } | Op::Swap { n } | Op::Ins { n, .. } if *n >= 16 => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "stack operation out of legal encoding bound")),
+            Op::Idx { path, .. } if !(1..=16).contains(&path.len()) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid `idx` sequence length")),
+            _ => Ok(()),
+        }
+    }
+
     pub fn translate<M2: ResultMode<D>, F: FnOnce(M::ReadResult) -> M2::ReadResult>(
         self,
         f: F,

--- a/onchain-vm/src/vm.rs
+++ b/onchain-vm/src/vm.rs
@@ -213,7 +213,7 @@ fn idx<D: DB>(
         }
         StateValue::BoundedMerkleTree(tree) => {
             let key = (&**AsRef::<Value>::as_ref(&key)).try_into()?;
-            if key >= (1u64 << tree.height() as u64) {
+            if 1u64.checked_shl(tree.height() as u32).map_or(false, |bound| key >= bound) {
                 Err(OnchainProgramError::MissingKey)
             } else {
                 Ok((
@@ -417,7 +417,12 @@ fn run_program_internal<M: ResultMode<D>, D: DB>(
                     StateValue::Cell(_) => (0, cost_model.type_cell),
                     StateValue::Null => (1, cost_model.type_null),
                     StateValue::Map(_) => (2, cost_model.type_map),
-                    StateValue::Array(a) => (3 + a.len() as u8 * 8, cost_model.type_array),
+                    StateValue::Array(a) => {
+                        if a.len() > 16 {
+                            return Err(OnchainProgramError::TypeError("attempted to take type of illegal array with >16 entries".to_string()));
+                        }
+                        (3 + a.len() as u8 * 8, cost_model.type_array)
+                    }
                     StateValue::BoundedMerkleTree(t) => {
                         (4 + t.height().saturating_sub(1) * 8, cost_model.type_bmt)
                     }
@@ -977,7 +982,7 @@ fn run_program_internal<M: ResultMode<D>, D: DB>(
                         }
                         StateValue::BoundedMerkleTree(t) => {
                             let idx = (&**AsRef::<Value>::as_ref(&key_cell)).try_into()?;
-                            if idx < (1u64 << t.height()) {
+                            if 1u64.checked_shl(t.height() as u32).map_or(true, |bound| idx < bound) {
                                 let cell_ref = curr.0.as_cell_ref().map_err(|e| {
                                     OnchainProgramError::TypeError(format!(
                                         "attempted to ins a non-cell value into a bmt: {e}"

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-serialize"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -129,25 +129,33 @@ impl<K: Deserializable + PartialOrd + Hash + Eq, V: Deserializable> Deserializab
     fn deserialize(reader: &mut impl Read, mut recursion_depth: u32) -> std::io::Result<Self> {
         Self::check_rec(&mut recursion_depth)?;
         let len = <u32 as Deserializable>::deserialize(reader, recursion_depth)?;
-        let mut result = HashMap::new();
+        let mut result = Vec::with_bounded_capacity(len as usize);
         for _ in 0..len {
             let k = <K as Deserializable>::deserialize(reader, recursion_depth)?;
             let v = <V as Deserializable>::deserialize(reader, recursion_depth)?;
-            result.insert(k, v);
+            result.push((k, v));
         }
-        Ok(result)
+        if result.iter().is_sorted_by_key(|(k, _)| k) && result.windows(2).all(|window| window[0].0 != window[1].0) {
+            Ok(result.into_iter().collect())
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "HashMap not normalized (not sorted or duplicate keys)"))
+        }
     }
 }
 
-impl<T: Deserializable + Hash + Eq> Deserializable for HashSet<T> {
+impl<T: Deserializable + PartialOrd + Hash + Eq> Deserializable for HashSet<T> {
     fn deserialize(reader: &mut impl Read, mut recursion_depth: u32) -> std::io::Result<Self> {
         Self::check_rec(&mut recursion_depth)?;
         let len = <u32 as Deserializable>::deserialize(reader, recursion_depth)?;
-        let mut result = HashSet::new();
+        let mut result = Vec::with_bounded_capacity(len as usize);
         for _ in 0..len {
-            result.insert(<T as Deserializable>::deserialize(reader, recursion_depth)?);
+            result.push(<T as Deserializable>::deserialize(reader, recursion_depth)?);
         }
-        Ok(result)
+        if result.iter().is_sorted() && result.windows(2).all(|window| window[0] != window[1]) {
+            Ok(result.into_iter().collect())
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "HashSet not normalized (not sorted or duplicate entries)"))
+        }
     }
 }
 
@@ -194,7 +202,8 @@ impl<T: ?Sized> Deserializable for PhantomData<T> {
 }
 
 impl<T: Deserializable> Deserializable for Box<T> {
-    fn deserialize(reader: &mut impl Read, recursion_depth: u32) -> std::io::Result<Self> {
+    fn deserialize(reader: &mut impl Read, mut recursion_depth: u32) -> std::io::Result<Self> {
+        Self::check_rec(&mut recursion_depth)?;
         T::deserialize(reader, recursion_depth).map(Box::new)
     }
 }

--- a/serialize/src/serializable.rs
+++ b/serialize/src/serializable.rs
@@ -73,7 +73,7 @@ impl<K: Serializable + Ord, V: Serializable> Serializable for HashMap<K, V> {
     }
 
     fn serialized_size(&self) -> usize {
-        self.iter().fold(4, |acc, (k, v)| {
+        self.iter().fold((self.len() as u32).serialized_size(), |acc, (k, v)| {
             acc + k.serialized_size() + v.serialized_size()
         })
     }
@@ -93,7 +93,7 @@ impl<T: Serializable + Ord> Serializable for HashSet<T> {
 
     fn serialized_size(&self) -> usize {
         self.iter()
-            .fold(4, |acc, elem| acc + elem.serialized_size())
+            .fold((self.len() as u32).serialized_size(), |acc, elem| acc + elem.serialized_size())
     }
 }
 

--- a/serialize/src/util.rs
+++ b/serialize/src/util.rs
@@ -36,7 +36,7 @@ pub trait VecExt {
 impl<T> VecExt for Vec<T> {
     fn with_bounded_capacity(n: usize) -> Self {
         const MEMORY_LIMIT: usize = 1 << 25; // 32 MiB
-        let alloc_limit = MEMORY_LIMIT / std::mem::size_of::<T>();
+        let alloc_limit = MEMORY_LIMIT.checked_div(std::mem::size_of::<T>()).unwrap_or(n);
         Self::with_capacity(usize::min(alloc_limit, n))
     }
 }
@@ -298,7 +298,10 @@ impl Deserializable for ScaleBigInt {
             SCALE_N_BYTE_MARKER => {
                 let n = top6bits(first) as usize + 4;
                 reader.read_exact(&mut res.0[..n])?;
-                if res.0[n - 1] == 0 {
+                // Trailing zeros imply this encoding isn't sufficiently compact.
+                // If n == 4, this integer should be *outside* the legal encoding for the 4-byte
+                // limit.
+                if res.0[n - 1] == 0 || (n == 4 && res.0[3] < 64) {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         "non-canonical scale encoding",

--- a/storage-core/Cargo.toml
+++ b/storage-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-storage-core"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 license.workspace = true
 description = "Provides the low-level storage primitives for Midnight's ledger."
@@ -22,8 +22,8 @@ layout-v2 = ["layout-v1"]
 gc-v1 = ["layout-v2"]
 
 [dependencies]
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
 parity-db = { version = "0.5.2", optional = true }
 
 archery = "^1.2.2"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midnight-storage"
 edition = "2024"
-version = "2.0.2"
+version = "2.0.3"
 license.workspace = true
 repository.workspace = true
 description = "Provides data structures and storage primitives for Midnight's ledger."
@@ -16,9 +16,9 @@ public-internal-structure = ["storage-core/public-internal-structure"]
 state-translation = ["storage-core/state-translation", "dep:hashbrown", "public-internal-structure"]
 
 [dependencies]
-storage-core = { version = "1.0.0", path = "../storage-core", package = "midnight-storage-core" }
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
+storage-core = { version = "1.2.1", path = "../storage-core", package = "midnight-storage-core" }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
 rand = { version = "^0.8.4", features = ["getrandom"] }
 derive-where = "^1.6.1"
 crypto = { version = "0.5.1", features = ["digest"] }

--- a/storage/src/merkle_patricia_trie.rs
+++ b/storage/src/merkle_patricia_trie.rs
@@ -131,8 +131,10 @@ impl<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>> MerklePatriciaTrie<V
     /// docs). This is a hand-enumerated statement of the structural rules,
     /// composed with the annotation-consistency check.
     ///
-    /// This is a pure inspection predicate: it is the oracle the property tests
-    /// use, and does not itself change what deserialization accepts.
+    /// This is wired in as the `Storable` invariant, so it is also what
+    /// deserialization enforces: it replaces the narrower
+    /// annotation-consistency-only check, and a trie whose *structure* is
+    /// non-canonical no longer decodes.
     pub fn canonicity(&self) -> Result<(), std::io::Error> {
         fn err<T>(msg: &str) -> Result<T, std::io::Error> {
             Err(std::io::Error::new(

--- a/storage/src/merkle_patricia_trie.rs
+++ b/storage/src/merkle_patricia_trie.rs
@@ -33,7 +33,7 @@ use serialize::{self, Deserializable, Serializable, Tagged, tag_enforcement_test
 #[derive_where(Debug, Eq, Clone, PartialEq; V, A)]
 #[derive(Storable)]
 #[storable(db = D)]
-#[storable(db = D, invariant = MerklePatriciaTrie::invariant)]
+#[storable(db = D, invariant = MerklePatriciaTrie::canonicity)]
 pub struct MerklePatriciaTrie<
     V: Storable<D>,
     D: DB = DefaultDB,
@@ -69,7 +69,7 @@ impl<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>> MerklePatriciaTrie<V
         MerklePatriciaTrie(Sp::new(Node::Empty))
     }
 
-    fn invariant(&self) -> Result<(), std::io::Error> {
+    fn annotation_consistency(&self) -> Result<(), std::io::Error> {
         fn err<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>>(
             ann: &A,
             true_val: A,
@@ -123,6 +123,83 @@ impl<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>> MerklePatriciaTrie<V
 
         let _ = sum_ann(self.0.deref())?;
         Ok(())
+    }
+
+    /// Check that the trie is in canonical form, returning a description of the
+    /// violated rule otherwise. A well-formed trie is *canonical*: its structure
+    /// is uniquely determined by its key-value contents (see the type-level
+    /// docs). This is a hand-enumerated statement of the structural rules,
+    /// composed with the annotation-consistency check.
+    ///
+    /// This is a pure inspection predicate: it is the oracle the property tests
+    /// use, and does not itself change what deserialization accepts.
+    pub fn canonicity(&self) -> Result<(), std::io::Error> {
+        fn err<T>(msg: &str) -> Result<T, std::io::Error> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("canonicity: {msg}"),
+            ))
+        }
+
+        fn structure<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>>(
+            node: &Node<V, D, A>,
+        ) -> Result<(), std::io::Error> {
+            match node {
+                Node::Empty | Node::Leaf { .. } => Ok(()),
+                Node::Branch { children, .. } => {
+                    if children
+                        .iter()
+                        .filter(|child| !matches!(***child, Node::Empty))
+                        .count()
+                        < 2
+                    {
+                        return err("Node::Branch must have at least two non-empty children");
+                    }
+                    children
+                        .iter()
+                        .try_for_each(|child| structure(child.deref()))
+                }
+                Node::Extension {
+                    compressed_path,
+                    child,
+                    ..
+                } => {
+                    if compressed_path.is_empty() {
+                        return err("Node::Extension path must be non-empty");
+                    }
+                    if compressed_path.len() > 255 {
+                        return err("Node::Extension path may not be longer than 255");
+                    }
+                    if compressed_path.iter().any(|b| *b > 0x0f) {
+                        return err("Node::Extension path must consist of nibbles");
+                    }
+                    match child.deref() {
+                        Node::Empty => {
+                            return err("Node::Extension child must not be Node::Empty");
+                        }
+                        Node::Extension { .. } if compressed_path.len() != 255 => {
+                            return err(
+                                "Node::Extension may only have a Node::Extension child when its own path is of length 255",
+                            );
+                        }
+                        _ => {}
+                    }
+                    structure(child.deref())
+                }
+                Node::MidBranchLeaf { child, .. } => match child.deref() {
+                    Node::Branch { .. } | Node::Extension { .. } => structure(child.deref()),
+                    _ => err("Node::MidBranchLeaf may only have Node::Branch or Node::Extension children"),
+                },
+            }
+        }
+
+        structure(self.0.deref())?;
+        self.annotation_consistency()
+    }
+
+    /// Whether [`Self::canonicity`] holds.
+    pub fn is_canonical(&self) -> bool {
+        self.canonicity().is_ok()
     }
 
     /// Insert a value into the trie
@@ -1483,9 +1560,12 @@ impl<T: Storable<D> + 'static, D: DB, A: Storable<D> + Annotation<T>> Storable<D
             }
             3 => {
                 let ann = A::deserialize(reader, 0)?;
-                let len = u8::deserialize(reader, 0)?;
-                let path =
-                    expand_nibbles(&std::vec::Vec::<u8>::deserialize(reader, 0)?, len as usize);
+                let len = u8::deserialize(reader, 0)? as usize;
+                let data = <std::vec::Vec<u8>>::deserialize(reader, 0)?;
+                if data.len() != len.div_ceil(2) {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("inferred nibble byte length {} did not match actual data length of {}", len.div_ceil(2), data.len())));
+                };
+                let path = expand_nibbles(&data, len as usize);
                 let child: Sp<Node<T, D, A>, D> = loader.get_next(child_hashes)?;
                 Node::Extension {
                     ann,

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -867,7 +867,7 @@ impl<V: Storable<D>, D: DB> Iterator for ArrayIter<'_, V, D> {
 
 #[derive(Storable)]
 #[derive_where(Clone, Eq, PartialEq, PartialOrd, Ord, Hash; V)]
-#[storable(db = D)]
+#[storable(db = D, invariant = MultiSet::invariant)]
 #[tag = "multi-set[v1]"]
 /// A set with quantity. Often known as a bag.
 pub struct MultiSet<V: Serializable + Storable<D>, D: DB> {
@@ -885,6 +885,14 @@ impl<V: Serializable + Storable<D>, D: DB> Default for MultiSet<V, D> {
 }
 
 impl<V: Serializable + Storable<D>, D: DB> MultiSet<V, D> {
+    fn invariant(&self) -> std::io::Result<()> {
+        if self.elements.iter().any(|e| *e.1 == 0) {
+            Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "MultiSet may not contain zero-count entries"))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Create a new, empty `MultiSet`
     pub fn new() -> Self {
         MultiSet {
@@ -1081,7 +1089,7 @@ impl Deserializable for BigEndianU64 {
 /// searching and pruning.
 #[derive(Storable)]
 #[derive_where(Clone, Eq, PartialEq, PartialOrd, Ord, Hash; C)]
-#[storable(db = D)]
+#[storable(db = D, invariant = TimeFilterMap::invariant)]
 pub struct TimeFilterMap<C: Serializable + Storable<D>, D: DB>
 where
     C: Container<D> + Serializable + Storable<D>,
@@ -1129,6 +1137,20 @@ where
 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<C: Container<D> + Storable<D> + Serializable, D: DB> TimeFilterMap<C, D>
+where
+    <C as Container<D>>::Item: Serializable,
+{
+    fn invariant(&self) -> std::io::Result<()> {
+        let reconstructed_set: MultiSet<<C as Container<D>>::Item, D> = self.time_map.iter().flat_map(|e| e.1.deref().clone().iter_items()).fold(MultiSet::new(), |s, i| s.insert(i));
+        if reconstructed_set != self.set {
+            Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "TimeFilterMap decoded with mismatching set/map representations"))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -1458,7 +1480,9 @@ fn from_nibbles<T: Deserializable>(value: &[u8]) -> std::io::Result<T> {
             Ok((nibbles_pair[0] << 4) | nibbles_pair[1])
         })
         .collect::<Result<std::vec::Vec<u8>, std::io::Error>>()?;
-    T::deserialize(&mut &bytes[..], 0)
+    let mut reader = &bytes[..];
+    let result = T::deserialize(&mut reader, 0)?;
+    reader.is_empty().then_some(result).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "bytes remaining after nibble decode"))
 }
 
 impl<K: Serializable + Deserializable, V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>>

--- a/transient-crypto/Cargo.toml
+++ b/transient-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-transient-crypto"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true
@@ -20,10 +20,10 @@ mock-verify = []
 public-internal-structure = []
 
 [dependencies]
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
 derive = { version = "1.0.0", path = "../base-crypto-derive", package = "midnight-base-crypto-derive" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
-storage-core = { version = "1.0.0", path = "../storage-core", package = "midnight-storage-core" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
+storage-core = { version = "1.2.1", path = "../storage-core", package = "midnight-storage-core" }
 
 ff = "^0.13.1"
 group = "^0.13.0"

--- a/transient-crypto/src/proofs.rs
+++ b/transient-crypto/src/proofs.rs
@@ -392,7 +392,10 @@ impl Distribution<VerifierKey> for Standard {
 
 impl From<MidnightVK> for VerifierKey {
     fn from(vk: MidnightVK) -> Self {
-        VerifierKey(Arc::new(Mutex::new(InnerVerifierKey::Initialized(vk))))
+        let mut raw = Vec::new();
+        vk.write(&mut raw, SerdeFormat::Processed)
+            .expect("in-memory serialization does not fail");
+        VerifierKey(Arc::new(Mutex::new(InnerVerifierKey::Initialized(vk, raw))))
     }
 }
 
@@ -402,7 +405,11 @@ impl From<MidnightVK> for VerifierKey {
 pub(crate) enum InnerVerifierKey {
     Uninitialized(Vec<u8>),
     Invalid(Vec<u8>),
-    Initialized(MidnightVK),
+    /// Parsed key alongside the original bytes it was decoded from, so that
+    /// serialization stays a function of the value and does not change when a
+    /// key is initialized in place (initialization is shared across clones via
+    /// the `Arc<Mutex>`).
+    Initialized(MidnightVK, Vec<u8>),
 }
 
 impl Clone for VerifierKey {
@@ -517,7 +524,7 @@ impl VerifierKey {
     pub(crate) fn force_init(&self) -> Result<MidnightVK, VerifyingError> {
         let mut mutex = self.0.lock().expect("mutex is not poisoned");
         let data = match &*mutex {
-            InnerVerifierKey::Initialized(key) => {
+            InnerVerifierKey::Initialized(key, _) => {
                 return Ok(key.clone());
             }
             InnerVerifierKey::Invalid(_) => {
@@ -525,10 +532,16 @@ impl VerifierKey {
             }
             InnerVerifierKey::Uninitialized(data) => data.clone(),
         };
-        let reader = &mut &data[..];
-        let vk = MidnightVK::read(reader, SerdeFormat::Processed)
+        let mut slice: &[u8] = &data;
+        let vk = MidnightVK::read(&mut slice, SerdeFormat::Processed)
             .map_err(|_| anyhow::anyhow!("problem reading the verifier key"))?;
-        *mutex = InnerVerifierKey::Initialized(vk.clone());
+        // Reject keys with unconsumed trailing bytes: two encodings must not map
+        // to the same key, and the trailing bytes would otherwise survive in the
+        // preserved-original serialization.
+        if !slice.is_empty() {
+            return Err(anyhow::anyhow!("trailing bytes after verifier key"));
+        }
+        *mutex = InnerVerifierKey::Initialized(vk.clone(), data);
         Ok(vk)
     }
 
@@ -537,7 +550,7 @@ impl VerifierKey {
             InnerVerifierKey::Uninitialized(data) | InnerVerifierKey::Invalid(data) => {
                 writer.write_all(data)
             }
-            InnerVerifierKey::Initialized(key) => key.write(&mut writer, SerdeFormat::Processed),
+            InnerVerifierKey::Initialized(_, original) => writer.write_all(original),
         }
     }
 

--- a/zkir-v3/Cargo.toml
+++ b/zkir-v3/Cargo.toml
@@ -23,9 +23,9 @@ proptest = [
 ]
 
 [dependencies]
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
-transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto", features = ["cli"] }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
+transient-crypto = { version = "2.1.1", path = "../transient-crypto", package = "midnight-transient-crypto", features = ["cli"] }
 
 midnight-curves = { version = "0.2.0" }
 midnight-proofs = { version = "^0.7.0" }

--- a/zkir-wasm/Cargo.toml
+++ b/zkir-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-zkir-wasm"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 license.workspace = true
 publish = false

--- a/zkir-wasm/package-lock.json
+++ b/zkir-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@midnight/zkir-v2",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@midnight/zkir-v2",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "typescript": "^6.0.0"

--- a/zkir-wasm/package.json
+++ b/zkir-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight/zkir-v2",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "devDependencies": {
     "rimraf": "6.0.1",

--- a/zkir/Cargo.toml
+++ b/zkir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-zkir"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true
@@ -23,9 +23,9 @@ proptest = [
 ]
 
 [dependencies]
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
-transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto", features = ["cli"] }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
+transient-crypto = { version = "2.1.1", path = "../transient-crypto", package = "midnight-transient-crypto", features = ["cli"] }
 
 midnight-proofs = { version = "^0.7.0" }
 midnight-circuits = { version = "^6.0.0" }

--- a/zswap/Cargo.toml
+++ b/zswap/Cargo.toml
@@ -11,12 +11,12 @@ default = ["proof-verifying"]
 proof-verifying = []
 
 [dependencies]
-base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
-transient-crypto = { version = "2.0.0", path = "../transient-crypto", package = "midnight-transient-crypto" }
-coin-structure = { version = "2.0.0", path = "../coin-structure", package = "midnight-coin-structure" }
-storage = { version = "2.0.2", path = "../storage", package = "midnight-storage" }
-serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
-midnight-onchain-runtime = { version = "3.0.0", path = "../onchain-runtime", package = "midnight-onchain-runtime", features = [ "vendored" ] }
+base-crypto = { version = "1.0.1", path = "../base-crypto", package = "midnight-base-crypto" }
+transient-crypto = { version = "2.1.1", path = "../transient-crypto", package = "midnight-transient-crypto" }
+coin-structure = { version = "2.0.2", path = "../coin-structure", package = "midnight-coin-structure" }
+storage = { version = "2.0.3", path = "../storage", package = "midnight-storage" }
+serialize = { version = "1.1.1", path = "../serialize", package = "midnight-serialize" }
+midnight-onchain-runtime = { version = "3.1.1", path = "../onchain-runtime", package = "midnight-onchain-runtime", features = [ "vendored" ] }
 midnight-ledger-static = { version = "9.0.0", path = "../static", package = "midnight-ledger-static" }
 
 # rand 0.9.0 is not yet supported by some of our dependencies, we will

--- a/zswap/src/structure.rs
+++ b/zswap/src/structure.rs
@@ -260,13 +260,15 @@ impl<D: DB> Input<ProofPreimage, D> {
     pub fn binding_randomness(&self) -> PedersenRandomness {
         // NOTE: This is tied to the implementation in construct.rs
         // rc is the last input, and should be a single Fr element.
-        (*self
+        //
+        // If retrieval fails, we return default – this is incorrect, but this should not happen
+        // during honest usage, and the alternative is largely to panic.
+        self
             .proof
             .inputs
             .last()
-            .expect("must have witness to extract from"))
-        .try_into()
-        .expect("extracted binding randomness is invalid")
+            .and_then(|inp| (*inp).try_into().ok())
+            .unwrap_or_default()
     }
 }
 
@@ -340,14 +342,15 @@ impl<D: DB> Output<ProofPreimage, D> {
         // NOTE: This is tied to the implementation in construct.rs.
         // rc is the last input, and should be a single Fr element.
         // NOTE: rc negated because output commitments are subtracted
-        -PedersenRandomness::try_from(
-            *self
-                .proof
-                .inputs
-                .last()
-                .expect("must have witness to extract from"),
-        )
-        .expect("extracted binding randomness is invalid")
+        //
+        // If retrieval fails, we return default – this is incorrect, but this should not happen
+        // during honest usage, and the alternative is largely to panic.
+        -self
+            .proof
+            .inputs
+            .last()
+            .and_then(|inp| PedersenRandomness::try_from(*inp).ok())
+            .unwrap_or_default()
     }
     pub fn segment(&self) -> Option<u16> {
         self.proof
@@ -551,7 +554,8 @@ impl Debug for DebugDelta {
 pub fn normalize_deltas<T: Ord, I: Iterator<Item = (T, i128)>>(deltas: I) -> Vec<(T, i128)> {
     let mut new_deltas: Vec<_> = deltas
         .fold(BTreeMap::new(), |mut map, (k, v)| {
-            *map.entry(k).or_insert(0) += v;
+            let entry = map.entry(k).or_insert(0);
+            *entry = (*entry as i128).saturating_add(v);
             map
         })
         .into_iter()


### PR DESCRIPTION
## Description

Public release after coordinated mainnet security patch. Fixes a class of encoding canonicity issues.

## Sanity Checklist

This PR:
- [X] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [X] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [ ] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
