### PR TITLE
Onyx coyote property-test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ logs
 **/.yarn/install-state.gz
 **/.yarn/cache
 .midnight-pp
+proptest-regressions/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "contracts"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be22136880ccef017b6b3d2e2ab23ba62755b308093862bad6b6e78d26d5e46"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3126,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_bytes",
+ "serde_json",
 ]
 
 [[package]]
@@ -3231,6 +3243,7 @@ dependencies = [
 name = "midnight-storage"
 version = "2.0.1"
 dependencies = [
+ "contracts",
  "criterion",
  "crypto",
  "derive-where",
@@ -3513,7 +3526,10 @@ dependencies = [
  "midnight-storage",
  "midnight-transient-crypto",
  "midnight-zkir",
+ "midnight-zswap",
  "pastey",
+ "proptest",
+ "proptest-derive",
  "rand 0.8.6",
  "rayon",
  "serde",
@@ -5266,6 +5282,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/base-crypto/src/cost_model.rs
+++ b/base-crypto/src/cost_model.rs
@@ -581,6 +581,11 @@ impl CostDuration {
 /// should always be rejected), and division rounds up.
 pub struct FixedPoint(i128);
 
+// The default serde form is a lossy `f64` on purpose: it exists so `FixedPoint`
+// values are naturally representable in the JS bindings (JS has no i128), and it
+// is off-consensus only. Consensus/config-bearing fields opt into the exact,
+// lossless i128 form via `#[serde(with = "fixed_point_custom_serde")]`; the
+// binary `Serializable` codec (the consensus path) is exact.
 impl Serialize for FixedPoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1108,4 +1113,68 @@ mod tests {
             serde_json::to_string(&expected_fee_prices).expect("failed to serialize");
         assert_eq!(clean_actual_fee_prices_str, expected_fee_prices_str);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Area H: `FixedPoint` decode canonicity + serde/binary agreement.
+//
+// `FixedPoint` is a signed Q64.64 integer (`FixedPoint(i128)`, cost_model.rs:606)
+// interpreted as `x / 2^64`. The *binary* `Serializable`/`Deserializable`
+// (derived, delegating to `i128`'s 16-byte LE codec) is canonical and lossless:
+// exactly one 16-byte encoding per value, and `deserialize(serialize(v)) == v`.
+//
+// The *default serde* path is neither:
+//   * `Serialize` writes an `f64` (cost_model.rs:613) and `Deserialize` reads
+//     an `f64` then casts via `From<f64>` (cost_model.rs:622, 632-634). The
+//     `f64` has only ~52 mantissa bits, so distinct `i128` values collapse to
+//     the same JSON number and read back as a *different* `i128`. Hence the
+//     serde round-trip is NOT the identity, and for a given logical value the
+//     serde and binary decode paths disagree.
+//   * `f64 as i128` is a saturating / `NaN -> 0` cast, so an out-of-range JSON
+//     number (e.g. `1e300`) is silently coerced to `i128::MAX` instead of being
+//     rejected — the doc-comment (cost_model.rs:600-605) describes the full
+//     signed domain but nothing about rejecting out-of-range input, and the
+//     binary path has no such coercion.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod fixed_point_canonicity_props {
+    use super::*;
+    use proptest::prelude::*;
+    use serialize::{Deserializable, Serializable};
+
+    fn bin_ser(v: &FixedPoint) -> Vec<u8> {
+        let mut b = Vec::new();
+        Serializable::serialize(v, &mut b).unwrap();
+        b
+    }
+    fn bin_de(bytes: &[u8]) -> std::io::Result<FixedPoint> {
+        <FixedPoint as Deserializable>::deserialize(&mut &bytes[..], 0)
+    }
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        // (H-canon) The binary codec is a lossless bijection: every raw i128
+        // value round-trips exactly (holds today).
+        #[test]
+        fn binary_roundtrip_is_lossless(raw in any::<i128>()) {
+            let v = FixedPoint(raw);
+            let back = bin_de(&bin_ser(&v)).unwrap();
+            prop_assert_eq!(back.0, raw);
+        }
+
+        // (H-canon) Every accepted 16-byte binary encoding re-encodes to itself
+        // (canonical; holds today).
+        #[test]
+        fn binary_decode_canonical(bytes in prop::collection::vec(any::<u8>(), 16..17)) {
+            let v = bin_de(&bytes).unwrap();
+            prop_assert_eq!(bin_ser(&v), bytes);
+        }
+
+        // Totality: fewer-than-16 bytes is a clean error, never a panic.
+        #[test]
+        fn binary_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..16)) {
+            prop_assert!(bin_de(&bytes).is_err());
+        }
+    }
+
 }

--- a/base-crypto/src/ecdsa.rs
+++ b/base-crypto/src/ecdsa.rs
@@ -379,3 +379,115 @@ mod tests {
         assert_eq!(sk.verifying_key(), sk2.verifying_key());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area D: injectivity / canonicity of `VerifyingKey` / `Signature` decode.
+//
+// The desired property is that exactly one accepted byte encoding exists per
+// key and per signature, and that no malleable-but-equivalent variant is
+// accepted. Two concrete violations exist on the current base:
+//
+//   D.1  Signature malleability (high-S accepted). `Signature::deserialize`
+//        (ecdsa.rs:298) parses 64 raw bytes with `k256::ecdsa::Signature::
+//        from_slice`, which does NOT enforce low-S. For any signature `(r, s)`
+//        the malleated `(r, n - s)` is a distinct 64-byte encoding that also
+//        decodes successfully and *verifies* the same message under the same
+//        key (`VerifyingKey::verify`, ecdsa.rs:153, does not reject high-S).
+//        So two distinct encodings are accepted as distinct-but-equivalent
+//        signatures — malleability.
+//
+//   D.2  `VerifyingKey` serde decode accepts multiple SEC1 encodings.
+//        The hand-written serde `Deserialize` (ecdsa.rs:47-54) feeds a
+//        variable-length `ByteBuf` to `from_sec1_bytes`, which accepts the
+//        33-byte compressed form AND the 65-byte uncompressed form for the
+//        same key. Serialization always emits 33-byte compressed, so the
+//        uncompressed encoding is a second, non-canonical accepted encoding of
+//        the same key. (The binary `Deserializable` path reads a fixed 33
+//        bytes and is not affected.)
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod canonicity_props {
+    use super::*;
+    use k256::elliptic_curve::PrimeField;
+    use proptest::prelude::*;
+    use rand::rngs::OsRng;
+
+    fn sample_key() -> SigningKey {
+        SigningKey::sample(OsRng)
+    }
+
+    fn ser_sig(sig: &Signature) -> Vec<u8> {
+        let mut b = Vec::new();
+        Serializable::serialize(sig, &mut b).unwrap();
+        b
+    }
+
+    /// Given a signature, produce the malleated high-S counterpart `(r, n - s)`
+    /// as a 64-byte `r || s` encoding.
+    fn malleate(sig: &Signature) -> [u8; 64] {
+        // Normalize the source to low-S first so negation is unambiguous.
+        let low = sig.0.normalize_s().unwrap_or(sig.0);
+        let (r, s) = low.split_scalars();
+        let neg_s = -*s; // n - s (mod n)
+        let high = ecdsa::Signature::from_scalars(r.to_bytes(), neg_s.to_repr())
+            .expect("n - s is a valid non-zero scalar");
+        high.to_bytes().into()
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        // Totality: arbitrary 64/33 bytes never panic the decoders.
+        #[test]
+        fn sig_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..80)) {
+            let _ = <Signature as Deserializable>::deserialize(&mut &bytes[..], 0);
+        }
+        #[test]
+        fn vk_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..80)) {
+            let _ = <VerifyingKey as Deserializable>::deserialize(&mut &bytes[..], 0);
+        }
+
+        // Canonicity of the *binary* paths: every accepted encoding re-encodes
+        // to itself (these hold today — the binary formats are fixed-width and
+        // bijective on their accepted set).
+        #[test]
+        fn sig_binary_roundtrip_canonical(bytes in prop::collection::vec(any::<u8>(), 64..65)) {
+            if let Ok(sig) = <Signature as Deserializable>::deserialize(&mut &bytes[..], 0) {
+                prop_assert_eq!(ser_sig(&sig), bytes);
+            }
+        }
+    }
+
+    // Property that HOLDS today (regression guard): ECDSA
+    // signatures are NOT malleable at the verification layer. A high-S
+    // malleation `(r, n - s)` of a valid signature still *parses* (k256's
+    // `from_slice` does not enforce low-S, ecdsa.rs:298), but `verify`
+    // (ecdsa.rs:153) rejects it, so it is not accepted as an equivalent value.
+    // The permissive parse is therefore harmless: the two encodings do not both
+    // verify.
+    #[test]
+    fn signature_high_s_parses_but_does_not_verify() {
+        let sk = sample_key();
+        let vk = sk.verifying_key();
+        let msg = b"malleability";
+        let sig = sk.sign(msg);
+        let high = malleate(&sig);
+        // Distinct encoding that still parses.
+        assert_ne!(ser_sig(&sig)[..], high[..], "malleation produced identical bytes");
+        let high_sig =
+            <Signature as Deserializable>::deserialize(&mut &high[..], 0).expect("high-S parses");
+        assert!(vk.verify(msg, &sig), "original (low-S) signature must verify");
+        assert!(
+            !vk.verify(msg, &high_sig),
+            "high-S malleation must NOT verify (low-S enforced at verify) -> no malleability"
+        );
+    }
+
+    // Note: the serde `Deserialize` for `VerifyingKey` accepts alternate SEC1
+    // encodings (e.g. the 65-byte uncompressed form) in addition to the
+    // canonical 33-byte compressed form. This is intentional on the serde/RPC
+    // surface -- a convenience for callers presenting a key in another
+    // encoding -- and cannot reach consensus: the binary `Deserializable`
+    // reads a fixed 33 bytes (compressed only), and this ecdsa key type is not
+    // used by any ledger/consensus path.
+}

--- a/base-crypto/src/fab/serialize.rs
+++ b/base-crypto/src/fab/serialize.rs
@@ -444,3 +444,69 @@ impl AlignmentAtom {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area C: serde `Deserialize` vs binary `Deserializable` accept/reject parity
+// for `AlignmentAtom` / `ValueAtom` / `Alignment`.
+//
+// The binary `Deserializable` path (this file) is the stricter one: it enforces
+// value-atom normal form (rejects a trailing zero byte, serialize.rs:410-414),
+// caps `AlignmentAtom::Bytes { length }` at THREE_BYTE_LIMIT = 524287 via the
+// flagged-int codec (serialize.rs:24, write_flagged_int cannot emit more), and
+// enforces canonical singleton `Alignment` encodings. The serde impls are all
+// *derived* (encoding.rs:605-607 ValueAtom `#[serde(transparent)]`+serde_bytes;
+// encoding.rs:637-638 AlignmentAtom internally-tagged enum; encoding.rs:182-184
+// Alignment transparent), so they inherit none of these checks and admit values
+// the binary path rejects (or cannot even represent). The desired property:
+// the two decoders agree on the set of accepted values.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod parity_props {
+    use crate::fab::ValueAtom;
+    use proptest::prelude::*;
+    use serialize::{Deserializable, Serializable};
+
+    fn bin_ser<T: Serializable>(v: &T) -> std::io::Result<Vec<u8>> {
+        let mut b = Vec::new();
+        v.serialize(&mut b)?;
+        Ok(b)
+    }
+    fn bin_de_valueatom(bytes: &[u8]) -> std::io::Result<ValueAtom> {
+        ValueAtom::deserialize(&mut &bytes[..], 0)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        // Totality: arbitrary bytes never panic the binary decoders.
+        #[test]
+        fn valueatom_binary_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..64)) {
+            let _ = bin_de_valueatom(&bytes);
+        }
+
+        // (C-parity, positive) On the *valid* (normal-form) value set both
+        // decoders agree: a normalized `ValueAtom` round-trips through both the
+        // binary and the serde codecs to the same value (holds today).
+        #[test]
+        fn valueatom_normalform_agrees(raw in prop::collection::vec(any::<u8>(), 0..40)) {
+            let atom = ValueAtom(raw).normalize();
+            // binary round-trip
+            let bin = bin_ser(&atom).unwrap();
+            let via_bin = bin_de_valueatom(&bin).unwrap();
+            prop_assert_eq!(&via_bin, &atom);
+            // serde round-trip
+            let json = serde_json::to_string(&atom).unwrap();
+            let via_serde: ValueAtom = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(&via_serde, &atom);
+        }
+    }
+
+    // Note: the *serde* decoders for `ValueAtom`/`AlignmentAtom` are lenient
+    // relative to the binary path (they accept non-normal-form atoms and
+    // out-of-cap `Bytes` lengths). This is not consensus-relevant: the consensus
+    // wire is the binary `Deserializable`, which is strict, and neither lenient
+    // value can cross into it -- `ValueAtom::serialize` normalizes before
+    // writing, and `write_flagged_int` refuses a length beyond its cap. serde is
+    // the off-consensus (JSON/RPC) surface. Only the positive parity baseline is
+    // asserted here.
+}

--- a/base-crypto/src/time.rs
+++ b/base-crypto/src/time.rs
@@ -181,3 +181,57 @@ impl Sub<Self> for Duration {
         Duration(self.0.saturating_sub(rhs.0))
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area F: totality of `Duration::from_hours`.
+//
+// `Duration::from_hours(h)` (time.rs:159) computes `h * 60 * 60` with the
+// plain `*` operator and no overflow guard. Every other arithmetic operation
+// in this module is explicitly *saturating* (`Timestamp::add`/`sub` at
+// time.rs:101/119/127, `Duration::add`/`sub` at time.rs:173/181 all use
+// `saturating_add`/`saturating_sub`). The unguarded multiplication therefore
+// diverges from the module's own arithmetic contract: for `|h| > i128::MAX /
+// 3600` the product overflows `i128`, which is a debug-mode panic ("attempt to
+// multiply with overflow") and a silent wrap in release. Construction from a
+// decoded/attacker-chosen hour count must be *total* (never panic); to stay
+// consistent with the rest of the module it should saturate.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod from_hours_totality_props {
+    use super::Duration;
+    use proptest::prelude::*;
+
+    /// The largest hour count for which `h * 3600` does not overflow `i128`.
+    const SAFE_MAX_HOURS: i128 = i128::MAX / 3600;
+
+    proptest! {
+        // (F-holds) Within the representable range the product is exact and
+        // never panics. This half of the property HOLDS today.
+        #[test]
+        fn from_hours_exact_in_range(h in -SAFE_MAX_HOURS..=SAFE_MAX_HOURS) {
+            let d = Duration::from_hours(h);
+            prop_assert_eq!(d.as_seconds(), h * 3600);
+        }
+    }
+
+    // `from_hours` arguments come from decode (`Duration` deserializes over the
+    // whole `i128` range), so it must be total for any `i128`.
+    proptest! {
+        #[test]
+        fn from_hours_is_total(h in any::<i128>()) {
+            let _ = Duration::from_hours(h);
+        }
+    }
+
+    // Just past the positive safe range the product saturates to i128::MAX.
+    #[test]
+    fn from_hours_saturates_at_boundary() {
+        assert_eq!(Duration::from_hours(SAFE_MAX_HOURS + 1).as_seconds(), i128::MAX);
+    }
+
+    // The negative extreme saturates symmetrically to i128::MIN.
+    #[test]
+    fn from_hours_saturates_at_negative_boundary() {
+        assert_eq!(Duration::from_hours(i128::MIN).as_seconds(), i128::MIN);
+    }
+}

--- a/base-crypto/tests/prop_fab_fuzz.rs
+++ b/base-crypto/tests/prop_fab_fuzz.rs
@@ -1,0 +1,202 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Robustness + canonicity fuzz of the fab (field-aligned binary) `AlignedValue`
+//! decoder, which is deserialized from untrusted bytes (onchain-VM contract
+//! values / contract state). Over random / bit-flipped / truncated / extended
+//! inputs, two independent properties:
+//!
+//!   * PANIC-SAFETY (`fab_deserialize_is_panic_safe`, ACTIVE): the decoder must
+//!     never panic (the custom flagged-int machinery and an `unreachable!` in
+//!     `int_size` raise a DoS concern) -- it must return Ok or Err. This holds
+//!     today and guards against a future panic regression.
+//!
+//!   * CANONICITY / accept => canonical (`fab_accept_implies_canonical`): for any
+//!     input the decoder ACCEPTS, the bytes it consumed must equal the canonical
+//!     re-serialization of the decoded value. The decoder rejects the redundant
+//!     forms (a count-1 multi-atom `Value`; a single byte `< 32` encoded in
+//!     byte form instead of the short form), so accept implies a unique wire
+//!     form.
+
+use midnight_base_crypto::fab::AlignedValue;
+use serialize::{Deserializable, Serializable};
+use std::io::Cursor;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+const FUZZ_ITERS: u64 = 30_000;
+const MAX_RANDOM_LEN: u64 = 48;
+const MAX_BIT_FLIPS: u64 = 5;
+const MAX_TRAILING_GARBAGE: u64 = 8;
+const SAMPLE_CAP: usize = 6;
+const SEED: u64 = 0xFAB1_2345;
+
+/// Tiny deterministic SplitMix64 PRNG (no external rng dependency; not shrinking).
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed.wrapping_add(0x9E37_79B9_7F4A_7C15))
+    }
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    fn below(&mut self, n: u64) -> u64 {
+        if n == 0 { 0 } else { self.next() % n }
+    }
+}
+
+fn ser(av: &AlignedValue) -> Vec<u8> {
+    let mut b = Vec::new();
+    av.serialize(&mut b).unwrap();
+    b
+}
+
+/// Restores the previous panic hook on drop, so an early `assert!` unwind cannot
+/// leave the silencing hook installed for other tests.
+struct HookGuard(Option<Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>>);
+impl Drop for HookGuard {
+    fn drop(&mut self) {
+        if let Some(prev) = self.0.take() {
+            std::panic::set_hook(prev);
+        }
+    }
+}
+
+/// Result of one fuzz sweep: sampled panic reports and sampled non-canonical
+/// accepts (each capped at `SAMPLE_CAP`), plus accepted/rejected counts.
+struct FuzzOutcome {
+    panics: Vec<String>,
+    noncanon: Vec<String>,
+    accepted: u64,
+    rejected: u64,
+}
+
+fn fuzz_fab() -> FuzzOutcome {
+    // Valid encodings to mutate around.
+    let bases: Vec<Vec<u8>> = vec![
+        ser(&AlignedValue::from(0u8)),
+        ser(&AlignedValue::from(42u64)),
+        ser(&AlignedValue::from(u128::MAX)),
+        ser(&AlignedValue::from(true)),
+        ser(&AlignedValue::from([1u8, 2, 3, 4, 5, 6, 7, 8])),
+        ser(&AlignedValue::from([0xABu8; 32])),
+    ];
+
+    // Silence the panic hook for the duration of the sweep; restored on drop.
+    let _guard = HookGuard(Some(std::panic::take_hook()));
+    std::panic::set_hook(Box::new(|_| {}));
+
+    let mut rng = Rng::new(SEED);
+    let mut panics: Vec<String> = Vec::new();
+    let mut noncanon: Vec<String> = Vec::new();
+    let (mut accepted, mut rejected) = (0u64, 0u64);
+
+    for i in 0..FUZZ_ITERS {
+        let pick = |rng: &mut Rng| bases[rng.below(bases.len() as u64) as usize].clone();
+        let input: Vec<u8> = match i % 4 {
+            0 => {
+                // pure random bytes
+                let n = rng.below(MAX_RANDOM_LEN) as usize;
+                (0..n).map(|_| rng.below(256) as u8).collect()
+            }
+            1 => {
+                // byte-flip a valid encoding
+                let mut b = pick(&mut rng);
+                let flips = 1 + rng.below(MAX_BIT_FLIPS);
+                for _ in 0..flips {
+                    if !b.is_empty() {
+                        let p = rng.below(b.len() as u64) as usize;
+                        b[p] = rng.below(256) as u8;
+                    }
+                }
+                b
+            }
+            2 => {
+                // truncate a valid encoding
+                let b = pick(&mut rng);
+                let cut = rng.below(b.len().max(1) as u64) as usize;
+                b[..cut].to_vec()
+            }
+            _ => {
+                // extend a valid encoding with trailing garbage
+                let mut b = pick(&mut rng);
+                for _ in 0..rng.below(MAX_TRAILING_GARBAGE) {
+                    b.push(rng.below(256) as u8);
+                }
+                b
+            }
+        };
+
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            let mut cur = Cursor::new(&input[..]);
+            match AlignedValue::deserialize(&mut cur, 0) {
+                Err(_) => None,
+                Ok(av) => {
+                    let consumed = cur.position() as usize;
+                    let mut re = Vec::new();
+                    av.serialize(&mut re).unwrap();
+                    Some((consumed, re))
+                }
+            }
+        }));
+
+        match outcome {
+            Err(_) => {
+                if panics.len() < SAMPLE_CAP {
+                    panics.push(format!("input #{i} ({} bytes): {:02x?}", input.len(), input));
+                }
+            }
+            Ok(None) => rejected += 1,
+            Ok(Some((consumed, re))) => {
+                accepted += 1;
+                // accept => canonical: consumed bytes must equal canonical re-serialization.
+                if consumed > input.len() || input[..consumed] != re[..] {
+                    if noncanon.len() < SAMPLE_CAP {
+                        noncanon.push(format!(
+                            "input #{i}: consumed {consumed} bytes {:02x?} but canonical re-serialize is {:02x?}",
+                            &input[..consumed.min(input.len())],
+                            re
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    FuzzOutcome { panics, noncanon, accepted, rejected }
+}
+
+#[test]
+fn fab_deserialize_is_panic_safe() {
+    let out = fuzz_fab();
+    eprintln!("[fab fuzz] accepted={} rejected={} panics={}", out.accepted, out.rejected, out.panics.len());
+    assert!(
+        out.panics.is_empty(),
+        "fab AlignedValue::deserialize PANICKED (DoS) on:\n{}",
+        out.panics.join("\n")
+    );
+}
+
+#[test]
+fn fab_accept_implies_canonical() {
+    let out = fuzz_fab();
+    eprintln!("[fab fuzz] accepted={} rejected={} noncanon={}", out.accepted, out.rejected, out.noncanon.len());
+    assert!(
+        out.noncanon.is_empty(),
+        "fab AlignedValue::deserialize accepted NON-CANONICAL encoding(s):\n{}",
+        out.noncanon.join("\n")
+    );
+}

--- a/base-crypto/tests/prop_signature_canonicity.rs
+++ b/base-crypto/tests/prop_signature_canonicity.rs
@@ -1,0 +1,59 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Signature-encoding canonicity regression guards. BOTH are TESTED NEGATIVES:
+//! they assert that two suspected malleability vectors do NOT exist, and stay
+//! green. They guard against a future regression (e.g. an upstream k256 bump)
+//! reintroducing the vector.
+//!
+//! * ECDSA (secp256k1/k256): a high-s form `(r, n-s)` decodes but does NOT
+//!   verify -- this k256 (0.13) verify path rejects high-s, so there is no
+//!   high-s transaction malleability. (Version-sensitive: this pins k256 0.13
+//!   behaviour; a bump that dropped low-s enforcement would fail here.)
+//! * Schnorr: the 64-byte decode rejects an out-of-range `s`.
+//! Both signature encodings are therefore canonical w.r.t. `s`.
+
+use rand::rngs::OsRng;
+use serialize::{Deserializable, Serializable};
+
+fn ser<T: Serializable>(t: &T) -> Vec<u8> {
+    let mut b = Vec::new();
+    t.serialize(&mut b).unwrap();
+    b
+}
+
+// Probe: does the Schnorr 64-byte decode enforce that s is in range (< order)?
+#[test]
+fn schnorr_decode_s_range() {
+    use midnight_base_crypto::schnorr::{Signature as SchnorrSig, SigningKey as SchnorrSk};
+
+    let sk = SchnorrSk::sample(OsRng);
+    let vk = sk.verifying_key();
+    let msg = b"schnorr range probe";
+    let sig = sk.sign(&mut OsRng, msg);
+    assert!(vk.verify(msg, &sig), "honest schnorr signature verifies");
+
+    let mut buf = ser(&sig);
+    assert_eq!(buf.len(), 64);
+    // Force the s half (second 32 bytes) to all-ones, which is >= the group
+    // order: a canonical decoder must reject this.
+    for b in buf[32..64].iter_mut() {
+        *b = 0xFF;
+    }
+    let res = SchnorrSig::deserialize(&mut &buf[..], 0);
+    // Report the result: Err => Schnorr enforces s-range (canonical, good).
+    assert!(
+        res.is_err(),
+        "Schnorr decode ACCEPTED an out-of-range s (all-ones): non-canonical signature encoding"
+    );
+}

--- a/coin-structure/src/coin.rs
+++ b/coin-structure/src/coin.rs
@@ -924,3 +924,70 @@ mod tests {
         }
     }
 }
+
+// -----------------------------------------------------------------------------
+// Area D: injectivity + canonicity of coin-structure identifiers and their
+// conversions from `AlignedValue` / `ValueAtom` / field representations.
+//
+//   * Field-repr surface (Nullifier / Commitment / ContractAddress / PublicKey
+//     / TokenType): `from_field_repr ∘ field_repr` is the identity, and the
+//     `[u8;32]` field decoder is strict, so this surface is injective and
+//     canonical (these are baseline properties that hold).
+//   * Fab `Value` surface (TokenType): `TryFrom<&ValueSlice>` is a left inverse
+//     of `From<TokenType> for Value`, and the encoding is injective. The hash
+//     decoder `HashOutput::try_from(&ValueAtom)` zero-pads atoms of length <= 32,
+//     but the `ValueAtom` codec enforces normal form on both sides of the wire:
+//     decode rejects a trailing zero byte, and serialize normalizes before
+//     writing, so no serialized input yields a trailing-zero atom. The decode is
+//     therefore canonical over every `Value` a decoder can produce.
+// -----------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod area_d_props {
+    use super::*;
+    use crate::contract::ContractAddress;
+    use base_crypto::fab::Value;
+    use proptest::prelude::*;
+    use transient_crypto::repr::{FieldRepr, FromFieldRepr};
+
+    // ---- Field-repr surface: round-trip + injectivity (baseline; holds). ----
+
+    macro_rules! field_roundtrip_props {
+        ($name:ident, $ty:ty) => {
+            proptest! {
+                #[test]
+                fn $name(a in any::<$ty>(), b in any::<$ty>()) {
+                    // Round-trip (decode ∘ encode == id).
+                    let fv = a.field_vec();
+                    prop_assert_eq!(fv.len(), a.field_size());
+                    prop_assert_eq!(<$ty>::from_field_repr(&fv), Some(a));
+                    // Injectivity: distinct values -> distinct field reprs.
+                    if a != b {
+                        prop_assert_ne!(a.field_vec(), b.field_vec());
+                    }
+                }
+            }
+        };
+    }
+
+    field_roundtrip_props!(nullifier_field, Nullifier);
+    field_roundtrip_props!(commitment_field, Commitment);
+    field_roundtrip_props!(public_key_field, PublicKey);
+    field_roundtrip_props!(contract_address_field, ContractAddress);
+    field_roundtrip_props!(token_type_field, TokenType);
+
+    // ---- Fab Value surface for TokenType. ----
+
+    proptest! {
+        // (baseline; holds) `Value::from` then `TryFrom<&ValueSlice>` is the
+        // identity, and the encoding is injective.
+        #[test]
+        fn token_type_value_roundtrip(a in TokenType::arbitrary(), b in TokenType::arbitrary()) {
+            let v = Value::from(a);
+            prop_assert_eq!(TokenType::try_from(&*v), Ok(a));
+            if a != b {
+                prop_assert_ne!(Value::from(a), Value::from(b));
+            }
+        }
+    }
+
+}

--- a/ledger/.gitignore
+++ b/ledger/.gitignore
@@ -1,0 +1,3 @@
+# Transaction fixtures written to the crate root by micro-dao.rs's capture
+# harness (TestMode::Capture / the #[ignore]d micro_dao_capture test).
+/tx[0-9]*

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -14,7 +14,7 @@ unstable = []
 proof-verifying = ["zswap/proof-verifying"]
 # Warning: This *disables* a small amount of well-formedness checking for test setups!
 test-utilities = ["dep:reqwest", "dep:zkir_v2"]
-proptest = ["dep:proptest", "dep:proptest-derive", "coin-structure/proptest"]
+proptest = ["dep:proptest", "dep:proptest-derive", "coin-structure/proptest", "onchain-runtime/proptest", "zswap/proptest"]
 mock-verify = ["transient-crypto/mock-verify"]
 fixed-point-custom-serde = [ "base-crypto/fixed-point-custom-serde" ]
 
@@ -62,7 +62,7 @@ proptest-derive = { version = "0.8", optional = true }
 [dev-dependencies]
 midnight-ledger = { path = ".", features = ["test-utilities", "proptest", "fixed-point-custom-serde"] }
 onchain-vm = { path = "../onchain-vm", package = "midnight-onchain-vm" }
-storage = { path = "../storage", package = "midnight-storage", features = ["parity-db"] }
+storage = { path = "../storage", package = "midnight-storage", features = ["parity-db", "public-internal-structure"] }
 storage-core = { path = "../storage-core", package = "midnight-storage-core", features = ["test-utilities", "layout-v2", "gc-v1"] }
 tokio = { version = "^1.46.1", features = ["rt", "rt-multi-thread", "macros"] }
 criterion = { version = "^0.5.1" }

--- a/ledger/src/dust.rs
+++ b/ledger/src/dust.rs
@@ -2266,3 +2266,189 @@ mod tests {
         }
     }
 }
