### PR TITLE
fix: widen VM lt to u128 for unshielded balance comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ with `zswap` being tracked in [Changelog Zswap](./CHANGELOG_zswap.md).
 
 ## Unreleased
 
+- fix: VM `lt` compares as `u128` so `unshieldedBalance*` checks work for the
+  full balance range (previously values above `u64::MAX` failed at decode).
+
 ## Ledger 8.2.0-rc.1
 
 - note: npm packages are now published under the `@midnightntwrk` scope (previously `@midnight-ntwrk`); update package.json dependencies accordingly

--- a/CHANGELOG_onchain-runtime.md
+++ b/CHANGELOG_onchain-runtime.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fix: VM `lt` now compares operands as `u128`, matching protocol unshielded
+  balances and Compact `unshieldedBalance*` builtins that take `Uint<128>`.
+  Values above `u64::MAX` no longer fail with `InvalidBuiltinDecode("u64")`.
 - fix: `communication_commitment` now hashes the value-only representation of its inputs.
 
 ## Version `3.1.0`

--- a/onchain-runtime/tests/vm.rs
+++ b/onchain-runtime/tests/vm.rs
@@ -60,6 +60,16 @@ mod tests {
     fn individual_vm_instructions() {
         let logic_operands = vec![(true, true), (true, false), (false, true), (false, false)];
         let cmp_operands = vec![(4u64, 5u64), (5u64, 5u64), (6u64, 5u64)];
+        // u128 operands cover the unshielded-balance comparison path: balances
+        // and Compact `unshieldedBalance*` thresholds are Uint<128>, including
+        // values above u64::MAX (e.g. UINT128_MAX - amount overflow guards).
+        let cmp_operands_u128 = vec![
+            (4u128, 5u128),
+            (u64::MAX as u128, (u64::MAX as u128) + 1),
+            (u128::MAX - 1, u128::MAX),
+            (u128::MAX, u128::MAX),
+            (u128::MAX, 0u128),
+        ];
         let arithmetic_operands = vec![(5u64, 4u64)];
 
         let run_program = run_program::<InMemoryDB, ResultModeGather>;
@@ -81,6 +91,13 @@ mod tests {
             assert_eq!(
                 run_program(&[vmval!((ops.0)), vmval!((ops.1))], &ops![eq]),
                 Ok((vec![vmval!((ops.0 == ops.1))], vec![]))
+            );
+        }
+
+        for ops in cmp_operands_u128 {
+            assert_eq!(
+                run_program(&[vmval!((ops.0)), vmval!((ops.1))], &ops![lt]),
+                Ok((vec![vmval!((ops.0 < ops.1))], vec![]))
             );
         }
 

--- a/onchain-vm/src/vm.rs
+++ b/onchain-vm/src/vm.rs
@@ -137,8 +137,11 @@ where
 }
 
 fn lt<D: DB>(a: &Value, b: &Value) -> Result<AlignedValue, OnchainProgramError<D>> {
-    let a: u64 = (&**a).try_into()?;
-    let b: u64 = (&**b).try_into()?;
+    // Decode as u128 so comparisons match protocol unshielded balances and
+    // Compact `unshieldedBalance*` builtins that take `Uint<128>`. Values that
+    // fit in u64 continue to compare identically.
+    let a: u128 = (&**a).try_into()?;
+    let b: u128 = (&**b).try_into()?;
     Ok((a < b).into())
 }
 

--- a/spec/onchain-runtime.md
+++ b/spec/onchain-runtime.md
@@ -151,9 +151,11 @@ require specifying if the data is expected to reside in-cache or not.
 In the description above, the following short-hand notations were used. Where
 not specified, result values are placed in a `Cell`, and encoded as FAB values.
 
-* `a + b`, `a - b`, or `a < b` (collectively `a op b`), for applying `op` on
-  the contents of `Cell`s `a` and `b`, interpreted as 64-bit unsigned integers,
-  with alignment `b8`.
+* `a + b` or `a - b`, for applying the op on the contents of `Cell`s `a` and
+  `b`, interpreted as 64-bit unsigned integers, with alignment `b8`.
+* `a < b`, for comparing the contents of `Cell`s `a` and `b`, interpreted as
+  128-bit unsigned integers, with alignment `b16`. Values that fit in fewer
+  than 16 bytes (including former `u64` operands) compare identically.
 * `a ++ b` is the FAB `AlignedValue` of the concatenation of `a` and `b`.
 * `a == b` for checking two `Cell`s for equality, at least one of which must
   contain at most 64 bytes of data (sum of all FAB atoms).


### PR DESCRIPTION
## Summary
- Widen onchain VM `lt` to decode operands as `u128`, matching protocol unshielded balances and Compact `unshieldedBalance*` (`Uint<128>`).
- Update `spec/onchain-runtime.md` so arithmetic stays u64 while `<` is u128.
- Add VM regression coverage for values above `u64::MAX` (e.g. overflow-guard idioms).

Fixes #664
