### PR TITLE
fix(proof-server): drop the unused http2 feature (RUSTSEC-2026-0258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,6 @@ dependencies = [
  "flate2",
  "foldhash 0.1.5",
  "futures-core",
- "h2",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -2010,25 +2009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86848f4fd157d91041a62c78046fb7b248bcc2dce78376d436a1756e9a038577"
 dependencies = [
  "crc32fast",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]

--- a/proof-server/Cargo.toml
+++ b/proof-server/Cargo.toml
@@ -24,7 +24,7 @@ introspection = "0.1.0"
 # rand 0.9.0 is not yet supported by some of our dependencies, we will
 # stick with 0.8.0 for now.
 rand = { version = "^0.8.4", features = ["getrandom"] }
-actix-web = { version = "^4.13.0", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "http2"] }
+actix-web = { version = "^4.13.0", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies"] }
 actix-cors = "^0.7.1"
 futures = "^0.3.31"
 futures-util = "0.3.32"


### PR DESCRIPTION
Unblocks , which is currently failing on **every** open PR in this repo.

`h2 0.3.27` carries [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) (published 2026-08-17, "unbounded empty DATA frames"). There is no upgrade path: `actix-http` 3.13.3 still requires `h2 ^0.3.27`, 0.3.27 is the last 0.3.x release, and the fix landed only in 0.4.16+.

But the dependency turns out to be avoidable rather than merely ignorable. `h2` is an **optional** dependency of `actix-http`, gated behind `actix-web`'s `http2` feature (`features.http2 = ["actix-http/http2"]`), and `proof-server/Cargo.toml` was the only crate in the workspace enabling it.

That feature is unused here:
- `proof-server/src/lib.rs` binds plaintext — `.bind(("0.0.0.0", port))` — with no `bind_rustls`/`bind_openssl` and no TLS references anywhere in the crate's source (the `rustls` dependency serves `reqwest` as an outbound client).
- actix-web negotiates HTTP/2 only via TLS ALPN, and does not serve h2c through `.bind()`, so no inbound HTTP/2 connection is possible.
- Nothing in `proof-server/src` references `http2` or `h2`.

So this is a **remediation, not a suppression** — no new `.cargo/audit.toml` entry — and it removes an unused HTTP/2 stack from a network-facing service.

**Diff is minimal and machine-generated:** one feature removed from the manifest, and `Cargo.lock` regenerated by cargo. Exactly one package (`h2`) leaves the lock; no other dependency moved.

Verified locally: `cargo check -p midnight-proof-server` finishes clean, `cargo tree -p midnight-proof-server` no longer lists h2, and `h2` is absent from `Cargo.lock`.

**If the proof server ever terminates TLS in-process**, re-adding `http2` would re-expose this, and there would be no fixed h2 available on actix-web 4.x — worth remembering rather than rediscovering.

Note: the `build-ledger` / `build-proof-server` failures on the aarch64 and macOS legs are a separate, unrelated problem (Nix daemon crashing while building toolchain derivations from source); filed separately.

Closes #721