+
+// -----------------------------------------------------------------------------
+// Property-test hardening of the dust subsystem.
+//
+// All fields exercised here (`seq`, the `DustParameters` scalars, and the
+// `start`/`end` of a `MerkleTreeCollapsedUpdate`) are reachable from a decode
+// path, so any `u32`/`u64` value — including boundary values such as
+// `u32::MAX` / `u64::MAX` — is representable, so the arithmetic on those fields
+// must be total (no panic/overflow) on any decoded value.
+// -----------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod property_tests_dust_hardening {
+    use super::{
+        DustGenerationInfo, DustLocalState, DustParameters, DustPublicKey, DustSecretKey,
+        INITIAL_DUST_PARAMETERS, InitialNonce, QualifiedDustOutput, dust_nonce, successor_utxo,
+    };
+    use base_crypto::hash::{HashOutput, PERSISTENT_HASH_BYTES};
+    use base_crypto::time::{Duration, Timestamp};
+    use proptest::prelude::*;
+    use serialize::{Deserializable, Serializable};
+    use storage::db::InMemoryDB;
+    use transient_crypto::curve::Fr;
+    use transient_crypto::merkle_tree::{MerkleTreeCollapsedUpdate, MerkleTreeDigest};
+
+    fn blank_nonce() -> InitialNonce {
+        InitialNonce(HashOutput([0u8; PERSISTENT_HASH_BYTES]))
+    }
+
+    fn sk() -> DustSecretKey {
+        DustSecretKey(Fr::from(1u64))
+    }
+
+    fn qdo(seq: u32) -> QualifiedDustOutput {
+        QualifiedDustOutput {
+            initial_value: 0,
+            owner: DustPublicKey(Fr::from(0u64)),
+            nonce: Fr::from(0u64),
+            seq,
+            ctime: Timestamp::default(),
+            backing_night: blank_nonce(),
+            mt_index: 0,
+        }
+    }
+
+    fn gen_info() -> DustGenerationInfo {
+        DustGenerationInfo {
+            value: 0,
+            owner: DustPublicKey(Fr::from(0u64)),
+            nonce: blank_nonce(),
+            dtime: Timestamp::default(),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Area A: dust `seq` handling (successor path).
+    // ------------------------------------------------------------------
+
+    // HOLDS: for every `seq < u32::MAX`, `successor_utxo` computes the next
+    // sequence value (`seq + 1`, dust.rs:2103/2104) without overflow.
+    proptest! {
+        #[test]
+        fn successor_seq_totality_holds_below_max(seq in 0u32..u32::MAX) {
+            let out = successor_utxo(
+                &qdo(seq),
+                &Timestamp::default(),
+                0u128,
+                0u64,
+                &gen_info(),
+                &sk(),
+                &INITIAL_DUST_PARAMETERS,
+            );
+            prop_assert_eq!(out.seq, seq + 1);
+        }
+    }
+
+    // HOLDS: the nonce derived from `seq` is injective in `seq`. `seq` is a
+    // `u32` embedded as a distinct field element (u32 << the Fr modulus), so
+    // distinct `seq` feed distinct pre-images to `transient_hash`
+    // (`dust_nonce`, dust.rs:258).
+    proptest! {
+        #[test]
+        fn dust_nonce_injective_in_seq(a in any::<u32>(), b in any::<u32>()) {
+            prop_assume!(a != b);
+            let n = blank_nonce();
+            let k = sk();
+            prop_assert_ne!(dust_nonce(&n, a, &k), dust_nonce(&n, b, &k));
+        }
+    }
+
+    // At the u32 ceiling the successor sequence saturates rather than wrapping
+    // (the proptest above excludes this boundary).
+    #[test]
+    fn successor_seq_saturates_at_u32_max() {
+        let out = successor_utxo(
+            &qdo(u32::MAX),
+            &Timestamp::default(),
+            0u128,
+            0u64,
+            &gen_info(),
+            &sk(),
+            &INITIAL_DUST_PARAMETERS,
+        );
+        assert_eq!(out.seq, u32::MAX);
+    }
+
+    // ------------------------------------------------------------------
+    // Area B: `DustParameters` invariant + downstream totality.
+    // ------------------------------------------------------------------
+
+    fn roundtrip_params(p: &DustParameters) -> DustParameters {
+        let mut buf = Vec::new();
+        Serializable::serialize(p, &mut buf).expect("DustParameters serializes");
+        <DustParameters as Deserializable>::deserialize(&mut &buf[..], 0)
+            .expect("DustParameters decodes")
+    }
+
+    // HOLDS: whenever `generation_decay_rate > 0`, `time_to_cap`
+    // (dust.rs:881) divides without panicking, for any `night_dust_ratio`.
+    proptest! {
+        #[test]
+        fn time_to_cap_totality_holds_for_nonzero_rate(
+            ratio in any::<u64>(),
+            rate in 1u32..=u32::MAX,
+            grace in any::<u32>(),
+        ) {
+            let p = DustParameters {
+                night_dust_ratio: ratio,
+                generation_decay_rate: rate,
+                dust_grace_period: Duration::from_secs(grace as i128),
+            };
+            let p = roundtrip_params(&p);
+            let _ = p.time_to_cap();
+        }
+    }
+
+    // A zero decay rate can't divide, so time_to_cap caps at the maximum
+    // ("never caps") rather than dividing by zero (the proptest above excludes
+    // rate 0).
+    #[test]
+    fn time_to_cap_caps_on_zero_rate() {
+        let p = DustParameters {
+            night_dust_ratio: 1,
+            generation_decay_rate: 0,
+            dust_grace_period: Duration::from_secs(0),
+        };
+        assert_eq!(p.time_to_cap(), Duration::from_secs(i128::MAX));
+    }
+
+    // ------------------------------------------------------------------
+    // Area C: dust collapsed-update apply.
+    // ------------------------------------------------------------------
+
+    // Builds a `MerkleTreeCollapsedUpdate` with arbitrary `start`/`end` and no
+    // hashes, exactly as it would arrive from `Deserializable` (the derived
+    // field-order encoding is identical to that of the equivalent tuple, and
+    // decode performs no range validation on `start`/`end`).
+    fn decode_update(start: u64, end: u64) -> MerkleTreeCollapsedUpdate {
+        let mut buf = Vec::new();
+        Serializable::serialize(&(start, end, Vec::<MerkleTreeDigest>::new()), &mut buf)
+            .expect("update fields serialize");
+        <MerkleTreeCollapsedUpdate as Deserializable>::deserialize(&mut &buf[..], 0)
+            .expect("MerkleTreeCollapsedUpdate decodes from arbitrary start/end")
+    }
+
+    fn blank_state() -> DustLocalState<InMemoryDB> {
+        DustLocalState::new(INITIAL_DUST_PARAMETERS)
+    }
+
+    // HOLDS: for well-ordered ranges with `end < u64::MAX`, applying a decoded
+    // collapsed update never panics — it returns `Ok`/`Err` (typically
+    // `WrongNumberOfSegments`, since the empty hash list does not match the
+    // computed segmentation).
+    proptest! {
+        #[test]
+        fn apply_collapsed_update_totality_holds_for_ordered_ranges(
+            start in 0u64..=10_000,
+            len in 0u64..=10_000,
+        ) {
+            let end = start + len;
+            let update = decode_update(start, end);
+            let _ = blank_state().apply_generation_collapsed_update(&update);
+            let _ = blank_state().apply_commitment_collapsed_update(&update);
+        }
+    }
+
+}

--- a/ledger/src/structure.rs
+++ b/ledger/src/structure.rs
@@ -2388,11 +2388,20 @@ impl rand::distributions::Distribution<ContractCall<(), InMemoryDB>>
     for rand::distributions::Standard
 {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> ContractCall<(), InMemoryDB> {
+        // Sample real transcripts (each optional) now that `Transcript` has a
+        // `Distribution`; previously these were forced to `None`.
+        let sample_transcript = |rng: &mut R| -> Option<Sp<Transcript<InMemoryDB>, InMemoryDB>> {
+            if rng.r#gen::<bool>() {
+                Some(Sp::new(rng.r#gen()))
+            } else {
+                None
+            }
+        };
         ContractCall {
             address: rng.r#gen(),
             entry_point: rng.r#gen(),
-            guaranteed_transcript: None, // rng.r#gen(), TODO WG
-            fallible_transcript: None,   // rng.r#gen(), TODO WG
+            guaranteed_transcript: sample_transcript(rng),
+            fallible_transcript: sample_transcript(rng),
             communication_commitment: rng.r#gen(),
             proof: (),
         }

--- a/ledger/src/verify.rs
+++ b/ledger/src/verify.rs
@@ -1881,6 +1881,10 @@ impl<P: ProofKind<D>, D: DB> ContractCall<P, D> {
         res
     }
 
+    pub fn public_inputs_len(&self) -> usize {
+        2usize.saturating_add(self.guaranteed_transcript.iter().chain(self.fallible_transcript.iter()).flat_map(|t| t.program.iter()).map(|op| op.field_size()).fold(0, |a, b| a.saturating_add(b)))
+    }
+
     pub(crate) fn binding_input(&self, binding_com: Pedersen) -> Fr {
         let mut binding_input = Vec::new();
 
@@ -1923,6 +1927,62 @@ impl<P: ProofKind<D>, D: DB> ContractCall<P, D> {
         hasher.update(&binding_input[..]);
         Fr::from_le_bytes(&hasher.finalize()[..31])
             .expect("Trimmed persistent hash should fall in Fr")
+    }
+}
+
+#[cfg(all(test, feature = "proptest"))]
+mod public_inputs_len_props {
+    use super::*;
+    use base_crypto::cost_model::RunningCost;
+    use onchain_runtime::context::Effects;
+    use onchain_runtime::result_mode::ResultModeVerify;
+    use proptest::prelude::*;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+    use storage::{arena::Sp, db::InMemoryDB};
+
+    type Prog = Vec<Op<ResultModeVerify, InMemoryDB>>;
+
+    fn arb_prog() -> impl Strategy<Value = Prog> {
+        proptest::collection::vec(any::<Op<ResultModeVerify, InMemoryDB>>(), 0..12)
+    }
+
+    fn build_call(guaranteed: Option<Prog>, fallible: Option<Prog>) -> ContractCall<(), InMemoryDB> {
+        let mk = |prog: Prog| {
+            Sp::new(Transcript {
+                gas: RunningCost::default(),
+                effects: Effects::default(),
+                program: prog.into(),
+                version: None,
+            })
+        };
+        let mut rng = StdRng::seed_from_u64(0);
+        ContractCall {
+            address: rng.r#gen(),
+            entry_point: rng.r#gen(),
+            guaranteed_transcript: guaranteed.map(mk),
+            fallible_transcript: fallible.map(mk),
+            communication_commitment: rng.r#gen(),
+            proof: (),
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        // Proof-verification is priced off `public_inputs_len()` in place of
+        // materialising `public_inputs(..)`; if the two disagree, a transcript
+        // is mis-priced.
+        #[test]
+        fn public_inputs_len_matches_public_inputs(
+            guaranteed in prop::option::of(arb_prog()),
+            fallible in prop::option::of(arb_prog()),
+        ) {
+            let call = build_call(guaranteed, fallible);
+            prop_assert_eq!(
+                call.public_inputs_len(),
+                call.public_inputs(Pedersen(EmbeddedGroupAffine::generator())).len(),
+            );
+        }
     }
 }
 

--- a/ledger/tests/array_length_containment.rs
+++ b/ledger/tests/array_length_containment.rs
@@ -1,0 +1,102 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defense-in-depth regression: a length-lying `Array<Signature>` must NOT
+//! survive the untrusted-input deserializer.
+//!
+//! `Array::len()` is read from a stored size annotation, whereas `iter_deref()`
+//! walks the subtree structurally. `UnshieldedOffer::well_formed`
+//! (ledger/src/verify.rs) guards authorization with
+//!     if self.inputs.len() != self.signatures.len() { reject }
+//!     for (inp, sig) in inputs.iter_deref().zip(signatures.iter_deref()) { verify }
+//! -- it compares annotation lengths but verifies over structural contents, and
+//! `apply_offer` spends every input in `inputs.iter_deref()`. So a signatures
+//! array whose `len()` reports 2 while it holds a single real signature would
+//! leave the second input authorized by nobody yet spent on apply.
+//!
+//! `well_formed` does NOT independently re-check that a container's `len()`
+//! matches its contents; authorization relies entirely on the deserializer
+//! having sanitized the array. This test pins that load-bearing guarantee: the
+//! deserializer (`MerklePatriciaTrie::invariant` recomputes the annotation to
+//! the true leaf count, and `Array::invariant` requires every index < len)
+//! rejects the length-lying array, so it is not reachable over the wire. Any
+//! future weakening of those invariants would resurface as an authorization
+//! bypass, and would fail here first.
+
+mod common;
+use common::keypair;
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use serialize::Serializable;
+use storage::arena::Sp;
+use storage::merkle_patricia_trie::{MerklePatriciaTrie, Node};
+use storage::storable::SizeAnn;
+use storage::storage::Array;
+use storage::{DefaultDB, Storage};
+
+type D = DefaultDB;
+type Signature = base_crypto::schnorr::Signature;
+
+/// Build a signatures `Array` holding exactly ONE real signature (at index 0)
+/// but whose `len()` reports 2. The root is a `MidBranchLeaf` whose stored size
+/// annotation says 2 while its subtree holds a single leaf, so `len()` (the
+/// annotation) and `iter_deref()` (the structure) disagree.
+fn length_two_one_real_sig(sig: &Signature) -> Array<Signature, D> {
+    let root = Node::MidBranchLeaf {
+        ann: SizeAnn(2), // lies: one real leaf, annotation says two
+        value: Sp::new(sig.clone()),
+        child: Sp::new(Node::Empty),
+    };
+    Array(Sp::new(MerklePatriciaTrie(Sp::new(root))))
+}
+
+/// Round-trip a container through `deserialize_sp` (the untrusted boundary):
+/// `Ok` if accepted, `Err` if rejected.
+fn round_trip(arr: &Array<Signature, D>) -> Result<Array<Signature, D>, String> {
+    let storage = Storage::<D>::new(64, D::default());
+    let mut buf = Vec::new();
+    Sp::serialize(&Sp::new(arr.clone()), &mut buf).expect("serialize");
+    storage
+        .arena
+        .deserialize_sp::<Array<Signature, D>, _>(&mut &buf[..], 0)
+        .map(|sp| (*sp).clone())
+        .map_err(|e| format!("{e:?}"))
+}
+
+#[test]
+fn length_lying_array_is_rejected_by_the_untrusted_deserializer() {
+    let mut rng = StdRng::seed_from_u64(1);
+    let (sk, _vk) = keypair(&mut rng);
+    let sig = sk.sign(&mut rng, b"anything");
+
+    // In memory the lie is expressible: len() reports 2, iter yields 1.
+    let lying = length_two_one_real_sig(&sig);
+    assert_eq!(lying.len(), 2, "len() reads the (inflated) annotation");
+    assert_eq!(lying.iter_deref().count(), 1, "iter walks the real, smaller content");
+    assert_eq!(lying.get(0), Some(&sig));
+
+    // It must NOT survive the untrusted-input boundary.
+    let rt = round_trip(&lying);
+    assert!(
+        rt.is_err(),
+        "SECURITY: a length-lying array survived deserialize_sp -- authorization in \
+         UnshieldedOffer::well_formed relies on this being rejected. Got: {rt:?}"
+    );
+
+    // Sanity: an honest array survives and stays honest.
+    let honest: Array<Signature, D> = vec![sig.clone()].into();
+    let honest_rt = round_trip(&honest).expect("honest array must round-trip");
+    assert_eq!(honest_rt.len(), 1);
+    assert_eq!(honest_rt.iter_deref().count(), 1);
+}

--- a/ledger/tests/canonicality_regression.rs
+++ b/ledger/tests/canonicality_regression.rs
@@ -1,0 +1,302 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ledger-level regression tests for the non-canonical MPT encodings, driven
+//! end-to-end through the real `tagged_deserialize` path on the actual ledger
+//! types (`Transaction`, `UtxoState`, the zswap nullifier set). They confirm
+//! that no ledger type bypasses the storage boundary: each crafted non-canonical
+//! encoding must be REJECTED at deserialization.
+//!
+//! The generic storage-level versions live in
+//! `storage/tests/canonicality_regression.rs`; this file pins the reachable
+//! ledger consequences and asserts the same correct behaviour (rejection).
+//!
+//! Two vector classes: NON-INJECTIVE KEYS (a canonical key path plus trailing
+//! nibbles that alias the same logical key) and a SOUND-BUT-NON-CANONICAL SHAPE
+//! (an empty-path `Extension` wrapping a container root).
+
+mod common;
+use common::{D, SEG, keypair};
+
+use base_crypto::hash::HashOutput;
+use base_crypto::time::Timestamp;
+use coin_structure::coin::{NIGHT, Nullifier, UnshieldedTokenType, UserAddress};
+use base_crypto::schnorr::Signature;
+use midnight_ledger::structure::{
+    Intent, IntentHash, ProofPreimageMarker, StandardTransaction, Transaction,
+    UnshieldedOffer, Utxo, UtxoMeta, UtxoOutput, UtxoSpend, UtxoState,
+};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use serialize::{Deserializable, Serializable, Tagged, tagged_deserialize, tagged_serialize};
+use std::marker::PhantomData;
+use std::ops::Deref;
+use storage::arena::Sp;
+use storage::merkle_patricia_trie::{MerklePatriciaTrie, Node};
+use storage::storable::SizeAnn;
+use storage::storage::{HashMap as StoreHashMap, Map};
+use transient_crypto::commitment::PedersenRandomness;
+
+type Tx = Transaction<Signature, ProofPreimageMarker, PedersenRandomness, D>;
+type Itnt = Intent<Signature, ProofPreimageMarker, PedersenRandomness, D>;
+
+/// The shared oracle: the canonical encoding must deserialize, the crafted
+/// non-canonical one must be a distinct wire form and must be REJECTED by the
+/// untrusted `tagged_deserialize` path.
+fn assert_only_canonical_accepted<T>(canonical: &T, noncanonical: &T, what: &str)
+where
+    T: Serializable + Deserializable + Tagged,
+{
+    let mut canon_bytes = Vec::new();
+    tagged_serialize(canonical, &mut canon_bytes).expect("serialize canonical");
+    let mut noncanon_bytes = Vec::new();
+    tagged_serialize(noncanonical, &mut noncanon_bytes).expect("serialize non-canonical");
+    assert_ne!(
+        canon_bytes, noncanon_bytes,
+        "{what}: the crafted encoding must be a genuinely distinct wire form"
+    );
+    assert!(
+        tagged_deserialize::<T>(&mut &canon_bytes[..]).is_ok(),
+        "{what}: the canonical encoding must still deserialize"
+    );
+    assert!(
+        tagged_deserialize::<T>(&mut &noncanon_bytes[..]).is_err(),
+        "{what}: the untrusted deserializer must REJECT the non-canonical encoding"
+    );
+}
+
+fn mk_intent(rng: &mut StdRng, ttl_secs: u64) -> Itnt {
+    Intent::new(
+        rng,
+        None,
+        None,
+        vec![],
+        vec![],
+        vec![],
+        None,
+        Timestamp::from_secs(ttl_secs),
+    )
+}
+
+fn std_tx(intents: StoreHashMap<u16, Itnt, D>) -> Tx {
+    Transaction::Standard(StandardTransaction {
+        network_id: "local-test".into(),
+        intents,
+        guaranteed_coins: None,
+        fallible_coins: StoreHashMap::new(),
+        binding_randomness: PedersenRandomness::default(),
+    })
+}
+
+// ===========================================================================
+// Non-injective key: a duplicate segment key in `intents`.
+//
+// If accepted, `Transaction::well_formed`/`balance` iterate and account for BOTH
+// intents, while `erase_proofs`/`erase_signatures` rebuild the map via
+// `.iter()...collect()`, which collapses the two same-key entries to ONE. The
+// transaction is then validated against two intents but applied with one -- a
+// validate-vs-apply divergence (GHSA-vhp6-px6f-jv94).
+// ===========================================================================
+#[test]
+fn duplicate_segment_key_intents_rejected() {
+    let mut rng = StdRng::seed_from_u64(0x0D0E);
+    let intent_a = mk_intent(&mut rng, 1_000_000);
+    let intent_b = mk_intent(&mut rng, 2_000_000);
+    assert_ne!(intent_a.ttl, intent_b.ttl, "intents must differ");
+
+    // Canonical: intent_a at key 1.
+    let canonical_intents: StoreHashMap<u16, Itnt, D> =
+        StoreHashMap::new().insert(1, intent_a.clone());
+
+    // Non-canonical: splice a second inner leaf (intent_b) at an over-long path
+    // that also decodes to key 1's ArenaHash.
+    let (p, existing) = canonical_intents
+        .0
+        .mpt
+        .iter()
+        .next()
+        .map(|(p, v)| (p, (*v).clone()))
+        .expect("one leaf");
+    let mut p2 = p.clone();
+    p2.extend_from_slice(&[0, 0]); // ignored trailing byte -> aliases key 1
+    let dup_value = (existing.0.clone(), Sp::new(intent_b.clone()));
+    let dup_inner_mpt = canonical_intents.0.mpt.deref().insert(&p2, dup_value);
+    let dup_intents: StoreHashMap<u16, Itnt, D> = StoreHashMap(Map {
+        mpt: Sp::new(dup_inner_mpt),
+        key_type: PhantomData,
+    });
+    assert_eq!(dup_intents.size(), 2, "two inner leaves, both under key 1");
+
+    assert_only_canonical_accepted(
+        &std_tx(canonical_intents),
+        &std_tx(dup_intents),
+        "Transaction with duplicate segment-key intents",
+    );
+}
+
+// ===========================================================================
+// Non-injective key: a duplicate UTXO in `UtxoState`.
+//
+// If accepted, the O(1) `NightAnn` total double-counts the duplicated leaf, so a
+// crafted `LedgerState` (this `UtxoState` plus `reserve_pool -= 2V`) passes
+// `check_night_balance_invariant` while the true distinct-UTXO NIGHT total is
+// short by V -- the NIGHT conservation safety-net is defeated. The same defect
+// applies to the `unclaimed_block_rewards`/`bridge_receiving`/`contract` pools
+// (`Map<UserAddress,u128,NightAnn>`), by the identical mechanism.
+// ===========================================================================
+#[test]
+fn duplicate_key_utxo_state_rejected() {
+    let mut rng = StdRng::seed_from_u64(0x419A7);
+    let utxo = Utxo {
+        value: 1_000_000_000,
+        owner: UserAddress(rng.r#gen()),
+        type_: NIGHT,
+        intent_hash: IntentHash(rng.r#gen()),
+        output_no: 0,
+    };
+    let meta = UtxoMeta {
+        ctime: Timestamp::from_secs(0),
+    };
+    let canonical = UtxoState::<D>::default().insert(utxo.clone(), meta.clone());
+
+    // Splice a second inner leaf for the SAME utxo at an over-long path.
+    let (p, existing) = canonical
+        .utxos
+        .0
+        .mpt
+        .iter()
+        .next()
+        .map(|(p, v)| (p, (*v).clone()))
+        .expect("one leaf");
+    let mut p2 = p.clone();
+    p2.extend_from_slice(&[0, 0]);
+    let dup_value = (existing.0.clone(), existing.1.clone());
+    let dup_mpt = canonical.utxos.0.mpt.deref().insert(&p2, dup_value);
+    let dup_utxos = StoreHashMap(Map {
+        mpt: Sp::new(dup_mpt),
+        key_type: PhantomData,
+    });
+    let dup_state = UtxoState { utxos: dup_utxos };
+    assert_eq!(dup_state.utxos.ann().value, 2 * utxo.value, "annotation double-counts");
+
+    assert_only_canonical_accepted(
+        &canonical,
+        &dup_state,
+        "UtxoState with a duplicate-key UTXO",
+    );
+}
+
+// ===========================================================================
+// Non-injective key: a nullifier held only at a non-canonical path.
+//
+// If accepted, the nullifier is present by `size()`/`iter()` but invisible to
+// the `contains_key` double-spend / faerie-gold checks (which use the canonical
+// path only), so a coin logically in the spent-set reads as ABSENT and can be
+// spent again. Also affects `coin_coms_set` and the dust uniqueness sets.
+// ===========================================================================
+#[test]
+fn noncanonical_nullifier_set_rejected() {
+    let mut rng = StdRng::seed_from_u64(0x2D5C);
+    let n = Nullifier(HashOutput(rng.r#gen()));
+
+    // Canonical: nullifier at its canonical inner path.
+    let canonical: StoreHashMap<Nullifier, (), D> = StoreHashMap::new().insert(n, ());
+    let (p, val) = canonical
+        .0
+        .mpt
+        .iter()
+        .next()
+        .map(|(p, v)| (p, (*v).clone()))
+        .expect("one leaf");
+
+    // Non-canonical: the same nullifier held ONLY at an over-long path.
+    let mut p2 = p.clone();
+    p2.extend_from_slice(&[0, 0]);
+    let desynced_mpt =
+        MerklePatriciaTrie::<(Sp<Nullifier, D>, Sp<()>), D>::new().insert(&p2, val);
+    let desynced: StoreHashMap<Nullifier, (), D> = StoreHashMap(Map {
+        mpt: Sp::new(desynced_mpt),
+        key_type: PhantomData,
+    });
+    assert!(!desynced.contains_key(&n), "sanity: contains_key misses the non-canonical path");
+
+    assert_only_canonical_accepted(
+        &canonical,
+        &desynced,
+        "nullifier set with the key at a non-canonical path",
+    );
+}
+
+// ===========================================================================
+// Sound-but-non-canonical SHAPE: empty-path `Extension` wrapping the
+// outer `intents` HashMap of an already-signed transaction.
+//
+// If accepted, the transaction has a second valid wire form with a DIFFERENT
+// `transaction_hash` while `data_to_sign`/`intent_hash` (and every signature)
+// are unchanged -- transaction-id malleability (mempool/dedup/tracking
+// confusion). Bounded: replay protection keys on `intent_hash`, not the txid.
+// ===========================================================================
+#[test]
+fn noncanonical_intents_shape_rejected() {
+    let mut rng = StdRng::seed_from_u64(0x27A11);
+    let tt = UnshieldedTokenType(rng.r#gen());
+    let (sk, vk) = keypair(&mut rng);
+
+    let input = UtxoSpend {
+        value: 1000,
+        owner: vk.clone(),
+        type_: tt,
+        intent_hash: IntentHash(rng.r#gen()),
+        output_no: 0,
+    };
+    let out = UtxoOutput {
+        value: 1000,
+        owner: UserAddress::from(vk.clone()),
+        type_: tt,
+    };
+    let unsigned: UnshieldedOffer<Signature, D> = UnshieldedOffer {
+        inputs: vec![input].into(),
+        outputs: vec![out].into(),
+        signatures: storage::storage::Array::new(),
+    };
+    let intent: Itnt = Intent::new(
+        &mut rng,
+        Some(unsigned),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        None,
+        Timestamp::from_secs(1_000_000),
+    );
+    let signed_intent = intent.sign(&mut rng, SEG, &[sk.clone()], &[], &[]).expect("sign");
+    let canonical_intents = StoreHashMap::<u16, Itnt, D>::new().insert(SEG, signed_intent);
+
+    // Non-canonical: wrap the intents' inner trie root in an empty-path
+    // Extension (correct annotation -> sound; distinct bytes -> distinct txid).
+    let wrapped_root = Node::Extension {
+        ann: SizeAnn(canonical_intents.size() as u64),
+        compressed_path: Vec::new(),
+        child: canonical_intents.0.mpt.0.clone(),
+    };
+    let wrapped_intents: StoreHashMap<u16, Itnt, D> = StoreHashMap(Map {
+        mpt: Sp::new(MerklePatriciaTrie(Sp::new(wrapped_root))),
+        key_type: PhantomData,
+    });
+
+    assert_only_canonical_accepted(
+        &std_tx(canonical_intents),
+        &std_tx(wrapped_intents),
+        "Transaction with an empty-path-Extension-wrapped intents map",
+    );
+}

--- a/ledger/tests/common/mod.rs
+++ b/ledger/tests/common/mod.rs
@@ -1,0 +1,125 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared helpers for the ledger property tests: key/utxo/offer construction and
+//! the system's own validation entry point. Each integration-test binary that
+//! `mod common;`s this file uses a different subset, so unused-code warnings are
+//! suppressed here rather than per-item.
+
+#![allow(dead_code)]
+
+use base_crypto::time::Timestamp;
+use coin_structure::coin::{UnshieldedTokenType, UserAddress};
+use base_crypto::schnorr::{Signature, SigningKey, VerifyingKey as SignatureVerifyingKey};
+use midnight_ledger::structure::{
+    ErasedIntent, Intent, IntentHash, ProofPreimageMarker, UnshieldedOffer, UtxoOutput, UtxoSpend,
+};
+use rand::Rng;
+use rand::rngs::StdRng;
+use storage::DefaultDB;
+use storage::storage::Array;
+use transient_crypto::commitment::PedersenRandomness;
+
+pub type D = DefaultDB;
+
+/// The transaction segment id used throughout these tests.
+pub const SEG: u16 = 1;
+
+pub fn keypair(rng: &mut StdRng) -> (SigningKey, SignatureVerifyingKey) {
+    let sk = SigningKey::sample(&mut *rng);
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+pub fn token(rng: &mut StdRng) -> UnshieldedTokenType {
+    UnshieldedTokenType(rng.r#gen())
+}
+
+pub fn spend(
+    rng: &mut StdRng,
+    owner: &SignatureVerifyingKey,
+    value: u128,
+    tt: UnshieldedTokenType,
+    output_no: u32,
+) -> UtxoSpend {
+    UtxoSpend {
+        value,
+        owner: owner.clone(),
+        type_: tt,
+        intent_hash: IntentHash(rng.r#gen()),
+        output_no,
+    }
+}
+
+pub fn output(owner: &SignatureVerifyingKey, value: u128, tt: UnshieldedTokenType) -> UtxoOutput {
+    UtxoOutput {
+        value,
+        owner: UserAddress::from(owner.clone()),
+        type_: tt,
+    }
+}
+
+/// Build the erased parent intent that carries these inputs/outputs in its
+/// guaranteed offer, and the exact byte-string that a legitimate signer would
+/// sign for `segment`. `well_formed` recomputes this same string from the
+/// parent, so signing it is what a correct owner signature must cover.
+pub fn parent_and_data(
+    rng: &mut StdRng,
+    inputs: &[UtxoSpend],
+    outputs: &[UtxoOutput],
+    segment: u16,
+) -> (ErasedIntent<D>, Vec<u8>) {
+    let unsigned: UnshieldedOffer<Signature, D> = UnshieldedOffer {
+        inputs: inputs.to_vec().into(),
+        outputs: outputs.to_vec().into(),
+        signatures: Array::new(),
+    };
+    let intent: Intent<Signature, ProofPreimageMarker, PedersenRandomness, D> = Intent::new(
+        rng,
+        Some(unsigned),
+        None,
+        vec![],
+        vec![],
+        vec![],
+        None,
+        Timestamp::from_secs(1_000_000),
+    );
+    let erased = intent.erase_proofs().erase_signatures();
+    let data = erased.data_to_sign(segment);
+    (erased, data)
+}
+
+pub fn offer(
+    inputs: &[UtxoSpend],
+    outputs: &[UtxoOutput],
+    sigs: Vec<Signature>,
+) -> UnshieldedOffer<Signature, D> {
+    UnshieldedOffer {
+        inputs: inputs.to_vec().into(),
+        outputs: outputs.to_vec().into(),
+        signatures: sigs.into(),
+    }
+}
+
+/// Run the system's own validation: structural checks + the deferred signature
+/// closure. Returns `Ok(())` iff the offer is accepted.
+pub fn verdict(
+    offer: UnshieldedOffer<Signature, D>,
+    segment: u16,
+    parent: &ErasedIntent<D>,
+) -> Result<(), String> {
+    match offer.well_formed(segment, parent) {
+        Err(e) => Err(format!("{e:?}")),
+        Ok(check) => check().map_err(|e| format!("{e:?}")),
+    }
+}

--- a/ledger/tests/noop-dos.rs
+++ b/ledger/tests/noop-dos.rs
@@ -13,6 +13,32 @@
 
 #![cfg(feature = "proving")]
 
+//! Regression gate for the Noop field-repr allocation DoS.
+//!
+//! `Op::Noop { n }` serialises in ~6 bytes, but its `FieldRepr` materialises
+//! `n` field elements. A crafted transcript carrying `Noop { n: u32::MAX }`
+//! forces ~137 GB of allocation inside `Transaction::well_formed`'s
+//! fee-costing path, OOM-killing every validating node. The agreed
+//! (costing-only) fix computes the public-input length as
+//! `2 + Σ op.field_size()` arithmetically, so the amplification is *priced*
+//! (and rejected as fee-too-high) without ever materialising the vector.
+//!
+//! WARNING — run ONLY under a memory cap. If the costing fix
+//! (`ContractCall::public_inputs_len`) is ever regressed, this test allocates
+//! ~137 GB; on an overcommit system that invokes the kernel OOM killer, which
+//! may kill unrelated processes. It is therefore `#[ignore]`d so it never runs
+//! in the default suite, and stays a *cap-required* regression guard even
+//! though it passes (~16 MiB) with the fix in place.
+//! To run it, confine it to a cgroup memory scope (the legitimate proving path
+//! peaks at ~30 MiB, so a 2 GiB cap is ~68x above the real workload and ~68x
+//! below the bad allocation):
+//!
+//! ```text
+//! cargo test -p midnight-ledger --features proving --test noop-dos --no-run
+//! systemd-run --user --scope -p MemoryMax=2G -p MemorySwapMax=0 \
+//!   target/debug/deps/noop_dos-<hash> --exact noop_dos --ignored --nocapture
+//! ```
+
 use base_crypto::fab::AlignedValue;
 use base_crypto::rng::SplittableRng;
 use base_crypto::time::Timestamp;
@@ -30,7 +56,6 @@ use onchain_runtime::result_mode::{ResultModeGather, ResultModeVerify};
 use onchain_runtime::state::{ContractOperation, ContractState, StateValue, stval};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use serialize::Serializable;
 use std::borrow::Cow;
 use std::time::{Duration, Instant};
 use storage::arena::Sp;
@@ -59,6 +84,7 @@ fn program_with_results<D: DB>(
 }
 
 #[tokio::test]
+#[ignore = "RUN ONLY under a memory cap (see module header) — allocates ~137GB if the public_inputs_len costing fix regresses. Passes at ~16 MiB with the fix in place."]
 async fn noop_dos() {
     let mut rng = StdRng::seed_from_u64(0x42);
     // Initial states
@@ -168,52 +194,70 @@ async fn noop_dos() {
         .await
         .unwrap()
     };
-    let mut noop_dos: Vec<Op<ResultModeVerify, InMemoryDB>> = Vec::new();
-    for _ in 0..1_000 {
-        noop_dos.push(Op::Noop { n: 0x1ffff });
-        noop_dos.push(Op::Dup { n: 1 });
-        noop_dos.push(Op::Pop);
-    }
+    // Craft the malicious payload: a single Noop with the maximal counter. On
+    // the wire this is ~6 bytes, but its FieldRepr materialises `n` field
+    // elements (~137 GB at u32::MAX). We inject it by overwriting the program
+    // of the call's *already-valid* fallible transcript -- mirroring an
+    // attacker-authored transcript arriving over the wire, and sidestepping the
+    // construction-side gas accounting that `partition_transcripts` would
+    // re-run (which could reject the payload before it reaches well_formed).
+    let poison_program: Vec<Op<ResultModeVerify, InMemoryDB>> = vec![Op::Noop { n: u32::MAX }];
+
     match &mut tx {
         Transaction::Standard(stx) => {
-            let mut call_action = (*stx
-                .intents
-                .clone()
-                .into_iter()
-                .collect::<std::collections::HashMap<_, _>>()
-                .iter()
-                .flat_map(|i| i.1.actions.iter_deref().cloned())
-                .find_map(|action| {
-                    if let ContractAction::Call(call) = action {
-                        Some(call)
-                    } else {
-                        None
-                    }
-                })
-                .unwrap())
-            .clone();
-
-            call_action.fallible_transcript = Some(Sp::new(
-                partition_transcripts(
-                    &[PreTranscript {
-                        context: QueryContext::new(state.ledger.index(addr).unwrap().data, addr),
-                        program: noop_dos,
-                        comm_comm: None,
-                    }],
-                    &INITIAL_PARAMETERS,
-                )
-                .unwrap()[0]
-                    .1
-                    .clone()
-                    .unwrap(),
-            ));
-            dbg!(call_action);
+            // `test_intents` keys the single intent at segment 1.
+            let mut intent = (*stx.intents.get(&1u16).expect("intent at segment 1")).clone();
+            let mut actions: Vec<_> = (&intent.actions).into();
+            let mut poisoned = false;
+            for action in actions.iter_mut() {
+                if let ContractAction::Call(call_sp) = action {
+                    let mut call = (**call_sp).clone();
+                    let mut transcript = call
+                        .fallible_transcript
+                        .as_deref()
+                        .expect("count call has a fallible transcript")
+                        .clone();
+                    transcript.program = poison_program.clone().into();
+                    call.fallible_transcript = Some(Sp::new(transcript));
+                    *action = ContractAction::Call(Sp::new(call));
+                    poisoned = true;
+                }
+            }
+            assert!(poisoned, "expected a Call action to poison");
+            intent.actions = actions.into();
+            // Write the mutated intent BACK into the transaction. The previous
+            // version of this test assigned the payload to a dropped clone, so
+            // it never reached well_formed and the test was vacuous.
+            stx.intents = stx.intents.insert(1u16, intent);
         }
         _ => unreachable!(),
     }
-    dbg!(Serializable::serialized_size(&tx));
+
+    // (1) Isolation: computing the transaction cost exercises exactly the path
+    // the fix changes (`validation_cost` -> public-input length), with no
+    // balancing or proof verification in the way. Post-fix this sums
+    // field_size() and returns fast; pre-fix it materialises the ~137 GB
+    // field-repr here (caught by the memory cap -- see the module header).
     let t0 = Instant::now();
-    dbg!(tx.well_formed(&state.ledger, strictness, state.time)).ok();
-    let t1 = Instant::now();
-    assert!(t1 - t0 < Duration::from_millis(100));
+    let _ = tx.cost(&INITIAL_PARAMETERS, false);
+    assert!(
+        t0.elapsed() < Duration::from_secs(2),
+        "Transaction::cost materialised the Noop field-repr instead of summing field_size()"
+    );
+
+    // (2) End-to-end: with balancing enforced, the over-budget cost is surfaced
+    // as a well_formed rejection (rather than silently swallowed).
+    let mut dos_strictness = WellFormedStrictness::default();
+    dos_strictness.enforce_balancing = true;
+    let t0 = Instant::now();
+    let result = tx.well_formed(&state.ledger, dos_strictness, state.time);
+    assert!(
+        result.is_err(),
+        "well_formed must reject a transcript whose Noop counter blows up the \
+         public-input cost, but returned Ok"
+    );
+    assert!(
+        t0.elapsed() < Duration::from_secs(2),
+        "well_formed materialised the Noop field-repr instead of summing field_size()"
+    );
 }

--- a/ledger/tests/prop_unshielded_auth.rs
+++ b/ledger/tests/prop_unshielded_auth.rs
@@ -1,0 +1,294 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Clean-room property tests for the AUTHORIZATION invariant of unshielded
+//! value transfers ("who is permitted to move what").
+//!
+//! Contract (derived from `UnshieldedOffer::well_formed` in
+//! `ledger/src/verify.rs:484` and `Intent::sign` in `ledger/src/construct.rs`):
+//! an `UnshieldedOffer` spends a set of `UtxoSpend` inputs, each carrying an
+//! `owner: SignatureVerifyingKey`. The offer is well-formed only if
+//!   * inputs are sorted and contain no duplicates,
+//!   * outputs are sorted and none has value 0,
+//!   * `signatures.len() == inputs.len()`, and
+//!   * for every position i, `signatures[i]` is a valid signature by
+//!     `inputs[i].owner` over the parent intent's `data_to_sign(segment)`.
+//! The last clause is the security-critical one: a UTXO may only be spent with
+//! a signature from ITS OWN owner, over the exact intent/segment being
+//! authorized. If validation accepts anything weaker, an attacker can move
+//! value they do not own.
+//!
+//! This suite generates offers both through the intended path (sign with the
+//! real owner key via the same primitive `Intent::sign` uses) AND
+//! structurally -- assembling `signatures` arrays the builder can never emit
+//! (wrong signer, permuted signatures, wrong count, signature over a different
+//! segment). The oracle is the authorization contract above: `well_formed`
+//! (plus its deferred signature closure) must ACCEPT iff the contract holds.
+//! No ZK prover is needed -- only Schnorr signatures -- and proof/binding
+//! machinery is irrelevant to authorization, so it is simply not exercised.
+
+use base_crypto::schnorr::{Signature, SigningKey, VerifyingKey as SignatureVerifyingKey};
+use midnight_ledger::structure::UtxoSpend;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+mod common;
+use common::{SEG, keypair, offer, output, parent_and_data, spend, token, verdict};
+
+// ---------------------------------------------------------------------------
+// Deterministic adversarial scenarios with known-correct verdicts.
+// ---------------------------------------------------------------------------
+#[test]
+fn auth_scenarios() {
+    let mut rng = StdRng::seed_from_u64(0xA1);
+    let tt = token(&mut rng);
+    let mut fail: Vec<String> = Vec::new();
+
+    let expect = |name: &str, res: Result<(), String>, want_ok: bool, fail: &mut Vec<String>| {
+        if res.is_ok() != want_ok {
+            fail.push(format!(
+                "{name}: expected {}, got {:?}",
+                if want_ok { "ACCEPT" } else { "REJECT" },
+                res
+            ));
+        }
+    };
+
+    // 1. Honest single-input offer, signed by the owner -> ACCEPT.
+    {
+        let (sk, vk) = keypair(&mut rng);
+        let ins = vec![spend(&mut rng, &vk, 100, tt, 0)];
+        let outs = vec![output(&vk, 100, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        let sig = sk.sign(&mut rng, &data);
+        expect("honest-single", verdict(offer(&ins, &outs, vec![sig]), SEG, &parent), true, &mut fail);
+    }
+
+    // 2. Honest two-input offer (two owners), each signs -> ACCEPT.
+    {
+        let (sk_a, vk_a) = keypair(&mut rng);
+        let (sk_b, vk_b) = keypair(&mut rng);
+        let mut ins = vec![
+            spend(&mut rng, &vk_a, 10, tt, 0),
+            spend(&mut rng, &vk_b, 20, tt, 1),
+        ];
+        ins.sort();
+        let outs = vec![output(&vk_a, 30, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        // Sign per input position, matching each input's owner.
+        let sigs = ins
+            .iter()
+            .map(|i| {
+                let sk = if i.owner == vk_a { &sk_a } else { &sk_b };
+                sk.sign(&mut rng, &data)
+            })
+            .collect::<Vec<_>>();
+        expect("honest-double", verdict(offer(&ins, &outs, sigs), SEG, &parent), true, &mut fail);
+    }
+
+    // 3. IMPERSONATION: victim owns the UTXO, attacker signs -> REJECT.
+    {
+        let (_sk_victim, vk_victim) = keypair(&mut rng);
+        let (sk_attacker, _vk_attacker) = keypair(&mut rng);
+        let ins = vec![spend(&mut rng, &vk_victim, 1_000_000, tt, 0)];
+        let outs = vec![output(&vk_victim, 1_000_000, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        let forged = sk_attacker.sign(&mut rng, &data); // valid sig, WRONG signer
+        expect(
+            "impersonation",
+            verdict(offer(&ins, &outs, vec![forged]), SEG, &parent),
+            false,
+            &mut fail,
+        );
+    }
+
+    // 4. PERMUTED signatures: two valid signatures, swapped between owners -> REJECT.
+    {
+        let (sk_a, vk_a) = keypair(&mut rng);
+        let (sk_b, vk_b) = keypair(&mut rng);
+        let mut ins = vec![
+            spend(&mut rng, &vk_a, 10, tt, 0),
+            spend(&mut rng, &vk_b, 20, tt, 1),
+        ];
+        ins.sort();
+        let outs = vec![output(&vk_a, 30, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        // Produce each owner's genuine signature, then place them in the wrong slots.
+        let sig_for = |vk: &SignatureVerifyingKey, rng: &mut StdRng| {
+            let sk = if *vk == vk_a { &sk_a } else { &sk_b };
+            sk.sign(rng, &data)
+        };
+        let mut sigs: Vec<Signature> = ins.iter().map(|i| sig_for(&i.owner, &mut rng)).collect();
+        sigs.swap(0, 1);
+        expect("permuted-sigs", verdict(offer(&ins, &outs, sigs), SEG, &parent), false, &mut fail);
+    }
+
+    // 5. WRONG SEGMENT: owner signs data for a different segment -> REJECT.
+    {
+        let (sk, vk) = keypair(&mut rng);
+        let ins = vec![spend(&mut rng, &vk, 100, tt, 0)];
+        let outs = vec![output(&vk, 100, tt)];
+        let (parent, _data_seg1) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        // Sign the SAME intent but for segment SEG+1.
+        let data_other = parent.data_to_sign(SEG + 1);
+        let sig = sk.sign(&mut rng, &data_other);
+        expect(
+            "wrong-segment",
+            verdict(offer(&ins, &outs, vec![sig]), SEG, &parent),
+            false,
+            &mut fail,
+        );
+    }
+
+    // 6. MISSING signature (0 sigs, 1 input) -> REJECT (length mismatch).
+    {
+        let (_sk, vk) = keypair(&mut rng);
+        let ins = vec![spend(&mut rng, &vk, 100, tt, 0)];
+        let outs = vec![output(&vk, 100, tt)];
+        let (parent, _data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        expect("missing-sig", verdict(offer(&ins, &outs, vec![]), SEG, &parent), false, &mut fail);
+    }
+
+    // 7. EXTRA signature (2 sigs, 1 input) -> REJECT (length mismatch).
+    {
+        let (sk, vk) = keypair(&mut rng);
+        let ins = vec![spend(&mut rng, &vk, 100, tt, 0)];
+        let outs = vec![output(&vk, 100, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        let s1 = sk.sign(&mut rng, &data);
+        let s2 = sk.sign(&mut rng, &data);
+        expect("extra-sig", verdict(offer(&ins, &outs, vec![s1, s2]), SEG, &parent), false, &mut fail);
+    }
+
+    // 8. ZERO-VALUE output -> ACCEPT. well_formed does not reject a
+    // zero-valued unshielded output; balance conservation is unaffected and the
+    // resulting zero-value UTXO is bounded by the ordinary per-output storage
+    // cost.
+    {
+        let (sk, vk) = keypair(&mut rng);
+        let ins = vec![spend(&mut rng, &vk, 100, tt, 0)];
+        let outs = vec![output(&vk, 0, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        let sig = sk.sign(&mut rng, &data);
+        expect("zero-output", verdict(offer(&ins, &outs, vec![sig]), SEG, &parent), true, &mut fail);
+    }
+
+    // 9. DUPLICATE input -> REJECT (structural, prevents double-count/double-spend).
+    {
+        let (sk, vk) = keypair(&mut rng);
+        let s = spend(&mut rng, &vk, 100, tt, 0);
+        let ins = vec![s.clone(), s.clone()];
+        let outs = vec![output(&vk, 200, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        let sig = sk.sign(&mut rng, &data);
+        expect(
+            "duplicate-input",
+            verdict(offer(&ins, &outs, vec![sig.clone(), sig]), SEG, &parent),
+            false,
+            &mut fail,
+        );
+    }
+
+    // 10. UNSORTED inputs -> REJECT (structural / non-normalized).
+    {
+        let (sk_a, vk_a) = keypair(&mut rng);
+        let (sk_b, vk_b) = keypair(&mut rng);
+        let mut ins = vec![
+            spend(&mut rng, &vk_a, 10, tt, 0),
+            spend(&mut rng, &vk_b, 20, tt, 1),
+        ];
+        ins.sort();
+        ins.reverse(); // now guaranteed unsorted (len 2, distinct)
+        let outs = vec![output(&vk_a, 30, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        let sigs = ins
+            .iter()
+            .map(|i| (if i.owner == vk_a { &sk_a } else { &sk_b }).sign(&mut rng, &data))
+            .collect::<Vec<_>>();
+        expect("unsorted-inputs", verdict(offer(&ins, &outs, sigs), SEG, &parent), false, &mut fail);
+    }
+
+    assert!(fail.is_empty(), "authorization scenario failures:\n{}", fail.join("\n"));
+}
+
+// ---------------------------------------------------------------------------
+// Randomized authorization fuzz: structural validity held FIXED (sorted,
+// distinct, non-zero, correct signature count); ONLY the per-position signer
+// assignment varies. Acceptance must hold iff every input is signed by its own
+// owner over the correct data. This isolates the authorization predicate.
+// ---------------------------------------------------------------------------
+#[test]
+fn auth_signer_assignment_fuzz() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for seed in 0..300u64 {
+        let mut rng = StdRng::seed_from_u64(0xF00D_0000 + seed);
+        let tt = token(&mut rng);
+        let n = 1 + (seed % 4) as usize; // 1..=4 inputs
+
+        // Distinct owners and inputs.
+        let keys: Vec<(SigningKey, SignatureVerifyingKey)> =
+            (0..n).map(|_| keypair(&mut rng)).collect();
+        // A spare key never associated with any input (an outsider/attacker).
+        let (outsider_sk, _outsider_vk) = keypair(&mut rng);
+
+        let mut ins: Vec<UtxoSpend> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, (_, vk))| spend(&mut rng, vk, 10 + i as u128, tt, i as u32))
+            .collect();
+        ins.sort();
+        // Re-associate keys to the sorted input owners for correct signing.
+        let owner_key = |vk: &SignatureVerifyingKey| -> &SigningKey {
+            &keys.iter().find(|(_, k)| k == vk).unwrap().0
+        };
+
+        let outs = vec![output(&keys[0].1, 999, tt)];
+        let (parent, data) = parent_and_data(&mut rng, &ins, &outs, SEG);
+        let wrong_data = parent.data_to_sign(SEG + 7);
+
+        // Per-position signing choice: 0 = correct owner+data (authorized),
+        // 1 = outsider key (wrong signer), 2 = owner but wrong data.
+        let mut all_authorized = true;
+        let sigs: Vec<Signature> = ins
+            .iter()
+            .map(|inp| match rng.gen_range(0u8..3) {
+                0 => owner_key(&inp.owner).sign(&mut rng, &data),
+                1 => {
+                    all_authorized = false;
+                    outsider_sk.sign(&mut rng, &data)
+                }
+                _ => {
+                    all_authorized = false;
+                    owner_key(&inp.owner).sign(&mut rng, &wrong_data)
+                }
+            })
+            .collect();
+
+        let res = verdict(offer(&ins, &outs, sigs), SEG, &parent);
+        if res.is_ok() != all_authorized {
+            failures.push(format!(
+                "seed {seed}: n={n} expected {} got {:?}",
+                if all_authorized { "ACCEPT" } else { "REJECT" },
+                res
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "authorization fuzz found validation disagreeing with the owner-signs contract \
+         (accept must imply every input authorized by its owner):\n{}",
+        failures.join("\n")
+    );
+}

--- a/ledger/tests/prop_validate_apply.rs
+++ b/ledger/tests/prop_validate_apply.rs
@@ -1,0 +1,212 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Clean-room VALIDATE -> APPLY agreement property for unshielded value flows.
+//!
+//! The invariant a ledger promises: applying a transaction the system accepted
+//! as valid produces exactly the effects its validation vouched for -- no more,
+//! no less. Validation alone cannot detect a check-vs-use gap; this test runs
+//! BOTH phases and compares.
+//!
+//! Surface: unshielded UTXO transfers (integer value + Schnorr signatures, no
+//! prover). Validation = `UnshieldedOffer::well_formed` + its signature closure
+//! (authorization). Application = `UtxoState::apply_offer` (semantics.rs:1902),
+//! which removes each spent input and inserts each declared output.
+//!
+//! Oracle, for every offer that validation ACCEPTS: after `apply_offer`
+//!   * every input UTXO is removed (exactly the spent set, nothing else),
+//!   * every declared output exists exactly once, keyed by the intent hash and
+//!     its positional `output_no`,
+//!   * the resulting UTXO count is `prior - inputs + outputs`, and
+//!   * unshielded value is conserved: total value after == total output value
+//!     == total input value (offers are constructed balanced).
+//! Any accepted offer whose application deviates from this declared accounting
+//! -- value created or destroyed, an input not actually spent, an output
+//! silently dropped -- is the target.
+//!
+//! We relax only proving machinery (irrelevant here: unshielded transfers carry
+//! no ZK proofs); authorization (signatures) and the value bookkeeping are
+//! exercised in full.
+
+use base_crypto::time::Timestamp;
+use coin_structure::coin::UnshieldedTokenType;
+use base_crypto::schnorr::Signature;
+use midnight_ledger::structure::{
+    ErasedIntent, LedgerState, UnshieldedOffer, Utxo, UtxoMeta, UtxoOutput, UtxoState,
+};
+use midnight_ledger::semantics::TransactionContext;
+use onchain_runtime::context::BlockContext;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+mod common;
+use common::{D, SEG, keypair, output, parent_and_data, spend};
+
+fn validate(offer: &UnshieldedOffer<Signature, D>, parent: &ErasedIntent<D>) -> Result<(), String> {
+    match offer.clone().well_formed(SEG, parent) {
+        Err(e) => Err(format!("{e:?}")),
+        Ok(check) => check().map_err(|e| format!("{e:?}")),
+    }
+}
+
+fn context() -> TransactionContext<D> {
+    TransactionContext {
+        ref_state: LedgerState::new("local-test"),
+        block_context: BlockContext {
+            tblock: Timestamp::from_secs(500_000),
+            ..BlockContext::default()
+        },
+        whitelist: None,
+    }
+}
+
+#[test]
+fn validate_then_apply_matches_declared_effects() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for seed in 0..80u64 {
+        let mut rng = StdRng::seed_from_u64(0x5A17_0000 + seed);
+        let tt = UnshieldedTokenType(rng.r#gen());
+
+        // 1..=3 inputs, each owned by a distinct key, distinct values.
+        let n_in = 1 + (seed % 3) as usize;
+        let mut owners = Vec::new();
+        let mut inputs = Vec::new();
+        for i in 0..n_in {
+            let (sk, vk) = keypair(&mut rng);
+            owners.push((sk, vk.clone()));
+            inputs.push(spend(&mut rng, &vk, 100 + (i as u128 + 1) * 10 + seed as u128, tt, i as u32));
+        }
+        inputs.sort();
+        inputs.dedup(); // guarantee distinct (well_formed rejects duplicates)
+        let total_in: u128 = inputs.iter().map(|i| i.value).sum();
+
+        // Declared outputs that conserve value: split `total_in` across 1..=2
+        // outputs (structural variation, incl. an output paying an input owner
+        // and, on some seeds, two same-(owner,value,type) outputs).
+        let (payee_sk_unused, payee_vk) = keypair(&mut rng);
+        let _ = payee_sk_unused;
+        let mut outputs: Vec<UtxoOutput> = if seed % 2 == 0 || total_in < 2 {
+            vec![output(&payee_vk, total_in, tt)]
+        } else {
+            let half = total_in / 2;
+            vec![
+                output(&payee_vk, half, tt),
+                output(&inputs[0].owner, total_in - half, tt),
+            ]
+        };
+        // well_formed requires sorted outputs; apply enumerates them in this
+        // same order, so our expected output_no assignment stays consistent.
+        outputs.sort();
+        // Skip degenerate zero-value outputs (well_formed rejects them).
+        if outputs.iter().any(|o| o.value == 0) {
+            continue;
+        }
+
+        let (parent, data) = parent_and_data(&mut rng, &inputs, &outputs, SEG);
+
+        // Sign each input with its owner's key (authorized).
+        let sigs: Vec<Signature> = inputs
+            .iter()
+            .map(|inp| {
+                let sk = &owners.iter().find(|(_, vk)| *vk == inp.owner).unwrap().0;
+                sk.sign(&mut rng, &data)
+            })
+            .collect();
+
+        let offer = UnshieldedOffer {
+            inputs: inputs.clone().into(),
+            outputs: outputs.clone().into(),
+            signatures: sigs.into(),
+        };
+
+        // VALIDATE.
+        if let Err(e) = validate(&offer, &parent) {
+            failures.push(format!("seed {seed}: authorized offer unexpectedly rejected: {e}"));
+            continue;
+        }
+
+        // Seed the UTXO set with exactly the inputs.
+        let meta = UtxoMeta {
+            ctime: Timestamp::from_secs(400_000),
+        };
+        let mut state = UtxoState::<D>::default();
+        for inp in &inputs {
+            state = state.insert(Utxo::from(inp.clone()), meta.clone());
+        }
+        let prior_size = state.utxos.size();
+
+        // APPLY.
+        let new_state = match state.apply_offer(&offer, &parent, SEG, &context()) {
+            Ok(s) => s,
+            Err(e) => {
+                failures.push(format!("seed {seed}: validated offer failed to apply: {e:?}"));
+                continue;
+            }
+        };
+
+        // ORACLE: applied effect == declared structure + value conserved.
+        // (a) every input spent.
+        for inp in &inputs {
+            if new_state.utxos.contains_key(&Utxo::from(inp.clone())) {
+                failures.push(format!("seed {seed}: input not spent on apply: {inp:?}"));
+            }
+        }
+        // (b) every declared output present exactly, keyed as apply builds it.
+        let ih = parent.intent_hash(SEG);
+        for (i, o) in outputs.iter().enumerate() {
+            let expected = Utxo {
+                value: o.value,
+                owner: o.owner,
+                type_: o.type_,
+                intent_hash: ih,
+                output_no: i as u32,
+            };
+            if !new_state.utxos.contains_key(&expected) {
+                failures.push(format!("seed {seed}: declared output #{i} not created: {o:?}"));
+            }
+        }
+        // (c) count == prior - inputs + outputs.
+        let expect_size = prior_size - inputs.len() + outputs.len();
+        if new_state.utxos.size() != expect_size {
+            failures.push(format!(
+                "seed {seed}: utxo count {} != expected {} (prior {} - {} inputs + {} outputs) \
+                 -- apply created/destroyed UTXOs beyond the declared structure",
+                new_state.utxos.size(),
+                expect_size,
+                prior_size,
+                inputs.len(),
+                outputs.len()
+            ));
+        }
+        // (d) value conservation: total remaining value == declared output value
+        //     == input value (balanced offer).
+        let total_out: u128 = outputs.iter().map(|o| o.value).sum();
+        let after_value: u128 = new_state.utxos.iter().map(|kv| kv.0.value).sum();
+        if total_out != total_in {
+            failures.push(format!("seed {seed}: constructed offer not balanced ({total_out} != {total_in})"));
+        }
+        if after_value != total_in {
+            failures.push(format!(
+                "seed {seed}: VALUE NOT CONSERVED across apply: after={after_value}, \
+                 validation accounted for {total_in}",
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "validate->apply agreement / conservation violations:\n{}",
+        failures.join("\n")
+    );
+}

--- a/ledger/tests/properties.rs
+++ b/ledger/tests/properties.rs
@@ -1,0 +1,598 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Semantic property tests for the ledger transaction model, exercising the
+//! validate -> apply -> UTXO-mutation path and byte round-trips.
+//!
+//! Coverage (all active): `apply` conserves unshielded token supply for pure
+//! transfers; a validated transfer applies and cannot be replayed; an expired
+//! intent is rejected at apply (TTL); and `ContractCall`/`DustActions` structures
+//! survive a tagged serialize/deserialize round-trip. These target *semantic*
+//! invariants -- the class that would have caught GHSA-vhp6-px6f-jv94, which
+//! survived the byte-level serialization barrier.
+
+use base_crypto::hash::HashOutput;
+use base_crypto::time::{Duration, Timestamp};
+use coin_structure::coin::{UnshieldedTokenType, UserAddress};
+use midnight_ledger::structure::{
+    Intent, ProofPreimageMarker, Transaction, UnshieldedOffer, UtxoOutput, UtxoSpend,
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use storage::arena::Sp;
+use storage::db::InMemoryDB;
+use storage::storage::HashMap;
+use transient_crypto::commitment::PedersenRandomness;
+
+type Db = InMemoryDB;
+
+
+/// **`apply` conserves unshielded token supply for pure transfers.**
+///
+/// This is the first property to exercise the full validate -> apply -> UTXO-set
+/// mutation path (nothing else fuzzes `apply`). Unlike NIGHT, non-NIGHT unshielded
+/// tokens have no built-in conservation invariant — the very gap that let
+/// GHSA-vhp6 mint tokens — so this external oracle is the durable regression guard:
+/// a transaction that only *moves* an existing UTXO must leave each token's total
+/// supply unchanged.
+///
+/// Each case seeds one UTXO of a random non-NIGHT token, then generates a random
+/// single-input transfer spending it into outputs that sum to the same amount,
+/// signs it, and applies it. On success, the token's total supply must be
+/// unchanged. Any future bug that mints or burns unshielded value on the transfer
+/// path (a new GHSA-vhp6-style divergence) breaks this.
+#[tokio::test]
+async fn prop_apply_conserves_unshielded_supply() {
+    use midnight_ledger::semantics::TransactionResult;
+    use base_crypto::schnorr::Signature;
+    use midnight_ledger::test_utilities::TestState;
+    use midnight_ledger::verify::WellFormedStrictness;
+
+    fn supply(state: &TestState<Db>, token: UnshieldedTokenType) -> u128 {
+        state
+            .ledger
+            .utxo
+            .utxos
+            .iter()
+            .map(|kv| (*kv.0).clone())
+            .filter(|u| u.type_ == token)
+            .map(|u| u.value)
+            .sum()
+    }
+
+    // Split `total` into `k` positive parts (each >= 1) summing to `total`.
+    fn split_value(rng: &mut StdRng, total: u128, k: usize) -> Vec<u128> {
+        let k = k.min(total as usize).max(1);
+        let mut parts = vec![1u128; k];
+        let mut rem = total - k as u128;
+        while rem > 0 {
+            let i = rng.gen_range(0..k);
+            let add = rng.gen_range(1..=rem);
+            parts[i] += add;
+            rem -= add;
+        }
+        parts
+    }
+
+    let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+    let mut failures: Vec<String> = Vec::new();
+    let mut exercised = 0u32;
+    // Track the richest generated shape actually applied, to prove breadth.
+    let mut max_inputs = 0usize;
+    let mut multi_token_applied = false;
+
+    for case in 0..24u64 {
+        let mut state = TestState::<Db>::new(&mut rng);
+
+        // Seed several UTXOs across a few distinct non-NIGHT tokens.
+        let n_tokens = rng.gen_range(1..=3usize);
+        let mut tokens: Vec<UnshieldedTokenType> = Vec::new();
+        for _ in 0..n_tokens {
+            let token = UnshieldedTokenType(HashOutput(rng.r#gen()));
+            if token == coin_structure::coin::NIGHT {
+                continue; // NIGHT goes through a different (proving) seeding path
+            }
+            // 1..=2 separate UTXOs of this token, to reach multi-input spends.
+            for _ in 0..rng.gen_range(1..=2usize) {
+                let amount: u128 = rng.gen_range(2..1_000_000u128);
+                state.rewards_unshielded(&mut rng, token, amount).await;
+            }
+            tokens.push(token);
+        }
+        if tokens.is_empty() {
+            continue;
+        }
+
+        // Snapshot supply of every seeded token before applying.
+        let before: Vec<(UnshieldedTokenType, u128)> =
+            tokens.iter().map(|t| (*t, supply(&state, *t))).collect();
+
+        // Collect the seeded UTXOs (owned by the night key) and spend a random
+        // non-empty subset — a partial spend leaves the rest untouched.
+        let mut all_utxos: Vec<_> = state
+            .ledger
+            .utxo
+            .utxos
+            .iter()
+            .map(|kv| (*kv.0).clone())
+            .filter(|u| tokens.contains(&u.type_))
+            .collect();
+        all_utxos.sort_by_key(|u| (u.value, u.output_no));
+        let keep = rng.gen_range(1..=all_utxos.len());
+        let chosen: Vec<_> = all_utxos.into_iter().take(keep).collect();
+
+        // Inputs: one spend per chosen UTXO.
+        let mut inputs: Vec<UtxoSpend> = chosen
+            .iter()
+            .map(|u| UtxoSpend {
+                value: u.value,
+                owner: state.night_key.verifying_key(),
+                type_: u.type_,
+                intent_hash: u.intent_hash,
+                output_no: u.output_no,
+            })
+            .collect();
+        inputs.sort();
+
+        // Outputs: for each spent token, re-emit its full input value split
+        // across a random number of outputs to fresh recipients (a pure move).
+        let mut outputs: Vec<UtxoOutput> = Vec::new();
+        for token in &tokens {
+            let token_in: u128 = chosen
+                .iter()
+                .filter(|u| u.type_ == *token)
+                .map(|u| u.value)
+                .sum();
+            if token_in == 0 {
+                continue;
+            }
+            let k = rng.gen_range(1..=3usize);
+            for value in split_value(&mut rng, token_in, k) {
+                let recipient = UserAddress::from(
+                    base_crypto::schnorr::SigningKey::sample(&mut rng)
+                        .verifying_key(),
+                );
+                outputs.push(UtxoOutput {
+                    value,
+                    owner: recipient,
+                    type_: *token,
+                });
+            }
+        }
+        outputs.sort(); // well_formed requires sorted outputs
+
+        let n_inputs = inputs.len();
+        let spent_tokens: std::collections::BTreeSet<_> =
+            chosen.iter().map(|u| u.type_).collect();
+
+        let offer = UnshieldedOffer::<Signature, Db> {
+            inputs: inputs.into(),
+            outputs: outputs.into(),
+            signatures: vec![].into(),
+        };
+        let intent: Intent<Signature, ProofPreimageMarker, PedersenRandomness, Db> =
+            Intent::new(&mut rng, None, Some(offer), vec![], vec![], vec![], None, state.time);
+        let segment = 1u16;
+        let intent = intent
+            .sign(&mut rng, segment, &[], &[state.night_key.clone()], &[])
+            .expect("input owner matches the signing key");
+        let tx = Transaction::from_intents("local-test", HashMap::new().insert(segment, intent));
+
+        let mut strictness = WellFormedStrictness::default();
+        strictness.enforce_balancing = false; // avoid the orthogonal Dust-fee path
+
+        match state.apply(&tx, strictness) {
+            Ok(TransactionResult::Success(_)) => {
+                exercised += 1;
+                max_inputs = max_inputs.max(n_inputs);
+                if spent_tokens.len() > 1 {
+                    multi_token_applied = true;
+                }
+                // Conservation: EVERY seeded token's total supply is unchanged —
+                // spent tokens are re-emitted in full, unspent tokens are untouched.
+                for (token, before_supply) in &before {
+                    let after = supply(&state, *token);
+                    if *before_supply != after {
+                        failures.push(format!(
+                            "case {case}: apply changed total supply {before_supply} -> {after} \
+                             for token {token:?} on a pure transfer ({n_inputs} inputs)"
+                        ));
+                    }
+                }
+            }
+            // Not applied (rejected / partial): nothing to assert about conservation.
+            other => {
+                if case == 0 {
+                    // Surface the shape once for debugging generator quality.
+                    eprintln!("case {case}: transfer not applied: {other:?}");
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "conservation guard: {exercised} applied; max inputs in one tx = {max_inputs}; \
+         multi-token transfer applied = {multi_token_applied}"
+    );
+
+    assert!(
+        exercised > 0,
+        "generator never produced an applicable transfer — property was vacuous"
+    );
+    assert!(
+        failures.is_empty(),
+        "apply failed to conserve unshielded supply in {} case(s):\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}
+
+/// **`ContractCall` (with real transcripts) round-trips through
+/// serialization.**
+///
+/// Exercises the transcript-generator wiring: the sampled `ContractCall`
+/// carries real `Transcript`s, so this covers the
+/// contract-action + transcript surface. The oracle is invariant-preservation:
+/// tagged serialize/deserialize is the identity on the object graph — including
+/// the optional transcripts, their `Effects` maps and (optional) version.
+#[test]
+fn prop_contract_call_serialization_roundtrips() {
+    use midnight_ledger::structure::ContractCall;
+    use serialize::{tagged_deserialize, tagged_serialize};
+
+    let mut rng = StdRng::seed_from_u64(0xCA11);
+    let mut failures: Vec<String> = Vec::new();
+    let mut with_transcript = 0u32;
+
+    for case in 0..128u64 {
+        let call: ContractCall<(), Db> = rng.r#gen();
+        if call.guaranteed_transcript.is_some() || call.fallible_transcript.is_some() {
+            with_transcript += 1;
+        }
+
+        let mut bytes = Vec::new();
+        tagged_serialize(&call, &mut bytes).expect("serialize");
+        let back: ContractCall<(), Db> = tagged_deserialize(&mut &bytes[..]).expect("deserialize");
+
+        if call != back {
+            failures.push(format!(
+                "case {case}: contract call changed across serialization roundtrip"
+            ));
+        }
+    }
+
+    assert!(
+        with_transcript > 0,
+        "generator never attached a transcript — the transcript wiring is not exercised"
+    );
+    assert!(
+        failures.is_empty(),
+        "contract-call roundtrip failed in {} case(s):\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}
+
+/// **`DustActions` round-trips through serialization and preserves its
+/// spend/registration multiset.**
+///
+/// Covers the dust action surface. The oracle is invariant-preservation: after a
+/// tagged serialize/deserialize cycle the value is unchanged (so every spend
+/// nullifier, registration key and `ctime` is preserved) and the spend/
+/// registration counts match — no dust action is silently dropped or duplicated
+/// at the serialization boundary (the failure mode of the sparse-`Array` class).
+#[test]
+fn prop_dust_actions_serialization_roundtrips() {
+    use midnight_ledger::dust::{
+        DustActions, DustCommitment, DustNullifier, DustPublicKey, DustRegistration, DustSpend,
+    };
+    use serialize::{tagged_deserialize, tagged_serialize};
+    use transient_crypto::curve::Fr;
+
+    let mut rng = StdRng::seed_from_u64(0xD057);
+    let mut failures: Vec<String> = Vec::new();
+    let mut nonempty = 0u32;
+
+    for case in 0..128u64 {
+        let spends: Vec<DustSpend<(), Db>> = (0..rng.gen_range(0..=3))
+            .map(|_| DustSpend {
+                v_fee: rng.r#gen(),
+                old_nullifier: DustNullifier(rng.r#gen::<Fr>()),
+                new_commitment: DustCommitment(rng.r#gen::<Fr>()),
+                proof: (),
+            })
+            .collect();
+        let registrations: Vec<DustRegistration<(), Db>> = (0..rng.gen_range(0..=2))
+            .map(|_| DustRegistration {
+                night_key: base_crypto::schnorr::SigningKey::sample(&mut rng).verifying_key(),
+                dust_address: if rng.r#gen::<bool>() {
+                    Some(Sp::new(DustPublicKey(rng.r#gen::<Fr>())))
+                } else {
+                    None
+                },
+                allow_fee_payment: rng.r#gen(),
+                signature: None,
+            })
+            .collect();
+        if !spends.is_empty() || !registrations.is_empty() {
+            nonempty += 1;
+        }
+        let (n_spends, n_regs) = (spends.len(), registrations.len());
+        let ctime = Timestamp::from_secs(rng.gen_range(0..1_000_000u64));
+        let actions = DustActions::<(), (), Db> {
+            spends: spends.into(),
+            registrations: registrations.into(),
+            ctime,
+        };
+
+        let mut bytes = Vec::new();
+        tagged_serialize(&actions, &mut bytes).expect("serialize");
+        let back: DustActions<(), (), Db> =
+            tagged_deserialize(&mut &bytes[..]).expect("deserialize");
+
+        if actions != back {
+            failures.push(format!(
+                "case {case}: dust actions changed across serialization roundtrip"
+            ));
+        }
+        if back.spends.len() != n_spends || back.registrations.len() != n_regs {
+            failures.push(format!(
+                "case {case}: dust action counts changed ({n_spends} spends / {n_regs} regs \
+                 -> {} / {})",
+                back.spends.len(),
+                back.registrations.len(),
+            ));
+        }
+    }
+
+    assert!(
+        nonempty > 0,
+        "generator only ever produced empty dust actions — property was near-vacuous"
+    );
+    assert!(
+        failures.is_empty(),
+        "dust-action roundtrip failed in {} case(s):\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}
+
+/// **validate == apply, and replay protection.**
+///
+/// Two semantic guards over the full validate -> apply path:
+/// 1. *validate == apply*: a transfer that passes `well_formed` also applies to
+///    `Success`, and the resulting UTXO-set delta matches the transaction's
+///    structure exactly (`after == before - inputs + outputs`). `well_formed`
+///    never claims a transfer is valid that `apply` then rejects.
+/// 2. *replay protection*: re-applying the identical transaction does not
+///    succeed a second time (the inputs are already consumed).
+#[tokio::test]
+async fn prop_validated_transfer_applies_and_no_replay() {
+    use midnight_ledger::semantics::TransactionResult;
+    use base_crypto::schnorr::Signature;
+    use midnight_ledger::test_utilities::TestState;
+    use midnight_ledger::verify::WellFormedStrictness;
+
+    let mut rng = StdRng::seed_from_u64(0x5EED_10AD);
+    let mut failures: Vec<String> = Vec::new();
+    let mut exercised = 0u32;
+
+    for case in 0..12u64 {
+        let mut state = TestState::<Db>::new(&mut rng);
+        let token = UnshieldedTokenType(HashOutput(rng.r#gen()));
+        if token == coin_structure::coin::NIGHT {
+            continue;
+        }
+        let amount: u128 = rng.gen_range(4..1_000_000u128);
+        state.rewards_unshielded(&mut rng, token, amount).await;
+
+        let Some(utxo) = state
+            .ledger
+            .utxo
+            .utxos
+            .iter()
+            .map(|kv| (*kv.0).clone())
+            .find(|u| u.type_ == token)
+        else {
+            continue;
+        };
+
+        // Full spend split into two outputs (net UTXO delta = +1).
+        let split = rng.gen_range(1..utxo.value);
+        let recipient = UserAddress::from(
+            base_crypto::schnorr::SigningKey::sample(&mut rng).verifying_key(),
+        );
+        let mut outputs = vec![
+            UtxoOutput { value: split, owner: recipient, type_: token },
+            UtxoOutput { value: utxo.value - split, owner: recipient, type_: token },
+        ];
+        outputs.sort();
+        let n_outputs = outputs.len();
+
+        let offer = UnshieldedOffer::<Signature, Db> {
+            inputs: vec![UtxoSpend {
+                value: utxo.value,
+                owner: state.night_key.verifying_key(),
+                type_: token,
+                intent_hash: utxo.intent_hash,
+                output_no: utxo.output_no,
+            }]
+            .into(),
+            outputs: outputs.into(),
+            signatures: vec![].into(),
+        };
+        let segment = 1u16;
+        let intent: Intent<Signature, ProofPreimageMarker, PedersenRandomness, Db> =
+            Intent::new(&mut rng, None, Some(offer), vec![], vec![], vec![], None, state.time);
+        let intent = intent
+            .sign(&mut rng, segment, &[], &[state.night_key.clone()], &[])
+            .expect("input owner matches the signing key");
+        let tx = Transaction::from_intents("local-test", HashMap::new().insert(segment, intent));
+
+        let mut strictness = WellFormedStrictness::default();
+        strictness.enforce_balancing = false;
+
+        // (1) validate: well_formed must accept before we apply.
+        if tx.well_formed(&state.ledger, strictness, state.time).is_err() {
+            failures.push(format!("case {case}: well_formed rejected a constructed transfer"));
+            continue;
+        }
+
+        let before = state.ledger.utxo.utxos.iter().count();
+        match state.apply(&tx, strictness) {
+            Ok(TransactionResult::Success(_)) => {
+                exercised += 1;
+                // validate == apply: the UTXO-set delta matches the tx structure.
+                let after = state.ledger.utxo.utxos.iter().count();
+                if after != before - 1 + n_outputs {
+                    failures.push(format!(
+                        "case {case}: UTXO delta {before} -> {after} does not match \
+                         1 input / {n_outputs} outputs"
+                    ));
+                }
+                // (2) replay: the identical tx must not succeed again.
+                match state.apply(&tx, strictness) {
+                    Ok(TransactionResult::Success(_)) => failures.push(format!(
+                        "case {case}: replay of an already-applied transaction succeeded"
+                    )),
+                    _ => {}
+                }
+            }
+            other => failures.push(format!(
+                "case {case}: a well_formed transfer failed to apply: {other:?}"
+            )),
+        }
+    }
+
+    assert!(exercised > 0, "no transfer was applied — property was vacuous");
+    assert!(
+        failures.is_empty(),
+        "validate==apply / replay guard failed in {} case(s):\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}
+
+/// **an expired intent is rejected at apply.**
+///
+/// TTL enforcement: an intent whose `ttl` is strictly before the block time must
+/// be refused. We seed and build an otherwise-valid transfer, then advance the
+/// ledger clock past the intent's TTL; `apply` (via `well_formed`'s
+/// `ttl_check_weak`) must reject it rather than mutate state.
+#[tokio::test]
+async fn prop_apply_rejects_expired_intent() {
+    use midnight_ledger::semantics::TransactionResult;
+    use base_crypto::schnorr::Signature;
+    use midnight_ledger::test_utilities::TestState;
+    use midnight_ledger::verify::WellFormedStrictness;
+
+    let mut rng = StdRng::seed_from_u64(0x7715);
+    let mut failures: Vec<String> = Vec::new();
+    let mut exercised = 0u32;
+
+    for case in 0..12u64 {
+        let mut state = TestState::<Db>::new(&mut rng);
+        let token = UnshieldedTokenType(HashOutput(rng.r#gen()));
+        if token == coin_structure::coin::NIGHT {
+            continue;
+        }
+        let amount: u128 = rng.gen_range(2..1_000_000u128);
+        // Seed at time 0.
+        state.rewards_unshielded(&mut rng, token, amount).await;
+
+        let Some(utxo) = state
+            .ledger
+            .utxo
+            .utxos
+            .iter()
+            .map(|kv| (*kv.0).clone())
+            .find(|u| u.type_ == token)
+        else {
+            continue;
+        };
+
+        // Build a transfer whose intent TTL is time 0...
+        let ttl = Timestamp::from_secs(0);
+        let recipient = UserAddress::from(
+            base_crypto::schnorr::SigningKey::sample(&mut rng).verifying_key(),
+        );
+        let offer = UnshieldedOffer::<Signature, Db> {
+            inputs: vec![UtxoSpend {
+                value: utxo.value,
+                owner: state.night_key.verifying_key(),
+                type_: token,
+                intent_hash: utxo.intent_hash,
+                output_no: utxo.output_no,
+            }]
+            .into(),
+            outputs: vec![UtxoOutput { value: utxo.value, owner: recipient, type_: token }].into(),
+            signatures: vec![].into(),
+        };
+        let segment = 1u16;
+        let intent: Intent<Signature, ProofPreimageMarker, PedersenRandomness, Db> =
+            Intent::new(&mut rng, None, Some(offer), vec![], vec![], vec![], None, ttl);
+        let intent = intent
+            .sign(&mut rng, segment, &[], &[state.night_key.clone()], &[])
+            .expect("input owner matches the signing key");
+        let tx = Transaction::from_intents("local-test", HashMap::new().insert(segment, intent));
+
+        // ...then advance the block clock strictly past the TTL.
+        state.time = Timestamp::from_secs(0) + Duration::from_secs(rng.gen_range(1i128..100_000i128));
+
+        let mut strictness = WellFormedStrictness::default();
+        strictness.enforce_balancing = false;
+
+        let supply_before = state
+            .ledger
+            .utxo
+            .utxos
+            .iter()
+            .map(|kv| (*kv.0).clone())
+            .filter(|u| u.type_ == token)
+            .map(|u| u.value)
+            .sum::<u128>();
+
+        exercised += 1;
+        match state.apply(&tx, strictness) {
+            Err(_) => {}
+            // A non-Success result that does not mutate supply is also acceptable
+            // (rejected without effect); a Success is a TTL-enforcement failure.
+            Ok(TransactionResult::Success(_)) => failures.push(format!(
+                "case {case}: an expired intent (ttl < block time) was applied"
+            )),
+            Ok(_) => {
+                let supply_after = state
+                    .ledger
+                    .utxo
+                    .utxos
+                    .iter()
+                    .map(|kv| (*kv.0).clone())
+                    .filter(|u| u.type_ == token)
+                    .map(|u| u.value)
+                    .sum::<u128>();
+                if supply_after != supply_before {
+                    failures.push(format!(
+                        "case {case}: an expired intent mutated supply {supply_before} -> {supply_after}"
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(exercised > 0, "no expired-intent case was exercised — property was vacuous");
+    assert!(
+        failures.is_empty(),
+        "expired-intent rejection guard failed in {} case(s):\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}

--- a/onchain-runtime/src/transcript.rs
+++ b/onchain-runtime/src/transcript.rs
@@ -49,18 +49,29 @@ pub struct Transcript<D: DB> {
 }
 tag_enforcement_test!(Transcript<storage::db::InMemoryDB>);
 
-// TODO WG
-// #[cfg(feature = "proptest")]
-// impl<D: DB> rand::distributions::Distribution<Transcript<D>> for rand::distributions::Standard {
-//     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Transcript<D> {
-//         Transcript {
-//             gas: rng.gen(),
-//             effects: rng.gen(),
-//             program: storage::storage::Vec::from_std_vec(vec![]),
-//             version: rng.gen(),
-//         }
-//     }
-// }
+#[cfg(feature = "proptest")]
+impl<D: DB> rand::distributions::Distribution<Transcript<D>> for rand::distributions::Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Transcript<D> {
+        // `Op` has no `Distribution`, so the sampled program is empty; the gas,
+        // effects and (optional) version fields carry the randomness. This keeps
+        // the generator total while still producing a structurally-valid,
+        // serializable `Transcript` for the contract-action property tests.
+        let version = if rng.r#gen::<bool>() {
+            Some(Sp::new(TranscriptVersion {
+                major: rng.r#gen(),
+                minor: rng.r#gen(),
+            }))
+        } else {
+            None
+        };
+        Transcript {
+            gas: rng.r#gen(),
+            effects: rng.r#gen(),
+            program: storage::storage::Array::new(),
+            version,
+        }
+    }
+}
 
 impl<D: DB> Transcript<D> {
     pub const VERSION: TranscriptVersion = TranscriptVersion { major: 2, minor: 3 };

--- a/onchain-state/Cargo.toml
+++ b/onchain-state/Cargo.toml
@@ -34,3 +34,4 @@ derive-where = "^1.6.1"
 midnight-onchain-state = { path = ".", features = ["proptest"] }
 rand = { version = "^0.8.5", features = ["getrandom"] }
 pastey = "0.2.1"
+serde_json = "^1.0.140"

--- a/onchain-state/src/state.rs
+++ b/onchain-state/src/state.rs
@@ -1048,3 +1048,75 @@ mod tests {
         }
     }
 }
+
+// -----------------------------------------------------------------------------
+// Area C: `StateValue::invariant` must hold across ALL decode paths.
+//
+// The binary `Storable`/`Deserializable` path enforces the invariant: the
+// derive is annotated `#[storable(invariant = StateValue::invariant)]`, so
+// `from_binary_repr` runs `invariant()` and rejects out-of-bound values. The
+// serde `Deserialize` path (`StateValueVisitor`) constructs `Array`, `Cell`,
+// and `BoundedMerkleTree` variants directly and NEVER calls `invariant()`, so
+// it accepts values the binary path (and the VM's structural assumptions)
+// forbid: arrays longer than 16, oversized cells, and merkle trees of height 0
+// or > 32. This module pins the divergence.
+// -----------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod area_c_serde_invariant {
+    use super::*;
+    use storage::db::InMemoryDB;
+
+    type D = InMemoryDB;
+
+    fn binary_roundtrip(v: &StateValue<D>) -> std::io::Result<StateValue<D>> {
+        let mut bytes = std::vec::Vec::new();
+        <StateValue<D> as Serializable>::serialize(v, &mut bytes)?;
+        <StateValue<D> as Deserializable>::deserialize(&mut &bytes[..], 0)
+    }
+
+    /// Builds an `Array` state value with `n` `Null` elements.
+    fn array_of_nulls(n: usize) -> StateValue<D> {
+        let arr = (0..n).fold(Array::new(), |arr, _| arr.push(StateValue::Null));
+        StateValue::Array(arr)
+    }
+
+    /// Baseline (holds today): the binary decode path enforces the invariant.
+    /// An over-long array serialized in binary is rejected on decode.
+    #[test]
+    fn binary_decode_enforces_array_bound() {
+        let v = array_of_nulls(17);
+        assert!(v.invariant().is_err(), "17-element array violates invariant");
+        assert!(
+            binary_roundtrip(&v).is_err(),
+            "binary decode must reject an over-long array"
+        );
+    }
+
+    /// The serde decode path enforces `StateValue::invariant` (matching the
+    /// binary path): an `Array` longer than 16 is rejected.
+    #[test]
+    fn serde_rejects_overlong_array() {
+        let v = array_of_nulls(17);
+        assert!(v.invariant().is_err(), "17-element array violates invariant");
+        let json = serde_json::to_string(&v).expect("serializes to JSON");
+        assert!(
+            serde_json::from_str::<StateValue<D>>(&json).is_err(),
+            "serde decode must reject an invariant-violating (len-17) Array"
+        );
+    }
+
+    /// The serde decode path rejects a height-0 `BoundedMerkleTree`
+    /// (`invariant` forbids height 0).
+    #[test]
+    fn serde_rejects_height_zero_bmt() {
+        use transient_crypto::merkle_tree::MerkleTree;
+        let mt: MerkleTree<(), D> = MerkleTree::blank(0).rehash();
+        let v = StateValue::BoundedMerkleTree(mt);
+        assert!(v.invariant().is_err());
+        let json = serde_json::to_string(&v).expect("serializes to JSON");
+        assert!(
+            serde_json::from_str::<StateValue<D>>(&json).is_err(),
+            "serde decode must reject a height-0 BoundedMerkleTree"
+        );
+    }
+}

--- a/onchain-vm/src/ops.rs
+++ b/onchain-vm/src/ops.rs
@@ -519,3 +519,204 @@ mod tests {
         assert_eq!(op, op2);
     }
 }
+
+#[cfg(all(test, feature = "proptest"))]
+mod op_field_repr_properties {
+    use super::*;
+    use crate::result_mode::ResultModeVerify;
+    use base_crypto::fab::AlignedValue;
+    use runtime_state::state::StateValue;
+    use serialize::{Deserializable, Serializable};
+    use storage::db::InMemoryDB;
+    use transient_crypto::repr::FieldRepr;
+
+    /// Round-trip an op through the checked deserialization path (the untrusted
+    /// decode boundary runs `Op::invariant` via `do_check`). This is the layer
+    /// the operand bound lives at; `field_repr` itself is unchanged.
+    fn decode(op: &TestOp) -> std::io::Result<TestOp> {
+        let mut buf = Vec::new();
+        Serializable::serialize(op, &mut buf)?;
+        Deserializable::deserialize(&mut &buf[..], 0)
+    }
+
+    type TestOp = Op<ResultModeVerify, InMemoryDB>;
+
+    /// A generator over the full argument range of every `Op` variant. Numeric
+    /// arguments span their whole type (`u8`/`u32`), rather than being masked
+    /// to the small ranges the derived `Arbitrary` uses. `Noop`'s counter is
+    /// capped only to avoid multi-gigabyte allocations while still ranging far
+    /// beyond its encoded byte size (which is what C2 is about).
+    fn arb_op() -> impl Strategy<Value = TestOp> {
+        let simple_value =
+            prop_oneof![Just(StateValue::Null), any::<u64>().prop_map(StateValue::from)];
+        let simple_result = any::<u8>().prop_map(AlignedValue::from);
+        prop_oneof![
+            (0u32..=100_000).prop_map(|n| Op::Noop { n }),
+            Just(Op::Lt),
+            Just(Op::Eq),
+            Just(Op::Type),
+            Just(Op::Size),
+            Just(Op::New),
+            Just(Op::And),
+            Just(Op::Or),
+            Just(Op::Neg),
+            Just(Op::Log),
+            Just(Op::Root),
+            Just(Op::Pop),
+            Just(Op::Add),
+            Just(Op::Sub),
+            Just(Op::Member),
+            Just(Op::Ckpt),
+            any::<u32>().prop_map(|immediate| Op::Addi { immediate }),
+            any::<u32>().prop_map(|immediate| Op::Subi { immediate }),
+            any::<u32>().prop_map(|skip| Op::Branch { skip }),
+            any::<u32>().prop_map(|skip| Op::Jmp { skip }),
+            (any::<bool>(), any::<u32>()).prop_map(|(cached, n)| Op::Concat { cached, n }),
+            any::<bool>().prop_map(|cached| Op::Rem { cached }),
+            // Full u8 range -- NOT masked to 0..16 as the derived Arbitrary does.
+            any::<u8>().prop_map(|n| Op::Dup { n }),
+            any::<u8>().prop_map(|n| Op::Swap { n }),
+            (any::<bool>(), any::<u8>()).prop_map(|(cached, n)| Op::Ins { cached, n }),
+            // Path length includes 0 (the empty path) and >16.
+            (
+                any::<bool>(),
+                any::<bool>(),
+                proptest::collection::vec(
+                    any::<u8>().prop_map(|v| Key::Value(AlignedValue::from(v))),
+                    0..3
+                ),
+            )
+                .prop_map(|(cached, push_path, keys)| Op::Idx {
+                    cached,
+                    push_path,
+                    path: keys.into_iter().collect(),
+                }),
+            (any::<bool>(), simple_value).prop_map(|(storage, value)| Op::Push { storage, value }),
+            (any::<bool>(), simple_result)
+                .prop_map(|(cached, result)| Op::Popeq { cached, result }),
+        ]
+    }
+
+    /// A generator biased towards the variants whose `field_repr` collides, so
+    /// the injectivity property reliably samples colliding pairs: `Noop` with a
+    /// tiny counter, `Idx` with an empty path, and `Dup`/`Swap`/`Ins` over the
+    /// full `u8` range (whose low nibble is OR-ed into a fixed opcode).
+    fn arb_collision_prone_op() -> impl Strategy<Value = TestOp> {
+        prop_oneof![
+            (0u32..=3).prop_map(|n| Op::Noop { n }),
+            (any::<bool>(), any::<bool>()).prop_map(|(cached, push_path)| Op::Idx {
+                cached,
+                push_path,
+                path: Vec::new().into_iter().collect(),
+            }),
+            any::<u8>().prop_map(|n| Op::Dup { n }),
+            any::<u8>().prop_map(|n| Op::Swap { n }),
+            (any::<bool>(), any::<u8>()).prop_map(|(cached, n)| Op::Ins { cached, n }),
+        ]
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// (C1) Distinct `Op`s produce distinct `field_repr` outputs.
+        ///
+        /// `field_repr` is the proof's sole program binding, and it is only
+        /// injective for in-range operands (`Dup{n}`/`Dup{n+16}` alias; an
+        /// empty-path `Idx` aliases `Noop{0}`). The decode bound is exactly what
+        /// makes it injective over the reachable domain, so the property is
+        /// stated over ops the decoder admits.
+        #[test]
+        fn field_repr_is_injective(ops in proptest::collection::vec(arb_collision_prone_op(), 2..48)) {
+            let ops: Vec<TestOp> = ops.into_iter().filter(|o| decode(o).is_ok()).collect();
+            for i in 0..ops.len() {
+                for j in (i + 1)..ops.len() {
+                    if ops[i] != ops[j] {
+                        prop_assert_ne!(
+                            ops[i].field_vec(),
+                            ops[j].field_vec(),
+                            "distinct decodable ops share a field_repr: {:?} vs {:?}",
+                            ops[i], ops[j]
+                        );
+                    }
+                }
+            }
+        }
+
+        /// Sanity: the binary encoding IS injective for distinct ops. This
+        /// isolates the defect to `field_repr` (it passes on the current base).
+        #[test]
+        fn serialization_is_injective(a in arb_op(), b in arb_op()) {
+            if a != b {
+                let mut ba = Vec::new();
+                let mut bb = Vec::new();
+                Serializable::serialize(&a, &mut ba).unwrap();
+                Serializable::serialize(&b, &mut bb).unwrap();
+                prop_assert_ne!(ba, bb, "distinct ops share an encoding: {:?} vs {:?}", a, b);
+            }
+        }
+
+        /// `field_vec().len()` must equal `field_size()` (the latter is the
+        /// allocation hint). This holds for every decodable op; an empty-path
+        /// `Idx` (`field_size() == 1`, emits nothing) is now rejected on decode.
+        #[test]
+        fn field_size_matches_field_repr_length(op in arb_op()) {
+            prop_assume!(decode(&op).is_ok());
+            prop_assert_eq!(op.field_vec().len(), op.field_size(), "for {:?}", op);
+        }
+    }
+
+    // --- Regression tests: the decode boundary rejects the ops whose
+    // `field_repr` would collide (the proof's program binding). ---
+
+    /// `Dup{n}`/`Swap{n}`/`Ins{_,n}` OR `n` into the opcode nibble, so `n >= 16`
+    /// aliases the low-nibble op in `field_repr`; the decoder must reject them.
+    #[test]
+    fn dup_swap_ins_out_of_range_rejected() {
+        for op in [
+            Op::Dup { n: 16 },
+            Op::Swap { n: 16 },
+            Op::Ins { cached: false, n: 16 },
+            Op::Ins { cached: true, n: 16 },
+        ] {
+            let op: TestOp = op;
+            assert!(decode(&op).is_err(), "out-of-range {op:?} must be rejected on decode");
+        }
+        for op in [
+            Op::Dup { n: 15 },
+            Op::Swap { n: 0 },
+            Op::Ins { cached: true, n: 15 },
+        ] {
+            let op: TestOp = op;
+            assert!(decode(&op).is_ok(), "in-range {op:?} must decode");
+        }
+    }
+
+    /// An empty-path `Idx` emits no field elements (aliasing `Noop{0}`) and
+    /// over-reports `field_size`; a path longer than 16 overflows the opcode
+    /// nibble. Both are rejected on decode; a 1..=16 path and `Noop{0}` decode.
+    #[test]
+    fn idx_path_length_bounds_enforced() {
+        let empty: TestOp = Op::Idx {
+            cached: false,
+            push_path: false,
+            path: Vec::new().into_iter().collect(),
+        };
+        assert!(decode(&empty).is_err(), "empty-path Idx must be rejected");
+
+        let long: TestOp = Op::Idx {
+            cached: false,
+            push_path: false,
+            path: (0u8..17).map(|v| Key::Value(AlignedValue::from(v))).collect(),
+        };
+        assert!(decode(&long).is_err(), "17-entry Idx path must be rejected");
+
+        let ok: TestOp = Op::Idx {
+            cached: false,
+            push_path: false,
+            path: (0u8..16).map(|v| Key::Value(AlignedValue::from(v))).collect(),
+        };
+        assert!(decode(&ok).is_ok(), "16-entry Idx path must decode");
+        let noop0: TestOp = Op::Noop { n: 0 };
+        assert!(decode(&noop0).is_ok(), "Noop{{0}} must still decode");
+    }
+}

--- a/onchain-vm/src/vm.rs
+++ b/onchain-vm/src/vm.rs
@@ -1038,3 +1038,164 @@ fn run_program_internal<M: ResultMode<D>, D: DB>(
     })
 }
 // See onchain-runtime/tests/vm.rs for tests.
+
+// -----------------------------------------------------------------------------
+// VM totality: VM operations that consume structural quantities of a
+// `StateValue` (container lengths, tree heights) must not panic or over/under-
+// flow on values a decoder might produce.
+//
+// `StateValue::invariant` caps `Array` length at 16, and the *binary* decoder
+// enforces that. The *serde* decoder does NOT (see the corresponding checks in
+// onchain-state/src/state.rs), so an `Array` of length >= 32 is decoder-
+// producible. The `Type` opcode computes the type tag as
+// `3 + a.len() as u8 * 8` (vm.rs:462); for `a.len() >= 32` the `u8`
+// multiplication overflows (`32 * 8 = 256`), panicking under overflow checks.
+// -----------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod area_c_vm_totality {
+    use super::*;
+    use crate::cost_model::INITIAL_COST_MODEL;
+    use crate::ops::Op;
+    use crate::result_mode::ResultModeGather;
+    use proptest::prelude::*;
+    use storage::db::InMemoryDB;
+
+    type D = InMemoryDB;
+
+    fn array_state(n: usize) -> StateValue<D> {
+        StateValue::Array(vec![StateValue::Null; n].into())
+    }
+
+    fn run_type(state: StateValue<D>) -> Result<(), OnchainProgramError<D>> {
+        let initial = [VmValue::new(ValueStrength::Strong, state)];
+        let program: [Op<ResultModeGather, D>; 1] = [Op::Type];
+        run_program(&initial, &program, None, &INITIAL_COST_MODEL).map(|_| ())
+    }
+
+    proptest! {
+        // `Type` runs during apply on state a serde decoder can produce; an
+        // array beyond the length-16 invariant must error rather than overflow
+        // the u8 type tag.
+        #[test]
+        fn type_op_ok_iff_array_within_invariant(n in 0usize..=40) {
+            prop_assert_eq!(run_type(array_state(n)).is_ok(), n <= 16);
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Area D: `idx` / `ins` on a `BoundedMerkleTree` must not shift-overflow.
+//
+// Both opcodes gate the index against the tree's capacity with `1u64 <<
+// tree.height()` (vm.rs:221 for `idx`, vm.rs:1022 for `ins`). `height()` is a
+// `u8`, so a height >= 64 makes the shift exceed the width of `u64` and panic
+// under overflow checks (and silently wrap in release).
+//
+// Reachability: the trees the VM actually operates on come from the binary
+// `Serializable`/`Deserializable` decode path (transcript `Push` values and
+// contract state), which runs `StateValue::invariant` and REJECTS any
+// `BoundedMerkleTree` with height 0 or > 32 (state.rs `invariant`). With height
+// bounded to 1..=32 the shift amount is always < 64, so `idx`/`ins` are total
+// on every tree reachable through that path — this area HOLDS for the runtime.
+// The raw shift is nonetheless a latent overflow: a height >= 64 tree (which
+// the serde decode path accepts, since it does not enforce the invariant — see
+// `area_c_serde_invariant`) would panic here if it ever reached the VM. That
+// latent case is pinned by the regression below.
+// -----------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod area_d_vm_tree_height {
+    use super::*;
+    use crate::cost_model::INITIAL_COST_MODEL;
+    use crate::ops::{Key, Op};
+    use crate::result_mode::ResultModeGather;
+    use proptest::prelude::*;
+    use serialize::Deserializable;
+    use storage::db::InMemoryDB;
+
+    type D = InMemoryDB;
+
+    fn bmt(height: u8) -> StateValue<D> {
+        StateValue::BoundedMerkleTree(MerkleTree::blank(height).rehash())
+    }
+
+    fn cell(v: u64) -> StateValue<D> {
+        StateValue::from(v)
+    }
+
+    /// Drives the real `idx` opcode with a constant key of 0 against `tree`.
+    fn run_idx(tree: StateValue<D>) -> Result<(), OnchainProgramError<D>> {
+        let initial = [VmValue::new(ValueStrength::Strong, tree)];
+        let program: [Op<ResultModeGather, D>; 1] = [Op::Idx {
+            cached: false,
+            push_path: false,
+            path: vec![Key::Value(AlignedValue::from(0u64))]
+                .into_iter()
+                .collect(),
+        }];
+        run_program(&initial, &program, None, &INITIAL_COST_MODEL).map(|_| ())
+    }
+
+    /// Drives the real `ins` opcode (inserting a cell at key 0) into `tree`.
+    fn run_ins(tree: StateValue<D>) -> Result<(), OnchainProgramError<D>> {
+        // Stack (bottom -> top): container, key, value.
+        let initial = [
+            VmValue::new(ValueStrength::Strong, tree),
+            VmValue::new(ValueStrength::Strong, cell(0)),
+            VmValue::new(ValueStrength::Strong, cell(0)),
+        ];
+        let program: [Op<ResultModeGather, D>; 1] = [Op::Ins {
+            cached: false,
+            n: 1,
+        }];
+        run_program(&initial, &program, None, &INITIAL_COST_MODEL).map(|_| ())
+    }
+
+    /// Binary round-trips a `StateValue` through the decode path the runtime
+    /// uses for transcript `Push` values and contract state.
+    fn binary_roundtrip(v: &StateValue<D>) -> std::io::Result<StateValue<D>> {
+        let mut bytes = std::vec::Vec::new();
+        <StateValue<D> as Serializable>::serialize(v, &mut bytes)?;
+        <StateValue<D> as Deserializable>::deserialize(&mut &bytes[..], 0)
+    }
+
+    proptest! {
+        // HOLDS: `idx` and `ins` are total for every in-bound tree height
+        // (1..=32). The shift `1u64 << height` never exceeds the `u64` width.
+        #[test]
+        fn idx_ins_total_for_in_bound_heights(height in 1u8..=32) {
+            let _ = run_idx(bmt(height));
+            let _ = run_ins(bmt(height));
+        }
+    }
+
+    proptest! {
+        // HOLDS: the binary decode path bounds `BoundedMerkleTree` height to
+        // 1..=32, so no tree with a panic-inducing height (0 or > 32) can be
+        // decoded from the format the VM consumes.
+        #[test]
+        fn binary_decode_bounds_bmt_height(height in 0u8..=64) {
+            let decoded = binary_roundtrip(&bmt(height));
+            if (1..=32).contains(&height) {
+                prop_assert!(decoded.is_ok(), "in-bound height {} must decode", height);
+            } else {
+                prop_assert!(decoded.is_err(), "out-of-bound height {} must be rejected", height);
+            }
+        }
+    }
+
+    // A `BoundedMerkleTree` of height 64 makes `idx` evaluate
+    // `1u64 << tree.height()`, a shift by 64 that overflows `u64` and panics.
+    // Unreachable via the binary decode path (height capped at 32) but reachable
+    // via the invariant-free serde decode path, so the shift must be
+    // checked/bounded rather than panic.
+    #[test]
+    fn regression_idx_shift_overflow_height_64() {
+        let _ = run_idx(bmt(64));
+    }
+
+    // Same shift overflow in `ins` (`1u64 << t.height()`) for a height-64 tree.
+    #[test]
+    fn regression_ins_shift_overflow_height_64() {
+        let _ = run_ins(bmt(64));
+    }
+}

--- a/serialize/src/deserializable.rs
+++ b/serialize/src/deserializable.rs
@@ -245,7 +245,360 @@ impl<'a, T: ToOwned + ?Sized> Deserializable for Cow<'a, T>
 where
     T::Owned: Deserializable,
 {
-    fn deserialize(reader: &mut impl Read, recursion_depth: u32) -> std::io::Result<Self> {
+    fn deserialize(reader: &mut impl Read, mut recursion_depth: u32) -> std::io::Result<Self> {
+        Self::check_rec(&mut recursion_depth)?;
         <T::Owned>::deserialize(reader, recursion_depth).map(Cow::Owned)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Area F: canonicity / injectivity of `HashMap` / `HashSet` `Deserializable`.
+//
+// The `Serializable` impls (see serializable.rs) emit a *canonical* wire form:
+// the length prefix followed by entries sorted ascending by key/element, with
+// no duplicates (a map/set cannot contain duplicate keys/elements). The
+// `Deserializable` impls above, however, read `len` entries and blindly
+// `insert` them into a fresh `HashMap`/`HashSet` with no ordering check and no
+// duplicate-key rejection. As a consequence:
+//   * any permutation of the entries decodes to the same value, and
+//   * an encoding whose `len` disagrees with the number of distinct keys
+//     (duplicate keys) is silently accepted, decoding to a *smaller* value.
+// Both break the "single canonical wire form" property the sorted encoder is
+// clearly trying to establish.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod canonicity_props {
+    use crate::{Deserializable, Serializable};
+    use proptest::prelude::*;
+    use std::collections::{HashMap, HashSet};
+
+    /// Build the wire form the `HashMap`/`HashSet` decoders read: a `u32`
+    /// length prefix followed by each entry, in the *given* order (no sorting).
+    fn map_wire(entries: &[(u8, u8)]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        (entries.len() as u32).serialize(&mut bytes).unwrap();
+        for (k, v) in entries {
+            k.serialize(&mut bytes).unwrap();
+            v.serialize(&mut bytes).unwrap();
+        }
+        bytes
+    }
+
+    fn set_wire(elems: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        (elems.len() as u32).serialize(&mut bytes).unwrap();
+        for e in elems {
+            e.serialize(&mut bytes).unwrap();
+        }
+        bytes
+    }
+
+    fn decode_map(bytes: &[u8]) -> std::io::Result<HashMap<u8, u8>> {
+        HashMap::deserialize(&mut &bytes[..], 0)
+    }
+    fn decode_set(bytes: &[u8]) -> std::io::Result<HashSet<u8>> {
+        HashSet::deserialize(&mut &bytes[..], 0)
+    }
+
+    proptest! {
+        // Totality: decoders never panic on arbitrary bytes.
+        #[test]
+        fn map_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..64)) {
+            let _ = decode_map(&bytes);
+        }
+        #[test]
+        fn set_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..64)) {
+            let _ = decode_set(&bytes);
+        }
+    }
+
+    // ===================================================================
+    // Canonical-decode regressions (minimized): the decoder rejects unsorted
+    // order and duplicate keys/elements (strict-ascending normal form).
+    // ===================================================================
+
+    #[test]
+    fn map_rejects_unsorted_order() {
+        // Two distinct keys in descending order -- not the canonical (ascending)
+        // encoding.
+        let unsorted = map_wire(&[(1, 0), (0, 0)]);
+        assert!(
+            decode_map(&unsorted).is_err(),
+            "unsorted map encoding must be rejected"
+        );
+    }
+
+    #[test]
+    fn map_rejects_duplicate_keys() {
+        // len says 2 but both entries share key 0.
+        let dup = map_wire(&[(0, 1), (0, 2)]);
+        assert!(
+            decode_map(&dup).is_err(),
+            "duplicate-key map encoding must be rejected (got {:?})",
+            decode_map(&dup)
+        );
+    }
+
+    #[test]
+    fn set_rejects_unsorted_order() {
+        let unsorted = set_wire(&[1, 0]);
+        assert!(
+            decode_set(&unsorted).is_err(),
+            "unsorted set encoding must be rejected"
+        );
+    }
+
+    #[test]
+    fn set_rejects_duplicate_elems() {
+        let dup = set_wire(&[0, 0]);
+        assert!(
+            decode_set(&dup).is_err(),
+            "duplicate-element set encoding must be rejected (got {:?})",
+            decode_set(&dup)
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Area A: totality of `Vec::<T>::deserialize`, including zero-sized element
+// types.
+//
+// `Vec::<T>::deserialize` (deserializable.rs:157) reads a `u32` length prefix
+// and then pre-allocates via `Vec::with_bounded_capacity(len as usize)`
+// (util.rs:36). That helper computes
+//     let alloc_limit = MEMORY_LIMIT / std::mem::size_of::<T>();
+// (util.rs:39). For a zero-sized element type such as `()`,
+// `size_of::<T>() == 0`, so this is an **integer divide-by-zero** and the
+// decoder *panics* before it can return either `Ok` or `Err` — violating the
+// totality property (a decoder must never panic on any declared length).
+//
+// The panic fires for *every* `Vec<()>` decode with a validly-decoded length
+// prefix, including the empty vector (`len == 0`), because the division is
+// evaluated unconditionally regardless of `n`.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod vec_totality_props {
+    use crate::{Deserializable, Serializable};
+    use proptest::prelude::*;
+
+    fn decode<T: Deserializable>(bytes: &[u8]) -> std::io::Result<Vec<T>> {
+        Vec::<T>::deserialize(&mut &bytes[..], 0)
+    }
+
+    /// The single canonical `u32` length prefix `0`, in the crate's SCALE
+    /// varint form (a lone `0x00` byte). This is the smallest input that
+    /// decodes a length successfully, i.e. the smallest input that reaches the
+    /// `with_bounded_capacity` allocation.
+    fn len_prefix(n: u32) -> Vec<u8> {
+        let mut b = Vec::new();
+        n.serialize(&mut b).unwrap();
+        b
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        // (A-tot) Non-ZST element types: decode is total on arbitrary bytes and
+        // arbitrary declared length prefixes (these hold today — the bounded
+        // allocation caps memory and a short buffer just yields an EOF `Err`).
+        #[test]
+        fn vec_u8_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..128)) {
+            let _ = decode::<u8>(&bytes);
+        }
+        #[test]
+        fn vec_u32_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..128)) {
+            let _ = decode::<u32>(&bytes);
+        }
+        #[test]
+        fn vec_pair_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..128)) {
+            let _ = decode::<(u8, u8)>(&bytes);
+        }
+        // A huge declared length must not OOM or panic: `with_bounded_capacity`
+        // caps the pre-allocation, and the element loop hits EOF and returns
+        // `Err` almost immediately.
+        #[test]
+        fn vec_u8_huge_len_is_err(extra in prop::collection::vec(any::<u8>(), 0..8)) {
+            let mut bytes = len_prefix(u32::MAX);
+            bytes.extend_from_slice(&extra);
+            // Never panics; a length of ~4e9 with too few bytes is an error.
+            prop_assert!(decode::<u8>(&bytes).is_err());
+        }
+
+        // A zero-sized element type must not divide-by-zero on the capacity
+        // bound; a declared length of `n` decodes to `n` units.
+        #[test]
+        fn vec_zst_decodes_to_declared_length(n in 0u32..=8) {
+            let decoded = decode::<()>(&len_prefix(n));
+            prop_assert!(decoded.is_ok());
+            prop_assert_eq!(decoded.unwrap().len(), n as usize);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Area D: the recursion-depth guard must bound decoding of *any* recursive
+// type, regardless of which smart pointer forms the recursive edge.
+//
+// `Deserializable::check_rec` (deserializable.rs:142) increments and range-
+// checks the depth counter against `RECURSION_LIMIT`. Container decoders that
+// can form the recursive edge of a type are expected to invoke it. `Arc`
+// (deserializable.rs:214) *does* call `check_rec` before recursing; but `Box`
+// (deserializable.rs:238) and `Cow` (deserializable.rs:244) do NOT — they
+// simply forward the *unchanged* depth to the inner `deserialize`. Any
+// recursive type whose recursive edge is a `Box` or `Cow` therefore decodes
+// with an unbounded depth counter, so a crafted deeply-nested encoding recurses
+// without limit and overflows the stack instead of being rejected — while the
+// identical shape built with `Arc` is correctly rejected at `RECURSION_LIMIT`.
+//
+// The three chain types below are deliberately identical except for the smart
+// pointer on the recursive edge, and each type's own `deserialize` intentionally
+// delegates depth accounting to the pointer (as a real recursive `Deserializable`
+// impl relies on its fields' decoders to advance the counter). This isolates the
+// pointer as the sole difference.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod recursion_depth_props {
+    use super::RECURSION_LIMIT;
+    use crate::Deserializable;
+    use proptest::prelude::*;
+    use std::borrow::Cow;
+    use std::io::Read;
+    use std::sync::Arc;
+
+    // Recursive edge = Arc (calls check_rec -> bounded).
+    #[derive(Clone, Debug)]
+    enum ArcChain {
+        Leaf,
+        Link(#[allow(dead_code)] Arc<ArcChain>),
+    }
+    impl Deserializable for ArcChain {
+        fn deserialize(reader: &mut impl Read, depth: u32) -> std::io::Result<Self> {
+            // Depth accounting is delegated to the recursive edge's decoder.
+            match u8::deserialize(reader, depth)? {
+                0 => Ok(ArcChain::Leaf),
+                _ => Ok(ArcChain::Link(<Arc<ArcChain>>::deserialize(reader, depth)?)),
+            }
+        }
+    }
+
+    // Recursive edge = Box (does NOT call check_rec -> unbounded).
+    #[derive(Clone, Debug)]
+    enum BoxChain {
+        Leaf,
+        Link(#[allow(dead_code)] Box<BoxChain>),
+    }
+    impl Deserializable for BoxChain {
+        fn deserialize(reader: &mut impl Read, depth: u32) -> std::io::Result<Self> {
+            match u8::deserialize(reader, depth)? {
+                0 => Ok(BoxChain::Leaf),
+                _ => Ok(BoxChain::Link(<Box<BoxChain>>::deserialize(reader, depth)?)),
+            }
+        }
+    }
+
+    // A leaf decoder that records the `recursion_depth` it was invoked with.
+    // Wrapping it in each smart pointer reveals whether that pointer advanced
+    // the depth counter before delegating. (`Cow<'static, DepthProbe>` is a
+    // *non-recursive* Cow, so it sidesteps the infinite-size cycle that a
+    // self-referential Cow edge would create — a Cow can only introduce heap
+    // indirection through an unsized target like `[T]`/`str`, whose `Owned`
+    // decoder is `Vec`/`String` and *does* call `check_rec`.)
+    #[derive(Clone, Debug, PartialEq)]
+    struct DepthProbe(u32);
+    impl Deserializable for DepthProbe {
+        fn deserialize(reader: &mut impl Read, depth: u32) -> std::io::Result<Self> {
+            let _ = u8::deserialize(reader, depth)?; // consume a byte for parity
+            Ok(DepthProbe(depth))
+        }
+    }
+
+    fn depth_seen_via_arc() -> u32 {
+        <Arc<DepthProbe>>::deserialize(&mut &[0u8][..], 0).unwrap().0
+    }
+    fn depth_seen_via_box() -> u32 {
+        <Box<DepthProbe>>::deserialize(&mut &[0u8][..], 0).unwrap().0
+    }
+    fn depth_seen_via_cow() -> u32 {
+        <Cow<'static, DepthProbe>>::deserialize(&mut &[0u8][..], 0)
+            .unwrap()
+            .into_owned()
+            .0
+    }
+
+    /// Wire form of a chain: `links` "Link" tags (`0x01`) followed by a single
+    /// "Leaf" terminator (`0x00`).
+    fn nested(links: u32) -> Vec<u8> {
+        let mut b = vec![1u8; links as usize];
+        b.push(0u8);
+        b
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        // (D-holds) The Arc-edged chain IS bounded: any nesting deeper than
+        // RECURSION_LIMIT is rejected with an error (never overflows). HOLDS.
+        #[test]
+        fn arc_chain_is_bounded(extra in 0u32..64) {
+            let bytes = nested(RECURSION_LIMIT + 1 + extra);
+            prop_assert!(
+                ArcChain::deserialize(&mut &bytes[..], 0).is_err(),
+                "Arc-edged recursion must be capped at RECURSION_LIMIT"
+            );
+        }
+
+        // (D-holds) Shallow nesting (within the limit) decodes fine for both
+        // pointer variants — the guard doesn't reject legitimate inputs. HOLDS.
+        #[test]
+        fn shallow_chains_decode_ok(links in 0u32..(RECURSION_LIMIT / 2)) {
+            let bytes = nested(links);
+            prop_assert!(ArcChain::deserialize(&mut &bytes[..], 0).is_ok());
+            prop_assert!(BoxChain::deserialize(&mut &bytes[..], 0).is_ok());
+        }
+    }
+
+    /// (D-holds) Root cause, directly observed: `Arc::deserialize` advances the
+    /// recursion-depth counter before delegating (inner sees depth `1`). HOLDS.
+    #[test]
+    fn arc_advances_recursion_depth() {
+        assert_eq!(depth_seen_via_arc(), 1);
+    }
+
+    /// `Box::deserialize` must advance the recursion-depth counter like `Arc`
+    /// (inner sees depth `1`, not `0`), so a `Box` edge contributes to the
+    /// recursion bound.
+    #[test]
+    fn box_advances_recursion_depth() {
+        assert_eq!(
+            depth_seen_via_box(),
+            depth_seen_via_arc(),
+            "Box must advance the recursion-depth counter like Arc"
+        );
+    }
+
+    /// `Cow::deserialize` must likewise advance the depth counter.
+    #[test]
+    fn cow_advances_recursion_depth() {
+        assert_eq!(
+            depth_seen_via_cow(),
+            depth_seen_via_arc(),
+            "Cow must advance the recursion-depth counter like Arc"
+        );
+    }
+
+    /// A `Box`-edged recursive type must respect the recursion limit: a chain
+    /// nested `RECURSION_LIMIT + 1` deep — one level past where the identical
+    /// `Arc`-edged type is rejected — must decode to an error, since the same
+    /// unbounded recursion at a genuinely adversarial length (millions of
+    /// `0x01` bytes) overflows the stack. The crafted encoding is only modestly
+    /// deep here to keep the test binary alive for a clean assertion failure.
+    #[test]
+    fn box_chain_respects_recursion_limit() {
+        let bytes = nested(RECURSION_LIMIT + 1);
+        assert!(
+            BoxChain::deserialize(&mut &bytes[..], 0).is_err(),
+            "Box-edged recursion must be capped at RECURSION_LIMIT like Arc"
+        );
+    }
+
 }

--- a/serialize/src/serializable.rs
+++ b/serialize/src/serializable.rs
@@ -231,3 +231,66 @@ impl<'a, T: ToOwned + ?Sized + Tagged> Tagged for Cow<'a, T> {
         T::tag_unique_factor()
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area C: `serialized_size()` must equal the number of bytes `serialize`
+// actually writes, for any `HashMap` / `HashSet`.
+//
+// The length prefix is written as a `u32` via the crate's SCALE varint
+// (`via_scale!(u32, 4)` in util.rs:209; the encoded width is 1/2/4/(n+1) bytes
+// depending on the *value*, see `ScaleBigInt::serialize`/`serialized_size` at
+// util.rs:227/251). `Vec::serialized_size` (serializable.rs:57) correctly
+// accounts for this by computing `(self.len() as u64).serialized_size()`.
+// However, `HashMap::serialized_size` (serializable.rs:76) and
+// `HashSet::serialized_size` (serializable.rs:94) both start their fold at the
+// hard-coded constant `4`, as if the prefix were a fixed 4-byte integer. It is
+// not: for any map/set whose `len` encodes to fewer than 4 bytes (i.e. every
+// map/set with `len < 2^14`, and in particular the *empty* map/set) the
+// reported size *overestimates* the bytes `serialize` writes. This breaks the
+// `serialized_size == bytes-written` invariant that the existing
+// `randomised_serialization_test!` oracle (util.rs:662) checks for other
+// types.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod map_set_size_props {
+    use crate::Serializable;
+    use proptest::prelude::*;
+
+    /// Reusable oracle mirroring `randomised_serialization_test!`'s
+    /// `proptest_serialized_size_*`: the number of bytes written by `serialize`
+    /// must equal `serialized_size()`.
+    fn size_matches<T: Serializable>(v: &T) -> Result<(), TestCaseError> {
+        let mut bytes = Vec::new();
+        v.serialize(&mut bytes).unwrap();
+        prop_assert_eq!(
+            bytes.len(),
+            v.serialized_size(),
+            "serialize wrote {} bytes but serialized_size() reported {}",
+            bytes.len(),
+            v.serialized_size()
+        );
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        // (C) HashMap: reported size must equal bytes written.
+        #[test]
+        fn hashmap_size_matches(m in prop::collection::hash_map(any::<u8>(), any::<u16>(), 0..40)) {
+            size_matches(&m)?;
+        }
+
+        // (C) HashSet: reported size must equal bytes written.
+        #[test]
+        fn hashset_size_matches(s in prop::collection::hash_set(any::<u16>(), 0..40)) {
+            size_matches(&s)?;
+        }
+
+        // The equivalent `Vec` property, as a cross-check on the oracle itself.
+        #[test]
+        fn vec_size_matches(v in prop::collection::vec(any::<u16>(), 0..40)) {
+            size_matches(&v)?;
+        }
+    }
+}

--- a/serialize/tests/prop_scale_noncanonical.rs
+++ b/serialize/tests/prop_scale_noncanonical.rs
@@ -1,0 +1,62 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `ScaleBigInt` marker-class minimality regression.
+//!
+//! The decoder rejects trailing-zero non-minimality WITHIN each marker class,
+//! but never checks that the marker CLASS itself is minimal. The N-byte marker
+//! path (`first & 0b11 == 0b11`) computes `n = top6bits(first) + 4` and reads
+//! `n` raw bytes, checking only that the top byte is non-zero. With
+//! `top6bits(first) == 0` we get `n == 4`: a 4-byte value encoded with the
+//! N-byte marker is accepted, even though the same value also has a (distinct)
+//! 4-byte-marker encoding. Two wire forms, one integer -- affecting every integer
+//! and field element (via `ScaleBigInt`).
+//!
+//! The correct behaviour asserted below is that the decoder REJECTS the
+//! non-minimal marker form. Because `ScaleBigInt` backs every integer and
+//! length-prefix decoder, this alias would otherwise apply to every integer on
+//! the wire whose top significant byte is in `1..=63`.
+
+use midnight_serialize::{Deserializable, ScaleBigInt, Serializable};
+
+#[test]
+fn scale_bigint_rejects_non_minimal_marker_class() {
+    // A value whose most-significant significant byte is the 4th (needs 4 bytes).
+    let mut a = [0u8; 67];
+    a[3] = 1; // value = 0x0100_0000
+    let x = ScaleBigInt(a);
+
+    // Canonical encoding chooses the 4-byte marker.
+    let mut canonical = Vec::new();
+    x.serialize(&mut canonical).expect("serialize");
+
+    // Hand-crafted N-byte-marker encoding with n = 4 (top6bits(first)=0):
+    //   first byte = 0b11 (N-byte marker), then 4 raw LE bytes [0,0,0,1].
+    // A distinct wire form of the SAME value.
+    let n_byte = vec![0b0000_0011u8, 0, 0, 0, 1];
+    assert_ne!(
+        canonical, n_byte,
+        "the two encodings are genuinely different wire forms"
+    );
+
+    // The canonical form must decode; the non-minimal marker form must be REJECTED.
+    assert!(
+        ScaleBigInt::deserialize(&mut &canonical[..], 0).is_ok(),
+        "the canonical 4-byte-marker form must decode"
+    );
+    assert!(
+        ScaleBigInt::deserialize(&mut &n_byte[..], 0).is_err(),
+        "SEVERE-primitive: the decoder must reject the non-minimal N-byte(n=4) marker \
+         (else two distinct wire forms decode to the same integer)"
+    );
+}

--- a/storage-core/src/arena.rs
+++ b/storage-core/src/arena.rs
@@ -2880,3 +2880,103 @@ mod tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area F: canonicity / injectivity of `DirectChildNode` / `ArenaKey` decode
+// around the inline/reference size boundary.
+//
+// The inline-vs-reference choice for a child is made deterministically by
+// `child_from` (storable.rs:139) using `is_in_small_object_limit`
+// (storable.rs:150): a child whose measured size `2 + data.len() + Σ child
+// sizes` is `<= SMALL_OBJECT_LIMIT` (1024) is inlined as `ArenaKey::Direct`,
+// otherwise it becomes a bare `ArenaKey::Ref(hash)`. This gives every logical
+// node a single canonical child representation keyed on the boundary. The
+// content hash (`arena::hash`, arena.rs:66; surfaced by `ArenaKey::hash`,
+// arena.rs:310) is computed from the node's data and its children's *hashes*
+// and is therefore representation-independent: one content hash per logical
+// node, regardless of whether a child is stored inline or by reference.
+//
+// Result: the desired canonicity invariants HOLD. `child_from` yields exactly
+// one representation per (data, children); the content hash is a function of
+// logical content only; and `DirectChildNode` decode is total and round-trips
+// canonically. (Non-canonical whole-graph encodings are additionally rejected
+// by the `Sp` normal-form re-serialization check at arena.rs:916-923.)
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod boundary_canonicity_props {
+    use super::*;
+    use crate::DefaultHasher;
+    use crate::storable::{SMALL_OBJECT_LIMIT, child_from};
+    use proptest::prelude::*;
+
+    type K = ArenaKey<DefaultHasher>;
+
+    fn de_key(bytes: &[u8]) -> std::io::Result<K> {
+        <K as Deserializable>::deserialize(&mut &bytes[..], 0)
+    }
+    fn de_direct(bytes: &[u8]) -> std::io::Result<DirectChildNode<DefaultHasher>> {
+        <DirectChildNode<DefaultHasher> as Deserializable>::deserialize(&mut &bytes[..], 0)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        // (F-tot) Arbitrary bytes never panic the node decoders.
+        #[test]
+        fn arena_key_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..96)) {
+            let _ = de_key(&bytes);
+        }
+        #[test]
+        fn direct_child_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..96)) {
+            let _ = de_direct(&bytes);
+        }
+
+        // (F-canon) One content hash per logical node: for any data, the
+        // `child_from` representation and a bare `Ref` to the directly-computed
+        // hash agree on the content hash (representation-independent).
+        #[test]
+        fn content_hash_is_representation_independent(data in prop::collection::vec(any::<u8>(), 0..1200)) {
+            let children: Vec<K> = Vec::new();
+            let key = child_from::<DefaultHasher>(&data, &children);
+            let direct_hash = crate::arena::hash::<DefaultHasher>(&data, children.iter().map(|c| c.hash()));
+            // The chosen representation exposes exactly this content hash...
+            prop_assert_eq!(key.hash(), &direct_hash);
+            // ...and a `Ref` to that hash exposes the same content hash.
+            let as_ref = ArenaKey::<DefaultHasher>::Ref(direct_hash.clone());
+            prop_assert_eq!(as_ref.hash(), &direct_hash);
+        }
+
+        // (F-canon) The inline/reference choice is a deterministic function of
+        // the boundary: size `<= SMALL_OBJECT_LIMIT` inlines (`Direct`), above
+        // references (`Ref`). A single canonical representation per node.
+        #[test]
+        fn boundary_choice_is_deterministic(len in 0usize..2048) {
+            let data = vec![0xABu8; len];
+            let children: Vec<K> = Vec::new();
+            let key = child_from::<DefaultHasher>(&data, &children);
+            let measured = 2 + data.len(); // empty children
+            match key {
+                ArenaKey::Direct(_) => prop_assert!(measured <= SMALL_OBJECT_LIMIT),
+                ArenaKey::Ref(_) => prop_assert!(measured > SMALL_OBJECT_LIMIT),
+            }
+        }
+    }
+
+    // A `DirectChildNode` round-trips through its binary codec, preserving the
+    // content hash (canonical decode). Holds today; kept as a regression guard.
+    #[test]
+    fn direct_child_roundtrip_preserves_hash() {
+        for len in [0usize, 1, 1022, 1023] {
+            let data = vec![0x5Au8; len];
+            let node = DirectChildNode::<DefaultHasher>::new(data, Vec::new());
+            let mut bytes = Vec::new();
+            node.serialize(&mut bytes).unwrap();
+            let back = de_direct(&bytes).unwrap();
+            assert_eq!(node.hash, back.hash, "content hash changed across round-trip (len={len})");
+            // Re-serialization is byte-identical (canonical wire form).
+            let mut re = Vec::new();
+            back.serialize(&mut re).unwrap();
+            assert_eq!(bytes, re, "DirectChildNode wire form not canonical (len={len})");
+        }
+    }
+}

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,0 +1,1 @@
+proptest-regressions/

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -20,6 +20,7 @@ storage-core = { version = "1.0.0", path = "../storage-core", package = "midnigh
 base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
 serialize = { version = "1.0.0", path = "../serialize", package = "midnight-serialize" }
 rand = { version = "^0.8.4", features = ["getrandom"] }
+contracts = "0.6"
 derive-where = "^1.6.1"
 digest = "^0.11.2"
 crypto = "0.5.1"

--- a/storage/src/merkle_patricia_trie.rs
+++ b/storage/src/merkle_patricia_trie.rs
@@ -26,6 +26,7 @@ use crate::Storable;
 use crate::arena::{ArenaKey, Sp};
 use crate::db::DB;
 use crate::storable::{Loader, SizeAnn};
+use contracts::debug_requires;
 use derive_where::derive_where;
 use serialize::{self, Deserializable, Serializable, Tagged, tag_enforcement_test};
 
@@ -33,7 +34,7 @@ use serialize::{self, Deserializable, Serializable, Tagged, tag_enforcement_test
 #[derive_where(Debug, Eq, Clone, PartialEq; V, A)]
 #[derive(Storable)]
 #[storable(db = D)]
-#[storable(db = D, invariant = MerklePatriciaTrie::invariant)]
+#[storable(db = D, invariant = MerklePatriciaTrie::annotation_consistency)]
 pub struct MerklePatriciaTrie<
     V: Storable<D>,
     D: DB = DefaultDB,
@@ -69,7 +70,7 @@ impl<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>> MerklePatriciaTrie<V
         MerklePatriciaTrie(Sp::new(Node::Empty))
     }
 
-    fn invariant(&self) -> Result<(), std::io::Error> {
+    fn annotation_consistency(&self) -> Result<(), std::io::Error> {
         fn err<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>>(
             ann: &A,
             true_val: A,
@@ -125,18 +126,98 @@ impl<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>> MerklePatriciaTrie<V
         Ok(())
     }
 
+    /// Check that the trie is in canonical form, returning a description of the
+    /// violated rule otherwise. A well-formed trie is *canonical*: its structure
+    /// is uniquely determined by its key-value contents (see the type-level
+    /// docs). This is a hand-enumerated statement of the structural rules,
+    /// composed with the annotation-consistency check.
+    ///
+    /// This is a pure inspection predicate: it is the oracle the property tests
+    /// use, and does not itself change what deserialization accepts.
+    pub fn canonicity(&self) -> Result<(), std::io::Error> {
+        fn err<T>(msg: &str) -> Result<T, std::io::Error> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("canonicity: {msg}"),
+            ))
+        }
+
+        fn structure<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>>(
+            node: &Node<V, D, A>,
+        ) -> Result<(), std::io::Error> {
+            match node {
+                Node::Empty | Node::Leaf { .. } => Ok(()),
+                Node::Branch { children, .. } => {
+                    if children
+                        .iter()
+                        .filter(|child| !matches!(***child, Node::Empty))
+                        .count()
+                        < 2
+                    {
+                        return err("Node::Branch must have at least two non-empty children");
+                    }
+                    children
+                        .iter()
+                        .try_for_each(|child| structure(child.deref()))
+                }
+                Node::Extension {
+                    compressed_path,
+                    child,
+                    ..
+                } => {
+                    if compressed_path.is_empty() {
+                        return err("Node::Extension path must be non-empty");
+                    }
+                    if compressed_path.len() > 255 {
+                        return err("Node::Extension path may not be longer than 255");
+                    }
+                    if compressed_path.iter().any(|b| *b > 0x0f) {
+                        return err("Node::Extension path must consist of nibbles");
+                    }
+                    match child.deref() {
+                        Node::Empty => {
+                            return err("Node::Extension child must not be Node::Empty");
+                        }
+                        Node::Extension { .. } if compressed_path.len() != 255 => {
+                            return err(
+                                "Node::Extension may only have a Node::Extension child when its own path is of length 255",
+                            );
+                        }
+                        _ => {}
+                    }
+                    structure(child.deref())
+                }
+                Node::MidBranchLeaf { child, .. } => match child.deref() {
+                    Node::Branch { .. } | Node::Extension { .. } => structure(child.deref()),
+                    _ => err("Node::MidBranchLeaf may only have Node::Branch or Node::Extension children"),
+                },
+            }
+        }
+
+        structure(self.0.deref())?;
+        self.annotation_consistency()
+    }
+
+    /// Whether [`Self::canonicity`] holds.
+    pub fn is_canonical(&self) -> bool {
+        self.canonicity().is_ok()
+    }
+
     /// Insert a value into the trie
+    #[debug_requires(path.iter().all(|b| *b <= 0xf), "path must consist of nibbles")]
     pub fn insert(&self, path: &[u8], value: V) -> Self {
         MerklePatriciaTrie(Node::<V, D, A>::insert(&self.0, path, value).0)
     }
 
     /// Lookup a value in the trie
+    #[debug_requires(path.iter().all(|b| *b <= 0xf), "path must consist of nibbles")]
     pub fn lookup(&self, path: &[u8]) -> Option<&V> {
         Node::<V, D, A>::lookup(&self.0, path)
     }
 
     /// Prunes all paths which are lexicographically less than the `target_path`.
     /// Returns the updated tree, and a vector of the removed leaves.
+    #[debug_requires(target_path.iter().all(|b| *b <= 0xf), "path must consist of nibbles")]
     pub(crate) fn prune(
         &self,
         target_path: &[u8],
@@ -147,11 +228,13 @@ impl<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>> MerklePatriciaTrie<V
     }
 
     /// Lookup a value in the trie
+    #[debug_requires(path.iter().all(|b| *b <= 0xf), "path must consist of nibbles")]
     pub fn lookup_sp(&self, path: &[u8]) -> Option<Sp<V, D>> {
         Node::<V, D, A>::lookup_sp(&self.0, path)
     }
 
     /// Given a path, find the nearest predecessor to that path
+    #[debug_requires(path.iter().all(|b| *b <= 0xf), "path must consist of nibbles")]
     pub(crate) fn find_predecessor<'a>(&'a self, path: &[u8]) -> Option<(Vec<u8>, &'a V)> {
         let mut best_predecessor = None;
         Node::<V, D, A>::find_predecessor_recursive(
@@ -164,6 +247,7 @@ impl<V: Storable<D>, D: DB, A: Storable<D> + Annotation<V>> MerklePatriciaTrie<V
     }
 
     /// Remove a value from the trie
+    #[debug_requires(path.iter().all(|b| *b <= 0xf), "path must consist of nibbles")]
     pub fn remove(&self, path: &[u8]) -> Self {
         MerklePatriciaTrie(Node::<V, D, A>::remove(&self.0, path).0)
     }
@@ -229,6 +313,132 @@ impl<V: Storable<D> + PartialOrd, D: DB, A: Storable<D> + PartialOrd + Annotatio
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.0.partial_cmp(&other.0)
+    }
+}
+
+/// Selects the family of tries produced by [`MerklePatriciaTrie`]'s
+/// [`proptest::arbitrary::Arbitrary`] implementation.
+#[cfg(feature = "proptest")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TrieGeneration {
+    /// Canonical tries, built by inserting a generated list of entries
+    /// through the public API.
+    #[default]
+    Canonical,
+    /// Arbitrary wire-representable structures, including non-canonical
+    /// ones, with occasionally corrupted annotations. These are suitable for
+    /// testing the deserialization barrier, which should reject exactly the
+    /// non-canonical ones.
+    Raw,
+}
+
+/// Arbitrary wire-representable node structures: extension paths always fit
+/// the `u8` length prefix and consist of nibbles (other shapes cannot arrive
+/// via deserialization at all), but no structural invariants are respected,
+/// and annotations, while usually correct, are occasionally corrupted
+/// through [`HasSize::set_size`].
+#[cfg(feature = "proptest")]
+fn arb_raw_node<V, D, A>() -> impl proptest::strategy::Strategy<Value = Node<V, D, A>>
+where
+    V: Storable<D> + proptest::arbitrary::Arbitrary,
+    D: DB,
+    A: Storable<D> + Annotation<V>,
+{
+    use proptest::prelude::*;
+
+    fn corrupt<A: HasSize>(ann: A, corruption: Option<u64>) -> A {
+        match corruption {
+            None => ann,
+            Some(x) => ann.set_size(ann.get_size() ^ (1 + (x % 255))),
+        }
+    }
+
+    fn arb_corruption() -> impl Strategy<Value = Option<u64>> {
+        prop_oneof![
+            6 => Just(None),
+            1 => proptest::prelude::any::<u64>().prop_map(Some),
+        ]
+    }
+
+    // Extension paths biased towards the interesting boundaries: empty, and
+    // the 255-nibble maximum.
+    fn arb_ext_path() -> impl Strategy<Value = std::vec::Vec<u8>> {
+        prop_oneof![
+            1 => Just(std::vec::Vec::new()),
+            5 => proptest::collection::vec(0u8..16, 1..6),
+            1 => proptest::collection::vec(0u8..16, 250..=255usize),
+        ]
+    }
+
+    let leaf = (any::<V>(), arb_corruption()).prop_map(|(value, corruption)| Node::Leaf {
+        ann: corrupt(A::from_value(&value), corruption),
+        value: Sp::new(value),
+    });
+    prop_oneof![1 => Just(Node::Empty), 2 => leaf].prop_recursive(4, 24, 8, |inner| {
+        let branch = (proptest::collection::vec(inner.clone(), 16), arb_corruption()).prop_map(
+            |(children, corruption)| {
+                let children: Box<[Sp<Node<V, D, A>, D>; 16]> =
+                    Box::new(core::array::from_fn(|i| Sp::new(children[i].clone())));
+                let ann = children
+                    .iter()
+                    .fold(A::empty(), |acc, child| acc.append(&Node::ann(child)));
+                Node::Branch {
+                    ann: corrupt(ann, corruption),
+                    children,
+                }
+            },
+        );
+        let ext = (arb_ext_path(), inner.clone(), arb_corruption()).prop_map(
+            |(compressed_path, child, corruption)| {
+                let child = Sp::new(child);
+                Node::Extension {
+                    ann: corrupt(Node::ann(&child), corruption),
+                    compressed_path,
+                    child,
+                }
+            },
+        );
+        let mbl = (any::<V>(), inner, arb_corruption()).prop_map(|(value, child, corruption)| {
+            let child = Sp::new(child);
+            Node::MidBranchLeaf {
+                ann: corrupt(Node::ann(&child).append(&A::from_value(&value)), corruption),
+                value: Sp::new(value),
+                child,
+            }
+        });
+        prop_oneof![branch, ext, mbl]
+    })
+}
+
+#[cfg(feature = "proptest")]
+impl<V: Storable<D> + proptest::arbitrary::Arbitrary, D: DB, A: Storable<D> + Annotation<V>>
+    proptest::arbitrary::Arbitrary for MerklePatriciaTrie<V, D, A>
+{
+    type Strategy = proptest::strategy::BoxedStrategy<Self>;
+    type Parameters = TrieGeneration;
+
+    fn arbitrary_with(generation: Self::Parameters) -> Self::Strategy {
+        use proptest::prelude::*;
+        // Unlike most storage types, these strategies shrink: canonical
+        // tries shrink through their generating insertion list, raw ones
+        // towards smaller and shallower shapes.
+        match generation {
+            TrieGeneration::Canonical => proptest::collection::vec(
+                (proptest::collection::vec(0u8..16, 0..64), any::<V>()),
+                0..32,
+            )
+            .prop_map(|pairs| {
+                pairs
+                    .into_iter()
+                    .fold(MerklePatriciaTrie::new(), |trie, (path, value)| {
+                        trie.insert(&path, value)
+                    })
+            })
+            .boxed(),
+            TrieGeneration::Raw => arb_raw_node()
+                .prop_map(|node| MerklePatriciaTrie(Sp::new(node)))
+                .boxed(),
+        }
     }
 }
 
@@ -1677,58 +1887,313 @@ mod tests {
         validate_long_path(&deserialized_mpt, 300, 100);
     }
 
-    #[test]
-    fn extended_path_insertion() {
-        let mut mpt = MerklePatriciaTrie::<u32>::new();
-        mpt = mpt.insert(&([1, 2]), 12);
-        mpt = mpt.insert(&([1, 2, 3, 4, 5]), 12345);
-        mpt = mpt.insert(&([1, 2, 3, 4, 6]), 12346);
-        mpt = mpt.insert(&([1, 2, 3, 5, 6]), 12356);
-        mpt = mpt.insert(&([1]), 1);
+}
 
-        // Make sure we can look up specific values
-        assert_eq!(mpt.lookup(&([1, 2])), Some(&12));
-        assert_eq!(mpt.lookup(&([1, 2, 3, 4, 5])), Some(&12345));
-        assert_eq!(mpt.lookup(&([1, 2, 3, 5, 6])), Some(&12356));
-        assert_eq!(mpt.lookup(&([1])), Some(&1));
+// The generator (`TrieGeneration`/`arb_raw_node`) and the `canonicity()` oracle
+// live in the module above. These properties assert that the deserialization
+// barrier accepts exactly the canonical tries.
+#[cfg(all(test, feature = "proptest"))]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+    use serialize::{Deserializable, Serializable};
+    use std::vec::Vec;
 
-        // and make sure we get none for things not in the tree
-        assert_eq!(mpt.lookup(&([4])), None);
-        assert_eq!(mpt.lookup(&([1, 2, 4])), None);
-        // In particular, 123 ends at a *branch*, which used to panic because branch assumed path was non-empty
-        assert_eq!(mpt.lookup(&([1, 2, 3])), None);
-        assert_eq!(mpt.lookup(&([1, 2, 3, 6])), None);
-        // in particular, this test case used to panic with an out of bounds error because the path is empty
-        assert_eq!(mpt.lookup(&([])), None);
+    type Trie = MerklePatriciaTrie<u32>;
+    type TrieA<A> = MerklePatriciaTrie<u32, DefaultDB, A>;
 
-        // Finally, make sure we can print the tree, which will force a traversal of the whole tree
-        println!("{:?}", mpt);
+    /// A value-bearing annotation: tracks both the leaf count and the sum of
+    /// the `u32` values, so that the annotation properties also exercise a
+    /// component the size-based node checks cannot see.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serializable, Storable)]
+    #[tag = "mpt-proptest-sum-ann"]
+    #[storable(base)]
+    struct SumAnn {
+        size: u64,
+        sum: u64,
     }
 
-    #[test]
-    fn test_canonicity() {
-        let segment1 = [0u8; 200];
-        let segment2 = [1u8; 200];
-        let path1 = segment1
-            .iter()
-            .chain(segment1.iter())
-            .chain(segment1.iter())
-            .copied()
-            .collect::<Vec<_>>();
-        let path2 = segment1
-            .iter()
-            .chain(segment2.iter())
-            .chain(segment2.iter())
-            .copied()
-            .collect::<Vec<_>>();
+    impl Semigroup for SumAnn {
+        fn append(&self, other: &Self) -> Self {
+            SumAnn {
+                size: self.size + other.size,
+                sum: self.sum.wrapping_add(other.sum),
+            }
+        }
+    }
 
-        let mpt1 = MerklePatriciaTrie::<()>::new().insert(&path1, ());
-        let mpt2 = MerklePatriciaTrie::<()>::new()
-            .insert(&path2, ())
-            .insert(&path1, ())
-            .remove(&path2);
-        dbg!(&mpt1);
-        dbg!(&mpt2);
-        assert_eq!(mpt1.0.hash(), mpt2.0.hash());
+    impl Monoid for SumAnn {
+        fn empty() -> Self {
+            SumAnn { size: 0, sum: 0 }
+        }
+    }
+
+    impl HasSize for SumAnn {
+        fn get_size(&self) -> u64 {
+            self.size
+        }
+
+        fn set_size(&self, x: u64) -> Self {
+            SumAnn {
+                size: x,
+                sum: self.sum,
+            }
+        }
+    }
+
+    impl Annotation<u32> for SumAnn {
+        fn from_value(value: &u32) -> Self {
+            SumAnn {
+                size: 1,
+                sum: u64::from(*value),
+            }
+        }
+    }
+
+    fn round_trip<A: Storable<DefaultDB> + Annotation<u32>>(
+        trie: &TrieA<A>,
+    ) -> Result<TrieA<A>, std::io::Error> {
+        let mut bytes = Vec::new();
+        Serializable::serialize(trie, &mut bytes)?;
+        Deserializable::deserialize(&mut bytes.as_slice(), 0)
+    }
+
+    /// The deserialization barrier accepts exactly the canonical tries.
+    fn check_barrier_matches_canonicity<A: Storable<DefaultDB> + Annotation<u32>>(
+        trie: &TrieA<A>,
+    ) -> Result<(), TestCaseError> {
+        match (round_trip(trie), trie.canonicity()) {
+            (Ok(deserialized), Ok(())) => prop_assert_eq!(&deserialized, trie),
+            (Ok(_), Err(violation)) => {
+                return Err(TestCaseError::fail(format!(
+                    "non-canonical trie passed the deserialization barrier: {violation}"
+                )));
+            }
+            (Err(rejection), Ok(())) => {
+                return Err(TestCaseError::fail(format!(
+                    "canonical trie rejected by the deserialization barrier: {rejection}"
+                )));
+            }
+            (Err(_), Err(_)) => {}
+        }
+        Ok(())
+    }
+
+    proptest! {
+        // The deserialization barrier accepts exactly the canonical trees.
+        #[test]
+        fn barrier_accepts_exactly_canonical(trie in any_with::<Trie>(TrieGeneration::Raw)) {
+            check_barrier_matches_canonicity(&trie)?;
+        }
+
+        // The same barrier property with a value-bearing annotation, so the
+        // annotation invariant is exercised beyond what size-only annotations
+        // can distinguish.
+        #[test]
+        fn sum_ann_barrier_accepts_exactly_canonical(
+            trie in any_with::<TrieA<SumAnn>>(TrieGeneration::Raw),
+        ) {
+            check_barrier_matches_canonicity(&trie)?;
+        }
+    }
+}
+
+#[cfg(all(test, feature = "proptest"))]
+mod deser_robustness {
+    use super::*;
+    use proptest::prelude::*;
+    use serialize::{Deserializable, Serializable};
+    use std::vec::Vec;
+
+    type Trie = MerklePatriciaTrie<u32>;
+    type TrieNode = Node<u32, DefaultDB, SizeAnn>;
+
+    fn deserialize_trie(bytes: &[u8]) -> std::io::Result<Trie> {
+        <Trie as Deserializable>::deserialize(&mut { bytes }, 0)
+    }
+
+    fn serialize_trie(trie: &Trie) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        Serializable::serialize(trie, &mut bytes).expect("serialization must succeed");
+        bytes
+    }
+
+    /// Deserialization outcome for a byte slice, catching any panic so the
+    /// property can assert totality. Returns `Ok(())` if `deserialize` returned
+    /// (whether `Ok` or `Err`), and `Err(())` if it panicked.
+    fn deserialize_is_total(bytes: &[u8]) -> Result<(), ()> {
+        let owned = bytes.to_vec();
+        std::panic::catch_unwind(move || {
+            let _ = deserialize_trie(&owned);
+        })
+        .map_err(|_| ())
+    }
+
+    /// Assert the membership triangle on a trie the barrier accepted.
+    fn membership_is_consistent(trie: &Trie) -> Result<(), String> {
+        let entries: Vec<(Vec<u8>, u32)> =
+            trie.iter().map(|(path, value)| (path, *value)).collect();
+
+        if trie.size() != entries.len() {
+            return Err(format!(
+                "size() = {} but iter() yielded {} entries: {trie:?}",
+                trie.size(),
+                entries.len()
+            ));
+        }
+        if trie.is_empty() != entries.is_empty() {
+            return Err(format!("is_empty() disagrees with iter(): {trie:?}"));
+        }
+        // Every iterated entry is retrievable by its own key.
+        for (path, value) in entries.iter() {
+            if trie.lookup(path) != Some(value) {
+                return Err(format!(
+                    "lookup({path:?}) missed an entry iter() reported ({value}): {trie:?}"
+                ));
+            }
+            if trie.lookup_sp(path).map(|sp| *sp) != Some(*value) {
+                return Err(format!(
+                    "lookup_sp({path:?}) missed an entry iter() reported ({value}): {trie:?}"
+                ));
+            }
+        }
+        // No two iterated entries share a key (otherwise lookup() could not
+        // distinguish them).
+        let mut keys: Vec<&Vec<u8>> = entries.iter().map(|(p, _)| p).collect();
+        keys.sort();
+        let mut deduped = keys.clone();
+        deduped.dedup();
+        if keys.len() != deduped.len() {
+            return Err(format!("iter() yielded duplicate keys: {trie:?}"));
+        }
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(4096))]
+
+        /// (A1) Deserializing arbitrary random bytes never panics.
+        #[test]
+        fn deserialize_random_bytes_never_panics(
+            bytes in proptest::collection::vec(any::<u8>(), 0..256),
+        ) {
+            prop_assert!(deserialize_is_total(&bytes).is_ok(), "panicked on random bytes");
+        }
+
+        /// (A2) For any trie the barrier accepts (round-trips), the membership
+        /// views agree. Gated on `canonicity()`, which is the invariant a
+        /// correct barrier should enforce -- this is the positive property and
+        /// must always hold.
+        #[test]
+        fn canonical_trie_membership_is_consistent(raw in any_with::<Trie>(TrieGeneration::Raw)) {
+            // Only canonical tries are checked; non-canonical ones pass
+            // vacuously (the barrier rejects them).
+            if raw.canonicity().is_ok() {
+                if let Err(msg) = membership_is_consistent(&raw) {
+                    return Err(TestCaseError::fail(msg));
+                }
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2048))]
+
+        /// (A1) Bit-flipping a valid encoding must never make deserialization
+        /// panic.
+        ///
+        /// Regression guard: a corrupted `Node::Extension` length prefix used
+        /// to drive `expand_nibbles` to index past the compressed-path bytes
+        /// and panic; the disc-3 arm now rejects a compressed path whose length
+        /// disagrees with the nibble count before `expand_nibbles` runs.
+        #[test]
+        fn deserialize_bitflipped_encoding_never_panics(
+            trie in any_with::<Trie>(TrieGeneration::Raw),
+            flips in proptest::collection::vec((any::<prop::sample::Index>(), 1u8..), 1..8),
+        ) {
+            let mut bytes = serialize_trie(&trie);
+            prop_assume!(!bytes.is_empty());
+            for (idx, mask) in flips {
+                let pos = idx.index(bytes.len());
+                bytes[pos] ^= mask;
+            }
+            prop_assert!(deserialize_is_total(&bytes).is_ok(), "panicked on bit-flipped encoding");
+        }
+
+        /// (A1) Truncating a valid encoding at any point must never make
+        /// deserialization panic. This holds on the current base (a truncation
+        /// that drops compressed-path bytes fails the inner `Vec<u8>` decode
+        /// before `expand_nibbles` runs), so it is an active property.
+        #[test]
+        fn deserialize_truncated_encoding_never_panics(
+            trie in any_with::<Trie>(TrieGeneration::Raw),
+            cut in any::<prop::sample::Index>(),
+        ) {
+            let bytes = serialize_trie(&trie);
+            prop_assume!(!bytes.is_empty());
+            let end = cut.index(bytes.len());
+            prop_assert!(deserialize_is_total(&bytes[..end]).is_ok(), "panicked on truncated encoding");
+        }
+
+        /// (A2) For any trie the *deserialization barrier* accepts (not merely
+        /// the canonical ones), membership must be consistent: a non-canonical
+        /// shape (e.g. `MidBranchLeaf` with a `Leaf` child) would otherwise
+        /// have two entries at one key. The barrier now rejects such shapes, so
+        /// every accepted trie is canonical and membership holds.
+        #[test]
+        fn accepted_trie_membership_is_consistent(raw in any_with::<Trie>(TrieGeneration::Raw)) {
+            let bytes = serialize_trie(&raw);
+            let trie = match deserialize_trie(&bytes) {
+                Ok(trie) => trie,
+                Err(_) => return Ok(()),
+            };
+            if let Err(msg) = membership_is_consistent(&trie) {
+                return Err(TestCaseError::fail(msg));
+            }
+        }
+    }
+
+    // --- Regression tests: minimized findings, pinning correct behavior. ---
+
+    /// Deserializing an empty buffer is a clean `Err`, not a panic.
+    #[test]
+    fn empty_buffer_is_rejected() {
+        assert!(deserialize_trie(&[]).is_err());
+    }
+
+    /// Positive control for (A2): a canonical trie's membership triangle holds.
+    #[test]
+    fn canonical_round_trip_membership_holds() {
+        let trie = Trie::new()
+            .insert(&[1, 2, 3], 100)
+            .insert(&[1, 2, 4], 104)
+            .insert(&[2, 2, 4], 105);
+        let decoded = deserialize_trie(&serialize_trie(&trie)).expect("must round-trip");
+        membership_is_consistent(&decoded).expect("canonical membership must be consistent");
+    }
+
+    /// A `MidBranchLeaf` whose child is a `Leaf` would, if accepted, report two
+    /// entries at the *same* key (the empty path) via `iter()`/`size()` while
+    /// `lookup()` retrieves only one. The barrier must reject it (or, failing
+    /// that, its membership must be consistent); it now rejects it.
+    #[test]
+    fn regression_midbranchleaf_with_leaf_child_membership() {
+        let node: TrieNode = Node::MidBranchLeaf {
+            ann: SizeAnn(2),
+            value: Sp::new(1u32),
+            child: Sp::new(Node::Leaf {
+                ann: SizeAnn(1),
+                value: Sp::new(2u32),
+            }),
+        };
+        let trie = MerklePatriciaTrie(Sp::new(node));
+        let decoded = match deserialize_trie(&serialize_trie(&trie)) {
+            // If a future fix rejects it at the barrier, the property is
+            // vacuously satisfied.
+            Err(_) => return,
+            Ok(trie) => trie,
+        };
+        membership_is_consistent(&decoded)
+            .expect("an accepted trie must have consistent membership");
     }
 }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -2300,3 +2300,168 @@ mod tests {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area E: decode-path (untrusted) invariants for `MultiSet` and
+// `TimeFilterMap`.
+//
+// Both types are `#[derive(Storable)]` and are decoded from user-controlled
+// bytes through `Arena::deserialize_sp` (storage-core/src/arena.rs:827), whose
+// own doc-comment calls it "a boundary for user controlled input ... we need
+// to be careful here to gracefully handle malformed (or even maliciously
+// formed?) input". The derived `Storable::from_binary_repr` merely
+// reconstructs the fields; it performs NONE of the cross-field/count checks
+// the public constructors maintain. Concretely:
+//
+//   * `MultiSet` (storage.rs:873) keeps its backing `HashMap<V, u32>` free of
+//     zero-count entries: `insert` only ever stores `>= 1`, and `remove_n`
+//     deletes the key once the count hits 0 (storage.rs:916). Its query
+//     methods rely on this: `member` = `contains_key` (storage.rs:948) while
+//     `count` = stored value or 0 (storage.rs:929). A decoded map holding a
+//     `(v, 0)` entry makes `member(v) == true` while `count(v) == 0`, so the
+//     two disagree (a normally-constructed set guarantees `member(v)` iff
+//     `count(v) > 0`).
+//
+//   * `TimeFilterMap` (storage.rs:1085) maintains `set` as exactly the
+//     flattened multiset of every item across `time_map`'s containers (see
+//     `insert`/`upsert`/`filter`, which mutate both fields in lock-step).
+//     `contains` answers purely from `set` (storage.rs:1207) while `get`
+//     answers from `time_map` (storage.rs:1148). A decoded value whose `set`
+//     mentions an item absent from every `time_map` container makes
+//     `contains(v) == true` even though no `get(..)` can ever surface `v`.
+//
+// These modules need `public-internal-structure` to *construct* the malformed
+// value (to reach the private fields), then round-trip it through the real
+// untrusted decode path (`Sp::serialize` -> `Sp::deserialize`, the latter
+// delegating to `Arena::deserialize_sp`). The decode faithfully reproduces the
+// invariant-violating value, i.e. it neither rejects nor normalizes it.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest", feature = "public-internal-structure"))]
+mod decode_invariant_props {
+    use super::*;
+    use crate::arena::Sp;
+    use base_crypto::time::Timestamp;
+    use proptest::prelude::*;
+
+    /// Round-trip a `Storable` value through the untrusted decode boundary
+    /// (`Sp::deserialize` -> `Arena::deserialize_sp`).
+    fn decode_roundtrip<T: Storable<DefaultDB> + Clone>(value: T) -> T {
+        let sp = Sp::<T, DefaultDB>::new(value);
+        let mut bytes = Vec::new();
+        Sp::serialize(&sp, &mut bytes).unwrap();
+        let decoded = Sp::<T, DefaultDB>::deserialize(&mut &bytes[..], 0)
+            .expect("untrusted decode must succeed on a serialized value");
+        (*decoded).clone()
+    }
+
+    /// Whether the untrusted decode boundary REJECTS a serialized value (its
+    /// `do_check` / `invariant` fires).
+    fn decode_rejected<T: Storable<DefaultDB> + Clone>(value: T) -> bool {
+        let sp = Sp::<T, DefaultDB>::new(value);
+        let mut bytes = Vec::new();
+        Sp::serialize(&sp, &mut bytes).unwrap();
+        Sp::<T, DefaultDB>::deserialize(&mut &bytes[..], 0).is_err()
+    }
+
+    // ---- MultiSet ------------------------------------------------------
+
+    /// Build a *malformed* `MultiSet<u8>` holding a single zero-count entry by
+    /// reaching the (feature-exposed) backing map directly.
+    fn multiset_with_zero_count(elem: u8) -> MultiSet<u8, DefaultDB> {
+        let elements = HashMap::<u8, u32>::new().insert(elem, 0u32);
+        MultiSet { elements }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        // (E-holds) A *well-formed* MultiSet (built only via `insert`) decodes
+        // back to a value that still satisfies `member(v) <=> count(v) > 0` and
+        // has no zero-count entries. HOLDS — the decode is faithful for good
+        // inputs; the problem is purely the lack of validation for bad ones.
+        #[test]
+        fn wellformed_multiset_decode_preserves_invariants(items in prop::collection::vec(any::<u8>(), 0..16)) {
+            let mut ms = MultiSet::<u8, DefaultDB>::new();
+            for it in &items {
+                ms = ms.insert(*it);
+            }
+            let decoded = decode_roundtrip(ms.clone());
+            for it in &items {
+                prop_assert_eq!(decoded.member(it), decoded.count(it) > 0);
+                prop_assert_eq!(decoded.count(it), ms.count(it));
+            }
+        }
+    }
+
+    /// A `MultiSet` carrying a zero-count entry (`member(v)` true but
+    /// `count(v) == 0`) is not producible by `insert`/`remove`; the untrusted
+    /// decoder must reject it via `MultiSet::invariant`. Path: `Sp::deserialize`
+    /// -> `Arena::deserialize_sp` (`do_check`).
+    #[test]
+    fn multiset_decode_rejects_zero_count_entries() {
+        let malformed = multiset_with_zero_count(0);
+        // Sanity: the in-memory value violates the invariant pre-decode.
+        assert!(malformed.member(&0) && malformed.count(&0) == 0);
+        assert!(
+            decode_rejected(malformed),
+            "decode must reject a MultiSet with a zero-count entry"
+        );
+    }
+
+    // ---- TimeFilterMap -------------------------------------------------
+
+    type C = Identity<u8>;
+
+    /// Build a *malformed* `TimeFilterMap` whose flattened `set` claims an item
+    /// that appears in no `time_map` container (an empty `time_map`).
+    fn tfm_set_disagrees_with_time_map(elem: u8) -> TimeFilterMap<C, DefaultDB> {
+        let set = MultiSet::<u8, DefaultDB>::new().insert(elem);
+        let time_map: Map<BigEndianU64, C, DefaultDB> = Map::new();
+        TimeFilterMap { time_map, set }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        // (E-holds) A well-formed TimeFilterMap (built via `insert`) decodes to
+        // a value whose `contains` still agrees with `get`. HOLDS.
+        #[test]
+        fn wellformed_tfm_decode_preserves_invariants(entries in prop::collection::vec((0u64..64, any::<u8>()), 0..12)) {
+            let mut tfm = TimeFilterMap::<C, DefaultDB>::new();
+            for (ts, v) in &entries {
+                tfm = tfm.insert(Timestamp::from_secs(*ts), *v);
+            }
+            let decoded = decode_roundtrip(tfm);
+            // Every item reported by `contains` must be surfaceable via some
+            // `get` (the last-inserted value at each timestamp).
+            for (ts, v) in &entries {
+                // The item inserted at `ts` is contained...
+                let ts = Timestamp::from_secs(*ts);
+                if let Some(container) = decoded.get(ts) {
+                    // ...and `get` returns a container; at minimum `contains`
+                    // must be consistent for whatever `get` surfaces.
+                    for item in <C as Container<DefaultDB>>::iter_items(container.clone()) {
+                        prop_assert!(decoded.contains(&item));
+                    }
+                }
+                let _ = v;
+            }
+        }
+    }
+
+    /// A `TimeFilterMap` whose `set` mentions an item absent from every
+    /// `time_map` container (`contains(v)` true but `get(..)` empty) is not
+    /// producible by the public API; the decoder must reject it via
+    /// `TimeFilterMap::invariant` (`set` must equal the flattening of `time_map`).
+    #[test]
+    fn tfm_decode_rejects_set_time_map_disagreement() {
+        let malformed = tfm_set_disagrees_with_time_map(0);
+        // Sanity: the in-memory value already violates the invariant.
+        assert!(malformed.contains(&0));
+        assert!(malformed.get(Timestamp::MAX).is_none());
+        assert!(
+            decode_rejected(malformed),
+            "decode must reject a TimeFilterMap whose set disagrees with time_map"
+        );
+    }
+}

--- a/storage/tests/canonicality_regression.rs
+++ b/storage/tests/canonicality_regression.rs
@@ -1,0 +1,241 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Named regression tests for the specific non-canonical MPT encodings the
+//! untrusted deserializer (`Arena::deserialize_sp`) must reject.
+//!
+//! Each test builds one concrete non-canonical encoding of a container and
+//! asserts the single correct behaviour: the untrusted deserializer REJECTS it.
+//! The general fuzz oracles for this class live in `prop_structural.rs`; this
+//! file pins the individual known vectors with descriptive names and documents,
+//! in each test, the concrete damage the vector causes if it is *not* rejected.
+
+#![cfg(feature = "public-internal-structure")]
+
+use midnight_storage::arena::{Arena, Sp};
+use midnight_storage::merkle_patricia_trie::{Annotation, MerklePatriciaTrie, Node};
+use midnight_storage::storable::SizeAnn;
+use midnight_storage::storage::{Array, HashMap as StoreHashMap, Map};
+use midnight_storage::{DefaultDB, Storable, Storage};
+use serialize::Serializable;
+use std::marker::PhantomData;
+use std::ops::Deref;
+
+type D = DefaultDB;
+
+fn arena() -> Arena<D> {
+    Storage::<D>::new(64, D::default()).arena
+}
+
+fn ser_sp<T: Storable<D>>(v: T) -> Vec<u8> {
+    let mut b = Vec::new();
+    Sp::serialize(&Sp::new(v), &mut b).expect("serialize");
+    b
+}
+
+/// The shared oracle for this file: a crafted non-canonical encoding must be a
+/// genuinely distinct wire form, the canonical form must still deserialize, and
+/// the untrusted deserializer must REJECT the non-canonical form.
+fn assert_rejected<T: Storable<D> + Clone>(canonical: T, noncanonical: T, what: &str) {
+    let a = arena();
+    let canon_bytes = ser_sp(canonical);
+    let noncanon_bytes = ser_sp(noncanonical);
+    assert_ne!(
+        canon_bytes, noncanon_bytes,
+        "{what}: the crafted encoding must be a genuinely distinct wire form"
+    );
+    assert!(
+        a.deserialize_sp::<T, _>(&mut &canon_bytes[..], 0).is_ok(),
+        "{what}: the canonical encoding must still deserialize"
+    );
+    assert!(
+        a.deserialize_sp::<T, _>(&mut &noncanon_bytes[..], 0).is_err(),
+        "{what}: the untrusted deserializer must REJECT the non-canonical encoding"
+    );
+}
+
+/// Wrap a trie root in an empty-path `Extension` carrying the correct
+/// (subtree-size) annotation -- a distinct encoding of the same logical trie
+/// that the public builder never emits. Sound (passes `check_invariant`) but
+/// non-canonical.
+fn wrap_empty_extension<V, A>(
+    mpt: &MerklePatriciaTrie<V, D, A>,
+    size: u64,
+) -> MerklePatriciaTrie<V, D, A>
+where
+    V: Storable<D>,
+    A: Storable<D> + Annotation<V>,
+    SizeAnn: Into<A>,
+{
+    let wrapped = Node::Extension {
+        ann: SizeAnn(size).into(),
+        compressed_path: Vec::new(),
+        child: mpt.0.clone(),
+    };
+    MerklePatriciaTrie(Sp::new(wrapped))
+}
+
+/// An all-empty `Branch` root: a logically-empty trie whose root is not `Empty`.
+/// Violates the ">= 2 non-empty children" rule.
+fn all_empty_branch_root() -> Sp<MerklePatriciaTrie<u64>> {
+    let children: Box<[Sp<Node<u64>>; 16]> = Box::new(std::array::from_fn(|_| Sp::new(Node::Empty)));
+    Sp::new(MerklePatriciaTrie(Sp::new(Node::Branch {
+        ann: SizeAnn(0),
+        children,
+    })))
+}
+
+/// Canonical nibble path for a key, mirroring the crate-private `to_nibbles`.
+fn nibbles_of<T: Serializable>(v: &T) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    v.serialize(&mut bytes).unwrap();
+    let mut n = Vec::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        n.push(b >> 4);
+        n.push(b & 0x0f);
+    }
+    n
+}
+
+// ===========================================================================
+// Sound-but-non-canonical SHAPE: empty-path `Extension` wrap.
+//
+// If accepted, a container has >= 2 distinct wire encodings of one logical
+// value. That breaks content-addressing: structural equality and `Hash` differ
+// for logically-identical containers (defeating dedup / set-membership), and it
+// is the substrate for transaction-hash malleability.
+// ===========================================================================
+#[test]
+fn empty_path_extension_rejected_mpt() {
+    let mut canon: MerklePatriciaTrie<u64> = MerklePatriciaTrie::new();
+    for k in 0u8..6 {
+        canon = canon.insert(&[k, k + 1, k + 2], k as u64 * 10);
+    }
+    let size = canon.size() as u64;
+    let wrapped = wrap_empty_extension(&canon, size);
+    assert_rejected(canon, wrapped, "MPT empty-path Extension wrap");
+}
+
+#[test]
+fn empty_path_extension_rejected_map() {
+    let mut canon: Map<u16, u64> = Map::new();
+    for k in 0u16..6 {
+        canon = canon.insert(k, k as u64 * 7);
+    }
+    let wrapped_mpt = wrap_empty_extension(&canon.mpt, canon.size() as u64);
+    let wrapped: Map<u16, u64> = Map {
+        mpt: Sp::new(wrapped_mpt),
+        key_type: PhantomData,
+    };
+    assert_rejected(canon, wrapped, "Map empty-path Extension wrap");
+}
+
+#[test]
+fn empty_path_extension_rejected_hashmap() {
+    let mut canon: StoreHashMap<u16, u64> = StoreHashMap::new();
+    for k in 0u16..6 {
+        canon = canon.insert(k, k as u64 * 13);
+    }
+    // HashMap wraps an inner `Map<ArenaHash, (Sp<K>, Sp<V>)>`; wrap that map's root.
+    let wrapped_mpt = wrap_empty_extension(&canon.0.mpt, canon.size() as u64);
+    let wrapped: StoreHashMap<u16, u64> = StoreHashMap(Map {
+        mpt: Sp::new(wrapped_mpt),
+        key_type: PhantomData,
+    });
+    assert_rejected(canon, wrapped, "HashMap empty-path Extension wrap");
+}
+
+// ===========================================================================
+// Rule-violating SHAPE: all-empty `Branch` root.
+//
+// If accepted, a logically-empty container reports `is_empty() == false` while
+// `size() == 0`, and compares `!= Map::new()`. The codebase's emptiness idioms
+// (`!container.is_empty()`, `container != X::new()`) then disagree with `size()`
+// and reach the wrong conclusion (e.g. the `DustActions` "empty" guard).
+// ===========================================================================
+#[test]
+fn all_empty_branch_root_rejected_map() {
+    let canon: Map<u16, u64> = Map::new();
+    let fake_empty: Map<u16, u64> = Map {
+        mpt: all_empty_branch_root(),
+        key_type: PhantomData,
+    };
+    assert_rejected(canon, fake_empty, "Map all-empty Branch root");
+}
+
+#[test]
+fn all_empty_branch_root_rejected_array() {
+    let canon: Array<u64> = Array::new();
+    let fake_empty: Array<u64> = Array(all_empty_branch_root());
+    assert_rejected(canon, fake_empty, "Array all-empty Branch root");
+}
+
+// ===========================================================================
+// NON-INJECTIVE KEYS: a key's canonical encoding followed by trailing
+// nibbles that fixed-width `from_nibbles` (`read_exact`) silently ignores.
+//
+// If accepted, one logical key is held twice: `size()`/`iter()` report two
+// entries while `get(k)` finds one, and re-collecting the entries (what
+// `Transaction::erase_proofs`/`erase_signatures` do via `.iter()...collect()`)
+// collapses the duplicate -- so the validated representation and the applied
+// representation disagree. This is the GHSA-vhp6-px6f-jv94 substrate.
+// ===========================================================================
+
+/// Build a `Map<u16,_>` holding a real entry for key `k` plus a second leaf at
+/// `canonical_path(k) ++ [0x00, 0x00]`, which fixed-width `from_nibbles::<u16>`
+/// decodes back to `k` (ignoring the trailing byte).
+fn map_with_over_long_key_leaf() -> Map<u16, u64> {
+    let p1 = nibbles_of(&1u16);
+    let mut p2 = p1.clone();
+    p2.extend_from_slice(&[0, 0]); // one extra (ignored) byte -> aliases key 1
+    let mut mpt = MerklePatriciaTrie::<u64>::new();
+    mpt = mpt.insert(&p1, 100);
+    mpt = mpt.insert(&p2, 200);
+    Map {
+        mpt: Sp::new(mpt),
+        key_type: PhantomData,
+    }
+}
+
+#[test]
+fn over_long_key_path_rejected_map() {
+    let canon: Map<u16, u64> = Map::new().insert(1u16, 100);
+    let aliased = map_with_over_long_key_leaf();
+    assert_rejected(canon, aliased, "Map over-long (aliasing) key path");
+}
+
+#[test]
+fn over_long_key_path_rejected_hashmap() {
+    // `HashMap<u16,_>` is the type of `StandardTransaction.intents`.
+    let canon: StoreHashMap<u16, u64> = StoreHashMap::new().insert(1, 100);
+
+    // Canonical inner path of the single leaf (over the ArenaHash key).
+    let (p, existing) = canon
+        .0
+        .mpt
+        .iter()
+        .next()
+        .map(|(p, v)| (p, (*v).clone()))
+        .expect("one leaf");
+    let mut p2 = p.clone();
+    p2.extend_from_slice(&[0, 0]); // extra byte ignored by ArenaHash's read_exact
+
+    // Second leaf carrying key 1 again with a different value.
+    let dup_value = (existing.0.clone(), Sp::new(200u64));
+    let aliased_inner = canon.0.mpt.deref().insert(&p2, dup_value);
+    let aliased: StoreHashMap<u16, u64> = StoreHashMap(Map {
+        mpt: Sp::new(aliased_inner),
+        key_type: PhantomData,
+    });
+    assert_rejected(canon, aliased, "HashMap over-long (aliasing) key path");
+}

--- a/storage/tests/prop_semantics.rs
+++ b/storage/tests/prop_semantics.rs
@@ -1,0 +1,528 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Clean-room property / randomized tests for the storage containers.
+//!
+//! These are *semantic* property tests, derived from the contracts the code
+//! states about itself, not from serialize->deserialize byte round-trips:
+//!
+//!  * `Map` must behave as a dictionary (model-checked against a reference
+//!    `BTreeMap`) -- its own doc-comments promise `get`/`insert`/`remove`/
+//!    `size`/`contains_key` semantics with specific complexities.
+//!  * `Array` must behave as a dense vector (model-checked against `Vec`); its
+//!    own `invariant()` asserts every stored index is `< len`, and the docs say
+//!    "elements are stored at indices `0..len()`".
+//!  * The trie is *content addressed*: the representation of a map must depend
+//!    only on its logical contents, never on the insertion/removal history.
+//!    Two maps with equal contents must serialize identically (canonical form).
+//!  * A value built through the public API must survive a round trip through the
+//!    *untrusted-input* loader, `Arena::deserialize_sp`, which enforces both
+//!    `check_invariant` (`Loader::CHECK_INVARIANTS == true`) and the storage
+//!    "normal form" check. If the API can build something the loader rejects,
+//!    the API and the loader disagree on well-formedness.
+//!  * `Arena::deserialize_sp` documents itself as "a boundary for user
+//!    controlled input ... we need to be careful here to gracefully handle
+//!    malformed (or even maliciously formed?) input" -- so it must never panic
+//!    on arbitrary bytes.
+//!
+//! Randomness is a small self-contained SplitMix64 PRNG seeded deterministically
+//! so every failure is reproducible from its seed.
+
+use midnight_storage::arena::Sp;
+use midnight_storage::storage::{Array, Map};
+use midnight_storage::{DefaultDB, Storage};
+use serialize::Serializable;
+use std::collections::BTreeMap;
+
+// ---------------------------------------------------------------------------
+// Tiny deterministic PRNG (SplitMix64). Avoids any dependency on rand's
+// distributions so the tests are fully self-contained and reproducible.
+// ---------------------------------------------------------------------------
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed.wrapping_add(0x9E37_79B9_7F4A_7C15))
+    }
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    /// Uniform in `0..n` (n > 0).
+    fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+    fn bool(&mut self) -> bool {
+        self.next_u64() & 1 == 0
+    }
+    /// A key drawn from a deliberately mixed distribution: often small (so keys
+    /// share long common prefixes and force Extension / Branch / MidBranchLeaf
+    /// nodes to appear), occasionally full-range.
+    fn key(&mut self, small_space: u64) -> u64 {
+        if self.bool() {
+            self.below(small_space)
+        } else {
+            self.next_u64()
+        }
+    }
+}
+
+fn fresh_arena() -> midnight_storage::arena::Arena<DefaultDB> {
+    Storage::<DefaultDB>::new(64, DefaultDB::default()).arena
+}
+
+// ---------------------------------------------------------------------------
+// Property 1: `Map` is a faithful dictionary (model-based oracle).
+// ---------------------------------------------------------------------------
+#[test]
+fn prop_map_behaves_as_dictionary() {
+    for seed in 0..48u64 {
+        let mut rng = Rng::new(seed.wrapping_mul(0xD1B5_4A32_D192_ED03));
+        // Vary the key space per seed so some runs are collision-heavy and
+        // some are sparse.
+        let small_space = 1 + (seed % 6) * 4; // 1,5,9,...
+        let mut model: BTreeMap<u64, u64> = BTreeMap::new();
+        let mut map: Map<u64, u64> = Map::new();
+        let mut touched: Vec<u64> = Vec::new();
+
+        for _ in 0..250 {
+            match rng.below(3) {
+                0 | 1 => {
+                    // insert (may overwrite)
+                    let k = rng.key(small_space.max(1));
+                    let v = rng.next_u64();
+                    map = map.insert(k, v);
+                    model.insert(k, v);
+                    if !touched.contains(&k) {
+                        touched.push(k);
+                    }
+                }
+                _ => {
+                    // remove: bias towards removing something that exists
+                    let k = if !model.is_empty() && rng.bool() {
+                        *model.keys().nth((rng.below(model.len() as u64)) as usize).unwrap()
+                    } else {
+                        rng.key(small_space.max(1))
+                    };
+                    map = map.remove(&k);
+                    model.remove(&k);
+                    if !touched.contains(&k) {
+                        touched.push(k);
+                    }
+                }
+            }
+
+            // Structural agreement.
+            assert_eq!(
+                map.size(),
+                model.len(),
+                "seed {seed}: size disagrees with model"
+            );
+            assert_eq!(
+                map.is_empty(),
+                model.is_empty(),
+                "seed {seed}: is_empty disagrees with model"
+            );
+
+            // Point-wise agreement on every key we've ever touched, plus a
+            // couple of never-touched keys (which must be absent).
+            for k in touched.iter().copied().chain([u64::MAX, small_space + 12345]) {
+                assert_eq!(
+                    map.get(&k).copied(),
+                    model.get(&k).copied(),
+                    "seed {seed}: get({k}) disagrees with model"
+                );
+                assert_eq!(
+                    map.contains_key(&k),
+                    model.contains_key(&k),
+                    "seed {seed}: contains_key({k}) disagrees with model"
+                );
+            }
+        }
+
+        // Whole-contents agreement, via the map's own iterator.
+        let from_iter: BTreeMap<u64, u64> = map.iter().map(|(k, v)| (k, *v)).collect();
+        assert_eq!(
+            from_iter, model,
+            "seed {seed}: iter() does not reproduce the logical contents"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 2: `Array` is a faithful dense vector (model-based oracle),
+// including the dense-index invariant it asserts about itself.
+// ---------------------------------------------------------------------------
+#[test]
+fn prop_array_behaves_as_vec() {
+    for seed in 0..48u64 {
+        let mut rng = Rng::new(seed.wrapping_mul(0x2545_F491_4F6C_DD1D) ^ 0xAAAA);
+        let mut model: Vec<u64> = Vec::new();
+        let mut arr: Array<u64> = Array::new();
+
+        for _ in 0..250 {
+            match rng.below(4) {
+                0 | 1 => {
+                    // push (grow by one)
+                    let v = rng.next_u64();
+                    arr = arr.push(v);
+                    model.push(v);
+                }
+                2 => {
+                    // in-bounds overwrite
+                    if model.is_empty() {
+                        continue;
+                    }
+                    let idx = rng.below(model.len() as u64) as usize;
+                    let v = rng.next_u64();
+                    arr = arr
+                        .insert(idx, v)
+                        .expect("insert at an in-bounds index must return Some");
+                    model[idx] = v;
+                }
+                _ => {
+                    // out-of-bounds overwrite must be rejected (returns None),
+                    // and must not change the array.
+                    let idx = model.len() + (rng.below(4) as usize);
+                    assert!(
+                        arr.insert(idx, 0xDEAD).is_none(),
+                        "seed {seed}: insert() at out-of-bounds index {idx} (len {}) must be None",
+                        model.len()
+                    );
+                }
+            }
+
+            assert_eq!(arr.len(), model.len(), "seed {seed}: len disagrees");
+            assert_eq!(arr.is_empty(), model.is_empty(), "seed {seed}: is_empty disagrees");
+            // Every in-bounds index must match; the one-past-the-end index must
+            // be None (dense, no holes past len).
+            for i in 0..model.len() {
+                assert_eq!(
+                    arr.get(i).copied(),
+                    Some(model[i]),
+                    "seed {seed}: get({i}) disagrees with model"
+                );
+            }
+            assert_eq!(
+                arr.get(model.len()),
+                None,
+                "seed {seed}: get(len) must be None"
+            );
+        }
+
+        // Iterator reproduces the vector exactly and in order.
+        let from_iter: Vec<u64> = arr.iter_deref().copied().collect();
+        assert_eq!(from_iter, model, "seed {seed}: iter_deref order/content mismatch");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 3: canonical (history-independent) representation.
+//
+// A content-addressed Merkle trie must serialize identically whenever the
+// logical contents are equal, regardless of the order of insertions/removals
+// used to reach that state. If not, two honest nodes computing the same map
+// could disagree on its hash/serialization -- a determinism/consensus hazard.
+// ---------------------------------------------------------------------------
+#[test]
+fn prop_map_representation_is_canonical() {
+    for seed in 0..40u64 {
+        let mut rng = Rng::new(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0x5151);
+        let small_space = 1 + (seed % 8) * 3;
+
+        // Decide the *target* logical contents.
+        let target_len = rng.below(40);
+        let mut target: BTreeMap<u64, u64> = BTreeMap::new();
+        for _ in 0..target_len {
+            let k = rng.key(small_space.max(1));
+            let v = rng.next_u64();
+            target.insert(k, v);
+        }
+
+        // Build A: insert target entries in one shuffled order.
+        let mut entries: Vec<(u64, u64)> = target.iter().map(|(k, v)| (*k, *v)).collect();
+        shuffle(&mut entries, &mut rng);
+        let mut map_a: Map<u64, u64> = Map::new();
+        for (k, v) in &entries {
+            map_a = map_a.insert(*k, *v);
+        }
+
+        // Build B: a *different* history reaching the same contents --
+        // different order, plus decoy keys that are later removed, plus
+        // overwrites of the final keys with junk before setting the real value.
+        shuffle(&mut entries, &mut rng);
+        let mut map_b: Map<u64, u64> = Map::new();
+        let mut decoys: Vec<u64> = Vec::new();
+        for (k, v) in &entries {
+            // overwrite-then-correct
+            map_b = map_b.insert(*k, rng.next_u64());
+            // sprinkle a decoy key that we'll delete later
+            if rng.bool() {
+                let d = rng.next_u64() | 1; // avoid clashing with small keys
+                if !target.contains_key(&d) {
+                    map_b = map_b.insert(d, rng.next_u64());
+                    decoys.push(d);
+                }
+            }
+            map_b = map_b.insert(*k, *v);
+        }
+        for d in &decoys {
+            map_b = map_b.remove(d);
+        }
+
+        // Sanity: same logical contents.
+        let contents_a: BTreeMap<u64, u64> = map_a.iter().map(|(k, v)| (k, *v)).collect();
+        let contents_b: BTreeMap<u64, u64> = map_b.iter().map(|(k, v)| (k, *v)).collect();
+        assert_eq!(contents_a, target, "seed {seed}: map_a contents wrong");
+        assert_eq!(contents_b, target, "seed {seed}: map_b contents wrong");
+
+        // The canonical-form oracle: identical serialization. `Sp::new`
+        // allocates against the default storage, which is where `Map::insert`
+        // built every internal node, so the whole sub-graph is reachable.
+        let sp_a = Sp::new(map_a);
+        let sp_b = Sp::new(map_b);
+        let mut buf_a = Vec::new();
+        let mut buf_b = Vec::new();
+        Sp::serialize(&sp_a, &mut buf_a).expect("serialize A");
+        Sp::serialize(&sp_b, &mut buf_b).expect("serialize B");
+        assert_eq!(
+            buf_a, buf_b,
+            "seed {seed}: two maps with identical contents serialized differently \
+             (non-canonical representation; contents={target:?})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 4: values built via the public API survive the untrusted-input
+// loader, which enforces `check_invariant` + storage normal form.
+// ---------------------------------------------------------------------------
+#[test]
+fn prop_api_built_map_reloads_under_checking_loader() {
+    for seed in 0..40u64 {
+        let mut rng = Rng::new(seed.wrapping_mul(0xC2B2_AE3D_27D4_EB4F) ^ 0x9999);
+        let small_space = 1 + (seed % 10) * 2;
+        let mut model: BTreeMap<u64, u64> = BTreeMap::new();
+        let mut map: Map<u64, u64> = Map::new();
+
+        for _ in 0..120 {
+            if model.is_empty() || rng.below(3) != 0 {
+                let k = rng.key(small_space.max(1));
+                let v = rng.next_u64();
+                map = map.insert(k, v);
+                model.insert(k, v);
+            } else {
+                let k = *model.keys().nth(rng.below(model.len() as u64) as usize).unwrap();
+                map = map.remove(&k);
+                model.remove(&k);
+            }
+        }
+
+        let sp = Sp::new(map);
+        let mut buf = Vec::new();
+        Sp::serialize(&sp, &mut buf).expect("serialize");
+
+        // A *fresh* arena rebuilds the value purely from the (self-contained)
+        // byte stream, exercising the invariant-checking loader from scratch.
+        let arena = fresh_arena();
+        let reloaded: Sp<Map<u64, u64>> = arena
+            .deserialize_sp(&mut &buf[..], 0)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "seed {seed}: API-built map REJECTED by the invariant-checking \
+                     loader (check_invariant or normal-form failure): {e}"
+                )
+            });
+
+        let reloaded_contents: BTreeMap<u64, u64> =
+            reloaded.iter().map(|(k, v)| (k, *v)).collect();
+        assert_eq!(
+            reloaded_contents, model,
+            "seed {seed}: reloaded map lost/altered contents"
+        );
+    }
+}
+
+#[test]
+fn prop_api_built_array_reloads_under_checking_loader() {
+    for seed in 0..40u64 {
+        let mut rng = Rng::new(seed.wrapping_mul(0x1656_67B1_9E37_79F9) ^ 0x4242);
+        let mut model: Vec<u64> = Vec::new();
+        let mut arr: Array<u64> = Array::new();
+        for _ in 0..120 {
+            if model.is_empty() || rng.below(3) != 0 {
+                let v = rng.next_u64();
+                arr = arr.push(v);
+                model.push(v);
+            } else {
+                let idx = rng.below(model.len() as u64) as usize;
+                let v = rng.next_u64();
+                arr = arr.insert(idx, v).unwrap();
+                model[idx] = v;
+            }
+        }
+
+        let sp = Sp::new(arr);
+        let mut buf = Vec::new();
+        Sp::serialize(&sp, &mut buf).expect("serialize");
+
+        let arena = fresh_arena();
+        let reloaded: Sp<Array<u64>> = arena
+            .deserialize_sp(&mut &buf[..], 0)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "seed {seed}: API-built array REJECTED by the invariant-checking \
+                     loader (check_invariant or normal-form failure): {e}"
+                )
+            });
+
+        let reloaded_contents: Vec<u64> = reloaded.iter_deref().copied().collect();
+        assert_eq!(
+            reloaded_contents, model,
+            "seed {seed}: reloaded array lost/altered contents"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 5: the untrusted-input deserialization boundary must never panic
+// on arbitrary / mutated bytes (its own doc comment promises graceful
+// handling of "malformed (or even maliciously formed?) input").
+// ---------------------------------------------------------------------------
+#[test]
+fn prop_deserialize_sp_never_panics_on_garbage() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    // Silence the noise of intentional panics during this test.
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+
+    // A valid serialization to use as a mutation base, so some inputs reach
+    // deep into the decoder rather than being rejected at the first byte.
+    let base = {
+        let mut m: Map<u64, u64> = Map::new();
+        for i in 0..20u64 {
+            m = m.insert(i, i.wrapping_mul(7));
+        }
+        let sp = Sp::new(m);
+        let mut buf = Vec::new();
+        Sp::serialize(&sp, &mut buf).unwrap();
+        buf
+    };
+
+    let mut rng = Rng::new(0xFEED_FACE_C0FF_EE00);
+    let mut failures: Vec<String> = Vec::new();
+
+    for i in 0..4000u64 {
+        // Three flavours of adversarial input.
+        let input: Vec<u8> = match i % 3 {
+            0 => {
+                // pure random bytes, random length up to 256
+                let len = rng.below(256) as usize;
+                (0..len).map(|_| rng.below(256) as u8).collect()
+            }
+            1 => {
+                // valid serialization with a handful of single-byte flips
+                let mut b = base.clone();
+                if !b.is_empty() {
+                    let flips = 1 + rng.below(6);
+                    for _ in 0..flips {
+                        let pos = rng.below(b.len() as u64) as usize;
+                        b[pos] = rng.below(256) as u8;
+                    }
+                }
+                b
+            }
+            _ => {
+                // valid serialization truncated at a random point
+                let cut = rng.below(base.len().max(1) as u64) as usize;
+                base[..cut].to_vec()
+            }
+        };
+
+        // Fresh arena per input: a panic must not be able to corrupt shared
+        // state and cascade into later iterations.
+        //
+        // "Did not panic" is only the floor. The stronger property: for every
+        // input the loader ACCEPTS (returns Ok), the resulting value must still
+        // satisfy the map's full semantic invariants -- otherwise malformed
+        // bytes have produced a "valid" value that flows downstream. So inside
+        // the guarded closure we run the same size- and canonicality-oracles we
+        // use on the honest path, and surface any violation.
+        let arena = fresh_arena();
+        let res: Result<Option<String>, _> = catch_unwind(AssertUnwindSafe(|| {
+            match arena.deserialize_sp::<Map<u64, u64>, _>(&mut &input[..], 0) {
+                Err(_) => None, // gracefully rejected -- fine
+                Ok(map) => {
+                    // (S) the reported size must equal the true entry count.
+                    let count = map.iter().count();
+                    if map.size() != count {
+                        return Some(format!(
+                            "accepted map with size()={} but iter() yields {count} entries",
+                            map.size()
+                        ));
+                    }
+                    // (C) the accepted encoding must be canonical: rebuilding
+                    // from its own contents via the public API must serialize
+                    // identically.
+                    let mut rebuilt: Map<u64, u64> = Map::new();
+                    for (k, v) in map.iter() {
+                        rebuilt = rebuilt.insert(k, *v);
+                    }
+                    let mut a = Vec::new();
+                    let mut b = Vec::new();
+                    Sp::serialize(&map, &mut a).unwrap();
+                    Sp::serialize(&Sp::new(rebuilt), &mut b).unwrap();
+                    if a != b {
+                        return Some("accepted a non-canonical map encoding".to_string());
+                    }
+                    None
+                }
+            }
+        }));
+        match res {
+            Err(_) => failures.push(format!(
+                "PANIC on input #{i} ({} bytes): {:02x?}",
+                input.len(),
+                input
+            )),
+            Ok(Some(reason)) => failures.push(format!(
+                "ACCEPT-INVARIANT-VIOLATION on input #{i}: {reason}; bytes ({}): {:02x?}",
+                input.len(),
+                input
+            )),
+            Ok(None) => {}
+        }
+        if failures.len() >= 5 {
+            break;
+        }
+    }
+
+    std::panic::set_hook(prev);
+    assert!(
+        failures.is_empty(),
+        "deserialize_sp PANICKED on malformed input (should return Err instead):\n{}",
+        failures.join("\n")
+    );
+}
+
+// Fisher-Yates using the local PRNG.
+fn shuffle<T>(v: &mut [T], rng: &mut Rng) {
+    let n = v.len();
+    for i in (1..n).rev() {
+        let j = rng.below((i + 1) as u64) as usize;
+        v.swap(i, j);
+    }
+}

--- a/storage/tests/prop_structural.rs
+++ b/storage/tests/prop_structural.rs
@@ -1,0 +1,247 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Clean-room *structural* / parser-differential property tests for the
+//! Merkle-Patricia trie.
+//!
+//! Iteration 1 only ever built "valid" values through the public constructor
+//! API, and its adversarial oracle was merely panic-freedom. This file closes
+//! both gaps by building candidate values DIRECTLY at the structural level
+//! (via the crate's own `public-internal-structure` feature) -- including
+//! shapes the public API cannot emit -- and, for anything the untrusted loader
+//! `Arena::deserialize_sp` ACCEPTS, asserting the type's FULL semantic
+//! invariants rather than "did not crash".
+//!
+//! Contracts under test (the code's own):
+//!   * `Node::check_invariant` states a `Branch` must have >=2 non-empty
+//!     children and that every node's annotation equals its subtree size.
+//!   * `Node::size` is *computed from the stored annotation*, whereas
+//!     `iter()`/`leaves()` walk the tree structurally -- so for any honest
+//!     value they must agree.
+//!   * A content-addressed structure must have exactly ONE serialization per
+//!     logical content (otherwise hashing / equality / dedup / consensus split).
+//!
+//! Oracle `prop_structural_mutants_accepted_size_consistent`:
+//! randomly assembles arbitrary (often denormalized) `Node` trees and, for
+//! every one the loader accepts, asserts
+//!   size() == iter().count()   and   is_empty() == (count == 0).
+//! It needs no canonical reference, so it cannot false-positive. The untrusted
+//! deserialize path enforces the trie's canonical form, so a denormalized node
+//! with `size() != iter().count()` is rejected. Kept as a GENERAL fuzz oracle;
+//! `canonicality_regression.rs` holds the specific known vectors as named
+//! rejection tests.
+
+#![cfg(feature = "public-internal-structure")]
+
+use midnight_storage::arena::Sp;
+use midnight_storage::merkle_patricia_trie::{MerklePatriciaTrie, Node};
+use midnight_storage::storable::SizeAnn;
+use midnight_storage::{DefaultDB, Storage};
+use serialize::Serializable;
+
+type N = Node<u64>;
+type Mpt = MerklePatriciaTrie<u64>;
+
+// --- tiny deterministic PRNG (SplitMix64) ---
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed.wrapping_add(0x9E37_79B9_7F4A_7C15))
+    }
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+}
+
+fn ser<T: Serializable>(t: &T) -> Vec<u8> {
+    let mut b = Vec::new();
+    t.serialize(&mut b).expect("serialize");
+    b
+}
+
+fn fresh_arena() -> midnight_storage::arena::Arena<DefaultDB> {
+    Storage::<DefaultDB>::new(64, DefaultDB::default()).arena
+}
+
+/// True (structural) leaf count -- what every annotation is supposed to equal,
+/// computed WITHOUT trusting any stored annotation.
+fn true_leaves(n: &N) -> u64 {
+    match n {
+        Node::Empty => 0,
+        Node::Leaf { .. } => 1,
+        Node::Branch { children, .. } => children.iter().map(|c| true_leaves(c)).sum(),
+        Node::Extension { child, .. } => true_leaves(child),
+        Node::MidBranchLeaf { child, .. } => true_leaves(child) + 1,
+    }
+}
+
+fn empty_children() -> Box<[Sp<N>; 16]> {
+    Box::new(std::array::from_fn(|_| Sp::new(Node::Empty)))
+}
+
+/// Honest annotation most of the time, deliberately wrong sometimes.
+fn ann_for(rng: &mut Rng, true_size: u64) -> SizeAnn {
+    if rng.below(3) == 0 {
+        SizeAnn(true_size ^ (1 + rng.below(5)))
+    } else {
+        SizeAnn(true_size)
+    }
+}
+
+/// Structural generator: arbitrary, often-denormalized `Node` trees with
+/// nibble-only paths.
+fn gen_node(rng: &mut Rng, depth: u32) -> N {
+    let choice = if depth >= 4 { rng.below(2) } else { rng.below(6) };
+    match choice {
+        0 => Node::Empty,
+        1 => Node::Leaf {
+            ann: ann_for(rng, 1),
+            value: Sp::new(rng.next_u64()),
+        },
+        2 => {
+            // Branch with k in 0..=3 non-empty children (k < 2 is denormalized).
+            let mut children = empty_children();
+            let k = rng.below(4);
+            let mut used = [false; 16];
+            for _ in 0..k {
+                let mut idx = rng.below(16) as usize;
+                while used[idx] {
+                    idx = (idx + 1) % 16;
+                }
+                used[idx] = true;
+                children[idx] = Sp::new(gen_node(rng, depth + 1));
+            }
+            let true_size: u64 = children.iter().map(|c| true_leaves(c)).sum();
+            Node::Branch {
+                ann: ann_for(rng, true_size),
+                children,
+            }
+        }
+        3 => {
+            // Extension, path length 0..=3 (0 == empty path, denormalized).
+            let plen = rng.below(4);
+            let path: Vec<u8> = (0..plen).map(|_| rng.below(16) as u8).collect();
+            let child = gen_node(rng, depth + 1);
+            let true_size = true_leaves(&child);
+            Node::Extension {
+                ann: ann_for(rng, true_size),
+                compressed_path: path,
+                child: Sp::new(child),
+            }
+        }
+        4 => {
+            // MidBranchLeaf; child may be any node (Leaf/Empty is denormalized).
+            let child = gen_node(rng, depth + 1);
+            let true_size = true_leaves(&child) + 1;
+            Node::MidBranchLeaf {
+                ann: ann_for(rng, true_size),
+                value: Sp::new(rng.next_u64()),
+                child: Sp::new(child),
+            }
+        }
+        _ => Node::Leaf {
+            ann: ann_for(rng, 1),
+            value: Sp::new(rng.next_u64()),
+        },
+    }
+}
+
+// ===========================================================================
+// Oracle (A): accepted structural mutants must be size- and emptiness-consistent.
+// (No canonical reference -> no possible false positive.)
+// ===========================================================================
+
+/// Classification of a single deserialize attempt in oracle (A).
+enum Class {
+    Rejected,
+    Good,
+    Bad(String),
+}
+
+#[test]
+fn prop_structural_mutants_accepted_size_consistent() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+
+    let (mut accepted, mut rejected, mut panicked) = (0u64, 0u64, 0u64);
+    let mut violations: Vec<String> = Vec::new();
+
+    for seed in 0..5000u64 {
+        let mut rng = Rng::new(seed.wrapping_mul(0x2545_F491_4F6C_DD1D) ^ 0xB16B);
+        let root = gen_node(&mut rng, 0);
+        let mpt: Mpt = MerklePatriciaTrie(Sp::new(root.clone()));
+        let buf = ser(&mpt);
+
+        let arena = fresh_arena();
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            match arena.deserialize_sp::<Mpt, _>(&mut &buf[..], 0) {
+                Err(_) => Class::Rejected,
+                Ok(sp) => {
+                    let count = sp.iter().count() as u64;
+                    let size = sp.size() as u64;
+                    if size != count {
+                        Class::Bad(format!(
+                            "size-consistency: size()={size} but iter() yields {count} leaves"
+                        ))
+                    } else if sp.is_empty() != (count == 0) {
+                        Class::Bad(format!(
+                            "emptiness-consistency: is_empty()={} but count={count}",
+                            sp.is_empty()
+                        ))
+                    } else {
+                        Class::Good
+                    }
+                }
+            }
+        }));
+
+        match outcome {
+            Err(_) => {
+                panicked += 1;
+                if violations.len() < 8 {
+                    violations.push(format!("seed {seed}: PANIC on {root:?}"));
+                }
+            }
+            Ok(Class::Rejected) => rejected += 1,
+            Ok(Class::Good) => accepted += 1,
+            Ok(Class::Bad(why)) => {
+                accepted += 1;
+                if violations.len() < 8 {
+                    violations.push(format!("seed {seed}: {why}\n    tree = {root:?}"));
+                }
+            }
+        }
+    }
+
+    std::panic::set_hook(prev);
+    eprintln!(
+        "[A structural mutants] accepted={accepted} rejected={rejected} panicked={panicked} \
+         violations(sampled)={}",
+        violations.len()
+    );
+    assert!(
+        violations.is_empty(),
+        "deserialize_sp ACCEPTED structurally-invalid tries (accept must imply invariants):\n{}",
+        violations.join("\n")
+    );
+}
+

--- a/transient-crypto/src/commitment.rs
+++ b/transient-crypto/src/commitment.rs
@@ -219,3 +219,54 @@ mod tests {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area E: `PureGeneratorPedersen` decode.
+//
+// The `Deserializable` impl is *derived* (commitment.rs:130): it decodes the
+// `commitment` / `target` / `reply` fields (each point validated as on-curve /
+// in-subgroup by the `EmbeddedGroupAffine` decoder, curve.rs:470) and does NOT
+// re-run the Schnorr `valid(challenge_pre)` check. That is by design: the PoK is
+// bound to a `challenge_pre` (`Intent::challenge_pre_for`, derived from the whole
+// Intent + segment) that the raw decoder cannot know, and it is verified on the
+// consensus path by `Intent::well_formed` (ledger verify.rs:512), which rejects a
+// PoK-invalid binding commitment. Only the context-free totality + round-trip
+// baselines are asserted here.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod pok_props {
+    use super::*;
+    use proptest::prelude::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    fn roundtrip(c: &PureGeneratorPedersen) -> std::io::Result<PureGeneratorPedersen> {
+        let mut b = Vec::new();
+        Serializable::serialize(c, &mut b)?;
+        PureGeneratorPedersen::deserialize(&mut &b[..], 0)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        // Totality: arbitrary bytes never panic the decoder.
+        #[test]
+        fn decode_total(bytes in prop::collection::vec(any::<u8>(), 0..128)) {
+            let _ = PureGeneratorPedersen::deserialize(&mut &bytes[..], 0);
+        }
+
+        // (E, positive) An honestly-constructed (valid) commitment stays valid
+        // across a serialize/deserialize round-trip (holds today).
+        #[test]
+        fn valid_commitment_survives_roundtrip(seed in any::<u64>()) {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let wit: EmbeddedFr = rng.r#gen();
+            let cp = b"area-e-challenge";
+            let c = PureGeneratorPedersen::new_from(&mut rng, &wit, cp);
+            prop_assert!(c.valid(cp), "constructor must produce a valid commitment");
+            let dec = roundtrip(&c).expect("valid commitment round-trips");
+            prop_assert!(dec.valid(cp), "decoded valid commitment must remain valid");
+        }
+    }
+
+}

--- a/transient-crypto/src/curve.rs
+++ b/transient-crypto/src/curve.rs
@@ -698,3 +698,79 @@ mod tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area G: totality + validity of `EmbeddedGroupAffine` / curve-point decode.
+//
+// `EmbeddedGroupAffine::deserialize` (curve.rs:470) reads a fixed-width repr and
+// decodes it with `JubjubSubgroup::from_bytes`, converting the resulting
+// `CtOption` into an `io::Error` on failure -- no `unwrap`/`expect`, so decode
+// is total (never panics) on arbitrary bytes. Because the target type is the
+// prime-order subgroup type, an accepted encoding is by construction a valid
+// subgroup element (off-curve / wrong-subgroup / non-canonical encodings must
+// be rejected). Properties asserted:
+//   * (G-tot)   decode never panics on arbitrary bytes / lengths.
+//   * (G-canon) every accepted encoding re-serializes to itself (the decoder
+//               accepts only canonical encodings) and valid points round-trip.
+//   * (G-inv)   a decoded point is a genuine subgroup element: multiplying it
+//               by the embedded scalar-field order yields the identity.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod curve_decode_props {
+    use super::*;
+    use proptest::prelude::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    fn point_len() -> usize {
+        Serializable::serialized_size(&EmbeddedGroupAffine::generator())
+    }
+    fn ser(p: &EmbeddedGroupAffine) -> Vec<u8> {
+        let mut b = Vec::new();
+        Serializable::serialize(p, &mut b).unwrap();
+        b
+    }
+    fn de(bytes: &[u8]) -> std::io::Result<EmbeddedGroupAffine> {
+        <EmbeddedGroupAffine as Deserializable>::deserialize(&mut &bytes[..], 0)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        // (G-tot) Arbitrary bytes of arbitrary length never panic.
+        #[test]
+        fn decode_total(bytes in prop::collection::vec(any::<u8>(), 0..80)) {
+            let _ = de(&bytes);
+        }
+
+        // (G-canon) Every accepted encoding is canonical: re-serializing a
+        // decoded point reproduces the exact input bytes (no non-canonical
+        // encoding is accepted).
+        #[test]
+        fn accepted_encoding_is_canonical(raw in prop::collection::vec(any::<u8>(), 0..64)) {
+            let n = point_len();
+            if raw.len() == n {
+                if let Ok(p) = de(&raw) {
+                    prop_assert_eq!(ser(&p), raw);
+                }
+            }
+        }
+
+        // (G-canon)+(G-inv) Randomly sampled valid points round-trip exactly and
+        // are genuine subgroup elements (order * P == identity).
+        #[test]
+        fn valid_points_roundtrip_and_in_subgroup(seed in any::<u64>()) {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let p: EmbeddedGroupAffine = rng.r#gen();
+            let back = de(&ser(&p)).expect("valid point decodes");
+            prop_assert_eq!(back, p);
+            // Multiplying by the full embedded scalar-field order maps any
+            // subgroup element to the identity. `EmbeddedFr` arithmetic is mod
+            // the order, so (0 - 1) + 1 == order == 0 in the field; multiply by
+            // the additive identity to land on the group identity.
+            let identity = p * EmbeddedFr::from(0u64);
+            let id_default = EmbeddedGroupAffine::default();
+            prop_assert_eq!(identity, id_default, "0 * P must be the identity");
+        }
+    }
+}

--- a/transient-crypto/src/fab.rs
+++ b/transient-crypto/src/fab.rs
@@ -684,3 +684,137 @@ mod tests {
         }
     }
 }
+
+#[cfg(all(test, feature = "proptest"))]
+mod aligned_value_invariant {
+    use super::*;
+    use base_crypto::fab::{
+        AlignedValue, Alignment, AlignmentAtom, AlignmentSegment, Value, ValueAtom,
+    };
+    use proptest::prelude::*;
+    use serialize::{Deserializable, Serializable};
+
+    fn arb_value_atom() -> impl Strategy<Value = ValueAtom> {
+        // Lengths chosen to straddle the FIELD_BYTE_LIMIT (64) boundary and
+        // the single-byte fast path, including the empty atom.
+        proptest::collection::vec(any::<u8>(), 0..70).prop_map(ValueAtom)
+    }
+
+    fn arb_value() -> impl Strategy<Value = Value> {
+        // Deliberately independent of any alignment, and often empty, so that
+        // atom counts frequently disagree with the alignment's expectations.
+        proptest::collection::vec(arb_value_atom(), 0..6).prop_map(Value)
+    }
+
+    fn arb_alignment_atom() -> impl Strategy<Value = AlignmentAtom> {
+        prop_oneof![
+            Just(AlignmentAtom::Compress),
+            Just(AlignmentAtom::Field),
+            prop_oneof![
+                Just(0u32),
+                Just(1),
+                Just(2),
+                Just(31),
+                Just(32),
+                Just(63),
+                Just(64),
+                Just(65),
+                0u32..300,
+            ]
+            .prop_map(|length| AlignmentAtom::Bytes { length }),
+        ]
+    }
+
+    fn arb_aligned_value() -> impl Strategy<Value = AlignedValue> {
+        (arb_value(), arb_alignment_vec()).prop_map(|(value, alignment)| AlignedValue {
+            value,
+            alignment,
+        })
+    }
+
+    fn arb_alignment_segment() -> impl Strategy<Value = AlignmentSegment> {
+        let leaf = arb_alignment_atom().prop_map(AlignmentSegment::Atom);
+        leaf.prop_recursive(3, 16, 4, |inner| {
+            prop_oneof![
+                4 => arb_alignment_atom().prop_map(AlignmentSegment::Atom),
+                1 => proptest::collection::vec(
+                        proptest::collection::vec(inner, 0..3).prop_map(Alignment),
+                        0..3,
+                     ).prop_map(AlignmentSegment::Option),
+            ]
+        })
+    }
+
+    fn arb_alignment_vec() -> impl Strategy<Value = Alignment> {
+        proptest::collection::vec(arb_alignment_segment(), 0..5).prop_map(Alignment)
+    }
+
+    /// Round-trips an arbitrarily-constructed `AlignedValue` through the binary
+    /// codec, returning whatever the decoder accepts.
+    fn decode_of(av: &AlignedValue) -> Option<AlignedValue> {
+        let mut bytes = Vec::new();
+        Serializable::serialize(av, &mut bytes).ok()?;
+        <AlignedValue as Deserializable>::deserialize(&mut &bytes[..], 0).ok()
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2048))]
+
+        /// (B1) A value accepted by binary `deserialize` must satisfy its own
+        /// declared alignment -- agreeing with the checked constructor.
+        ///
+        /// Regression guard: the binary `Deserializable for AlignedValue` used
+        /// to read `value` and `alignment` independently without checking
+        /// `alignment.fits(&value)` (unlike the serde `TryFrom` path), so it
+        /// accepted values that violate their alignment; the decoder now
+        /// enforces `fits` and rejects them.
+        #[test]
+        fn decoded_value_satisfies_its_alignment(av in arb_aligned_value()) {
+            if let Some(decoded) = decode_of(&av) {
+                prop_assert!(
+                    decoded.alignment.fits(&decoded.value),
+                    "binary decode accepted a value that does not fit its alignment: {:?}",
+                    decoded
+                );
+                // Cross-check against the checked constructor: it must agree.
+                prop_assert!(
+                    AlignedValue::new(decoded.value.clone(), decoded.alignment.clone()).is_some(),
+                    "binary decode accepted what AlignedValue::new rejects: {:?}",
+                    decoded
+                );
+            }
+        }
+
+        /// (B2) For any value the binary decoder accepts, `field_repr()` and
+        /// `binary_repr()` must not panic.
+        ///
+        /// Regression guard: this used to fail as a *consequence* of the B1 bug
+        /// -- the decoder handed back non-fitting values, and the unchecked repr
+        /// walkers then indexed past the value's atoms (or tripped a debug
+        /// assert). With the B1 `fits` check in place, non-fitting values never
+        /// reach the repr walkers.
+        #[test]
+        fn repr_of_decoded_value_never_panics(av in arb_aligned_value()) {
+            if let Some(decoded) = decode_of(&av) {
+                let _ = decoded.field_vec();
+                let _ = ValueReprAlignedValue(decoded).binary_vec();
+            }
+        }
+    }
+
+    // --- Regression tests: minimized findings, pinning correct behavior. ---
+
+    /// The concrete divergence between the two decode paths. `value` has two
+    /// atoms; `alignment` is a single `Field` (which consumes exactly one
+    /// atom), so the value does NOT fit. This holds on the current base and
+    /// documents the invariant the binary path is supposed to share.
+    #[test]
+    fn checked_constructors_reject_non_fitting_value() {
+        let value = Value(vec![ValueAtom(vec![1]), ValueAtom(vec![2])]);
+        let alignment = Alignment(vec![AlignmentSegment::Atom(AlignmentAtom::Field)]);
+        assert!(!alignment.fits(&value));
+        // Checked constructor rejects it...
+        assert!(AlignedValue::new(value.clone(), alignment.clone()).is_none());
+    }
+
+}

--- a/transient-crypto/src/merkle_tree.rs
+++ b/transient-crypto/src/merkle_tree.rs
@@ -1108,6 +1108,12 @@ impl<A: Storable<D>, D: DB> MerkleTree<A, D> {
         &self,
         update: &MerkleTreeCollapsedUpdate,
     ) -> Result<Self, InvalidUpdate> {
+        if update.end < update.start {
+            return Err(InvalidUpdate::EndBeforeStart(update.start, update.end));
+        }
+        if (update.end as u128) >= (1u128 << self.height()) {
+            return Err(InvalidUpdate::EndOutOfTree(update.end));
+        }
         let segments = MerkleTreeCollapsedUpdate::step_sizes(update.start, update.end + 1);
         if segments.len() != update.hashes.len() {
             return Err(InvalidUpdate::WrongNumberOfSegments(
@@ -1751,5 +1757,106 @@ mod tests {
                 InvalidUpdate::IndexOutOfTree(index),
             );
         }
+    }
+}
+
+#[cfg(all(test, feature = "proptest"))]
+mod apply_collapsed_update_totality {
+    use super::*;
+    use proptest::prelude::*;
+    use storage_core::db::InMemoryDB;
+
+    type DB = InMemoryDB<sha2::Sha256>;
+
+    /// Build an update directly from its (public-on-the-wire) fields, without
+    /// going through the validating `MerkleTreeCollapsedUpdate::new`. This is
+    /// exactly the shape a `Deserializable::deserialize` can hand back.
+    fn raw_update(start: u64, end: u64, hashes: Vec<u64>) -> MerkleTreeCollapsedUpdate {
+        MerkleTreeCollapsedUpdate {
+            start,
+            end,
+            hashes: hashes
+                .into_iter()
+                .map(|h| MerkleTreeDigest(Fr::from(h)))
+                .collect(),
+        }
+    }
+
+    /// A generator over the full representable space of updates, biased towards
+    /// the structurally-interesting boundaries: `u64::MAX`, values around
+    /// `end + 1`, and short/empty hash vectors.
+    fn arb_bound() -> impl Strategy<Value = u64> {
+        prop_oneof![
+            5 => any::<u64>(),
+            2 => 0u64..=64,
+            1 => Just(u64::MAX),
+            1 => Just(u64::MAX - 1),
+        ]
+    }
+
+    fn arb_update() -> impl Strategy<Value = MerkleTreeCollapsedUpdate> {
+        (
+            arb_bound(),
+            arb_bound(),
+            proptest::collection::vec(any::<u64>(), 0..8),
+        )
+            .prop_map(|(start, end, hashes)| raw_update(start, end, hashes))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(4096))]
+
+        // A collapsed update is deserialized from the wire, so applying any
+        // well-typed update to a blank tree of any height must return Ok/Err,
+        // never panic.
+        #[test]
+        fn apply_never_panics(
+            height in 0u8..=32,
+            update in arb_update(),
+        ) {
+            let tree = MerkleTree::<(), DB>::blank(height);
+            // Only requirement: this returns (Ok/Err), rather than panicking.
+            let _ = tree.apply_collapsed_update(&update);
+        }
+    }
+
+    // Each regression pins a distinct out-of-range update that must be rejected
+    // (the proptest above only asserts no-panic; these assert the rejection).
+
+    // end == u64::MAX (would overflow `end + 1`).
+    #[test]
+    fn regression_end_is_u64_max_is_rejected_not_panic() {
+        let tree = MerkleTree::<(), DB>::blank(4);
+        let update = raw_update(0, u64::MAX, vec![]);
+        // A total implementation should reject an out-of-tree end, not panic.
+        assert!(tree.apply_collapsed_update(&update).is_err());
+    }
+
+    // start == end + 1 (would hit `ilog2(0)` in `step_sizes`).
+    #[test]
+    fn regression_start_equals_end_plus_one_is_rejected_not_panic() {
+        let tree = MerkleTree::<(), DB>::blank(4);
+        // start = 1, end = 0  =>  a = 1, b = end + 1 = 1  =>  b ^ a == 0.
+        let update = raw_update(1, 0, vec![0u64]);
+        assert!(tree.apply_collapsed_update(&update).is_err());
+    }
+
+    // A step height exceeding the tree height (would underflow the `u8`
+    // subtraction in `partial_insert`).
+    #[test]
+    fn regression_step_taller_than_tree_is_rejected_not_panic() {
+        // Height-1 tree, but the update range spans indices that force a step
+        // of height >= 2, taller than the tree.
+        let tree = MerkleTree::<(), DB>::blank(1);
+        let update = raw_update(0, 7, vec![0u64]);
+        assert!(tree.apply_collapsed_update(&update).is_err());
+    }
+
+    // start > end + 1 (would overflow the `u64` accumulator in `step_sizes`).
+    #[test]
+    fn regression_start_far_above_end_is_rejected_not_panic() {
+        let tree = MerkleTree::<(), DB>::blank(0);
+        let update = raw_update((1u64 << 63) + 1, 0, vec![]);
+        assert!(tree.apply_collapsed_update(&update).is_err());
     }
 }

--- a/zkir-v3/src/ir.rs
+++ b/zkir-v3/src/ir.rs
@@ -891,3 +891,54 @@ randomised_serialization_test!(IrSource);
 
 #[cfg(feature = "proptest")]
 randomised_serialization_test!(Instruction);
+
+// -----------------------------------------------------------------------------
+// Area E: `Operand::Immediate` text/binary round-trip.
+//
+// The encoder emits a canonical spelling (lowercase `0x` + minimal little-endian
+// bytes), and that spelling round-trips on both the serde and binary surfaces.
+//
+// The decoders also accept non-canonical spellings of the same value (uppercase
+// `0X`/digits, trailing-zero padding, a redundant leading `-`). That is
+// deliberately OUT OF SCOPE: the zkir IR is a proving-time structure, not an
+// in-consensus one, so a single canonical wire form is not a goal for it. Only
+// the round-trip baseline is asserted here.
+// -----------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod area_e_props {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// serde: decode a raw operand spelling (the inner string, unquoted).
+    fn dec_json(spelling: &str) -> Result<Operand, serde_json::Error> {
+        let quoted = serde_json::to_string(spelling).unwrap(); // JSON-escape + quote
+        serde_json::from_str::<Operand>(&quoted)
+    }
+    fn enc_json(op: &Operand) -> String {
+        // Returns the inner string (strip the surrounding JSON quotes).
+        let s = serde_json::to_string(op).unwrap();
+        serde_json::from_str::<String>(&s).unwrap()
+    }
+
+    fn dec_bin(bytes: &[u8]) -> std::io::Result<Operand> {
+        <Operand as Deserializable>::deserialize(&mut &bytes[..], 0)
+    }
+    fn enc_bin(op: &Operand) -> Vec<u8> {
+        let mut v = Vec::new();
+        Serializable::serialize(op, &mut v).unwrap();
+        v
+    }
+
+    proptest! {
+        /// (baseline; holds) The canonical encoding round-trips on both
+        /// surfaces.
+        #[test]
+        fn immediate_roundtrip(x in any::<u64>()) {
+            let op = Operand::Immediate(Fr::from(x));
+            let s = enc_json(&op);
+            prop_assert_eq!(dec_json(&s).unwrap(), op.clone());
+            prop_assert_eq!(dec_bin(&enc_bin(&op)).unwrap(), op);
+        }
+    }
+
+}

--- a/zkir-v3/src/ir_instructions/encode.rs
+++ b/zkir-v3/src/ir_instructions/encode.rs
@@ -189,3 +189,82 @@ pub fn jubjub_scalar_from_biguint(
         .jubjub()
         .scalar_from_reduced_le_bytes(layouter, &r_le_bytes)
 }
+
+// ---------------------------------------------------------------------------
+// Area B: totality of the off-circuit value decoder `decode_offcircuit`, in
+// particular the `Bytes32` arm.
+//
+// `decode_offcircuit` (encode.rs:114) is documented to "Return an error if the
+// provided raw values cannot be decoded as the given type" — i.e. it must be
+// total over its `&[Fr]` input, which comes straight from `deserialize`
+// (`ProofPreimage::{inputs,public_transcript_outputs,private_transcript}` are
+// `Vec<Fr>`), spanning the entire representable field-element space. Every arm
+// returns `Option`/`None` on bad input EXCEPT `Bytes32` (encode.rs:121), which
+// uses `assert_eq!`:
+//   * `assert_eq!(bytes[31], 0)` (encode.rs:126) panics whenever the first
+//     field element's little-endian byte 31 is non-zero — true for any field
+//     element >= 2^248 (well within the ~2^254.9 modulus).
+//   * `assert_eq!(*b, 0)` (encode.rs:130) panics whenever the second field
+//     element has any non-zero byte past index 0 (i.e. value >= 256).
+// Both are reachable from decoded input, so decoding aborts the process
+// instead of returning `Err`.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod decode_offcircuit_totality_props {
+    use super::{decode_offcircuit, encode_offcircuit};
+    use crate::ir_types::{IrType, IrValue};
+    use proptest::prelude::*;
+    use transient_crypto::curve::Fr;
+
+    /// Uniformly reduce 64 arbitrary bytes into a canonical field element,
+    /// covering the whole representable space (including values with a non-zero
+    /// top byte).
+    fn arb_fr() -> impl Strategy<Value = Fr> {
+        prop::array::uniform32(any::<u8>()).prop_flat_map(|lo| {
+            prop::array::uniform32(any::<u8>()).prop_map(move |hi| {
+                let mut wide = [0u8; 64];
+                wide[..32].copy_from_slice(&lo);
+                wide[32..].copy_from_slice(&hi);
+                Fr::from_uniform_bytes(&wide)
+            })
+        })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        // Decode runs on attacker-controlled field data: it must never panic,
+        // and must accept only canonical encodings — an accepted value has to
+        // re-encode to exactly its input.
+        #[test]
+        fn bytes32_decode_total_and_sound(a in arb_fr(), b in arb_fr()) {
+            if let Ok(v) = decode_offcircuit(&[a, b], &IrType::Bytes32) {
+                let re: Vec<Fr> = encode_offcircuit(&v)
+                    .into_iter()
+                    .map(|x| match x { IrValue::Native(f) => f, _ => unreachable!() })
+                    .collect();
+                prop_assert_eq!(re, vec![a, b]);
+            }
+        }
+
+        // (B-holds) The `Native` arm IS total over the whole field space (it
+        // returns `Option`, never asserts). HOLDS.
+        #[test]
+        fn native_decode_is_total(a in arb_fr()) {
+            let _ = decode_offcircuit(&[a], &IrType::Native);
+        }
+
+        // (B-holds) A *canonically encoded* Bytes32 value always decodes back
+        // to itself — the happy path is unaffected. HOLDS.
+        #[test]
+        fn bytes32_roundtrip_ok(bytes in prop::array::uniform32(any::<u8>())) {
+            let encoded: Vec<Fr> = encode_offcircuit(&IrValue::Bytes32(bytes))
+                .into_iter()
+                .map(|v| match v { IrValue::Native(f) => f, _ => unreachable!() })
+                .collect();
+            let decoded = decode_offcircuit(&encoded, &IrType::Bytes32).unwrap();
+            prop_assert_eq!(decoded, IrValue::Bytes32(bytes));
+        }
+    }
+
+}

--- a/zkir-v3/src/ir_vm.rs
+++ b/zkir-v3/src/ir_vm.rs
@@ -1294,3 +1294,90 @@ impl Relation for IrSource {
         tagged_deserialize(&mut &raw[..])
     }
 }
+
+// ---------------------------------------------------------------------------
+// Area A: totality of `preprocess` over the transcript-consuming instruction
+// arms.
+//
+// The circuit-*input* loop (ir_vm.rs:215) is guarded: before slicing
+// `preimage.inputs[idx..idx + w]` it checks `if idx + w > preimage.inputs.len()`
+// and `bail!`s (ir_vm.rs:217). The transcript-consuming arms are NOT: the
+// `PublicInput` arm slices `preimage.public_transcript_outputs[idx..idx + w]`
+// (ir_vm.rs:382) and the `PrivateInput` arm slices
+// `preimage.private_transcript[idx..idx + w]` (ir_vm.rs:401) with no prior
+// bounds check. A decoded `ProofPreimage` (all transcript vectors are
+// `Vec<Fr>` straight from `deserialize`) whose transcript is shorter than the
+// instructions demand therefore causes an out-of-bounds slice panic
+// ("range end index .. out of range for slice of length ..") instead of
+// returning `Err`, breaking the totality contract the input loop already
+// upholds.
+// ---------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod preprocess_totality_props {
+    use super::{I, Identifier, IrSource};
+    use crate::ir_types::IrType;
+    use proptest::prelude::*;
+    use std::sync::Arc;
+    use transient_crypto::curve::Fr;
+    use transient_crypto::proofs::{KeyLocation, ProofPreimage};
+
+    /// An `IrSource` with a single unguarded `PublicInput` (Native, width 1),
+    /// so `preprocess` must consume exactly one public-transcript output.
+    fn ir_with_public_input() -> IrSource {
+        IrSource {
+            instructions: Arc::new(vec![I::PublicInput {
+                guard: None,
+                val_t: IrType::Native,
+                output: Identifier("x".into()),
+            }]),
+            ..Default::default()
+        }
+    }
+
+    /// Same, but consuming from the private transcript.
+    fn ir_with_private_input() -> IrSource {
+        IrSource {
+            instructions: Arc::new(vec![I::PrivateInput {
+                guard: None,
+                val_t: IrType::Native,
+                output: Identifier("x".into()),
+            }]),
+            ..Default::default()
+        }
+    }
+
+    fn empty_preimage() -> ProofPreimage {
+        ProofPreimage {
+            inputs: vec![],
+            private_transcript: vec![],
+            public_transcript_inputs: vec![],
+            public_transcript_outputs: vec![],
+            binding_input: Fr::from(0u64),
+            communications_commitment: None,
+            key_location: KeyLocation(std::borrow::Cow::Borrowed("")),
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        // `preprocess` decodes an untrusted `ProofPreimage`; a transcript that
+        // doesn't supply exactly the reads a circuit performs must error, not
+        // slice out of bounds.
+        #[test]
+        fn public_input_preprocess_requires_exact_transcript(n in 0usize..4) {
+            let ir = ir_with_public_input();
+            let mut pre = empty_preimage();
+            pre.public_transcript_outputs = vec![Fr::from(0u64); n];
+            prop_assert_eq!(ir.preprocess(&pre).is_ok(), n == 1);
+        }
+
+        #[test]
+        fn private_input_preprocess_requires_exact_transcript(n in 0usize..4) {
+            let ir = ir_with_private_input();
+            let mut pre = empty_preimage();
+            pre.private_transcript = vec![Fr::from(0u64); n];
+            prop_assert_eq!(ir.preprocess(&pre).is_ok(), n == 1);
+        }
+    }
+}

--- a/zswap/Cargo.toml
+++ b/zswap/Cargo.toml
@@ -9,6 +9,7 @@ description = "Implementation of the Zswap shielded token atomic swap mechanism.
 [features]
 default = ["proof-verifying"]
 proof-verifying = []
+proptest = ["dep:proptest", "dep:proptest-derive", "coin-structure/proptest", "transient-crypto/proptest", "storage/proptest", "serialize/proptest"]
 
 [dependencies]
 base-crypto = { version = "1.0.0", path = "../base-crypto", package = "midnight-base-crypto" }
@@ -33,7 +34,12 @@ futures = { version = "^0.3.31" }
 serde = { version = "^1.0.219", features = ["derive"] }
 derive-where = "^1.6.1"
 
+# proptest 1.7.0+ rely on rand 0.9.0, which we are not yet updating to.
+proptest = { version = "~1.6.0", optional = true }
+proptest-derive = { version = "0.8", optional = true }
+
 [dev-dependencies]
+midnight-zswap = { path = ".", features = ["proptest"] }
 zkir_v2 = { path = "../zkir", package = "midnight-zkir" }
 fake = { version = "^2.10.0", features = ["derive"] }
 rand = { version = "^0.8.4", features = ["getrandom"] }

--- a/zswap/src/structure.rs
+++ b/zswap/src/structure.rs
@@ -631,3 +631,395 @@ pub const INPUT_PROOF_SIZE: usize = 4_832;
 pub const OUTPUT_PIS: usize = 77;
 pub const OUTPUT_PROOF_SIZE: usize = 4_832;
 pub const AUTHORIZED_CLAIM_PIS: usize = 13;
+
+// -----------------------------------------------------------------------------
+// Proptest generators.
+//
+// These sample proof-erased (`P = ()`) zswap structures. The `Offer` generator
+// produces a value in *normal form* (sorted inputs/outputs/transient; deltas
+// strictly increasing by token type with non-zero values) so it is accepted by
+// `Offer::<(), D>::well_formed` by construction — the property tests then perturb
+// it adversarially for the rejection cases.
+// -----------------------------------------------------------------------------
+#[cfg(feature = "proptest")]
+mod proptest_generators {
+    use super::*;
+    use rand::distributions::{Distribution, Standard};
+
+    impl Distribution<CoinCiphertext> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> CoinCiphertext {
+            CoinCiphertext {
+                c: rng.r#gen(),
+                ciph: rng.r#gen(),
+            }
+        }
+    }
+
+    impl Distribution<Delta> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Delta {
+            // Non-zero value: a zero delta is rejected by `well_formed`.
+            let mut value: i128 = rng.r#gen();
+            if value == 0 {
+                value = 1;
+            }
+            Delta {
+                token_type: rng.r#gen(),
+                value,
+            }
+        }
+    }
+
+    impl<D: DB> Distribution<Input<(), D>> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Input<(), D> {
+            Input {
+                nullifier: rng.r#gen(),
+                value_commitment: Pedersen(rng.r#gen()),
+                contract_address: if rng.r#gen::<bool>() {
+                    Some(Sp::new(rng.r#gen()))
+                } else {
+                    None
+                },
+                merkle_tree_root: rng.r#gen(),
+                proof: Arc::new(()),
+            }
+        }
+    }
+
+    impl<D: DB> Distribution<Output<(), D>> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Output<(), D> {
+            Output {
+                coin_com: rng.r#gen(),
+                value_commitment: Pedersen(rng.r#gen()),
+                contract_address: if rng.r#gen::<bool>() {
+                    Some(Sp::new(rng.r#gen()))
+                } else {
+                    None
+                },
+                ciphertext: if rng.r#gen::<bool>() {
+                    Some(Sp::new(rng.r#gen()))
+                } else {
+                    None
+                },
+                proof: Arc::new(()),
+            }
+        }
+    }
+
+    impl<D: DB> Distribution<Transient<(), D>> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Transient<(), D> {
+            Transient {
+                nullifier: rng.r#gen(),
+                coin_com: rng.r#gen(),
+                value_commitment_input: Pedersen(rng.r#gen()),
+                value_commitment_output: Pedersen(rng.r#gen()),
+                contract_address: if rng.r#gen::<bool>() {
+                    Some(Sp::new(rng.r#gen()))
+                } else {
+                    None
+                },
+                ciphertext: if rng.r#gen::<bool>() {
+                    Some(Sp::new(rng.r#gen()))
+                } else {
+                    None
+                },
+                proof_input: Arc::new(()),
+                proof_output: Arc::new(()),
+            }
+        }
+    }
+
+    impl<D: DB> Distribution<Offer<(), D>> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Offer<(), D> {
+            let mut inputs: std::vec::Vec<Input<(), D>> =
+                (0..rng.gen_range(0..=3)).map(|_| rng.r#gen()).collect();
+            let mut outputs: std::vec::Vec<Output<(), D>> =
+                (0..rng.gen_range(0..=3)).map(|_| rng.r#gen()).collect();
+            let mut transient: std::vec::Vec<Transient<(), D>> =
+                (0..rng.gen_range(0..=2)).map(|_| rng.r#gen()).collect();
+            inputs.sort();
+            outputs.sort();
+            transient.sort();
+
+            // Deltas must be strictly increasing by token type (unique) and
+            // non-zero — build from a deduped, sorted set of token types.
+            let mut tokens: std::vec::Vec<ShieldedTokenType> =
+                (0..rng.gen_range(0..=3)).map(|_| rng.r#gen()).collect();
+            tokens.sort();
+            tokens.dedup();
+            let deltas: std::vec::Vec<Delta> = tokens
+                .into_iter()
+                .map(|token_type| {
+                    let mut value: i128 = rng.r#gen();
+                    if value == 0 {
+                        value = 1;
+                    }
+                    Delta { token_type, value }
+                })
+                .collect();
+
+            Offer {
+                inputs: inputs.into(),
+                outputs: outputs.into(),
+                transient: transient.into(),
+                deltas: deltas.into(),
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Area A: zswap `Offer` / `Input` / `Output` / `Transient` + `binding_randomness`.
+//
+// Two property families:
+//   (A-tot) Totality: decoding arbitrary bytes never panics, and derivations
+//           reachable from decoded values (notably `binding_randomness`) do not
+//           panic / over/underflow.
+//   (A-inv) Invariant preservation: an `Offer` obtained from `deserialize`
+//           satisfies the same well-formedness (`Offer::well_formed`: sorted
+//           inputs/outputs/transient, strictly-increasing unique delta token
+//           types, non-zero delta values) that the checked path enforces.
+//
+// The `Storable` derive gives these types a binary `Serializable` /
+// `Deserializable` (through `Sp`), so `serialize` then `deserialize` is a
+// faithful decode. Neither the `Array` decoder nor `check_invariant` (default
+// `Ok`) re-establishes normal form, so a hand-built non-normal `Offer`
+// round-trips unchanged and is accepted by `deserialize` while `well_formed`
+// rejects it. `binding_randomness` (on `P = ProofPreimage`) reads
+// `proof.inputs.last()` and `EmbeddedFr::try_from` it, both via `expect`, so an
+// empty or out-of-range witness vector panics.
+// -----------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod area_a_props {
+    use super::*;
+    use proptest::prelude::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use serialize::{Deserializable, Serializable};
+    use storage::db::InMemoryDB;
+    use transient_crypto::proofs::{KeyLocation, ProofPreimage};
+
+    type D = InMemoryDB;
+
+    fn roundtrip<T: Serializable + Deserializable>(v: &T) -> std::io::Result<T> {
+        let mut bytes = std::vec::Vec::new();
+        v.serialize(&mut bytes)?;
+        T::deserialize(&mut &bytes[..], 0)
+    }
+
+    /// A `ProofPreimage` with a chosen `inputs` vector and otherwise-trivial
+    /// fields; the other fields are irrelevant to `binding_randomness`.
+    fn preimage_with_inputs(inputs: std::vec::Vec<Fr>) -> ProofPreimage {
+        ProofPreimage {
+            inputs,
+            private_transcript: std::vec::Vec::new(),
+            public_transcript_inputs: std::vec::Vec::new(),
+            public_transcript_outputs: std::vec::Vec::new(),
+            binding_input: Fr::from(0u64),
+            communications_commitment: None,
+            key_location: KeyLocation(std::borrow::Cow::Borrowed("")),
+        }
+    }
+
+    fn input_with_preimage(pre: ProofPreimage) -> Input<ProofPreimage, D> {
+        let mut rng = StdRng::seed_from_u64(1);
+        Input {
+            nullifier: rng.r#gen(),
+            value_commitment: Pedersen(rng.r#gen()),
+            contract_address: None,
+            merkle_tree_root: rng.r#gen(),
+            proof: Arc::new(pre),
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        // (A-tot) Arbitrary bytes never panic the proof-erased decoders.
+        #[test]
+        fn offer_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..256)) {
+            let _ = <Offer<(), D> as Deserializable>::deserialize(&mut &bytes[..], 0);
+        }
+        #[test]
+        fn input_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..256)) {
+            let _ = <Input<(), D> as Deserializable>::deserialize(&mut &bytes[..], 0);
+        }
+        #[test]
+        fn output_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..256)) {
+            let _ = <Output<(), D> as Deserializable>::deserialize(&mut &bytes[..], 0);
+        }
+        #[test]
+        fn transient_decode_total(bytes in prop::collection::vec(any::<u8>(), 0..256)) {
+            let _ = <Transient<(), D> as Deserializable>::deserialize(&mut &bytes[..], 0);
+        }
+
+        // Decoded witnesses are untrusted: extraction must never panic (an
+        // unusable witness yields the default instead of aborting).
+        #[test]
+        fn input_binding_randomness_never_panics(pre in any::<ProofPreimage>()) {
+            let decoded = roundtrip(&pre).expect("ProofPreimage round-trips");
+            let input = input_with_preimage(decoded);
+            let _ = input.binding_randomness();
+        }
+
+        // The default is only a failure fallback: an honest witness (whose last
+        // element is the binding randomness) must recover it exactly, so the
+        // fallback stays unreachable on honestly-produced inputs.
+        #[test]
+        fn input_binding_randomness_recovers_honest_scalar(
+            rc in any::<PedersenRandomness>(),
+            prefix_len in 0usize..4,
+        ) {
+            let mut inputs: std::vec::Vec<Fr> =
+                (0..prefix_len).map(|i| Fr::from(i as u64 + 1)).collect();
+            inputs.push(Fr::try_from(rc).expect("embedded scalar embeds into the base field"));
+            let input = input_with_preimage(preimage_with_inputs(inputs));
+            prop_assert_eq!(input.binding_randomness(), rc);
+        }
+    }
+
+}
+
+// -----------------------------------------------------------------------------
+// Area B: `Offer::merge` and delta normalization.
+//
+// `merge` (structure.rs:579) concatenates the two offers' `deltas` and then
+// calls `normalize` -> `normalize_deltas` (structure.rs:551), which sums the
+// `i128` values of same-`token_type` deltas via an unchecked
+//     *map.entry(k).or_insert(0) += v;   (structure.rs:554)
+// There is no checked/saturating guard, so summing two same-token deltas whose
+// magnitudes exceed the `i128` range overflows: **panic in debug builds**
+// (`attempt to add with overflow`), **silent wraparound in release** — the
+// latter yields a merged `Offer` whose delta (and hence value-balance
+// commitment) is arithmetically wrong, yet still passes `well_formed`
+// (verify.rs:320-326 checks only sortedness, strict token ordering, and
+// non-zero).
+//
+// Properties asserted here:
+//   * (B-tot)  merge never panics for deltas within a non-overflowing range.
+//   * (B-inv)  the merged offer's deltas are in normal form: strictly
+//              increasing by `token_type` (=> sorted + key-unique) and all
+//              non-zero, matching what `normalize_deltas` guarantees.
+// The regressions below pin the overflow (B-tot violated at the i128
+// boundary).
+// -----------------------------------------------------------------------------
+#[cfg(all(test, feature = "proptest"))]
+mod area_b_merge_props {
+    use super::*;
+    use proptest::prelude::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use storage::db::InMemoryDB;
+
+    type D = InMemoryDB;
+
+    /// A small fixed pool of distinct token types, so generated deltas collide
+    /// on `token_type` often enough to exercise the summation path in
+    /// `normalize_deltas`.
+    fn token_pool() -> Vec<ShieldedTokenType> {
+        let mut rng = StdRng::seed_from_u64(0xB0B0);
+        (0..4).map(|_| rng.r#gen()).collect()
+    }
+
+    /// Build a deltas-only offer (empty input/output/transient sets, so `merge`
+    /// never trips the disjointness check).
+    fn deltas_offer(deltas: Vec<Delta>) -> Offer<(), D> {
+        Offer {
+            inputs: std::vec::Vec::new().into(),
+            outputs: std::vec::Vec::new().into(),
+            transient: std::vec::Vec::new().into(),
+            deltas: deltas.into(),
+        }
+    }
+
+    /// Turn a list of `(pool_index, value)` into `Delta`s (dropping zeros so the
+    /// inputs are themselves plausible partial deltas).
+    fn make_deltas(pool: &[ShieldedTokenType], raw: &[(u8, i64)]) -> Vec<Delta> {
+        raw.iter()
+            .filter(|(_, v)| *v != 0)
+            .map(|(i, v)| Delta {
+                token_type: pool[(*i as usize) % pool.len()],
+                value: *v as i128,
+            })
+            .collect()
+    }
+
+    fn deltas_vec(offer: &Offer<(), D>) -> Vec<Delta> {
+        offer.deltas.iter_deref().cloned().collect()
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        // (B-tot)+(B-inv): merging two deltas-only offers whose values live in
+        // the i64 range never panics, and the result is in delta normal form.
+        #[test]
+        fn merge_preserves_delta_normal_form(
+            a in prop::collection::vec((any::<u8>(), any::<i64>()), 0..6),
+            b in prop::collection::vec((any::<u8>(), any::<i64>()), 0..6),
+        ) {
+            let pool = token_pool();
+            let oa = deltas_offer(make_deltas(&pool, &a));
+            let ob = deltas_offer(make_deltas(&pool, &b));
+            let merged = oa.merge(&ob).expect("disjoint (empty) coin sets merge");
+            let ds = deltas_vec(&merged);
+            // strictly increasing by token_type => sorted AND key-unique.
+            for w in ds.windows(2) {
+                prop_assert!(
+                    w[0].token_type < w[1].token_type,
+                    "merged deltas not strictly increasing by token_type"
+                );
+            }
+            // all non-zero.
+            prop_assert!(ds.iter().all(|d| d.value != 0), "merged deltas contain a zero");
+            // and it agrees with the reference normalization of the concatenation.
+            let mut concat: Vec<(ShieldedTokenType, i128)> =
+                make_deltas(&pool, &a).into_iter().chain(make_deltas(&pool, &b))
+                    .map(|d| (d.token_type, d.value)).collect();
+            concat = normalize_deltas(concat.into_iter());
+            let got: Vec<(ShieldedTokenType, i128)> =
+                ds.iter().map(|d| (d.token_type, d.value)).collect();
+            prop_assert_eq!(got, concat, "merge disagrees with normalize_deltas");
+        }
+
+        // (B-tot): merge is commutative on the delta set (normal form is order
+        // independent) — a sanity property that holds today.
+        #[test]
+        fn merge_delta_set_is_commutative(
+            a in prop::collection::vec((any::<u8>(), any::<i64>()), 0..6),
+            b in prop::collection::vec((any::<u8>(), any::<i64>()), 0..6),
+        ) {
+            let pool = token_pool();
+            let oa = deltas_offer(make_deltas(&pool, &a));
+            let ob = deltas_offer(make_deltas(&pool, &b));
+            let as_pairs = |o: &Offer<(), D>| -> Vec<(ShieldedTokenType, i128)> {
+                deltas_vec(o).iter().map(|d| (d.token_type, d.value)).collect()
+            };
+            let ab = as_pairs(&oa.merge(&ob).unwrap());
+            let ba = as_pairs(&ob.merge(&oa).unwrap());
+            prop_assert_eq!(ab, ba);
+        }
+    }
+
+    // Merging same-token deltas at the i128 extremes saturates rather than
+    // wrapping to the opposite sign.
+
+    #[test]
+    fn regression_merge_delta_overflow() {
+        let tt = token_pool()[0];
+        let a = deltas_offer(vec![Delta { token_type: tt, value: i128::MAX }]);
+        let b = deltas_offer(vec![Delta { token_type: tt, value: i128::MAX }]);
+        let merged = a.merge(&b).expect("empty coin sets merge");
+        let vals: Vec<i128> = deltas_vec(&merged).iter().map(|d| d.value).collect();
+        assert_eq!(vals, vec![i128::MAX]);
+    }
+
+    #[test]
+    fn regression_merge_delta_underflow() {
+        let tt = token_pool()[0];
+        let a = deltas_offer(vec![Delta { token_type: tt, value: i128::MIN }]);
+        let b = deltas_offer(vec![Delta { token_type: tt, value: i128::MIN }]);
+        let merged = a.merge(&b).expect("empty coin sets merge");
+        let vals: Vec<i128> = deltas_vec(&merged).iter().map(|d| d.value).collect();
+        assert_eq!(vals, vec![i128::MIN]);
+    }
+}

--- a/zswap/tests/properties.rs
+++ b/zswap/tests/properties.rs
@@ -1,0 +1,108 @@
+// This file is part of midnight-ledger.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Property tests for zswap offers.
+//!
+//! Uses the `proptest`-feature generators (activated here via
+//! the self dev-dependency). Follows the non-shrinking `StdRng`+`Distribution`
+//! pattern used by the ledger property tests.
+
+use coin_structure::coin::ShieldedTokenType;
+use midnight_zswap::error::MalformedOffer;
+use midnight_zswap::{Delta, Offer};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use serialize::{tagged_deserialize, tagged_serialize};
+use storage::db::InMemoryDB;
+
+type Db = InMemoryDB;
+
+/// **Serialization roundtrip.** A generated (proof-erased) offer survives a
+/// tagged serialize/deserialize cycle unchanged. This is the byte-level control:
+/// it must hold, and it is *not* the oracle that catches semantic bugs — the
+/// `well_formed` property below is.
+#[test]
+fn prop_offer_serialization_roundtrips() {
+    let mut rng = StdRng::seed_from_u64(0x2405A);
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in 0..128u64 {
+        let offer: Offer<(), Db> = rng.r#gen();
+
+        let mut bytes = Vec::new();
+        tagged_serialize(&offer, &mut bytes).expect("serialize");
+        let back: Offer<(), Db> = tagged_deserialize(&mut &bytes[..]).expect("deserialize");
+
+        if offer != back {
+            failures.push(format!("case {case}: offer changed across serialization roundtrip"));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "offer serialization roundtrip failed in {} case(s):\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}
+
+/// **Semantic normal-form oracle.** `Offer::<(), _>::well_formed` accepts an
+/// offer iff it is in normal form (sorted inputs/outputs/transient, strictly
+/// increasing unique deltas, all deltas non-zero).
+///
+/// Positive case: the generator produces normalized offers by construction, so
+/// `well_formed` must accept. Negative case: we splice in a single zero-value
+/// delta — a guaranteed normal-form violation regardless of the rest of the
+/// offer — and `well_formed` must reject with `NotNormalized`. This is a
+/// semantic oracle over the object graph, not a byte roundtrip.
+#[test]
+fn prop_offer_well_formed_iff_normalized() {
+    let mut rng = StdRng::seed_from_u64(0xB0F0F);
+    let mut failures: Vec<String> = Vec::new();
+    let mut positives = 0u32;
+
+    for case in 0..128u64 {
+        let segment: u16 = rng.gen_range(0..=64u16);
+        let offer: Offer<(), Db> = rng.r#gen();
+
+        // Positive: normalized-by-construction must be accepted.
+        match offer.well_formed(segment) {
+            Ok(_) => positives += 1,
+            Err(e) => failures.push(format!(
+                "case {case} (positive): well_formed rejected a normalized offer: {e:?}"
+            )),
+        }
+
+        // Negative: a zero-value delta is never normal form.
+        let mut malformed = offer.clone();
+        let bad_delta = Delta {
+            token_type: rng.r#gen::<ShieldedTokenType>(),
+            value: 0,
+        };
+        malformed.deltas = vec![bad_delta].into();
+        match malformed.well_formed(segment) {
+            Err(MalformedOffer::NotNormalized) => {}
+            other => failures.push(format!(
+                "case {case} (negative): well_formed did not reject a zero-value delta as \
+                 NotNormalized: {other:?}"
+            )),
+        }
+    }
+
+    assert!(positives > 0, "generator never produced an accepted offer — property was vacuous");
+    assert!(
+        failures.is_empty(),
+        "well_formed disagreed with the normal-form oracle in {} case(s):\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}


### PR DESCRIPTION
## Description

The consolidated property-test suite ported to the ledger-8 line, without the accompanying product fixes. Fix-gated regressions are present and un-ignored, so they fail until their fix lands (see the companion fixes branch); the general oracles/holds pass.

Note: This is *heavily* AI generated, but *strictly* confined to testing and validation. It was split out from #719 to let the fixes be reviewed more sanely.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [ ] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
