### PR TITLE
Ledger 10: give fetchurl a User-Agent crates.io accepts

### DIFF
--- a/bagel.nix
+++ b/bagel.nix
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{ system, rust-build-toolchain, nixpkgs, stdenv }:
+{ system, rust-build-toolchain, nixpkgs, stdenv, overlays ? [] }:
 
 {
   name,
@@ -30,7 +30,7 @@
 }:
 
 let
-  pkgs = import nixpkgs { inherit system; };
+  pkgs = import nixpkgs { inherit system overlays; };
   raw-wasm = ((pkgs.makeRustPlatform {
       rustc = rust-build-toolchain;
       cargo = rust-build-toolchain;

--- a/flake.nix
+++ b/flake.nix
@@ -37,30 +37,31 @@
   }:
     utils.lib.eachDefaultSystem (
       system: let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [
-            # crates.io returns 403 to any request whose User-Agent starts with
-            # "curl/", which is exactly what nixpkgs' fetchurl sends
-            # ("curl/$curlVersion Nixpkgs/$nixpkgsVersion"), so every crate
-            # tarball missing from the binary cache fails to download. Replace
-            # the agent for all fetchurl derivations.
-            #
-            # `args` is forwarded untouched because fetchurl also accepts the
-            # fixed-point (`finalAttrs:`) form; the agent is appended to the
-            # built derivation instead. curlOptsList is expanded as an array
-            # after the built-in --user-agent, so it wins.
-            (_final: prev: {
-              fetchurl =
-                args:
-                  (prev.fetchurl args).overrideAttrs (old: {
-                    curlOptsList =
-                      (old.curlOptsList or [])
-                      ++ ["--user-agent" "midnight-ledger/1.0"];
-                  });
-            })
-          ];
-        };
+        # crates.io returns 403 to any request whose User-Agent starts with
+        # "curl/", which is exactly what nixpkgs' fetchurl sends
+        # ("curl/$curlVersion Nixpkgs/$nixpkgsVersion"), so every crate tarball
+        # missing from the binary cache fails to download. Replace the agent for
+        # all fetchurl derivations.
+        #
+        # `args` is forwarded untouched because fetchurl also accepts the
+        # fixed-point (`finalAttrs:`) form; the agent is appended to the built
+        # derivation instead. curlOptsList is expanded as an array after the
+        # built-in --user-agent, so it wins.
+        #
+        # Every nixpkgs instantiation needs this -- see bagel.nix, which builds
+        # the wasm packages from its own import.
+        overlays = [
+          (_final: prev: {
+            fetchurl =
+              args:
+                (prev.fetchurl args).overrideAttrs (old: {
+                  curlOptsList =
+                    (old.curlOptsList or [])
+                    ++ ["--user-agent" "midnight-ledger/1.0"];
+                });
+          })
+        ];
+        pkgs = import nixpkgs {inherit system overlays;};
         pkgsStatic = pkgs.pkgsStatic;
         mkShell = pkgs.mkShell.override {
           stdenv = pkgs.clangStdenv;
@@ -107,7 +108,7 @@
           doCheck = false;
         };
         bagel-wasm = (import ./bagel.nix) {
-          inherit system nixpkgs;
+          inherit system nixpkgs overlays;
           stdenv = pkgs.clangStdenv;
           inherit (self.packages.${system}) rust-build-toolchain;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -40,16 +40,8 @@
         # crates.io returns 403 to any request whose User-Agent starts with
         # "curl/", which is exactly what nixpkgs' fetchurl sends
         # ("curl/$curlVersion Nixpkgs/$nixpkgsVersion"), so every crate tarball
-        # missing from the binary cache fails to download. Replace the agent for
-        # all fetchurl derivations.
-        #
-        # `args` is forwarded untouched because fetchurl also accepts the
-        # fixed-point (`finalAttrs:`) form; the agent is appended to the built
-        # derivation instead. curlOptsList is expanded as an array after the
-        # built-in --user-agent, so it wins.
-        #
-        # Every nixpkgs instantiation needs this -- see bagel.nix, which builds
-        # the wasm packages from its own import.
+        # missing from the binary cache fails to download.
+        # To solve this we replace the agent for all fetchurl derivations.
         overlays = [
           (_final: prev: {
             fetchurl =

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,30 @@
   }:
     utils.lib.eachDefaultSystem (
       system: let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            # crates.io returns 403 to any request whose User-Agent starts with
+            # "curl/", which is exactly what nixpkgs' fetchurl sends
+            # ("curl/$curlVersion Nixpkgs/$nixpkgsVersion"), so every crate
+            # tarball missing from the binary cache fails to download. Replace
+            # the agent for all fetchurl derivations.
+            #
+            # `args` is forwarded untouched because fetchurl also accepts the
+            # fixed-point (`finalAttrs:`) form; the agent is appended to the
+            # built derivation instead. curlOptsList is expanded as an array
+            # after the built-in --user-agent, so it wins.
+            (_final: prev: {
+              fetchurl =
+                args:
+                  (prev.fetchurl args).overrideAttrs (old: {
+                    curlOptsList =
+                      (old.curlOptsList or [])
+                      ++ ["--user-agent" "midnight-ledger/1.0"];
+                  });
+            })
+          ];
+        };
         pkgsStatic = pkgs.pkgsStatic;
         mkShell = pkgs.mkShell.override {
           stdenv = pkgs.clangStdenv;


### PR DESCRIPTION
## Problem

Every nix-based CI job has failed on every branch since 2026-08-29, after ~90 seconds,
before anything compiles:

    trying https://crates.io/api/v1/crates/nalgebra/0.33.3/download
    curl: (22) The requested URL returned error: 403        (x4 retries)
    error: cannot download crate-nalgebra-0.33.3.tar.gz from any mirror

The crate named varies per run — whichever tarball isn't already in `cache.nixos.org` and
therefore has to be fetched (`nalgebra` in build-ledger, `objc2-open-directory` in coverage,
`actix-cors` and `halo2derive` in the scheduled `ledger-8` runs).

This is not caused by any PR. The scheduled `Ledger Build and Test All` runs on `ledger-8`
fail identically:

| date | result | duration |
| --- | --- | --- |
| 2026-08-28 | success | 25m49s |
| 2026-08-29 → 09-02 | failure | 1m10s–1m40s |

## Cause

crates.io (via Fastly) now returns 403 to any request whose `User-Agent` **starts with
`curl/`**, and that is exactly what nixpkgs' fetchurl sends — `pkgs/build-support/fetchurl/builder.sh`:

    --user-agent "curl/$curlVersion Nixpkgs/$nixpkgsVersion"

Measured against the live endpoint:

| User-Agent | response |
| --- | --- |
| `curl/8.14.1 Nixpkgs/25.11` (the real one) | **403** |
| `curl/8.7.1` | 403 |
| `Nixpkgs/25.11 (+https://nixos.org)` | 200 |
| `cargo 1.90.0` | 200 |
| *(empty)* | 200 |

Only the prefix matters. Cargo's own downloads still succeed in the same job because it sends
a different agent, which is why the failure is confined to nix's crate-tarball derivations.

## Fix

An overlay on `fetchurl` that replaces the agent for every fetchurl derivation. `pkgsStatic`
inherits it — the static jobs are among the failing ones — and overriding `fetchurl` is safe
because stdenv bootstrap uses `fetchurlBoot`.

Note for anyone editing this later: our nixpkgs is 26.05, where `fetchurl` is built with
`lib.extendMkDerivation` and so also accepts the fixed-point `finalAttrs:` form. Transforming
the *argument* (`args // { ... }`) fails with `expected a set but found a function: «lambda
extendsWithExclusion»` as soon as a caller uses that form. The overlay therefore forwards
`args` untouched and appends the agent to the resulting derivation with `overrideAttrs`.

Note 2: this repo instantiates nixpkgs twice — `flake.nix` and `bagel.nix` (wasm builds).
Both need the overlay; overlaying only the first leaves every wasm package fetching
crates with the blocked agent.

## Alternatives ruled out

- **`NIX_CURL_FLAGS`** — it is in fetchurl's `impureEnvVars` and lands after `--user-agent`
  in the argv, so it looks like the obvious fix, but it had no effect: with a daemon install
  the client environment is not forwarded to fixed-output builders.
- **Bumping `flake.lock`** — nixpkgs master still sends the `curl/`-prefixed agent.
- **Binary cache (cachix)** — would mask this only for tarballs already pushed; cold builds
  would still fail.

## Verification

A/B on the real flake-produced derivation for the same crate, with substituters disabled so
it must hit crates.io:

| | result |
| --- | --- |
| without overlay (`p42cgbzg…-crate-equivalent-1.0.2.tar.gz.drv`) | `curl: (22) ... error: 403` — CI's exact failure |
| with overlay (`01mw6zsp…-crate-equivalent-1.0.2.tar.gz.drv`) | downloaded, hash verified |

- The agent reaches the crate fetches: the derivation's structured attrs carry
  `curlOptsList = ["--user-agent" "midnight-ledger/1.0"]` next to
  `urls = ["https://crates.io/api/v1/crates/equivalent/1.0.2/download"]`, across all 643
  crate-tarball derivations in the ledger closure.
- Binary-cache hits are unaffected: these are fixed-output derivations, so output paths are
  unchanged (`ah1i9a5r…-crate-equivalent-1.0.2.tar.gz` identical before and after) and still
  substitute from `cache.nixos.org`. Only the `.drv` hashes change.
- Every package CI builds still evaluates: `default`, `ledger`, `ledger-wasm`, `zkir`,
  `zkir-v3`, `zkir-v3-wasm`, `onchain-runtime-wasm`, `proof-server`, `test-artifacts`,
  `integration-test-deps`, `local-params`, `public-params`.

`nix flake check` was not run to completion — it starts building the workspace; the eval sweep
above covers the same surface without the build. CI on this PR is the real check.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [X] I have self-reviewed the PR diff
- [ ] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.# Overview
