### PR TITLE
Exempt release notes from SRE/security ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 * @midnightntwrk/mn-codeowners-ledger @midnightntwrk/mn-qa
 /.github/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
+/.github/release-notes/ @midnightntwrk/mn-codeowners-ledger @midnightntwrk/mn-qa
 CODE_OF_CONDUCT.md @midnightntwrk/mn-security @midnightntwrk/mn-sre
 CODEOWNERS @midnightntwrk/mn-security @midnightntwrk/mn-sre
 CONTRIBUTING.md @midnightntwrk/mn-security @midnightntwrk/mn-sre


### PR DESCRIPTION
## Description

`/.github/` is owned by `@midnightntwrk/mn-security` and `@midnightntwrk/mn-sre`, so every release PR that adds a `.github/release-notes/*.md` file blocks on an SRE or security approval — see #751, which is `BLOCKED` on exactly that one added file. Release notes hold no CI workflow or security configuration, so this adds a more specific `/.github/release-notes/` rule assigning them to the ledger codeowners and QA, matching the repository default.

This restores the prior scope rather than carving out something new. Until 6ebe72c1 (#706, 2026-09-03), SRE and security owned only `/.github/ISSUE_TEMPLATE/`, `/.github/PULL_REQUEST_TEMPLATE/`, `/.github/workflows/scan.yaml`, and `/.github/workflows/dependabot.yml`; release notes fell through to `*`. That PR collapsed the four rules into a single `/.github/` rule, incidentally to its subject (issue forms and label dispatchers), and widened ownership to the whole directory.

The `/.github/` rule itself is unchanged: workflows, actions, and issue templates still require SRE and security review.

## Sanity Checklist

This PR:
- [ ] contains changes to transaction behaviour [^1]
- [ ] contains changes to architecture [^1]
- [ ] contains breaking API changes [^1][^2]
- [ ] contains data format changes [^1]
- [ ] contains circuit behaviour changes [^3]
- [ ] requires a backport to prior versions
- [X] is primarily authored by AI
- [x] I have self-reviewed the PR diff
- [X] changelog and package versions have been amended, or don't require it
- [ ] has ignored the checklist

[^1]: If any of these are true, target a future release instead of the default branch.
[^2]: Exceptions may be considered on a case-to-case basis where the impact is minimal.
[^3]: Ensure that these changes are backwards-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
