### PR TITLE
fix(ci): stop purging the Nix store cache on every run

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,7 +61,7 @@ jobs:
             accept-flake-config = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,7 +67,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh
@@ -124,7 +125,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh
@@ -194,7 +196,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh
@@ -217,6 +220,7 @@ jobs:
 
       - name: Build and Test (default features)
         run: |
+          set -eo pipefail
           cargo install cargo2junit
           nix develop .#ci -c cargo test --release -- -Z unstable-options --format json --report-time --nocapture --test-threads=1 | tee test-results.json
           # Filter is a workaround for johnterickson/cargo2junit#85
@@ -256,7 +260,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh
@@ -279,6 +284,7 @@ jobs:
 
       - name: Build and Test - Proof server (default features)
         run: |
+          set -eo pipefail
           cargo install cargo2junit
           cd proof-server
           nix develop .#ci -c cargo test --release -- -Z unstable-options --format json --report-time --nocapture --test-threads=1 | tee test-results-proof-server.json

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -134,7 +134,7 @@ jobs:
           docker push ghcr.io/midnight-ntwrk/proof-server:$PROOF_SERVER_VERSION-arm64
 
   docker-manifest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [docker-amd64, docker-arm64]
     permissions:
       contents: read

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -62,7 +62,7 @@ jobs:
             accept-flake-config = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -117,7 +117,7 @@ jobs:
             accept-flake-config = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -174,7 +174,7 @@ jobs:
             accept-flake-config = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -68,7 +68,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Create proof-server images
         run: |
@@ -122,7 +123,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Build and push arm64 image
         run: |
@@ -178,7 +180,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Create and push manifest
         run: |

--- a/.github/workflows/generate-markdown-docs.yml
+++ b/.github/workflows/generate-markdown-docs.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  #v7.0.1
@@ -47,7 +47,7 @@ jobs:
           git push --force origin $NEW_BRANCH
 
   create-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - name: Check if PR already exists

--- a/.github/workflows/hardfork-test-patch.yml
+++ b/.github/workflows/hardfork-test-patch.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   patch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup api.github.com credentials
         uses: extractions/netrc@c3879108aae6b4ed5c4eb60854ae04f06d2f2f68

--- a/.github/workflows/merge-to-next.yml
+++ b/.github/workflows/merge-to-next.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   create-merge-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout ledger-8
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,7 @@ jobs:
             accept-flake-config = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,7 +63,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh

--- a/.github/workflows/prepare-cost-model-docker.yml
+++ b/.github/workflows/prepare-cost-model-docker.yml
@@ -65,7 +65,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh

--- a/.github/workflows/prepare-cost-model-docker.yml
+++ b/.github/workflows/prepare-cost-model-docker.yml
@@ -59,7 +59,7 @@ jobs:
             accept-flake-config = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -37,7 +37,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -278,7 +278,7 @@ jobs:
 
   integration:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
