### PR TITLE
fix(ci): flatten proof-server public key into manifest artifact

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -281,6 +281,11 @@ jobs:
           }
           trap cleanup EXIT
 
+          # upload-artifact roots the artifact at the least common ancestor of
+          # its matched files, so a key left under proof-server/ would keep that
+          # prefix and land outside the flat path the release job uploads from.
+          cp proof-server/midnight-proof-server-public.asc .
+
           printf '%s' "$SIGNING_KEY" | gpg --batch --import
           KEY_ID=$(gpg --list-secret-keys --with-colons \
             | awk -F: '/^sec:/ {print $5; exit}')
@@ -316,5 +321,5 @@ jobs:
           path: |
             build-manifest.json
             build-manifest.json.asc
-            proof-server/midnight-proof-server-public.asc
+            midnight-proof-server-public.asc
           if-no-files-found: error


### PR DESCRIPTION
## Problem

Every release since the manifest signing landed has failed in
`attach-proof-server-manifest`, the last job in the graph — after the GitHub
release was created and announced on Slack:

```
no matches found for `./proof-server-release-assets/midnight-proof-server-public.asc`
```

Affected runs: [8.1.2](https://github.com/midnightntwrk/midnight-ledger/actions/runs/33745652745),
[9.1.0.0-rc.4](https://github.com/midnightntwrk/midnight-ledger/actions/runs/31505698168),
[9.1.0.0-rc.3](https://github.com/midnightntwrk/midnight-ledger/actions/runs/31390921065).

## Cause

`upload-artifact` roots an artifact at the least common ancestor of its matched
files. The signing step uploads two files from the workspace root and one from a
subdirectory:

```
build-manifest.json
build-manifest.json.asc
proof-server/midnight-proof-server-public.asc
```

The ancestor is therefore the workspace root, and the key keeps its
`proof-server/` prefix inside the zip. `prerelease.yml` then asks
`gh release upload` for `./proof-server-release-assets/midnight-proof-server-public.asc`,
one level above where the key actually unpacks. Confirmed by downloading the
artifact from run 34220541435:

```
build-manifest.json
build-manifest.json.asc
proof-server/midnight-proof-server-public.asc
```

`release/ledger-8.1.2` has a second instance of the same class of bug: at
`533d746` the key file is not in the tree at all, so its artifact holds only the
two manifest files. `if-no-files-found: error` did not catch that, because it
fires only when *no* pattern matches anything — not when one of three matches
nothing.

## Fix

Copy the key next to the manifest before upload, so all three assets sit at the
artifact root and the artifact unpacks flat into the path `prerelease.yml`
already expects. No change to `prerelease.yml`.

The copy runs under `set -euo pipefail`, so it also closes the second failure
mode: a branch that never received the key now fails loudly in the signing step
rather than producing a short artifact that surfaces four jobs later.

## Verification

`docker-manifest` runs only on release dispatch, so this cannot be exercised on
a PR. Reviewed against the artifact layout observed in run 34220541435, which
matches the `upload-artifact` least-common-ancestor rule exactly.

`release/ledger-8.1.2` additionally needs `proof-server/midnight-proof-server-public.asc`
cherry-picked from 5d3fc1e1 on top of this change.