@@ -425,7 +425,7 @@ jobs:
     # irreversible job create/announce the release anyway.
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.coverage.result == 'success' && needs.integration.result == 'success' && needs.unit-tests.result == 'success' && (needs.publish-npm.result == 'success' || (github.event.inputs.dry_run == 'true' && needs.publish-npm.result == 'skipped')) }}
     needs: [ build, coverage, integration, unit-tests, publish-npm ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     env:
@@ -451,8 +451,8 @@ jobs:
 
           for f in downloaded-artifacts/npm-packages/*.tgz; do cp "$f" "$STAGING/"; done
           for f in downloaded-artifacts/unit-test-results/test-results.*; do cp "$f" "$STAGING/"; done
-          for f in downloaded-artifacts/ledger-wasm-test-results-ctrf-ubuntu-latest/*; do cp "$f" "$STAGING/integration-ctrf-report.json"; done
-          for f in downloaded-artifacts/ledger-wasm-test-results-junit-ubuntu-latest/*; do cp "$f" "$STAGING/integration-junit.xml"; done
+          for f in downloaded-artifacts/ledger-wasm-test-results-ctrf-ubuntu-24.04/*; do cp "$f" "$STAGING/integration-ctrf-report.json"; done
+          for f in downloaded-artifacts/ledger-wasm-test-results-junit-ubuntu-24.04/*; do cp "$f" "$STAGING/integration-junit.xml"; done
           for f in downloaded-artifacts/integration-coverage-txt/*; do cp "$f" "$STAGING/integration-coverage.txt"; done
 
           if [ -d downloaded-artifacts/"Lcov Coverage Report" ]; then

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -70,7 +70,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Get project versions
         run: |
@@ -307,7 +308,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh
@@ -401,7 +403,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Build and publish
         env:

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -48,7 +48,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure cargo
         run: .github/scripts/configure-cargo.sh

--- a/.github/workflows/upload-srs.yml
+++ b/.github/workflows/upload-srs.yml
@@ -46,7 +46,8 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 0
+          purge-primary-key: never
+          purge-created: P7D
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/upload-srs.yml
+++ b/.github/workflows/upload-srs.yml
@@ -40,7 +40,7 @@ jobs:
             accept-flake-config = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -50,7 +50,7 @@ jobs:
           purge-created: P7D
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: arn:aws:iam::903367786860:role/MidnightLedgerSrsUploadRole
           aws-region: eu-west-1

--- a/.github/workflows/upload-srs.yml
+++ b/.github/workflows/upload-srs.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   upload-srs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Configure git rewrite
         run: |


### PR DESCRIPTION
Implements the first two fixes from #723. The `build-ledger` / `build-proof-server` legs on `ubuntu-24.04-arm` and `macos-latest` crash with `error: Nix daemon disconnected unexpectedly`, and re-running never clears it. Here is the mechanism, verified against the pinned action's `action.yml`:

1. The restore step runs and purges caches. `purge-created: 0` means *purge every selected cache created more than zero seconds ago* — i.e. all of them, every run.
2. The job fails. `cache-nix-action` declares `post-if: "success()"`, so the save step never runs and nothing is written back.
3. The next run finds nothing. Observed directly on the macOS leg:
   ```
   primary-key: nix-macOS-5dc352f8032674a98d4515fba71b7bb5162c6ab2302ddcc89b6209c1c10c0b3a
   Could not find a cache with the given "primary-key" and "paths".
   ```
4. Cold store, so that job built **146 derivations from source** (805 came from substituters). The expensive ones are the toolchain derivations, and that is where the daemon dies.

It is a closed loop: purge always, save only on success. That also explains the platform split — every `ubuntu-latest`-only job passes, while `extra-substituters = https://cache.iog.io` is x86_64-linux-centric so the aarch64 legs have no substitutes for these derivations and must build them.

**Change 1 — keep the cache we depend on.** `purge-primary-key: never` and `purge-created: P7D`, applied to all five cache blocks. Purging still garbage-collects, but never the current key and never anything from the past week.

**Change 2 — stop hiding the real error.** `set -eo pipefail` on the two test steps. `nix develop .#ci -c cargo test … | tee test-results.json` returned tee's exit status, so the step continued past a failed build and died later at `> ./target/test-results.xml`. Every infrastructure crash was therefore reported as `./target/test-results.xml: No such file or directory`, which is why this took a while to localise.

Verified: `actionlint` findings unchanged at 42 before and after (all pre-existing `SC2086`/`SC2129` in untouched steps), `yamllint` clean.

**Residual risk worth naming:** because saving is still gated on `success()`, the aarch64/macOS caches only warm up once one of those legs goes green. If they still cannot finish a cold build, the remaining items in #723 apply — capping Nix parallelism, reclaiming runner disk, larger runners, or publishing the toolchain derivations to an org Cachix for those platforms. I deliberately did not bundle that speculative tuning here.

Refs #723